### PR TITLE
Fix Memory tab for non-OpenClaw runtimes + remove the duplicate runtime picker

### DIFF
--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -2394,11 +2394,17 @@ class LocalStore:
                 continue
         return out
 
-    def ingest_memory_blob(self, blob_row: dict[str, Any]) -> None:
+    def ingest_memory_blob(self, blob_row: dict[str, Any]) -> bool:
         """Upsert one memory blob (e.g. CLAUDE.md, ~/.openclaw/memory/notes.md).
 
         Required: agent_type, path. Optional: agent_id, blob, sha256, ts.
-        Re-ingesting with the same sha256 is a no-op (cheap dedup)."""
+        Re-ingesting with the same sha256 is a no-op (cheap dedup).
+
+        Returns True when a row was actually written, False on the dedup
+        no-op — the sync daemon uses this to decide whether the cloud
+        memory cache blob needs rebuilding (it changes rarely; rebuilding
+        it every heartbeat would re-read + re-encrypt megabytes for
+        nothing)."""
         atype = blob_row.get("agent_type")
         path = blob_row.get("path")
         if not atype or not path:
@@ -2424,7 +2430,7 @@ class LocalStore:
                 )
                 row = cur.fetchone()
                 if row and row[0] == sha:
-                    return
+                    return False
             self._conn.execute("""
                 INSERT INTO memory_blobs (
                     agent_type, agent_id, path, ts, blob, sha256, size_bytes, updated_at
@@ -2436,6 +2442,7 @@ class LocalStore:
                     size_bytes = excluded.size_bytes,
                     updated_at = excluded.updated_at
             """, [atype, agent_id, path, blob_row.get("ts"), blob, sha, size, now_ms])
+        return True
 
     def ingest_channel(self, ch: dict[str, Any]) -> None:
         """Upsert one OpenClaw channel-context row. Required: session_id.

--- a/clawmetry/runtime_memory.py
+++ b/clawmetry/runtime_memory.py
@@ -672,6 +672,33 @@ def list_files(runtime_id: str, category: Optional[str] = None) -> dict:
     return {"runtime": entry.id, "label": entry.label, "groups": groups}
 
 
+def runtime_is_locked(runtime_id: str) -> bool:
+    """True when this runtime needs a paid entitlement the caller lacks.
+
+    Single source of truth for the memory/skills paywall: ``routes/
+    runtime_memory.py`` uses it to decide 402, and the sync daemon uses it to
+    decide what it may ingest and ship to cloud. Keeping the two on one
+    predicate is the point — the daemon used to sync every detected runtime's
+    memory regardless of entitlement, so a free user's paid-runtime files
+    reached the cloud Memory tab that the local API would have refused.
+
+    Free runtimes are never locked. For paid runtimes ``allows_runtime`` on
+    the resolved entitlement is authoritative (it already honours grace mode).
+    Any exception falls OPEN — a resolver hiccup should not blank out a
+    paying user's memory; the read endpoints re-check on every request.
+    """
+    try:
+        from clawmetry.entitlements import FREE_RUNTIMES, get_entitlement
+    except Exception:
+        return False
+    if runtime_id in FREE_RUNTIMES:
+        return False
+    try:
+        return not bool(get_entitlement().allows_runtime(runtime_id))
+    except Exception:
+        return False
+
+
 def list_all_files(category: Optional[str] = None,
                    exclude_runtimes: Optional[Iterable] = None) -> dict:
     """Merge every runtime that has files on disk into one grouped listing.

--- a/clawmetry/runtime_memory.py
+++ b/clawmetry/runtime_memory.py
@@ -666,8 +666,44 @@ def list_files(runtime_id: str, category: Optional[str] = None) -> dict:
             "scope": spec.scope,
             "exists": exists,
             "files": files,
+            "runtime": entry.id,
+            "runtime_label": entry.label,
         })
     return {"runtime": entry.id, "label": entry.label, "groups": groups}
+
+
+def list_all_files(category: Optional[str] = None,
+                   exclude_runtimes: Optional[Iterable] = None) -> dict:
+    """Merge every runtime that has files on disk into one grouped listing.
+
+    Backs the "All runtimes" scope of the Memory / Skills browser. Each
+    group keeps its ``runtime`` / ``runtime_label`` so the UI can say which
+    agent owns the files, and the label is prefixed with the runtime name
+    (two runtimes both calling a root "Global memory" is otherwise
+    indistinguishable once merged).
+
+    Empty roots are dropped: a runtime the user has not installed should
+    read as absent, not as a broken empty folder. Same shape as
+    :func:`list_files` so one renderer handles both.
+
+    ``exclude_runtimes`` drops runtime ids entirely — the route layer
+    passes the paid runtimes the caller is not entitled to, so "All
+    runtimes" can never become a side door around the per-runtime 402.
+    """
+    skip = set(exclude_runtimes or ())
+    groups: list = []
+    for entry in _catalog():
+        if entry.id in skip:
+            continue
+        payload = list_files(entry.id, category=category)
+        for g in payload.get("groups", []):
+            if not g.get("exists") or not g.get("files"):
+                continue
+            merged = dict(g)
+            base = merged.get("label") or ""
+            merged["label"] = f"{entry.label} - {base}" if base else entry.label
+            groups.append(merged)
+    return {"runtime": "all", "label": "All runtimes", "groups": groups}
 
 
 def read_runtime_file(runtime_id: str, root: str, path: str,
@@ -679,17 +715,29 @@ def read_runtime_file(runtime_id: str, root: str, path: str,
     interpreted **relative to ``root``**; ``root`` MUST match one of the
     runtime's catalog roots verbatim (post-expansion), so callers can only
     read what the UI has already listed.
+
+    ``runtime_id='all'`` matches ``root`` against EVERY runtime's roots —
+    the "All runtimes" listing merges groups from several runtimes, so a
+    click there has no single owning runtime. The traversal guarantee is
+    unchanged: the root must still appear verbatim in some catalog entry.
     """
-    entry = _entry_by_id(runtime_id)
-    if entry is None:
-        return {"ok": False, "error": "unknown_runtime", "status": 404}
+    if runtime_id == "all":
+        candidates = list(_catalog())
+    else:
+        entry = _entry_by_id(runtime_id)
+        if entry is None:
+            return {"ok": False, "error": "unknown_runtime", "status": 404}
+        candidates = [entry]
 
     # Match root against catalog (post-expansion)
     matched_spec: Optional[RootSpec] = None
     root_norm = os.path.abspath(os.path.expanduser(root))
-    for spec in entry.roots:
-        if os.path.abspath(spec.expanded_root()) == root_norm:
-            matched_spec = spec
+    for _entry in candidates:
+        for spec in _entry.roots:
+            if os.path.abspath(spec.expanded_root()) == root_norm:
+                matched_spec = spec
+                break
+        if matched_spec is not None:
             break
     if matched_spec is None:
         return {"ok": False, "error": "root not in catalog for runtime", "status": 403}

--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -10165,7 +10165,10 @@ var _CM_RT_NODEWIDE = {
   // approvals + alerts left this map 2026-08-03: approvals rows filter by
   // the requesting session's runtime prefix, and alert rules carry their own
   // per-rule scope (runtime column, node-wide chip when 'all').
-  crons: 1, memory: 1, security: 1, skills: 1, selfevolve: 1,
+  // memory + skills left this map 2026-08-15: both now browse the selected
+  // runtime's own files (clawmetry/runtime_memory.py catalog), so the
+  // "not specific to any runtime" note was actively wrong there.
+  crons: 1, security: 1, selfevolve: 1,
   policy: 1, nemoclaw: 1, notifications: 1, dives: 1,
   clusters: 1, actions: 1,
   // logs + version-impact are NOT node-wide: logs stream a specific runtime's
@@ -10239,10 +10242,11 @@ var _CM_CAP_TABS = {
 // approvals: one local queue spans all runtimes (see _CM_CAP_TABS note).
 // memory + skills: the multi-runtime file browser (PR #4821) resolves every
 // runtime's on-disk memory/skills paths, so both tabs are node-level (not
-// gated by a per-adapter capability). Without this, the runtime chip bar
-// inside Memory/Skills would be unreachable because the whole tab was
-// hidden by _cmApplyRuntimeTabVisibility whenever a non-OpenClaw runtime
-// was selected in the top-of-page runtime dropdown.
+// gated by a per-adapter capability). Without this,
+// _cmApplyRuntimeTabVisibility would hide the whole tab whenever a
+// non-OpenClaw runtime was selected — exactly the runtimes whose memory the
+// browser exists to show. The tab body scopes itself to the selected runtime
+// (cmRuntimeApplyScope).
 var _CM_NODE_TABS = ['alerts','notifications','security','approvals','memory','skills'];
 // Every togglable sidebar tab (so switching runtimes RE-SHOWS what a prior one
 // hid). overview is never togglable.
@@ -25827,17 +25831,20 @@ setTimeout(checkLicenseExpiry, 1200);
 //
 // Each supported runtime stores its long-lived memory and its skills in
 // different places on disk (see clawmetry/runtime_memory.py). This module
-// renders two things across the Memory + Skills tabs:
-//   1. A chip bar of runtimes (dimmed if not present on this machine)
-//   2. A file-browser view (left tree, right preview) for the picked runtime
+// renders a file-browser view (left tree, right preview) for the runtime
+// picked in the GLOBAL runtime switcher in the header.
 //
-// OpenClaw remains the default; picking it hides the browser and shows the
-// existing rich Memory / Skills UI. All other runtimes route through the
-// browser. Backwards compatible — the old view is untouched.
+// OpenClaw keeps its rich native Memory / Skills UI; every other runtime (and
+// the "All" scope, which merges them) routes through the browser.
+//
+// History: these two tabs used to carry their OWN chip bar of runtimes, which
+// meant one screen had two independent runtime pickers that could disagree —
+// the header said "Claude Code" while the chip bar said "OpenClaw" and the page
+// showed OpenClaw's files. There is now exactly one runtime control on the
+// page, the global one.
 // ─────────────────────────────────────────────────────────────────────────
 
 var _cmRuntimeCatalog = null;
-var _cmRuntimeSelected = { memory: 'openclaw', skills: 'openclaw' };
 
 function _cmRuntimeIsCloud() {
   try {
@@ -25869,65 +25876,54 @@ function _cmRuntimeIcon(id) {
   return map[id] || '•';
 }
 
-function _cmRuntimeChip(runtime, selected, tab, category) {
-  var count = 0;
-  if (category && runtime.counts) count = runtime.counts[category] || 0;
-  else if (runtime.counts) {
-    Object.keys(runtime.counts).forEach(function(k) { count += runtime.counts[k] || 0; });
-  }
-  var isSel = runtime.id === selected;
-  var isPresent = !!runtime.present;
-  var isLocked = !!runtime.locked;
-  var bg = isSel ? '#6366f1' : (isPresent ? 'var(--bg-secondary)' : 'transparent');
-  var color = isSel ? '#fff' : (isPresent ? 'var(--text-primary)' : 'var(--text-muted)');
-  var border = isSel ? '#6366f1' : 'var(--border-primary)';
-  var op = (isPresent || isSel) ? 1 : 0.55;
-  var badge = '';
-  if (isLocked) {
-    badge = '<span title="Paid runtime — upgrade to browse its files" style="margin-left:6px;font-size:10px;opacity:0.85;">🔒</span>';
-  } else if (count > 0) {
-    badge = '<span style="background:rgba(255,255,255,0.16);padding:1px 6px;border-radius:8px;font-size:10px;margin-left:6px;">' + count + '</span>';
-  }
-  var titleTip = isLocked
-    ? escHtml(runtime.label) + ' — paid runtime, upgrade to browse'
-    : escHtml(runtime.label) + (isPresent ? '' : ' (not detected on this machine)');
-  return '<div class="cm-runtime-chip" data-runtime="' + runtime.id + '" '
-    + 'onclick="cmRuntimeSelect(\'' + tab + '\',\'' + runtime.id + '\')" '
-    + 'style="padding:4px 10px;border-radius:14px;font-size:11px;font-weight:600;cursor:pointer;'
-    + 'background:' + bg + ';color:' + color + ';border:1px solid ' + border + ';opacity:' + op + ';'
-    + 'display:inline-flex;align-items:center;gap:4px;" title="' + titleTip + '">'
-    + escHtml(runtime.label) + badge + '</div>';
+// Which runtime the Memory / Skills browser should show, derived from the
+// GLOBAL switcher. `category` is 'memory' or 'skills'.
+//
+// The interesting case is 'all'. Showing OpenClaw's native surface under "All"
+// is what made the Memory tab look broken on a Claude-Code-only machine: the
+// header said "All", OpenClaw had one file (or none), and 400 Claude Code
+// memory files were nowhere on screen. So 'all' means: merged browser when any
+// non-OpenClaw runtime actually has files of this kind, and OpenClaw's native
+// view when it doesn't (the flagship single-runtime install is unchanged).
+async function _cmRuntimeScopeFor(category) {
+  var rt = (typeof _cmRuntimeFilter === 'function') ? _cmRuntimeFilter() : 'all';
+  // OTLP-observed apps have no on-disk memory/skills layout of their own.
+  if (typeof _cmIsOtlpRuntime === 'function' && _cmIsOtlpRuntime(rt)) rt = 'all';
+  if (rt !== 'all') return rt;
+  var cat = await _cmRuntimeFetchCatalog();
+  var others = (cat.runtimes || []).filter(function(r) {
+    return r.id !== 'openclaw' && r.present && !r.locked &&
+           ((r.counts || {})[category] || 0) > 0;
+  });
+  return others.length ? 'all' : 'openclaw';
 }
 
-async function cmRuntimeMountChips(chipsEl) {
-  if (!chipsEl) return;
-  var tab = chipsEl.getAttribute('data-tab') || 'memory';
-  var category = chipsEl.getAttribute('data-category') || null;
-  chipsEl.innerHTML = '<span style="font-size:11px;color:var(--text-muted);">Loading runtimes…</span>';
-  var cat = await _cmRuntimeFetchCatalog();
-  var runtimes = (cat.runtimes || []).slice();
-  // Sort: present first, then by label
-  runtimes.sort(function(a, b) {
-    if (!!a.present !== !!b.present) return a.present ? -1 : 1;
-    return (a.label || '').localeCompare(b.label || '');
-  });
-  var sel = _cmRuntimeSelected[tab] || 'openclaw';
-  var chips = runtimes.map(function(rt) {
-    return _cmRuntimeChip(rt, sel, tab, category);
-  });
-  chipsEl.innerHTML = chips.join('');
+// Point a tab ('memory' | 'skills') at the globally selected runtime.
+// Idempotent — safe to call on every tab switch and every runtime change.
+async function cmRuntimeApplyScope(tab) {
+  // Cloud renders Memory from the E2E-encrypted heartbeat blob (there is no
+  // filesystem in the container to browse), so it owns its own scoping.
+  if (_cmRuntimeIsCloud()) return;
+  var category = (tab === 'skills') ? 'skills' : 'memory';
+  try {
+    cmRuntimeSelect(tab, await _cmRuntimeScopeFor(category));
+  } catch (e) {}
 }
 
 function cmRuntimeSelect(tab, runtimeId) {
-  _cmRuntimeSelected[tab] = runtimeId;
-  // Re-render both chip bars if present (keeps them in sync visually)
-  var chips = document.querySelectorAll('[id$="-runtime-chips"][data-tab="' + tab + '"]');
-  chips.forEach(function(el) { cmRuntimeMountChips(el); });
   // Toggle native OpenClaw view vs runtime file browser
   var browser = document.getElementById(tab + '-runtime-browser');
   if (tab === 'memory') {
     var nativeIds = ['memory-summary-view', 'memory-access-view', 'memory-all-view'];
-    if (runtimeId === 'openclaw') {
+    // Summary / All files / Access log are OpenClaw-shaped views (the access
+    // log reads OpenClaw's memory_search tool events). Under any other runtime
+    // they either render empty or fight the file browser for the same space,
+    // so hide the switch entirely rather than offer three dead buttons.
+    var isOpenClaw = (runtimeId === 'openclaw');
+    Array.prototype.forEach.call(
+      document.querySelectorAll('#page-memory .mem-view-tab'),
+      function(el) { el.style.display = isOpenClaw ? '' : 'none'; });
+    if (isOpenClaw) {
       nativeIds.forEach(function(id) {
         var el = document.getElementById(id);
         if (!el) return;
@@ -25968,10 +25964,12 @@ async function cmRuntimeMountBrowser(container, runtimeId, tab) {
     + escHtml(runtimeId) + '…</div>';
   var payload;
   try {
-    var url = '/api/runtimes/' + encodeURIComponent(runtimeId) + '/files';
-    if (tab === 'memory' || tab === 'skills') {
-      // No category filter — show everything the runtime exposes.
-    }
+    // Scope to the tab's own category. Without this the Memory tab listed a
+    // runtime's skills/commands/hooks too — on a machine with 400+ skill files
+    // that buries the handful of memory files the tab exists to show.
+    var category = (tab === 'skills') ? 'skills' : 'memory';
+    var url = '/api/runtimes/' + encodeURIComponent(runtimeId) + '/files'
+      + '?category=' + encodeURIComponent(category);
     var r = await fetch(url);
     if (r.status === 402) {
       // Paid runtime the caller isn't entitled to. Show upsell CTA
@@ -26001,18 +25999,29 @@ async function cmRuntimeMountBrowser(container, runtimeId, tab) {
   var totalFiles = groups.reduce(function(s, g) { return s + (g.files || []).length; }, 0);
 
   if (!groups.length) {
+    var _kind = (tab === 'skills') ? 'skills' : 'memory';
+    if (runtimeId === 'all') {
+      // The merged listing only ever carries roots that exist, so there are no
+      // candidate paths to print — say plainly that no runtime has files here.
+      container.innerHTML =
+        '<div style="padding:24px;text-align:center;color:var(--text-muted);font-size:13px;line-height:1.5;">'
+        + '<div style="font-weight:700;color:var(--text-secondary);margin-bottom:6px;">No ' + _kind + ' files found for any runtime</div>'
+        + 'Pick a single runtime in the header switcher to see exactly where ClawMetry looks for its files.'
+        + '</div>';
+      return;
+    }
     container.innerHTML =
       '<div style="padding:24px;text-align:center;color:var(--text-muted);font-size:13px;line-height:1.5;">'
-      + '<div style="font-weight:700;color:var(--text-secondary);margin-bottom:6px;">Nothing found on disk for ' + escHtml(payload.label || runtimeId) + '</div>'
-      + 'ClawMetry looks for this runtime\'s memory and skills at these paths:'
+      + '<div style="font-weight:700;color:var(--text-secondary);margin-bottom:6px;">No ' + _kind + ' files on disk for ' + escHtml(payload.label || runtimeId) + '</div>'
+      + 'ClawMetry looks for them here:'
       + '<div style="margin-top:12px;text-align:left;display:inline-block;font-family:\'JetBrains Mono\',\'SF Mono\',monospace;font-size:11px;color:var(--text-muted);">'
       + absent.map(function(g) {
           return '<div>• <span style="color:var(--text-secondary);">' + escHtml(g.category)
             + '</span> <span style="opacity:0.7;">(' + escHtml(g.scope) + ')</span> — <code>' + escHtml(g.root) + '</code></div>';
         }).join('')
       + '</div>'
-      + '<div style="margin-top:14px;font-size:11px;">Install ' + escHtml(payload.label || runtimeId)
-      + ' or drop files at one of these paths to make them appear here.</div>'
+      + '<div style="margin-top:14px;font-size:11px;">They show up here as soon as '
+      + escHtml(payload.label || runtimeId) + ' writes to one of these paths.</div>'
       + '</div>';
     return;
   }
@@ -26057,7 +26066,25 @@ async function cmRuntimeMountBrowser(container, runtimeId, tab) {
 
   // Stash the payload on the container so cmRuntimeOpenFile can look up
   // (root, path) by (gi, fi) without another fetch.
-  container._cmRuntimePayload = payload;
+  //
+  // Stash the FILTERED groups, not payload.groups: the tree's data-gi indexes
+  // into `groups` (roots that exist), so handing the lookup the unfiltered list
+  // silently pointed every click at the wrong group. With any absent root —
+  // e.g. Claude Code with no global ~/.claude/CLAUDE.md — gi=0 resolved to an
+  // empty group and the click did nothing at all.
+  container._cmRuntimePayload = {
+    runtime: payload.runtime, label: payload.label, groups: groups,
+  };
+
+  // Open the first file straight away. An empty right pane on arrival reads as
+  // "nothing here" even with a full tree on the left — the OpenClaw memory IDE
+  // auto-selects too, so this keeps the two surfaces consistent.
+  var firstFile = container.querySelector('.cm-rt-file');
+  if (firstFile) {
+    cmRuntimeOpenFile(firstFile, runtimeId,
+                      parseInt(firstFile.getAttribute('data-gi'), 10) || 0,
+                      parseInt(firstFile.getAttribute('data-fi'), 10) || 0);
+  }
 }
 
 async function cmRuntimeOpenFile(clickEl, runtimeId, gi, fi) {
@@ -26083,7 +26110,10 @@ async function cmRuntimeOpenFile(clickEl, runtimeId, gi, fi) {
   if (body) body.innerHTML = '<div style="color:var(--text-muted);">Loading…</div>';
 
   try {
-    var url = '/api/runtimes/' + encodeURIComponent(runtimeId)
+    // In the merged "All runtimes" listing each group carries the runtime that
+    // owns it — read through that one, not the literal 'all'.
+    var owner = group.runtime || runtimeId;
+    var url = '/api/runtimes/' + encodeURIComponent(owner)
       + '/file?root=' + encodeURIComponent(group.root)
       + '&path=' + encodeURIComponent(file.path || '');
     var r = await fetch(url);
@@ -26117,18 +26147,17 @@ async function cmRuntimeOpenFile(clickEl, runtimeId, gi, fi) {
   }
 }
 
-// Hook into tab switches so the chip bars mount on first paint.
+// Hook into tab switches so the browser scopes to the globally selected
+// runtime on first paint. Changing the header switcher re-runs switchTab for
+// the current tab (see _cmOnGlobalRuntimeChange), so this covers both entry
+// points with one hook.
 (function _cmRuntimeInstallHooks() {
   var origSwitchTab = (typeof switchTab === 'function') ? switchTab : null;
   if (!origSwitchTab || origSwitchTab._cmRuntimeWrapped) return;
   var wrapped = function(name) {
     var out = origSwitchTab.apply(this, arguments);
     try {
-      if (name === 'memory') {
-        cmRuntimeMountChips(document.getElementById('memory-runtime-chips'));
-      } else if (name === 'skills') {
-        cmRuntimeMountChips(document.getElementById('skills-runtime-chips'));
-      }
+      if (name === 'memory' || name === 'skills') cmRuntimeApplyScope(name);
     } catch (e) {}
     return out;
   };

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -3921,6 +3921,12 @@ def _local_ingest_runtime_memory() -> int:
             # the cloud-facing OpenClaw path names). Skip to avoid two rows
             # for the same file under different path spellings.
             continue
+        if runtime_memory.runtime_is_locked(runtime_id):
+            # Same predicate the /api/runtimes/<rt>/files route 402s on. The
+            # daemon must not become the side door: without this, a free
+            # user's paid-runtime memory would be ingested and shipped to the
+            # cloud Memory tab that the local API refuses to serve.
+            continue
         try:
             listing = runtime_memory.list_files(runtime_id, category="memory")
         except Exception as e:
@@ -8600,13 +8606,17 @@ def _mark_memory_cache_dirty() -> None:
 
 
 def _memory_runtime_ids() -> list:
-    """Runtime ids to pull memory rows for, catalog-derived + openclaw."""
+    """Runtime ids to pull memory rows for, catalog-derived + openclaw.
+
+    Locked paid runtimes are excluded here as well as at ingest: rows already
+    in the store from an entitled period must stop being shipped when the
+    entitlement lapses, or a downgrade would keep serving them to cloud."""
     ids = ["openclaw"]
     try:
         from clawmetry import runtime_memory
         for entry in runtime_memory.list_runtimes():
             rid = entry.get("id")
-            if rid and rid not in ids:
+            if rid and rid not in ids and not runtime_memory.runtime_is_locked(rid):
                 ids.append(rid)
     except Exception:
         pass

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -8579,6 +8579,13 @@ MEMORY_CACHE_TTL_SEC = 21600       # 6h — matches Brain TTL; files change slow
 MEMORY_CACHE_LIMIT = 200            # per RUNTIME, so one chatty agent can't
                                     # crowd the others out of the blob
 MEMORY_CONTENT_TRUNCATE = 200_000   # per file, bounds the heartbeat blob
+# Ceiling for the whole pushed payload. Per-file and per-runtime caps alone
+# still multiply out to something no one wants riding a heartbeat, so cut the
+# list off here as well. Rows arrive newest-first, so what survives is the
+# memory the agent touched most recently. Dropped files are left OUT of the
+# file list entirely rather than listed with missing content — a tree entry
+# that opens to nothing reads as a broken tab.
+MEMORY_CACHE_MAX_TOTAL_BYTES = 4_000_000
 
 # Runtimes whose memory we ship to cloud. Derived from the on-disk catalog so a
 # new runtime added to clawmetry/runtime_memory.py is carried automatically.
@@ -8690,6 +8697,8 @@ def _build_memory_cache_pushes(config: dict) -> list:
     contents: list[dict] = []
     per_runtime: dict = {}
     seen: set = set()
+    budget = MEMORY_CACHE_MAX_TOTAL_BYTES
+    dropped = 0
     for r in rows:
         path = r.get("path") or ""
         runtime_id = r.get("agent_type") or "openclaw"
@@ -8713,14 +8722,24 @@ def _build_memory_cache_pushes(config: dict) -> list:
         size = r.get("size_bytes")
         if size is None:
             size = len(content.encode("utf-8", errors="replace"))
-        files.append({"name": path, "path": path, "size": int(size or 0),
-                      "runtime": runtime_id})
         # Truncate per-file content to bound the encrypted blob size — the
         # cloud Memory IDE shows a viewer pane (no diffing), so a huge single
         # file is wasted heartbeat bandwidth.
-        contents.append({"path": path, "runtime": runtime_id,
-                         "content": content[:MEMORY_CONTENT_TRUNCATE]})
+        body = content[:MEMORY_CONTENT_TRUNCATE]
+        if len(body) > budget:
+            dropped += 1
+            continue
+        budget -= len(body)
+        files.append({"name": path, "path": path, "size": int(size or 0),
+                      "runtime": runtime_id})
+        contents.append({"path": path, "runtime": runtime_id, "content": body})
         per_runtime[runtime_id] = per_runtime.get(runtime_id, 0) + 1
+    if dropped:
+        log.info(
+            "Memory cache push: %d file(s) left out of the %d-byte payload "
+            "budget (oldest first); %d shipped",
+            dropped, MEMORY_CACHE_MAX_TOTAL_BYTES, len(files),
+        )
     if not files:
         return []
     payload = {

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -3844,13 +3844,137 @@ def _local_ingest_memory_files(all_files: list, changed_paths: list) -> None:
     for name, content in all_files:
         if name not in changed_set:
             continue
-        store.ingest_memory_blob({
+        if store.ingest_memory_blob({
             "agent_type": "openclaw",  # OpenClaw harness writes these files
             "agent_id": "main",
             "path": name,
             "ts": now_iso,
             "blob": content,
-        })
+        }):
+            _mark_memory_cache_dirty()
+
+
+# ── Per-runtime memory ingest ──────────────────────────────────────────────
+# The OpenClaw workspace is only one of the places an agent keeps long-lived
+# memory: Claude Code has ``~/.claude`` (CLAUDE.md + per-project auto-memory),
+# Codex/opencode/Copilot read ``AGENTS.md``, Cursor has ``.cursor/rules``, and
+# so on. ``clawmetry/runtime_memory.py`` is the catalog of those locations.
+#
+# Before this, the daemon only ingested the OpenClaw workspace files, so a node
+# that runs Claude Code (and no OpenClaw) had ZERO rows in ``memory_blobs`` —
+# which meant ``_build_memory_cache_pushes`` returned [], the cloud memory cache
+# key was never written, and the cloud Memory tab sat on "Syncing memory files…"
+# forever waiting for a heartbeat that had nothing to send.
+#
+# Caps exist because per-project auto-memory can be large (429 files / 1.4 MB on
+# the author's laptop). We take the most recently modified files per runtime and
+# stop at a byte budget; the dashboard's local file browser still reads
+# everything straight off disk, so nothing is hidden locally — the cap only
+# bounds what we persist + ship.
+RUNTIME_MEMORY_MAX_FILES_PER_RUNTIME = 120
+RUNTIME_MEMORY_MAX_FILE_BYTES = 200_000
+RUNTIME_MEMORY_MAX_TOTAL_BYTES = 6_000_000
+
+
+def _memory_display_path(abs_path: str) -> str:
+    """``/Users/x/.claude/CLAUDE.md`` -> ``~/.claude/CLAUDE.md``.
+
+    The Memory UI groups by directory prefix and shows the path verbatim, so a
+    home-relative path is both unique (the DuckDB PK is (agent_type, agent_id,
+    path)) and readable. Paths outside $HOME stay absolute."""
+    home = os.path.expanduser("~")
+    if abs_path.startswith(home + os.sep):
+        return "~/" + abs_path[len(home) + 1:]
+    return abs_path
+
+
+def _local_ingest_runtime_memory() -> int:
+    """Ingest every DETECTED runtime's memory files into local DuckDB.
+
+    Returns the number of files whose contents CHANGED (the store dedups on
+    sha256, so a steady state writes nothing and returns 0). Never raises —
+    a missing runtime dir, an unreadable file, or an import error degrades
+    to "fewer files", never to a crashed sync tick.
+    """
+    try:
+        from clawmetry import local_store, runtime_memory
+    except Exception as e:
+        log.debug("runtime memory ingest unavailable: %s", e)
+        return 0
+
+    try:
+        store = local_store.get_store()
+    except Exception as e:
+        log.debug("runtime memory ingest: no store: %s", e)
+        return 0
+
+    now_iso = datetime.now(timezone.utc).isoformat()
+    budget = RUNTIME_MEMORY_MAX_TOTAL_BYTES
+    written = 0
+
+    for entry in runtime_memory.list_runtimes():
+        runtime_id = entry.get("id") or ""
+        if not runtime_id or not entry.get("present"):
+            continue
+        if runtime_id == "openclaw":
+            # Already covered by _local_ingest_memory_files (which also owns
+            # the cloud-facing OpenClaw path names). Skip to avoid two rows
+            # for the same file under different path spellings.
+            continue
+        try:
+            listing = runtime_memory.list_files(runtime_id, category="memory")
+        except Exception as e:
+            log.debug("runtime memory list failed (%s): %s", runtime_id, e)
+            continue
+
+        candidates: list = []
+        for group in listing.get("groups", []):
+            root = group.get("root") or ""
+            if not group.get("exists"):
+                continue
+            for f in group.get("files", []):
+                rel = f.get("path") or ""
+                full = os.path.join(root, rel) if rel else root
+                candidates.append((int(f.get("mtime") or 0), full,
+                                   int(f.get("size") or 0)))
+
+        # Most recently modified first — an agent's newest notes are the ones
+        # worth carrying when we have to truncate.
+        candidates.sort(reverse=True)
+        for _mtime, full, size in candidates[:RUNTIME_MEMORY_MAX_FILES_PER_RUNTIME]:
+            if budget <= 0:
+                break
+            if size > RUNTIME_MEMORY_MAX_FILE_BYTES:
+                continue
+            try:
+                with open(full, "rb") as fh:
+                    raw = fh.read(RUNTIME_MEMORY_MAX_FILE_BYTES)
+            except OSError:
+                continue
+            try:
+                content = raw.decode("utf-8")
+            except UnicodeDecodeError:
+                continue  # binary file in a memory dir — not renderable
+            budget -= len(raw)
+            try:
+                if store.ingest_memory_blob({
+                    "agent_type": runtime_id,
+                    "agent_id": "main",
+                    "path": _memory_display_path(full),
+                    "ts": now_iso,
+                    "blob": content,
+                }):
+                    written += 1
+            except Exception as e:
+                log.debug("runtime memory ingest failed (%s): %s", full, e)
+        if budget <= 0:
+            log.debug("runtime memory ingest hit the %d-byte budget",
+                      RUNTIME_MEMORY_MAX_TOTAL_BYTES)
+            break
+
+    if written:
+        _mark_memory_cache_dirty()
+    return written
 
 
 _sessions_json_cache: dict = {"ts": 0.0, "data": None, "mtime": 0.0}
@@ -8446,8 +8570,47 @@ def _build_brain_cache_pushes(config: dict) -> list:
 # Cloud read path: ``routes/cloud.py:cloud_memory_files``.
 
 MEMORY_CACHE_TTL_SEC = 21600       # 6h — matches Brain TTL; files change slowly
-MEMORY_CACHE_LIMIT = 200            # plenty for SOUL.md/USER.md/AGENTS.md/etc.
-MEMORY_CONTENT_TRUNCATE = 500_000   # mirrors routes/infra.py truncation
+MEMORY_CACHE_LIMIT = 200            # per RUNTIME, so one chatty agent can't
+                                    # crowd the others out of the blob
+MEMORY_CONTENT_TRUNCATE = 200_000   # per file, bounds the heartbeat blob
+
+# Runtimes whose memory we ship to cloud. Derived from the on-disk catalog so a
+# new runtime added to clawmetry/runtime_memory.py is carried automatically.
+# 'openclaw' is always included (its rows come from _local_ingest_memory_files,
+# which predates the catalog).
+
+# How often an UNCHANGED memory blob is re-pushed purely to refresh the cache
+# key's TTL. Memory files change on the order of hours but the heartbeat fires
+# every ~60s, so pushing every tick would ship the same ~700 KB of ciphertext
+# 60x an hour (~1 GB/node/day of egress) for an identical result. One refresh an
+# hour keeps a 6h TTL comfortably alive with 60x less traffic.
+MEMORY_CACHE_REFRESH_SEC = 3600
+
+# Cached built entry. Rebuilt when the dirty flag is set (an ingest helper wrote
+# a changed blob); otherwise the cached ciphertext is re-pushed on the refresh
+# cadence above and skipped entirely in between.
+_memory_cache_entry: dict = {"dirty": True, "pushes": [], "key": "",
+                             "pushed_at": 0.0}
+
+
+def _mark_memory_cache_dirty() -> None:
+    """Invalidate the cached memory cache-push blob. Called by the ingest
+    helpers whenever a memory file's contents actually changed."""
+    _memory_cache_entry["dirty"] = True
+
+
+def _memory_runtime_ids() -> list:
+    """Runtime ids to pull memory rows for, catalog-derived + openclaw."""
+    ids = ["openclaw"]
+    try:
+        from clawmetry import runtime_memory
+        for entry in runtime_memory.list_runtimes():
+            rid = entry.get("id")
+            if rid and rid not in ids:
+                ids.append(rid)
+    except Exception:
+        pass
+    return ids
 
 
 def _build_memory_cache_pushes(config: dict) -> list:
@@ -8462,9 +8625,19 @@ def _build_memory_cache_pushes(config: dict) -> list:
     ``_cloudLoadMemory``):
 
         {
-          "memory_state":   {"files": [{"name": <path>, "size": <bytes>}, ...]},
-          "memory_content": [{"path": <path>, "content": <utf8 str>}, ...]
+          "memory_state":   {"files": [{"name", "path", "size", "runtime"}, ...]},
+          "memory_content": [{"path", "content", "runtime"}, ...],
+          "runtimes":       [{"id", "files"}, ...]
         }
+
+    ``runtime`` is the per-file owner (``openclaw``, ``claude_code``, …) so the
+    cloud Memory tab can scope to the runtime picked in the header switcher.
+    Older cloud builds ignore the extra key and render the merged list, so this
+    is backwards compatible in both directions.
+
+    Rows are pulled PER RUNTIME rather than as one global most-recent-200: a
+    node with 400 Claude Code auto-memory files would otherwise push a blob
+    containing nothing else, and the OpenClaw Memory tab would go blank.
 
     The browser holds the key; cloud only ever stores ciphertext.
     """
@@ -8475,25 +8648,48 @@ def _build_memory_cache_pushes(config: dict) -> list:
     node_id = config.get("node_id", "")
     if not (api_key and node_id):
         return []
+    owner_hash = _owner_hash_for_token(api_key)
+    cache_key = f"memory:{owner_hash}:{node_id}:files"
+
+    if not _memory_cache_entry["dirty"] and _memory_cache_entry["key"] == cache_key:
+        age = time.time() - float(_memory_cache_entry.get("pushed_at") or 0)
+        if age < MEMORY_CACHE_REFRESH_SEC:
+            return []          # unchanged and recently pushed — nothing to ship
+        _memory_cache_entry["pushed_at"] = time.time()
+        return list(_memory_cache_entry["pushes"])
+
     try:
         from clawmetry import local_store
     except Exception:
         return []
     try:
         store = local_store.get_store(read_only=True)
-        rows = store.query_memory_blobs(limit=MEMORY_CACHE_LIMIT)
     except Exception:
         return []
+
+    rows: list = []
+    for runtime_id in _memory_runtime_ids():
+        try:
+            rows.extend(store.query_memory_blobs(agent_type=runtime_id,
+                                                 limit=MEMORY_CACHE_LIMIT))
+        except Exception:
+            continue
     if not rows:
         return []
     files: list[dict] = []
     contents: list[dict] = []
+    per_runtime: dict = {}
     seen: set = set()
     for r in rows:
         path = r.get("path") or ""
-        if not path or path in seen:
+        runtime_id = r.get("agent_type") or "openclaw"
+        # Several runtimes read the same on-disk file (AGENTS.md is shared by
+        # Codex, opencode, Copilot…), so dedup on (runtime, path) — not path
+        # alone, which would hide the file from every runtime but the first.
+        dedup_key = (runtime_id, path)
+        if not path or dedup_key in seen:
             continue
-        seen.add(path)
+        seen.add(dedup_key)
         blob_raw = r.get("blob")
         if isinstance(blob_raw, (bytes, bytearray)):
             try:
@@ -8507,16 +8703,21 @@ def _build_memory_cache_pushes(config: dict) -> list:
         size = r.get("size_bytes")
         if size is None:
             size = len(content.encode("utf-8", errors="replace"))
-        files.append({"name": path, "path": path, "size": int(size or 0)})
+        files.append({"name": path, "path": path, "size": int(size or 0),
+                      "runtime": runtime_id})
         # Truncate per-file content to bound the encrypted blob size — the
-        # cloud Memory IDE shows a viewer pane (no diffing), so >500KB per
+        # cloud Memory IDE shows a viewer pane (no diffing), so a huge single
         # file is wasted heartbeat bandwidth.
-        contents.append({"path": path, "content": content[:MEMORY_CONTENT_TRUNCATE]})
+        contents.append({"path": path, "runtime": runtime_id,
+                         "content": content[:MEMORY_CONTENT_TRUNCATE]})
+        per_runtime[runtime_id] = per_runtime.get(runtime_id, 0) + 1
     if not files:
         return []
     payload = {
         "memory_state":   {"files": files},
         "memory_content": contents,
+        "runtimes":       [{"id": k, "files": v}
+                           for k, v in sorted(per_runtime.items())],
         "_source":        "local_store",
         "_shape":         "memory_files",
     }
@@ -8524,12 +8725,14 @@ def _build_memory_cache_pushes(config: dict) -> list:
         blob = encrypt_payload(payload, enc_key)
     except Exception:
         return []
-    owner_hash = _owner_hash_for_token(api_key)
-    return [{
-        "key":    f"memory:{owner_hash}:{node_id}:files",
+    pushes = [{
+        "key":    cache_key,
         "ttl_s":  MEMORY_CACHE_TTL_SEC,
         "blob":   blob,
     }]
+    _memory_cache_entry.update({"dirty": False, "pushes": pushes,
+                                "key": cache_key, "pushed_at": time.time()})
+    return list(pushes)
 
 
 # ── Crons list cache push (cloud#948 — Crons tab fix) ───────────────────────
@@ -11532,12 +11735,31 @@ def sync_session_metadata(config: dict, state: dict = None) -> int:
 
 
 def sync_memory(config: dict, state: dict, paths: dict) -> int:
-    """Sync memory files (MEMORY.md + memory/*.md) to cloud.
+    """Sync memory files to the local store (and, for OpenClaw, to cloud).
+
+    Two halves:
+      1. Every DETECTED runtime's memory files -> local DuckDB, via the
+         ``clawmetry.runtime_memory`` catalog. This is what the Memory tab
+         (local and cloud) reads, so a Claude-Code-only node gets a working
+         Memory tab instead of an endless "Syncing memory files…".
+      2. The OpenClaw workspace files (MEMORY.md + memory/*.md), which also
+         POST to the legacy ``/ingest/memory`` endpoint.
 
     Skipped when sync is paused (expired trial)."""
     if not _sync_allowed():
         return 0
     _record_sync_progress("memory", 0)
+
+    # Per-runtime memory first: it is independent of the OpenClaw workspace
+    # (which may not exist at all on a Claude Code / Codex-only machine) and
+    # must not be skipped by the "no workspace memory files" early return below.
+    try:
+        rt_written = _local_ingest_runtime_memory()
+        if rt_written:
+            log.info("  Memory: %d runtime memory file(s) updated", rt_written)
+    except Exception as e:
+        log.warning("Runtime memory ingest error: %s", e)
+
     workspace = paths.get("workspace", "")
     api_key = config["api_key"]
     enc_key = config.get("encryption_key")

--- a/clawmetry/templates/tabs/memory.html
+++ b/clawmetry/templates/tabs/memory.html
@@ -4,7 +4,9 @@
       <div style="font-size:18px;font-weight:700;color:var(--text-primary);" data-i18n="memory.title">Memory</div>
       <div style="font-size:12px;color:var(--text-muted);margin-top:4px;" data-i18n="memory.subtitle">Markdown files your agent reads and updates. Edit them too if you want.</div>
     </div>
-    <div id="memory-runtime-chips" data-tab="memory" data-category="memory" style="display:flex;gap:6px;flex-wrap:wrap;align-items:center;max-width:60%;"></div>
+    <!-- The runtime shown here follows the GLOBAL runtime switcher in the
+         header. This used to be a second, independent chip bar of every
+         runtime, which meant two pickers on one screen that could disagree. -->
     <div style="display:flex;gap:6px;align-items:center;">
       <div class="mem-view-tab" data-view="summary" onclick="memorySwitchView('summary')" style="padding:6px 14px;border-radius:6px;font-size:12px;font-weight:600;cursor:pointer;background:var(--bg-secondary);border:1px solid var(--border-primary);color:var(--text-primary);" data-i18n="memory.view_summary">Summary</div>
       <div class="mem-view-tab" data-view="all" onclick="memorySwitchView('all')" style="padding:6px 14px;border-radius:6px;font-size:12px;font-weight:600;cursor:pointer;background:transparent;border:1px solid transparent;color:var(--text-muted);" data-i18n="memory.view_all_files">All files</div>

--- a/clawmetry/templates/tabs/skills.html
+++ b/clawmetry/templates/tabs/skills.html
@@ -9,7 +9,8 @@
       <button class="refresh-btn" onclick="loadSkills()">↻ <span data-i18n="common.refresh">Refresh</span></button>
     </div>
   </div>
-  <div id="skills-runtime-chips" data-tab="skills" data-category="skills" style="display:flex;gap:6px;flex-wrap:wrap;align-items:center;margin:10px 0 4px 0;"></div>
+  <!-- Runtime scope follows the GLOBAL switcher in the header (the per-tab
+       chip bar that used to sit here was a second, conflicting picker). -->
   <div id="skills-runtime-browser" class="runtime-file-browser" data-tab="skills" data-category="skills" style="display:none;"></div>
   <div id="skills-summary-row" style="display:flex;gap:12px;flex-wrap:wrap;margin:14px 0 16px 0;"></div>
   <div id="skills-list"><div style="color:var(--text-muted);font-size:13px;padding:16px;" data-i18n="app.loading">Loading...</div></div>

--- a/routes/runtime_memory.py
+++ b/routes/runtime_memory.py
@@ -41,6 +41,7 @@ from flask import Blueprint, jsonify, request
 
 from clawmetry.runtime_memory import (
     CATEGORIES,
+    list_all_files,
     list_files,
     list_runtimes,
     read_runtime_file,
@@ -111,11 +112,25 @@ def api_runtime_files(runtime_id: str):
     Query params:
       - category: optional filter (memory | skills | commands | agents | hooks)
 
+    ``runtime_id='all'`` merges every runtime the caller is entitled to
+    into one listing — the Memory / Skills browser uses it when the
+    global runtime switcher is on "All". Locked paid runtimes are dropped
+    from the merge rather than 402-ing the whole request, so a free user
+    still sees their OpenClaw files instead of an error page.
+
     Returns HTTP 402 ``upgrade_required`` when the runtime is a paid
     runtime and the resolved entitlement does not cover it. This is the
     OSS conversion moment prescribed by ``FLYWHEEL.md`` §1b — never
     silently disable, always surface the upgrade CTA.
     """
+    if runtime_id == "all":
+        category = (request.args.get("category") or "").strip() or None
+        if category and category not in CATEGORIES:
+            return jsonify({"error": "invalid category"}), 400
+        locked = [rt["id"] for rt in list_runtimes()
+                  if _runtime_is_locked(rt["id"])]
+        return jsonify(list_all_files(category=category,
+                                      exclude_runtimes=locked))
     if _runtime_is_locked(runtime_id):
         return jsonify({
             "error": "upgrade_required",
@@ -137,7 +152,18 @@ def api_runtime_file(runtime_id: str):
 
     Same entitlement gate as ``/files``: paid runtimes return HTTP 402
     when the resolved entitlement does not cover them.
+
+    ``runtime_id='all'`` is gated on the runtime that actually OWNS the
+    requested root (the merged listing groups carry it), so the merged
+    view cannot be used to read a locked runtime's files. The browser
+    normally sends the owning runtime directly; this is the backstop.
     """
+    if runtime_id == "all":
+        _root = request.args.get("root", "")
+        for _g in list_all_files().get("groups", []):
+            if _g.get("root") == _root:
+                runtime_id = _g.get("runtime") or runtime_id
+                break
     if _runtime_is_locked(runtime_id):
         return jsonify({
             "error": "upgrade_required",

--- a/routes/runtime_memory.py
+++ b/routes/runtime_memory.py
@@ -45,44 +45,16 @@ from clawmetry.runtime_memory import (
     list_files,
     list_runtimes,
     read_runtime_file,
+    runtime_is_locked as _runtime_is_locked,
 )
-
-try:
-    # ``allows_runtime`` returns True for OpenClaw/NemoClaw (free) and
-    # for any paid runtime covered by the resolved entitlement. In grace
-    # mode it is intentionally permissive; the OSS enforcement layer at
-    # request time is what turns a denial into HTTP 402.
-    from clawmetry.entitlements import (
-        FREE_RUNTIMES,
-        get_entitlement,
-    )
-except Exception:  # pragma: no cover — entitlements is core; only fails in tests
-    FREE_RUNTIMES = frozenset({"openclaw", "nemoclaw"})
-
-    def get_entitlement(*_a, **_k):
-        return None
-
 
 bp_runtime_memory = Blueprint("runtime_memory", __name__)
 
-
-def _runtime_is_locked(runtime_id: str) -> bool:
-    """True when this runtime needs a paid entitlement the user lacks.
-
-    Free runtimes are never locked. For paid runtimes, ``allows_runtime``
-    on the resolved entitlement is authoritative (it already honours
-    grace mode). Any exception (entitlement resolution failure) falls
-    open — we prefer showing content on the local dashboard over a
-    silent lock-out from a resolver hiccup; the actual read endpoint
-    still returns 402 if the resolver later hardens.
-    """
-    if runtime_id in FREE_RUNTIMES:
-        return False
-    try:
-        ent = get_entitlement()
-        return not bool(ent.allows_runtime(runtime_id))
-    except Exception:
-        return False
+# ``_runtime_is_locked`` lives in clawmetry/runtime_memory.py so the sync
+# daemon shares it: the daemon decides which runtimes' memory it may ingest
+# and ship to cloud, and that decision has to be the same predicate this
+# module 402s on. Two copies would let the daemon become a side door around
+# the paywall (it did — it synced every detected runtime regardless).
 
 
 @bp_runtime_memory.route("/api/runtimes/memory-catalog")

--- a/tests/test_runtime_memory_sync.py
+++ b/tests/test_runtime_memory_sync.py
@@ -1,0 +1,227 @@
+"""Memory is per-runtime, not "whatever is in the OpenClaw workspace".
+
+Every supported runtime keeps its long-lived context somewhere different on
+disk (``clawmetry/runtime_memory.py`` is the catalog). The daemon used to sync
+ONLY the OpenClaw workspace files, so a machine running Claude Code — and no
+OpenClaw — produced zero ``memory_blobs`` rows, no memory cache push, and a
+cloud Memory tab stuck on "Syncing memory files…" waiting for a heartbeat that
+had nothing to send.
+
+Covered here:
+  1. ``_local_ingest_runtime_memory`` ingests each detected runtime's memory
+     files tagged with that runtime (``agent_type``).
+  2. Re-running is a no-op — the store dedups on sha256, so an unchanged
+     laptop does not rewrite the table every tick.
+  3. OpenClaw is left to ``_local_ingest_memory_files`` (no double rows under
+     two different path spellings).
+  4. The cloud cache push carries the per-file ``runtime`` tag + per-runtime
+     counts, which is what lets the cloud Memory tab scope to the runtime
+     picked in the header switcher.
+  5. Rows are pulled PER RUNTIME, so a runtime with hundreds of memory files
+     cannot crowd another runtime out of the pushed blob.
+  6. An unchanged blob is not re-pushed on every heartbeat (it is ~megabytes
+     of ciphertext; pushing it 60x an hour was pure egress).
+  7. ``list_all_files`` merges runtimes for the "All" scope and drops runtimes
+     the caller is not entitled to.
+"""
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+
+import pytest
+
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+
+@pytest.fixture
+def sync_env(tmp_path, monkeypatch):
+    """Fresh DuckDB + a fake two-runtime catalog rooted in tmp_path."""
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "s.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "1")
+    sys.modules.pop("clawmetry.local_store", None)
+    sys.modules.pop("clawmetry.sync", None)
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    import clawmetry.runtime_memory as rm
+    import clawmetry.sync as s
+    importlib.reload(s)
+
+    cc_dir = tmp_path / "claude" / "memory"
+    cc_dir.mkdir(parents=True)
+    (cc_dir / "CLAUDE.md").write_text("# Claude Code\nproject rules\n")
+    (cc_dir / "notes.md").write_text("# Notes\nremember this\n")
+    cx_dir = tmp_path / "codex"
+    cx_dir.mkdir(parents=True)
+    (cx_dir / "AGENTS.md").write_text("# Codex\nagent rules\n")
+    oc_dir = tmp_path / "openclaw"
+    oc_dir.mkdir(parents=True)
+    (oc_dir / "SOUL.md").write_text("# Soul\n")
+
+    def fake_list_runtimes():
+        return [
+            {"id": "openclaw", "label": "OpenClaw", "present": True},
+            {"id": "claude_code", "label": "Claude Code", "present": True},
+            {"id": "codex", "label": "Codex", "present": True},
+            {"id": "cursor", "label": "Cursor", "present": False},
+        ]
+
+    def fake_list_files(runtime_id, category=None):
+        roots = {
+            "openclaw": str(oc_dir),
+            "claude_code": str(cc_dir),
+            "codex": str(cx_dir),
+        }
+        root = roots.get(runtime_id)
+        if not root:
+            return {"runtime": runtime_id, "groups": []}
+        files = [{"path": n, "size": os.path.getsize(os.path.join(root, n)),
+                  "mtime": int(os.path.getmtime(os.path.join(root, n)))}
+                 for n in sorted(os.listdir(root))]
+        return {"runtime": runtime_id, "groups": [
+            {"root": root, "exists": True, "category": "memory", "files": files},
+        ]}
+
+    monkeypatch.setattr(rm, "list_runtimes", fake_list_runtimes)
+    monkeypatch.setattr(rm, "list_files", fake_list_files)
+
+    config = {
+        "node_id": "node-rt-mem",
+        "api_key": "cm_rt_mem_token",
+        "encryption_key": s.generate_encryption_key(),
+    }
+    yield s, ls, config
+    try:
+        ls.get_store().stop(flush=False)
+    except Exception:
+        pass
+
+
+def _rows_by_runtime(ls):
+    rows = ls.get_store().query_memory_blobs(limit=500)
+    out: dict = {}
+    for r in rows:
+        out.setdefault(r["agent_type"], []).append(r["path"])
+    return out
+
+
+def test_ingests_each_runtimes_memory_tagged_with_that_runtime(sync_env):
+    s, ls, _ = sync_env
+    assert s._local_ingest_runtime_memory() == 3   # 2 claude_code + 1 codex
+    by_rt = _rows_by_runtime(ls)
+    assert sorted(by_rt) == ["claude_code", "codex"]
+    assert len(by_rt["claude_code"]) == 2
+    assert any(p.endswith("CLAUDE.md") for p in by_rt["claude_code"])
+    assert any(p.endswith("AGENTS.md") for p in by_rt["codex"])
+
+
+def test_reingest_is_a_noop_when_nothing_changed(sync_env):
+    s, _, _ = sync_env
+    assert s._local_ingest_runtime_memory() == 3
+    assert s._local_ingest_runtime_memory() == 0
+
+
+def test_changed_file_is_picked_up(sync_env, tmp_path):
+    s, ls, _ = sync_env
+    s._local_ingest_runtime_memory()
+    (tmp_path / "claude" / "memory" / "notes.md").write_text("# Notes\nCHANGED\n")
+    assert s._local_ingest_runtime_memory() == 1
+
+
+def test_openclaw_is_left_to_the_workspace_ingest(sync_env):
+    """OpenClaw rows come from _local_ingest_memory_files, which owns the
+    cloud-facing path spelling. Ingesting it here too would produce two rows
+    for the same file under different names."""
+    s, ls, _ = sync_env
+    s._local_ingest_runtime_memory()
+    assert "openclaw" not in _rows_by_runtime(ls)
+
+
+def test_cache_push_tags_each_file_with_its_runtime(sync_env):
+    s, _, config = sync_env
+    s._local_ingest_runtime_memory()
+    pushes = s._build_memory_cache_pushes(config)
+    assert len(pushes) == 1
+    payload = s.decrypt_payload(pushes[0]["blob"], config["encryption_key"])
+    files = payload["memory_state"]["files"]
+    assert files, "cache push must carry the memory file list"
+    assert {f["runtime"] for f in files} == {"claude_code", "codex"}
+    assert all(c.get("runtime") for c in payload["memory_content"])
+    assert {r["id"]: r["files"] for r in payload["runtimes"]} == {
+        "claude_code": 2, "codex": 1,
+    }
+
+
+def test_one_chatty_runtime_cannot_crowd_out_the_others(sync_env, monkeypatch):
+    """Rows are pulled per runtime. With a single global most-recent-N query, a
+    node with hundreds of Claude Code auto-memory files pushed a blob with
+    nothing else in it and the OpenClaw Memory tab went blank."""
+    s, ls, config = sync_env
+    monkeypatch.setattr(s, "MEMORY_CACHE_LIMIT", 2)
+    for extra in range(6):
+        ls.get_store().ingest_memory_blob({
+            "agent_type": "claude_code", "path": f"~/.claude/x{extra}.md",
+            "blob": f"# filler {extra}\n",
+        })
+    s._local_ingest_runtime_memory()
+    payload = s.decrypt_payload(
+        s._build_memory_cache_pushes(config)[0]["blob"],
+        config["encryption_key"])
+    by_rt = {}
+    for f in payload["memory_state"]["files"]:
+        by_rt[f["runtime"]] = by_rt.get(f["runtime"], 0) + 1
+    assert by_rt["claude_code"] == 2      # capped
+    assert by_rt["codex"] == 1            # still represented
+
+
+def test_unchanged_blob_is_not_repushed_every_heartbeat(sync_env):
+    s, _, config = sync_env
+    s._local_ingest_runtime_memory()
+    assert len(s._build_memory_cache_pushes(config)) == 1
+    assert s._build_memory_cache_pushes(config) == []
+    s._mark_memory_cache_dirty()
+    assert len(s._build_memory_cache_pushes(config)) == 1
+
+
+def test_ttl_refresh_repushes_the_cached_blob(sync_env):
+    s, _, config = sync_env
+    s._local_ingest_runtime_memory()
+    s._build_memory_cache_pushes(config)
+    s._memory_cache_entry["pushed_at"] = 0     # older than the refresh window
+    assert len(s._build_memory_cache_pushes(config)) == 1
+
+
+def test_list_all_files_merges_runtimes_and_honours_the_entitlement_gate(
+        tmp_path, monkeypatch):
+    """The "All runtimes" scope must not become a side door around the
+    per-runtime 402: locked runtimes are dropped from the merge."""
+    from clawmetry import runtime_memory as rm
+
+    a = tmp_path / "a"; a.mkdir(); (a / "MEMORY.md").write_text("a\n")
+    b = tmp_path / "b"; b.mkdir(); (b / "CLAUDE.md").write_text("b\n")
+    empty = tmp_path / "empty"; empty.mkdir()
+
+    monkeypatch.setattr(rm, "_catalog", lambda: [
+        rm.RuntimeCatalogEntry(id="openclaw", label="OpenClaw", roots=(
+            rm.RootSpec("memory", str(a), ("*.md",), "Agent memory"),)),
+        rm.RuntimeCatalogEntry(id="claude_code", label="Claude Code", roots=(
+            rm.RootSpec("memory", str(b), ("*.md",), "Global CLAUDE.md"),
+            rm.RootSpec("memory", str(empty), ("*.md",), "Project memory"),
+            rm.RootSpec("memory", str(tmp_path / "gone"), ("*.md",), "Absent"),)),
+    ])
+
+    merged = rm.list_all_files(category="memory")
+    assert merged["runtime"] == "all"
+    assert [g["runtime"] for g in merged["groups"]] == ["openclaw", "claude_code"]
+    for g in merged["groups"]:
+        assert g["files"], "empty + absent roots are dropped from the merge"
+        assert g["label"].startswith(g["runtime_label"])
+
+    kept = rm.list_all_files(category="memory", exclude_runtimes=["claude_code"])
+    assert {g["runtime"] for g in kept["groups"]} == {"openclaw"}

--- a/tests/test_runtime_memory_sync.py
+++ b/tests/test_runtime_memory_sync.py
@@ -219,6 +219,23 @@ def test_one_chatty_runtime_cannot_crowd_out_the_others(sync_env, monkeypatch):
     assert by_rt["codex"] == 1            # still represented
 
 
+def test_payload_budget_drops_files_instead_of_listing_unopenable_ones(
+        sync_env, monkeypatch):
+    """A tree entry that opens to nothing reads as a broken tab, so files that
+    do not fit the payload budget are left out of the list entirely."""
+    s, ls, config = sync_env
+    monkeypatch.setattr(s, "MEMORY_CACHE_MAX_TOTAL_BYTES", 40)
+    s._local_ingest_runtime_memory()
+    payload = s.decrypt_payload(
+        s._build_memory_cache_pushes(config)[0]["blob"],
+        config["encryption_key"])
+    listed = payload["memory_state"]["files"]
+    carried = {c["path"] for c in payload["memory_content"]}
+    assert len(listed) < 3, "budget must actually drop something here"
+    assert {f["path"] for f in listed} == carried, \
+        "every listed file must have its content in the same payload"
+
+
 def test_unchanged_blob_is_not_repushed_every_heartbeat(sync_env):
     s, _, config = sync_env
     s._local_ingest_runtime_memory()

--- a/tests/test_runtime_memory_sync.py
+++ b/tests/test_runtime_memory_sync.py
@@ -143,6 +143,45 @@ def test_openclaw_is_left_to_the_workspace_ingest(sync_env):
     assert "openclaw" not in _rows_by_runtime(ls)
 
 
+def test_locked_paid_runtime_is_never_ingested_or_shipped(sync_env, monkeypatch):
+    """The daemon must not be a side door around the memory paywall.
+
+    ``/api/runtimes/<rt>/files`` returns 402 for a paid runtime the user is
+    not entitled to. If the daemon ingested it anyway, the file would ride the
+    heartbeat to the cloud Memory tab and render there for free — so both use
+    the same predicate."""
+    s, ls, config = sync_env
+    from clawmetry import runtime_memory as rm
+    monkeypatch.setattr(rm, "runtime_is_locked",
+                        lambda rt: rt == "claude_code")
+
+    assert s._local_ingest_runtime_memory() == 1        # codex only
+    by_rt = _rows_by_runtime(ls)
+    assert "claude_code" not in by_rt
+    assert "codex" in by_rt
+
+    payload = s.decrypt_payload(
+        s._build_memory_cache_pushes(config)[0]["blob"],
+        config["encryption_key"])
+    assert {f["runtime"] for f in payload["memory_state"]["files"]} == {"codex"}
+
+
+def test_downgrade_stops_shipping_rows_ingested_while_entitled(sync_env, monkeypatch):
+    """Rows already in the store from a paid period must stop riding the
+    heartbeat once the entitlement lapses — otherwise a downgrade keeps
+    serving them to the cloud Memory tab."""
+    s, ls, config = sync_env
+    s._local_ingest_runtime_memory()
+    from clawmetry import runtime_memory as rm
+    monkeypatch.setattr(rm, "runtime_is_locked", lambda rt: rt == "claude_code")
+    s._mark_memory_cache_dirty()
+
+    payload = s.decrypt_payload(
+        s._build_memory_cache_pushes(config)[0]["blob"],
+        config["encryption_key"])
+    assert {f["runtime"] for f in payload["memory_state"]["files"]} == {"codex"}
+
+
 def test_cache_push_tags_each_file_with_its_runtime(sync_env):
     s, _, config = sync_env
     s._local_ingest_runtime_memory()


### PR DESCRIPTION
## What was broken

Reported from the cloud Memory tab on a Claude Code node: the page sat on **"Syncing memory files…"** forever, and the same screen showed **two runtime pickers** (the header switcher said "Claude Code", a chip bar below it said "OpenClaw").

Root cause, verified end to end on the reporting node:

- `sync_memory` only ever read the **OpenClaw workspace** (`MEMORY.md`, `memory/*.md`). That machine has no OpenClaw workspace, so `memory_hashes` was empty, `memory_blobs` had **0 rows**, `_build_memory_cache_pushes` returned `[]`, the cloud cache key was never written, and `/api/cloud/memory-files` answered `cache_pending` — forever.
- Meanwhile the same node had **430 Claude Code memory files** on disk that nothing ever read.
- The Memory/Skills tabs carried their own chip bar of all 20 runtimes, independent of the global switcher — two controls, one screen, free to disagree.

## What this changes

**Daemon** — `sync_memory` now ingests every detected runtime's memory files through the `clawmetry/runtime_memory.py` catalog, tagged with the owning runtime, and runs *before* the "no OpenClaw files" early return that used to skip the helper entirely. Capped at 120 files / 200KB per file / 6MB per pass, newest first.

**Cache push** — files carry `runtime` + per-runtime counts so the cloud tab can scope. Rows are pulled **per runtime** instead of one global most-recent-200 (400 Claude Code files would otherwise crowd OpenClaw out of the blob). The blob is cached and only re-pushed when memory actually changed, or hourly to refresh the TTL: it was shipping ~700KB of *unchanged* ciphertext every 60s (~1GB/node/day of egress).

**UI** — both chip bars are gone; the browser follows the global switcher. `all` merges every runtime that has files (new `/api/runtimes/all/files`; locked runtimes are excluded so the merge is not a side door around the per-runtime 402) and falls back to OpenClaw's native IDE when no other runtime has any, so single-runtime installs are unchanged.

### Bugs found while in here

- **Tree clicks were dead** whenever any root was absent: `data-gi` indexed the *filtered* group list, the click handler looked up the *unfiltered* one. With Claude Code (no global `~/.claude/CLAUDE.md`) `gi=0` resolved to an empty group and every click did nothing.
- The browser listed a runtime's skills/commands/hooks under **Memory**; now scoped to the tab's category.
- Memory/Skills no longer claim to be "node-wide" in the scope note (they are runtime-scoped now), and the OpenClaw-shaped Summary / All files / Access log switch is hidden under other runtimes instead of offering three dead buttons.
- The browser auto-opens the first file instead of leaving an empty right pane.

## Verification

Local dashboard on :8907, real filesystem, zero console errors:

| scope | result |
|---|---|
| `?runtime=claude_code` | 431 files, tree + rendered markdown, no chip bar, no scope note |
| `?runtime=all` | "All runtimes - 433 files across 3 locations", groups labelled per runtime |
| `?runtime=openclaw` | native memory IDE unchanged, browser hidden, 3 view tabs visible |
| Skills / `claude_code` | honest empty state naming the two paths it looks at |

Tests: `tests/test_runtime_memory_sync.py` (9 new) covers per-runtime ingest, sha256 no-op re-ingest, OpenClaw not double-ingested, runtime-tagged push payload, the per-runtime cap, push cadence, and the merged/entitlement-filtered `list_all_files`. Existing `test_memory_cache_push.py` + `test_memory_local_store.py` + `tests/test_appjs_units.js` (220) all pass.

The cloud half (scoping the decrypted blob to the selected runtime) is a companion PR in clawmetry-cloud and needs this version pinned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)