### PR TITLE
One paywall predicate, per-runtime push buckets, and the test suite (stacks on #4851)

### DIFF
--- a/clawmetry/runtime_memory.py
+++ b/clawmetry/runtime_memory.py
@@ -690,6 +690,36 @@ def list_runtimes() -> list:
 SKILLS_TAB_CATEGORIES: tuple = ("skills", "commands", "agents", "hooks")
 
 
+def runtime_is_locked(runtime_id: str) -> bool:
+    """True when this runtime needs a paid entitlement the caller lacks.
+
+    THE single predicate for the memory/skills paywall. Three callers must
+    agree or the paywall leaks:
+
+      * ``routes/runtime_memory.py`` — returns 402 / omits from the ``all``
+        sweep.
+      * the sync daemon's ingest — never writes a locked runtime's files.
+      * the sync daemon's cache-push build — never SHIPS them, which is a
+        separate decision: rows written while entitled would otherwise keep
+        riding the heartbeat after the entitlement lapsed.
+
+    Free runtimes are never locked. For paid runtimes ``allows_runtime`` on
+    the resolved entitlement is authoritative (it already honours grace mode).
+    Any exception falls OPEN — a resolver hiccup must not blank out a paying
+    user's memory, and the read endpoints re-check on every request.
+    """
+    try:
+        from clawmetry.entitlements import FREE_RUNTIMES, get_entitlement
+    except Exception:
+        return False
+    if runtime_id in FREE_RUNTIMES:
+        return False
+    try:
+        return not bool(get_entitlement().allows_runtime(runtime_id))
+    except Exception:
+        return False
+
+
 def parse_categories(category) -> set:
     """Normalise a category filter into a set of valid category names.
 

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -8463,6 +8463,44 @@ MEMORY_PUSH_MIN_INTERVAL_SEC = MEMORY_CACHE_TTL_SEC // 2
 _memory_push_state: dict = {"fingerprint": None, "ts": 0.0}
 
 
+def _memory_rows_by_runtime(store) -> list:
+    """Memory rows pulled PER RUNTIME, not as one global most-recent-N.
+
+    A single ``query_memory_blobs(limit=N)`` sorts by updated_at across every
+    runtime, so the noisiest one takes the whole budget: this laptop has 429
+    Claude Code memory files and 406 Hermes skill files, which is already past
+    a 600-row cap before OpenClaw gets a single row. The Memory tab for the
+    crowded-out runtime then renders empty — the exact failure this branch is
+    fixing, reintroduced one layer down.
+
+    Locked paid runtimes are skipped here as well as at ingest: rows written
+    while entitled must stop shipping when the entitlement lapses, otherwise a
+    downgrade keeps serving them to cloud.
+    """
+    rows: list = []
+    seen_runtimes: set = set()
+    try:
+        from clawmetry import runtime_memory
+    except Exception:
+        return store.query_memory_blobs(limit=MEMORY_CACHE_LIMIT)
+
+    try:
+        catalog = [e.get("id") for e in runtime_memory.list_runtimes()]
+    except Exception:
+        catalog = []
+    for rt_id in ["openclaw"] + [c for c in catalog if c]:
+        if (not rt_id or rt_id in seen_runtimes
+                or runtime_memory.runtime_is_locked(rt_id)):
+            continue
+        seen_runtimes.add(rt_id)
+        try:
+            rows.extend(store.query_memory_blobs(agent_type=rt_id,
+                                                 limit=MEMORY_CACHE_LIMIT))
+        except Exception:
+            continue
+    return rows
+
+
 def _build_memory_cache_pushes(config: dict) -> list:
     """Heartbeat cache_push entry holding the encrypted memory-file snapshot.
 
@@ -8494,17 +8532,21 @@ def _build_memory_cache_pushes(config: dict) -> list:
         return []
     try:
         store = local_store.get_store(read_only=True)
-        rows = store.query_memory_blobs(limit=MEMORY_CACHE_LIMIT)
+        rows = _memory_rows_by_runtime(store)
     except Exception:
         return []
     if not rows:
         return []
     # Change-gate before the expensive part (JSON encode + AES of several MB).
     # The sha256 column is exactly the per-file content hash we need.
+    # Keyed by (runtime, path): the same file can be registered by several
+    # runtimes, and a path-only key would collapse them into one fingerprint
+    # entry that misses a change on all but the first.
     try:
         import hashlib as _hl
         fp = _hl.sha256("|".join(sorted(
-            f"{r.get('path')}:{r.get('sha256')}" for r in rows
+            f"{r.get('agent_type')}:{r.get('path')}:{r.get('sha256')}"
+            for r in rows
         )).encode()).hexdigest()
     except Exception:
         fp = None
@@ -8538,9 +8580,14 @@ def _build_memory_cache_pushes(config: dict) -> list:
     dropped = 0
     for r in rows:
         path = r.get("path") or ""
-        if not path or path in seen:
+        # Dedup on (runtime, path), never path alone. Several runtimes read
+        # the SAME file on disk — AGENTS.md is Codex, opencode and Copilot;
+        # a path-only key kept it for whichever runtime sorted first and left
+        # the file invisible under every other one.
+        dedup_key = (r.get("agent_type") or "openclaw", path)
+        if not path or dedup_key in seen:
             continue
-        seen.add(path)
+        seen.add(dedup_key)
         blob_raw = r.get("blob")
         if isinstance(blob_raw, (bytes, bytearray)):
             try:
@@ -8582,7 +8629,11 @@ def _build_memory_cache_pushes(config: dict) -> list:
             dropped += 1
         else:
             spent += len(body)
-        contents.append({"path": path, "content": body})
+        # Tagged with the runtime for the same reason the dedup key is: two
+        # runtimes can carry the same path, so a viewer that matches on path
+        # alone would show one runtime's copy under the other's tree.
+        contents.append({"path": path, "content": body,
+                         "runtime": r.get("agent_type") or "openclaw"})
     if not files:
         return []
     if dropped:
@@ -11650,21 +11701,10 @@ def sync_runtime_memory_files(config: dict, state: dict, paths: dict) -> int:
         return 0
 
     # Never ingest a paid runtime the user isn't entitled to — that would
-    # push its file contents to cloud behind the paywall's back.
-    try:
-        from clawmetry.entitlements import FREE_RUNTIMES, get_entitlement
-        ent = get_entitlement()
-
-        def _allowed(rt_id: str) -> bool:
-            if rt_id in FREE_RUNTIMES:
-                return True
-            try:
-                return bool(ent.allows_runtime(rt_id))
-            except Exception:
-                return False
-    except Exception:
-        def _allowed(rt_id: str) -> bool:
-            return True
+    # push its file contents to cloud behind the paywall's back. Shared with
+    # the /files route and the cache-push build so the three cannot drift.
+    def _allowed(rt_id: str) -> bool:
+        return not runtime_memory.runtime_is_locked(rt_id)
 
     try:
         store = local_store.get_store()

--- a/routes/runtime_memory.py
+++ b/routes/runtime_memory.py
@@ -58,44 +58,14 @@ from clawmetry.runtime_memory import (
     list_runtimes,
     parse_categories,
     read_runtime_file,
+    # THE paywall predicate. It lives in clawmetry/runtime_memory.py rather
+    # than here because the sync daemon needs the same answer twice — once to
+    # decide what it may ingest, once to decide what it may ship — and a copy
+    # per caller is how the daemon ended up pushing files this route 402s on.
+    runtime_is_locked as _runtime_is_locked,
 )
 
-try:
-    # ``allows_runtime`` returns True for OpenClaw/NemoClaw (free) and
-    # for any paid runtime covered by the resolved entitlement. In grace
-    # mode it is intentionally permissive; the OSS enforcement layer at
-    # request time is what turns a denial into HTTP 402.
-    from clawmetry.entitlements import (
-        FREE_RUNTIMES,
-        get_entitlement,
-    )
-except Exception:  # pragma: no cover — entitlements is core; only fails in tests
-    FREE_RUNTIMES = frozenset({"openclaw", "nemoclaw"})
-
-    def get_entitlement(*_a, **_k):
-        return None
-
-
 bp_runtime_memory = Blueprint("runtime_memory", __name__)
-
-
-def _runtime_is_locked(runtime_id: str) -> bool:
-    """True when this runtime needs a paid entitlement the user lacks.
-
-    Free runtimes are never locked. For paid runtimes, ``allows_runtime``
-    on the resolved entitlement is authoritative (it already honours
-    grace mode). Any exception (entitlement resolution failure) falls
-    open — we prefer showing content on the local dashboard over a
-    silent lock-out from a resolver hiccup; the actual read endpoint
-    still returns 402 if the resolver later hardens.
-    """
-    if runtime_id in FREE_RUNTIMES:
-        return False
-    try:
-        ent = get_entitlement()
-        return not bool(ent.allows_runtime(runtime_id))
-    except Exception:
-        return False
 
 
 @bp_runtime_memory.route("/api/runtimes/memory-catalog")

--- a/tests/test_runtime_memory_sync.py
+++ b/tests/test_runtime_memory_sync.py
@@ -1,0 +1,264 @@
+"""Per-runtime memory/skills sync: ingest, entitlement, and the cloud push.
+
+Memory is NOT node-wide. Each runtime keeps its long-lived context somewhere
+different on disk (``clawmetry/runtime_memory.py`` is the catalog), and the
+daemon used to sync only the OpenClaw workspace — so a machine running Claude
+Code and no OpenClaw produced zero ``memory_blobs`` rows, no cache push, and a
+cloud Memory tab stuck on "Syncing memory files…" forever.
+
+The ingest + push half of that fix is covered here:
+
+  1. Every detected runtime's files land tagged with the owning runtime and
+     the category they came from.
+  2. Re-running is a sha256 no-op, so an idle laptop doesn't rewrite the table
+     on every tick.
+  3. A paid runtime the user is not entitled to is never ingested — the daemon
+     must not be a side door around the 402 the /files route returns.
+  4. …and never shipped either, so a DOWNGRADE stops serving rows that were
+     ingested while the entitlement was live.
+  5. Rows are pulled PER RUNTIME. With one global most-recent-N, the noisiest
+     runtime (429 Claude Code files on the author's laptop) eats the whole
+     budget and a quieter runtime's Memory tab renders empty — the original
+     bug, one layer down.
+  6. Files are deduped on (runtime, path), not path: several runtimes read the
+     same file on disk (AGENTS.md is Codex + opencode + Copilot).
+  7. Over-budget files stay LISTED with empty content rather than vanishing —
+     a tree that hides files is lying about what the agent's memory is.
+"""
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+
+import pytest
+
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+
+@pytest.fixture
+def sync_env(tmp_path, monkeypatch):
+    """Fresh DuckDB + a fake catalog of three runtimes rooted in tmp_path."""
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "s.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "1")
+    sys.modules.pop("clawmetry.local_store", None)
+    sys.modules.pop("clawmetry.sync", None)
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    import clawmetry.runtime_memory as rm
+    import clawmetry.sync as s
+    importlib.reload(s)
+
+    roots = {}
+    for rt, names in (
+        ("openclaw", ["SOUL.md"]),
+        ("claude_code", ["CLAUDE.md", "notes.md"]),
+        ("codex", ["AGENTS.md"]),
+    ):
+        d = tmp_path / rt
+        d.mkdir()
+        for n in names:
+            (d / n).write_text(f"# {rt} {n}\n")
+        roots[rt] = str(d)
+
+    def fake_list_runtimes():
+        return [{"id": r, "label": r, "present": True} for r in roots] + [
+            {"id": "cursor", "label": "Cursor", "present": False},
+        ]
+
+    def fake_list_files(runtime_id, category=None):
+        root = roots.get(runtime_id)
+        if not root or (category or "memory") != "memory":
+            return {"runtime": runtime_id, "groups": []}
+        files = [{"path": n, "size": os.path.getsize(os.path.join(root, n)),
+                  "mtime": int(os.path.getmtime(os.path.join(root, n)))}
+                 for n in sorted(os.listdir(root))]
+        return {"runtime": runtime_id, "groups": [
+            {"root": root, "exists": True, "category": "memory",
+             "scope": "global", "files": files},
+        ]}
+
+    monkeypatch.setattr(rm, "list_runtimes", fake_list_runtimes)
+    monkeypatch.setattr(rm, "list_files", fake_list_files)
+
+    config = {
+        "node_id": "node-rt-mem",
+        "api_key": "cm_rt_mem_token",
+        "encryption_key": s.generate_encryption_key(),
+    }
+    yield s, ls, config, roots
+    try:
+        ls.get_store().stop(flush=False)
+    except Exception:
+        pass
+
+
+def _entitle(monkeypatch, *, denied=()):
+    """Force the entitlement resolver to deny exactly `denied`."""
+    import clawmetry.entitlements as ent
+
+    class _Ent:
+        def allows_runtime(self, rt):
+            return rt not in denied
+
+    monkeypatch.setattr(ent, "get_entitlement", lambda *a, **k: _Ent())
+    monkeypatch.setattr(ent, "FREE_RUNTIMES", frozenset({"openclaw"}))
+
+
+def _by_runtime(ls):
+    out: dict = {}
+    for r in ls.get_store().query_memory_blobs(limit=500):
+        out.setdefault(r["agent_type"], []).append(r["path"])
+    return out
+
+
+def test_every_detected_runtime_is_ingested_and_tagged(sync_env, monkeypatch):
+    s, ls, config, _ = sync_env
+    _entitle(monkeypatch)
+    assert s.sync_runtime_memory_files(config, {}, {}) == 4
+    by_rt = _by_runtime(ls)
+    assert sorted(by_rt) == ["claude_code", "codex", "openclaw"]
+    assert len(by_rt["claude_code"]) == 2
+    rows = ls.get_store().query_memory_blobs(agent_type="codex", limit=10)
+    assert rows and rows[0]["category"] == "memory"
+    assert rows[0]["root"], "root column must be populated for the viewer"
+
+
+def test_reingest_is_a_noop_when_nothing_changed(sync_env, monkeypatch):
+    s, _, config, _ = sync_env
+    _entitle(monkeypatch)
+    assert s.sync_runtime_memory_files(config, {}, {}) == 4
+    assert s.sync_runtime_memory_files(config, {}, {}) == 0
+
+
+def test_changed_file_is_picked_up(sync_env, monkeypatch):
+    s, _, config, roots = sync_env
+    _entitle(monkeypatch)
+    s.sync_runtime_memory_files(config, {}, {})
+    with open(os.path.join(roots["claude_code"], "notes.md"), "w") as fh:
+        fh.write("# claude_code notes.md CHANGED\n")
+    assert s.sync_runtime_memory_files(config, {}, {}) == 1
+
+
+def test_locked_paid_runtime_is_never_ingested(sync_env, monkeypatch):
+    """The daemon must not be a side door around the memory paywall:
+    /api/runtimes/<rt>/files returns 402 for an unentitled paid runtime, so
+    the daemon must not ship its contents to cloud either."""
+    s, ls, config, _ = sync_env
+    _entitle(monkeypatch, denied=("claude_code",))
+    s.sync_runtime_memory_files(config, {}, {})
+    by_rt = _by_runtime(ls)
+    assert "claude_code" not in by_rt
+    assert {"openclaw", "codex"} <= set(by_rt)
+
+
+def test_downgrade_stops_shipping_rows_ingested_while_entitled(
+        sync_env, monkeypatch):
+    """Ingest-time gating alone is not enough: rows written during a paid
+    period would keep riding the heartbeat after the entitlement lapsed."""
+    s, _, config, _ = sync_env
+    _entitle(monkeypatch)
+    s.sync_runtime_memory_files(config, {}, {})
+    assert s._build_memory_cache_pushes(config), "sanity: pushes while entitled"
+
+    _entitle(monkeypatch, denied=("claude_code",))
+    s._memory_push_state["fingerprint"] = None      # force a rebuild
+    payload = s.decrypt_payload(
+        s._build_memory_cache_pushes(config)[0]["blob"],
+        config["encryption_key"])
+    shipped = {f["runtime"] for f in payload["memory_state"]["files"]}
+    assert "claude_code" not in shipped
+    assert "openclaw" in shipped
+
+
+def test_one_chatty_runtime_cannot_crowd_out_the_others(sync_env, monkeypatch):
+    """Rows are pulled per runtime. A single global most-recent-N query lets
+    the noisiest runtime take the whole budget, and the crowded-out runtime's
+    Memory tab renders empty — the bug this branch exists to fix."""
+    s, ls, config, _ = sync_env
+    _entitle(monkeypatch)
+    monkeypatch.setattr(s, "MEMORY_CACHE_LIMIT", 2)
+    for i in range(8):
+        ls.get_store().ingest_memory_blob({
+            "agent_type": "claude_code", "path": f"/x/filler{i}.md",
+            "blob": f"# filler {i}\n", "category": "memory", "root": "/x",
+        })
+    s.sync_runtime_memory_files(config, {}, {})
+    s._memory_push_state["fingerprint"] = None
+    payload = s.decrypt_payload(
+        s._build_memory_cache_pushes(config)[0]["blob"],
+        config["encryption_key"])
+    shipped = {}
+    for f in payload["memory_state"]["files"]:
+        shipped[f["runtime"]] = shipped.get(f["runtime"], 0) + 1
+    assert shipped["claude_code"] == 2, "per-runtime cap applies"
+    assert shipped.get("openclaw"), "quiet runtime still represented"
+    assert shipped.get("codex"), "quiet runtime still represented"
+
+
+def test_a_file_shared_by_two_runtimes_survives_under_both(sync_env, monkeypatch):
+    """AGENTS.md is read by Codex, opencode and Copilot alike. Deduping on
+    path alone kept it for whichever runtime sorted first and left the file
+    invisible under every other one."""
+    s, ls, config, _ = sync_env
+    _entitle(monkeypatch)
+    shared = "/Users/x/AGENTS.md"
+    for rt in ("codex", "openclaw"):
+        ls.get_store().ingest_memory_blob({
+            "agent_type": rt, "path": shared, "blob": "# shared\n",
+            "category": "memory", "root": "/Users/x",
+        })
+    s._memory_push_state["fingerprint"] = None
+    payload = s.decrypt_payload(
+        s._build_memory_cache_pushes(config)[0]["blob"],
+        config["encryption_key"])
+    owners = {f["runtime"] for f in payload["memory_state"]["files"]
+              if f["path"] == shared}
+    assert owners == {"codex", "openclaw"}
+    bodies = [c for c in payload["memory_content"] if c["path"] == shared]
+    assert {c.get("runtime") for c in bodies} == {"codex", "openclaw"}, \
+        "contents must be runtime-tagged too, or the viewer picks the wrong copy"
+
+
+def test_over_budget_files_are_listed_without_content_not_hidden(
+        sync_env, monkeypatch):
+    """A tree that silently hides files lies about what the agent's memory is."""
+    s, _, config, _ = sync_env
+    _entitle(monkeypatch)
+    monkeypatch.setattr(s, "MEMORY_CACHE_TOTAL_BUDGET", 30)
+    s.sync_runtime_memory_files(config, {}, {})
+    s._memory_push_state["fingerprint"] = None
+    payload = s.decrypt_payload(
+        s._build_memory_cache_pushes(config)[0]["blob"],
+        config["encryption_key"])
+    files = payload["memory_state"]["files"]
+    assert len(files) == 4, "every file stays listed"
+    assert payload["_content_dropped"] > 0
+    assert any(not c["content"] for c in payload["memory_content"])
+
+
+def test_unchanged_snapshot_is_not_repushed_every_heartbeat(sync_env, monkeypatch):
+    """It runs to megabytes of ciphertext; pushing it every 60s was pure
+    egress for a payload that changes hourly at best."""
+    s, _, config, _ = sync_env
+    _entitle(monkeypatch)
+    s.sync_runtime_memory_files(config, {}, {})
+    assert len(s._build_memory_cache_pushes(config)) == 1
+    assert s._build_memory_cache_pushes(config) == []
+
+
+def test_content_change_defeats_the_push_floor(sync_env, monkeypatch):
+    """The floor is a rate limit on UNCHANGED content, not on updates."""
+    s, ls, config, roots = sync_env
+    _entitle(monkeypatch)
+    s.sync_runtime_memory_files(config, {}, {})
+    s._build_memory_cache_pushes(config)
+    with open(os.path.join(roots["codex"], "AGENTS.md"), "w") as fh:
+        fh.write("# codex AGENTS.md CHANGED\n")
+    s.sync_runtime_memory_files(config, {}, {})
+    assert len(s._build_memory_cache_pushes(config)) == 1


### PR DESCRIPTION
Stacks on #4851 (retarget to `main` when that merges). I hit the same user report independently, built a duplicate in #4855, and closed it in favour of #4851 — this PR is the delta that branch doesn't already have. Coordinated with the #4851 and #4854 owners.

## 1. The paywall predicate had three homes, and the third was missing

`_runtime_is_locked` existed in `routes/runtime_memory.py`; #4851 added a second copy as an `_allowed()` closure inside the daemon's ingest. There was no third copy on the **cache-push build** — so rows ingested while entitled kept riding the heartbeat after the entitlement lapsed. A downgrade went on serving paid-runtime memory to the cloud Memory tab.

`runtime_is_locked()` now lives in `clawmetry/runtime_memory.py`, and the route, the ingest, and the push build all read it. One answer, three callers.

## 2. One chatty runtime crowded out the others

The push did a single `query_memory_blobs(limit=600)`, sorted by `updated_at` across every runtime. This laptop has **429 Claude Code memory files** and **406 Hermes skill files** — the cap is spent before OpenClaw gets a single row, and OpenClaw's Memory tab renders empty. That is the exact bug this stack exists to fix, reintroduced one layer down. Rows are pulled per runtime now.

## 3. Dedup on path alone hid files shared between runtimes

`AGENTS.md` is read by Codex, opencode **and** Copilot; `seen` keyed on path meant it survived under whichever runtime sorted first and was invisible under every other one. Dedup is `(runtime, path)` now, the change-fingerprint is keyed the same way (a path-only key misses a change on all but the first owner), and `memory_content` entries carry their `runtime` so a viewer matching on path alone can't render one runtime's copy under another's tree.

## 4. Tests

`tests/test_runtime_memory_sync.py` — 10 tests, and I verified they actually fail without their fix rather than trusting green:

```
FAILED test_downgrade_stops_shipping_rows_ingested_while_entitled
FAILED test_one_chatty_runtime_cannot_crowd_out_the_others
FAILED test_a_file_shared_by_two_runtimes_survives_under_both
```

(that's with the three fixes reverted; all 10 pass with them). Coverage: per-runtime ingest + `category`/`root` tagging, sha256 no-op re-ingest, change pickup, locked-runtime ingest, the downgrade case, the crowd-out cap, shared-file dedup, over-budget files staying **listed** with empty content per the blueprint contract, the push floor, and a content change defeating that floor.

`tests/test_appjs_units.js` still 220/220.

🤖 Generated with [Claude Code](https://claude.com/claude-code)