### PR TITLE
fix: count workspace.conflict events in message_count and JSONL fallback (#4865)

### DIFF
--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -12280,6 +12280,11 @@ _RENDERABLE_EVENT_TYPES = (
     "tool.completed",
     # Compactions render as a special bubble in the replay scrubber.
     "compaction",
+    # Cloud workspace conflict (#3928) — rendered as a system-role notification
+    # in the transcript; must be counted here so message_count in the session
+    # list matches what the detail modal renders. Keep in sync with
+    # ``_RENDERABLE_TRANSCRIPT_EVENT_TYPES`` in ``routes/sessions.py``.
+    "workspace.conflict",
     # Subagent fan-out — child turns surface in the parent's transcript
     # via ``query_events_with_subagents`` (#1597); count them so the
     # list-vs-detail check stays accurate for parents that delegated.

--- a/routes/sessions.py
+++ b/routes/sessions.py
@@ -3649,6 +3649,9 @@ _RENDERABLE_JSONL_OPENCLAW_TYPES = frozenset({
     "prompt.submitted", "trace.artifacts", "model.completed",
     "tool.call", "tool.invoked", "tool.result", "tool.completed",
     "compaction",
+    # Cloud workspace conflict (#3928/#4865) — rendered as a system-role
+    # notification; must be counted so JSONL fallback matches DuckDB path.
+    "workspace.conflict",
 })
 _RENDERABLE_JSONL_ANTHROPIC_ROLES = frozenset({
     "user", "assistant", "system", "tool", "tool_result",


### PR DESCRIPTION
## Summary

`workspace.conflict` events are rendered correctly in the transcript detail view (added in #3928), but they were never added to the two *counting* lists that keep the session-list badge and the JSONL fallback in sync with what the detail view actually renders. Sessions with a workspace-conflict event therefore display one fewer message in the session list than the transcript modal shows.

## Changes

- **`clawmetry/local_store.py`** — added `"workspace.conflict"` to `_RENDERABLE_EVENT_TYPES`, the tuple that drives the `message_count` SQL column in `query_sessions` / `query_sessions_for_agent`.
- **`routes/sessions.py`** — added `"workspace.conflict"` to `_RENDERABLE_JSONL_OPENCLAW_TYPES`, the frozenset used by the legacy `_count_jsonl_renderable_lines` fallback counter when DuckDB is unavailable.

Both additions include a cross-reference comment to keep them in sync going forward (matching the existing note at `routes/sessions.py:3619`).

## Test plan

- [ ] `python3 -c 'import ast; ast.parse(open("clawmetry/local_store.py").read())'` — passes
- [ ] `python3 -c 'import ast; ast.parse(open("routes/sessions.py").read())'` — passes
- [ ] In a workspace with at least one session that emitted a `workspace.conflict` event: the session list's message count for that session should increase by one (matching the transcript detail count)

## Bot meta

<!-- bot-autofix -->
Draft PR opened autonomously based on the plan in #4865. Marked draft for human review — mark Ready for Review once happy.

Closes #4865

---
_Generated by [Claude Code](https://claude.ai/code/session_01UgqFM3sJ78vqrD8BhW5sg8)_