### PR TITLE
Memory tree: disambiguate generic filenames, don't replace them

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -25955,6 +25955,11 @@ var _CM_RT_GENERIC_DIR = {
   skills: 1, memory: 1, plugins: 1, external_plugins: 1, marketplaces: 1,
   commands: 1, agents: 1, hooks: 1, '.claude': 1, '.agents': 1,
 };
+// The disambiguator is a PREFIX, never a replacement: dropping the filename
+// left rows in the live Memory tab reading "-Users-vivek--openclaw-workspace"
+// with no MEMORY.md anywhere on them, next to sibling rows that did show a
+// filename. Keep the base and lead with the folder that identifies it, so
+// every row still names a file.
 function _cmRtDisplayName(rel, fallback) {
   var segs = String(rel || '').split('/').filter(Boolean);
   if (!segs.length) return fallback || '(file)';
@@ -25962,7 +25967,7 @@ function _cmRtDisplayName(rel, fallback) {
   if (!_CM_RT_GENERIC_FILE[base]) return base;
   var parts = segs.slice(0, -1).filter(function(s) { return !_CM_RT_GENERIC_DIR[s]; });
   if (!parts.length) return base;
-  return parts.slice(-2).join('/');
+  return parts.slice(-1)[0] + '/' + base;
 }
 
 async function cmRuntimeMountBrowser(container, runtimeId, tab) {

--- a/tests/test_appjs_units.js
+++ b/tests/test_appjs_units.js
@@ -1476,6 +1476,48 @@ console.log('\ncmRuntimeIcon (runtime pixel logos, runtime-logos.js)');
   truthy(win.cmRuntimeKnown('codex') === true && win.cmRuntimeKnown('nope') === false, 'cmRuntimeKnown known/unknown');
 }
 
+// ── Runtime file tree: every row names a file ─────────────────────────────
+console.log('_cmRtDisplayName (disambiguate generic filenames, never drop them)');
+{
+  const maps = src.match(/var _CM_RT_GENERIC_FILE = \{[\s\S]*?\};/)[0]
+    + '\n' + src.match(/var _CM_RT_GENERIC_DIR = \{[\s\S]*?\};/)[0];
+  const sandbox = { String: String };
+  vm.createContext(sandbox);
+  vm.runInContext(maps + '\n' + extractFunction('_cmRtDisplayName')
+    + '\nthis.dn = _cmRtDisplayName;', sandbox);
+  const dn = sandbox.dn;
+
+  // A distinctive filename is already the answer.
+  eq(dn('no-em-dashes.md'), 'no-em-dashes.md', 'distinctive basename passes through');
+  eq(dn('a/b/vivek-clawmetry-founder.md'), 'vivek-clawmetry-founder.md',
+     'distinctive basename wins over any nesting');
+
+  // Generic container filenames get a disambiguating PREFIX — the filename
+  // itself must survive. Live regression on 0.12.706: rows rendered as a bare
+  // "-Users-vivek--openclaw-workspace" with no MEMORY.md on them, right next
+  // to sibling rows that did show their filename.
+  eq(dn('-Users-vivek--openclaw-workspace/memory/MEMORY.md'),
+     '-Users-vivek--openclaw-workspace/MEMORY.md',
+     'generic name keeps its filename, prefixed by the identifying folder');
+  eq(dn('.claude/skills/pdf-tools/SKILL.md'), 'pdf-tools/SKILL.md',
+     'structural dirs dropped, skill folder + filename kept');
+
+  // Nothing to disambiguate with -> the bare name is still correct.
+  eq(dn('MEMORY.md'), 'MEMORY.md', 'top-level generic file keeps its name');
+  eq(dn('memory/MEMORY.md'), 'MEMORY.md',
+     'an all-structural path falls back to the bare filename');
+  eq(dn('', 'Global CLAUDE.md'), 'Global CLAUDE.md',
+     'empty rel falls back to the group label');
+
+  // Whatever the rule, a row must never render empty or as a stray slash.
+  ['SKILL.md', 'a/SKILL.md', 'x/y/z/settings.json', '', 'memory/AGENTS.md']
+    .forEach(function (p) {
+      const out = dn(p, 'fallback');
+      truthy(out && out !== '/' && out.indexOf('//') === -1,
+        'row label is never empty or a stray slash for ' + JSON.stringify(p));
+    });
+}
+
 // Auth-bootstrap scenarios above are async — wait for the microtask /
 // macrotask queue to drain before printing the summary. (The previous
 // synchronous test blocks all completed in-tick, so no wait was needed


### PR DESCRIPTION
Found by looking at the shipped 0.12.706 dashboard, not by CI.

## The bug

Rows in the Claude Code memory tree rendered as a bare `-Users-vivek--openclaw-workspace` — no `MEMORY.md` anywhere on them — sitting directly next to sibling rows that *did* show their filename. A file row that doesn't name a file.

`_cmRtDisplayName` is right to disambiguate: a Skills tree of thirty identical `SKILL.md` rows tells you nothing. But it returned the identifying folders **instead of** the filename. Making it a prefix keeps both:

| path | was | now |
|---|---|---|
| `-Users-vivek--openclaw-workspace/memory/MEMORY.md` | `-Users-vivek--openclaw-workspace` | `-Users-vivek--openclaw-workspace/MEMORY.md` |
| `.claude/skills/pdf-tools/SKILL.md` | `skills/pdf-tools` | `pdf-tools/SKILL.md` |

Distinctive names (`no-em-dashes.md`) still pass straight through, and a path with nothing left to disambiguate with still falls back to the bare filename.

## Tests

12 new assertions in `tests/test_appjs_units.js`, verified failing against current behaviour before the fix:

```
FAIL generic name keeps its filename, prefixed by the identifying folder
FAIL structural dirs dropped, skill folder + filename kept
FAIL — 230 passed, 2 failed
```

232/232 with the fix. Covers pass-through, both prefix cases, the two fallbacks, and a guard that a row label is never empty or a stray slash.

## Verified in the browser

Against the real 434-file tree on the live daemon, the row now reads `-Users-vivek--openclaw-workspace/MEMORY.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)