### PR TITLE
fix(trial): arm the paywall, stop paid-runtime ingest on lapse, remove the pro package

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -600,6 +600,12 @@ class Entitlement:
     features: frozenset = field(default_factory=lambda: FREE_FEATURES)
     runtimes: frozenset = field(default_factory=lambda: FREE_RUNTIMES)
     grace: bool = True
+    # True once this account has consumed its free trial (cloud
+    # ``users.trial_used``). This is the ONLY thing that distinguishes a
+    # lapsed trial from a never-trialed install: both resolve to the
+    # ``cloud_free`` tier, and only the former may be paywalled. Defaults to
+    # False so any install we cannot positively classify keeps working.
+    trial_used: bool = False
 
     @property
     def is_paid(self) -> bool:
@@ -2381,7 +2387,13 @@ class Entitlement:
         }
 
 
-def _build(tier: str, source: str, node_limit: int = 1, expiry: float | None = None) -> Entitlement:
+def _build(
+    tier: str,
+    source: str,
+    node_limit: int = 1,
+    expiry: float | None = None,
+    trial_used: bool = False,
+) -> Entitlement:
     paid_feats = _TIER_FEATURES.get(tier, frozenset())
     runtimes = FREE_RUNTIMES | PAID_RUNTIMES if tier in _TIER_PAID_RUNTIMES else FREE_RUNTIMES
     return Entitlement(
@@ -2392,6 +2404,7 @@ def _build(tier: str, source: str, node_limit: int = 1, expiry: float | None = N
         features=FREE_FEATURES | paid_feats,
         runtimes=runtimes,
         grace=not is_enforced(),
+        trial_used=bool(trial_used),
     )
 
 
@@ -2425,6 +2438,7 @@ def _read_cloud_plan() -> Entitlement | None:
             "cloud",
             node_limit=int(data.get("node_limit", 1) or 1),
             expiry=data.get("expiry"),
+            trial_used=bool(data.get("trial_used") or False),
         )
     except Exception as exc:
         logger.warning("entitlements: cloud-plan read failed: %s", exc)

--- a/clawmetry/license.py
+++ b/clawmetry/license.py
@@ -330,6 +330,159 @@ def _pro_installed_version() -> str | None:
         return None
 
 
+def _pro_install_locations() -> list:
+    """Every directory a clawmetry-pro install could live in.
+
+    The provisioner writes to the interpreter's site-packages when it is
+    writable and to the HOME-owned fallback otherwise, and either can be the
+    live one on a given box, so removal must sweep both or a "removed" install
+    stays importable from the other."""
+    out = []
+    try:
+        target, _writable = _site_packages_target()
+        if target:
+            out.append(target)
+    except Exception:
+        pass
+    out.append(_PRO_FALLBACK_DIR)
+    seen = set()
+    return [d for d in out if d and not (d in seen or seen.add(d))]
+
+
+def _purge_pro_from_memory() -> None:
+    """Drop already-imported clawmetry_pro modules so the RUNNING process stops
+    serving paid adapters immediately.
+
+    Deleting files is not enough: the daemon has the adapter classes imported,
+    and Python happily keeps using a module whose file is gone. Without this the
+    paid runtimes would keep ingesting until the next daemon restart, which is
+    exactly the window the removal exists to close. Never raises."""
+    try:
+        import sys
+        for name in [m for m in list(sys.modules) if m == "clawmetry_pro"
+                     or m.startswith("clawmetry_pro.")]:
+            sys.modules.pop(name, None)
+        try:
+            import importlib
+            importlib.invalidate_caches()
+        except Exception:
+            pass
+    except Exception:
+        pass
+
+
+def deprovision_pro(reason: str = "") -> tuple[bool, str]:
+    """Remove the clawmetry-pro package from this machine.
+
+    Called when an account's trial has demonstrably lapsed. Gating the paid
+    runtimes at the entitlement layer stops ClawMetry from USING them, but the
+    closed-source wheel stays on disk where a curious user can import the
+    adapters directly and keep the paid capability without paying. Removing the
+    code is the only version of that boundary which actually holds.
+
+    Deliberately NOT destructive beyond the package: already-ingested rows stay
+    in DuckDB, so a user who pays later gets their history back rather than a
+    hole. Re-provisioning is automatic (``auto_provision_pro`` on the next
+    entitled heartbeat, or ``activate``), so this is reversible by paying.
+
+    Never raises. Returns (removed_something, status_message)."""
+    import shutil
+
+    removed = []
+    errors = []
+
+    # pip first when it exists: it removes the dist-info + RECORD cleanly so
+    # importlib.metadata stops reporting a version. Daemon venvs are often
+    # built WITHOUT pip, so a failure here is expected and non-fatal.
+    try:
+        ok, out = _pip_run(["uninstall", "-y", "clawmetry-pro"])
+        if ok:
+            removed.append("pip uninstall")
+        else:
+            errors.append(f"pip: {str(out)[:120]}")
+    except Exception as exc:
+        errors.append(f"pip: {exc}")
+
+    # Then sweep both install locations by hand. This is what actually catches
+    # the unzip-installed copies (pip-less venv / read-only site-packages).
+    for d in _pro_install_locations():
+        try:
+            if not os.path.isdir(d):
+                continue
+            pkg = os.path.join(d, "clawmetry_pro")
+            if os.path.isdir(pkg):
+                shutil.rmtree(pkg, ignore_errors=True)
+                if not os.path.isdir(pkg):
+                    removed.append(pkg)
+                else:
+                    errors.append(f"could not remove {pkg}")
+            for entry in os.listdir(d):
+                if entry.startswith("clawmetry_pro-") and (
+                        entry.endswith(".dist-info") or entry.endswith(".egg-info")):
+                    p = os.path.join(d, entry)
+                    shutil.rmtree(p, ignore_errors=True)
+                    if not os.path.isdir(p):
+                        removed.append(p)
+        except Exception as exc:
+            errors.append(f"{d}: {exc}")
+
+    _purge_pro_from_memory()
+
+    # Clear the provisioned marker last, so a crash mid-removal leaves the
+    # marker present and the next tick retries rather than believing the
+    # package is gone while files remain.
+    try:
+        if os.path.isfile(_PRO_MARKER_PATH):
+            os.remove(_PRO_MARKER_PATH)
+    except Exception as exc:
+        errors.append(f"marker: {exc}")
+
+    still_there = _pro_installed_version()
+    if still_there:
+        return False, (
+            f"clawmetry-pro {still_there} still importable after removal "
+            f"({'; '.join(errors) if errors else 'no error reported'})")
+    if removed:
+        return True, (f"clawmetry-pro removed ({reason or 'entitlement lapsed'})"
+                      + (f"; issues: {'; '.join(errors)}" if errors else ""))
+    return False, "clawmetry-pro was not installed"
+
+
+def should_deprovision_pro(ent=None) -> bool:
+    """True only when we can POSITIVELY prove this install's trial has lapsed.
+
+    Fails OPEN on every uncertainty, which is the opposite of the request-time
+    gate's fail-closed stance, and deliberately so: a wrongly-blocked request
+    self-heals on the next heartbeat, whereas a wrongly-REMOVED package needs a
+    re-download the machine may not be able to make (offline, air-gapped, cloud
+    outage). Asymmetric costs, asymmetric defaults.
+
+    Requires all of: a resolvable entitlement, an unpaid tier, a consumed
+    trial, and an expiry that has actually passed. A never-trialed free install
+    has nothing to remove and is never touched; a paying customer -- whose
+    trial_used is also True, since signup is trial-by-default -- is excluded by
+    the is_paid check. Never raises."""
+    import time as _t_dp
+    try:
+        if ent is None:
+            from clawmetry import entitlements as _ent
+            ent = _ent.get_entitlement(force=True)
+        if ent is None:
+            return False
+        if getattr(ent, "is_paid", False):
+            return False
+        if getattr(ent, "source", "") == "license":
+            return False  # a signed local license governs, not the cloud plan
+        if not getattr(ent, "trial_used", False):
+            return False
+        expiry = getattr(ent, "expiry", None)
+        if expiry is None:
+            return False
+        return _t_dp.time() > float(expiry)
+    except Exception:
+        return False
+
+
 def _read_pro_marker() -> dict:
     try:
         with open(_PRO_MARKER_PATH, "r", encoding="utf-8") as fh:

--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -24,6 +24,36 @@
   var OVERLAY_ID     = 'cm-hard-block-overlay';
   var STYLE_ID       = 'cm-hard-block-overlay-style';
 
+  // Plan picker state + copy.
+  //
+  // PRICES MIRROR THE CLOUD'S _SUB_PRICING TABLE (clawmetry-cloud
+  // routes/api.py) -- that table is the billing source of truth and what
+  // Stripe actually charges. These numbers are display-only; if they ever
+  // disagree, Stripe wins and the user sees the real amount on the checkout
+  // page. Keep them in this one place so a repricing is a single edit.
+  var PLAN_PRICES = {
+    starter: { month: 9,  year: 90  },
+    pro:     { month: 19, year: 190 },
+  };
+  var _selTier = 'starter';
+  var _selInterval = 'year';   // annual preselected: better retention + the device perk
+  // Filled from /api/entitlement (allowlisted, so it answers while blocked).
+  // Never hardcode a runtime count -- it has drifted every time it was.
+  var _paidRuntimeCount = 0;
+
+  function planPriceLabel() {
+    var p = PLAN_PRICES[_selTier] || PLAN_PRICES.starter;
+    var amt = _selInterval === 'year' ? p.year : p.month;
+    return '$' + amt + ' / node / ' + (_selInterval === 'year' ? 'year' : 'month');
+  }
+
+  function runtimesLine() {
+    return _paidRuntimeCount
+      ? ('All ' + _paidRuntimeCount + ' runtimes (Claude Code, Codex, Cursor +'
+         + Math.max(0, _paidRuntimeCount - 3) + ')')
+      : 'Every supported runtime (Claude Code, Codex, Cursor, …)';
+  }
+
   function injectStyles() {
     if (document.getElementById(STYLE_ID)) return;
     var st = document.createElement('style');
@@ -64,6 +94,66 @@
       + '  transition: background 120ms ease;'
       + '}'
       + '#' + OVERLAY_ID + ' .cm-hbo-cta:hover { background: #ffa726; }'
+      // ── plan picker ──────────────────────────────────────────────────
+      + '#' + OVERLAY_ID + ' .cm-hbo-seg {'
+      + '  display: flex; gap: 4px; padding: 4px; margin: 0 0 14px 0;'
+      + '  background: #14171b; border: 1px solid #2a2f36; border-radius: 10px;'
+      + '}'
+      + '#' + OVERLAY_ID + ' .cm-hbo-seg button {'
+      + '  flex: 1; padding: 9px 10px; border: 0; border-radius: 7px;'
+      + '  background: transparent; color: #b5b8be; font-size: 13px;'
+      + '  font-weight: 600; cursor: pointer; font-family: inherit;'
+      + '}'
+      + '#' + OVERLAY_ID + ' .cm-hbo-seg button[aria-pressed="true"] {'
+      + '  background: #ff9500; color: #1a1d22;'
+      + '}'
+      + '#' + OVERLAY_ID + ' .cm-hbo-seg .cm-hbo-save {'
+      + '  font-weight: 400; opacity: 0.85; margin-left: 4px;'
+      + '}'
+      + '#' + OVERLAY_ID + ' .cm-hbo-tier {'
+      + '  display: flex; align-items: center; gap: 11px; width: 100%;'
+      + '  padding: 13px 14px; margin: 0 0 8px 0; text-align: left;'
+      + '  background: #14171b; border: 1px solid #2a2f36; border-radius: 10px;'
+      + '  color: #e8eaed; cursor: pointer; font-family: inherit;'
+      + '}'
+      + '#' + OVERLAY_ID + ' .cm-hbo-tier[aria-pressed="true"] {'
+      + '  border-color: #ff9500; background: #211a12;'
+      + '}'
+      + '#' + OVERLAY_ID + ' .cm-hbo-radio {'
+      + '  width: 16px; height: 16px; border-radius: 50%; flex: 0 0 auto;'
+      + '  border: 2px solid #4a4f57;'
+      + '}'
+      + '#' + OVERLAY_ID + ' .cm-hbo-tier[aria-pressed="true"] .cm-hbo-radio {'
+      + '  border-color: #ff9500; box-shadow: inset 0 0 0 3px #ff9500;'
+      + '}'
+      + '#' + OVERLAY_ID + ' .cm-hbo-tier-name {'
+      + '  font-size: 15px; font-weight: 700; color: #fff; display: block;'
+      + '}'
+      + '#' + OVERLAY_ID + ' .cm-hbo-tier-sub {'
+      + '  font-size: 12px; color: #9aa0a8; display: block; margin-top: 2px;'
+      + '}'
+      + '#' + OVERLAY_ID + ' .cm-hbo-feats {'
+      + '  margin: 12px 0 14px 0; padding: 0; list-style: none;'
+      + '  font-size: 13px; color: #b5b8be;'
+      + '}'
+      + '#' + OVERLAY_ID + ' .cm-hbo-feats li { margin: 0 0 6px 0; }'
+      + '#' + OVERLAY_ID + ' .cm-hbo-feats li::before {'
+      + '  content: "+"; color: #22c55e; font-weight: 700; margin-right: 8px;'
+      + '}'
+      + '#' + OVERLAY_ID + ' .cm-hbo-price {'
+      + '  text-align: center; margin: 0 0 14px 0;'
+      + '  font-size: 26px; font-weight: 700; color: #fff;'
+      + '}'
+      + '#' + OVERLAY_ID + ' .cm-hbo-device {'
+      + '  margin: 0 0 14px 0; padding: 11px 13px; border-radius: 9px;'
+      + '  border: 1px solid #33406b; background: #151a2b;'
+      + '  font-size: 12.5px; color: #b9c2dd; line-height: 1.45;'
+      + '}'
+      + '#' + OVERLAY_ID + ' .cm-hbo-device strong { color: #22c55e; }'
+      + '#' + OVERLAY_ID + ' .cm-hbo-price small {'
+      + '  display: block; margin-top: 4px; font-size: 12px;'
+      + '  font-weight: 500; color: #22c55e;'
+      + '}'
       + '#' + OVERLAY_ID + ' .cm-hbo-divider {'
       + '  display: flex; align-items: center; gap: 10px;'
       + '  color: #6b7078; font-size: 11px; text-transform: uppercase;'
@@ -153,8 +243,35 @@
       + '  <div class="cm-hbo-eyebrow">' + eyebrow + '</div>'
       + '  <h2 id="cm-hbo-title">' + escapeHtml(reason) + '</h2>'
       + '  <p class="cm-hbo-body">' + escapeHtml(subline) + '</p>'
+      + '  <div class="cm-hbo-seg" role="group" aria-label="Billing interval">'
+      + '    <button type="button" data-interval="month" aria-pressed="' + (_selInterval === 'month') + '">Monthly</button>'
+      + '    <button type="button" data-interval="year" aria-pressed="' + (_selInterval === 'year') + '">Annual<span class="cm-hbo-save">save 2 months</span></button>'
+      + '  </div>'
+      + '  <button type="button" class="cm-hbo-tier" data-tier="starter" aria-pressed="' + (_selTier === 'starter') + '">'
+      + '    <span class="cm-hbo-radio"></span>'
+      + '    <span><span class="cm-hbo-tier-name">Starter</span>'
+      + '      <span class="cm-hbo-tier-sub">' + escapeHtml(runtimesLine()) + '</span></span>'
+      + '  </button>'
+      + '  <button type="button" class="cm-hbo-tier" data-tier="pro" aria-pressed="' + (_selTier === 'pro') + '">'
+      + '    <span class="cm-hbo-radio"></span>'
+      + '    <span><span class="cm-hbo-tier-name">Pro</span>'
+      + '      <span class="cm-hbo-tier-sub">Adds enforcement + audit layer</span></span>'
+      + '  </button>'
+      + '  <ul class="cm-hbo-feats">'
+      + '    <li>' + escapeHtml(runtimesLine()) + '</li>'
+      + '    <li>Unlimited channels + cloud sync</li>'
+      + '    <li>Approval queue</li>'
+      + '  </ul>'
+      // Annual-only perk. The cloud already collects a shipping address on
+      // annual checkouts for this (_annual_device_checkout_extras), and it
+      // ships on the first PAID invoice, so this is not a promise we invent
+      // here. Hidden on monthly.
+      + '  <div class="cm-hbo-device" id="cm-hbo-device" style="' + (_selInterval === 'year' ? '' : 'display:none;') + '">'
+      + '    Includes the $149 desk device, <strong>free</strong> with any annual plan.'
+      + '  </div>'
+      + '  <div class="cm-hbo-price" id="cm-hbo-price">' + escapeHtml(planPriceLabel()) + '</div>'
       + '  <a class="cm-hbo-cta" href="' + escapeAttr(upgradeUrl) + '" target="_blank" rel="noopener">'
-      + '    Continue to payment  →'
+      + '    Continue to Stripe  →'
       + '  </a>'
       + '  <div class="cm-hbo-divider">or</div>'
       + '  <label class="cm-hbo-label" for="cm-hbo-key">Paste license key</label>'
@@ -191,6 +308,60 @@
     // upgrade page. The tab MUST be opened synchronously in the click
     // handler (popup blockers kill window.open from inside a fetch
     // callback) and is redirected once the URL arrives.
+    // Plan picker. Selection lives in module state (not the DOM) so a
+    // re-render from the background poll never silently resets the user's
+    // choice back to the default mid-checkout.
+    var priceEl = el.querySelector('#cm-hbo-price');
+    function repaintPicker() {
+      Array.prototype.forEach.call(
+        el.querySelectorAll('.cm-hbo-seg button'), function (b) {
+          b.setAttribute('aria-pressed', String(b.getAttribute('data-interval') === _selInterval));
+        });
+      Array.prototype.forEach.call(
+        el.querySelectorAll('.cm-hbo-tier'), function (b) {
+          b.setAttribute('aria-pressed', String(b.getAttribute('data-tier') === _selTier));
+        });
+      if (priceEl) priceEl.textContent = planPriceLabel();
+      var devEl = el.querySelector('#cm-hbo-device');
+      if (devEl) devEl.style.display = (_selInterval === 'year') ? '' : 'none';
+    }
+    Array.prototype.forEach.call(
+      el.querySelectorAll('.cm-hbo-seg button'), function (b) {
+        b.addEventListener('click', function () {
+          _selInterval = b.getAttribute('data-interval') === 'year' ? 'year' : 'month';
+          repaintPicker();
+        });
+      });
+    Array.prototype.forEach.call(
+      el.querySelectorAll('.cm-hbo-tier'), function (b) {
+        b.addEventListener('click', function () {
+          _selTier = b.getAttribute('data-tier') === 'pro' ? 'pro' : 'starter';
+          repaintPicker();
+        });
+      });
+
+    // Runtime count for the copy. /api/entitlement is allowlisted so it
+    // answers even while blocked; on failure we keep the countless wording
+    // rather than printing a number we cannot stand behind.
+    if (!_paidRuntimeCount) {
+      try {
+        fetch('/api/entitlement')
+          .then(function (r) { return r.json().catch(function () { return {}; }); })
+          .then(function (ent) {
+            var all = ent && ent.all_runtimes;
+            if (Array.isArray(all) && all.length) {
+              _paidRuntimeCount = all.length;
+              Array.prototype.forEach.call(
+                el.querySelectorAll('.cm-hbo-tier[data-tier="starter"] .cm-hbo-tier-sub'),
+                function (n) { n.textContent = runtimesLine(); });
+              var firstFeat = el.querySelector('.cm-hbo-feats li');
+              if (firstFeat) firstFeat.textContent = runtimesLine();
+            }
+          })
+          .catch(function () {});
+      } catch (e) { /* noop */ }
+    }
+
     var ctaEl = el.querySelector('.cm-hbo-cta');
     var statusElForCta = el.querySelector('.cm-hbo-status');
     ctaEl.addEventListener('click', function (ev) {
@@ -204,7 +375,14 @@
       }
       statusElForCta.className = 'cm-hbo-status';
       statusElForCta.textContent = 'Opening secure checkout…';
-      fetch('/api/trial/checkout', { method: 'POST' })
+      fetch('/api/trial/checkout', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          tier: _selTier,
+          plan: _selInterval === 'year' ? 'yearly' : 'monthly',
+        }),
+      })
         .then(function (r) { return r.json().catch(function () { return {}; }); })
         .then(function (resp) {
           go(resp && resp.url ? resp.url : ctaEl.href);
@@ -218,7 +396,11 @@
         fetch('/api/paywall/event', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ event: 'hard_block_checkout_click' }),
+          body: JSON.stringify({
+            event: 'hard_block_checkout_click',
+            tier: _selTier,
+            interval: _selInterval,
+          }),
         }).catch(function () {});
       } catch (e) { /* noop */ }
     });

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -1186,6 +1186,8 @@ _TRIAL_STATE = {
     "sync_allowed": True,    # default: assume allowed until cloud says otherwise
     "plan": None,
     "trial_days_left": None,
+    "trial_end": None,       # users.trial_end (ISO-8601 UTC) once the cloud sends it
+    "trial_used": None,      # users.trial_used — True once a trial was consumed
     "upgrade_url": "https://app.clawmetry.com/cloud",
     "checkout_url": None,    # signed per-account Stripe checkout URL, if any
     "last_log_day": "",     # YYYY-MM-DD of the last "sync paused" log
@@ -1306,10 +1308,59 @@ def _sync_auto_update_with_plan(tier: str | None) -> None:
         log.debug("immediate pro provision on upgrade skipped: %s", _ppe)
 
 
-def _persist_cloud_plan_to_disk(plan: str | None, trial_days_left=None) -> None:
+def _parse_trial_end(raw) -> float | None:
+    """Coerce the heartbeat's ``trial_end`` into an epoch float.
+
+    The cloud sends an ISO-8601 UTC string (``users.trial_end``, e.g.
+    ``"2026-08-13T08:44:45.286492Z"``); older builds may send an epoch number.
+    Returns None for anything unparseable so a malformed value degrades to
+    "no expiry known" rather than a bogus timestamp that would either brick a
+    live trial or resurrect a dead one. Never raises."""
+    if raw is None:
+        return None
+    if isinstance(raw, (int, float)):
+        try:
+            return float(raw) or None
+        except (TypeError, ValueError):
+            return None
+    try:
+        s = str(raw).strip()
+        if not s:
+            return None
+        # Python 3.9's fromisoformat rejects "Z" and >6-digit fractions.
+        s = s.replace("Z", "+00:00")
+        if "." in s:
+            head, _, tail = s.partition(".")
+            frac, plus, off = tail.partition("+")
+            if plus:
+                s = f"{head}.{frac[:6]}+{off}"
+            else:
+                s = f"{head}.{frac[:6]}"
+        dt = datetime.fromisoformat(s)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt.timestamp()
+    except Exception as exc:
+        log.debug("cloud_plan: unparseable trial_end %r: %s", raw, exc)
+        return None
+
+
+def _persist_cloud_plan_to_disk(
+    plan: str | None,
+    trial_days_left=None,
+    trial_end=None,
+    trial_used=None,
+) -> None:
     """Mirror the heartbeat plan into ``~/.clawmetry/cloud_plan.json`` so the
     dashboard process (which runs ``clawmetry.entitlements.get_entitlement``)
     can resolve a cloud entitlement.
+
+    ``trial_end`` / ``trial_used`` mirror ``users.trial_end`` /
+    ``users.trial_used`` from the cloud. They are what lets the resolver tell a
+    LAPSED trial apart from an install that simply never trialed — without
+    them a burnt trial and a fresh ``pip install`` are both plain
+    ``cloud_free`` and the paywall (correctly) refuses to fire on either. See
+    ``trial_enforcement._resolver_says_unpaid_or_expired``.
 
     Best-effort: any IO error logs at debug and is swallowed — the cache is an
     optimisation, the daemon still works without it. When ``plan`` is unknown
@@ -1325,16 +1376,26 @@ def _persist_cloud_plan_to_disk(plan: str | None, trial_days_left=None) -> None:
     # the trial ``expiry`` countdown doesn't churn a write + entitlement
     # invalidation every cycle. Only an actual tier transition re-writes + flips
     # the resolver, so paid runtimes start syncing the moment the plan upgrades.
+    _trial_end_epoch = _parse_trial_end(trial_end)
+    _trial_used = bool(trial_used) if trial_used is not None else None
     try:
         _existing_plan = None
+        _existing_trial = None
         if os.path.isfile(_CLOUD_PLAN_CACHE_PATH):
             with open(_CLOUD_PLAN_CACHE_PATH, encoding="utf-8") as _fh:
-                _existing_plan = (json.load(_fh) or {}).get("plan")
+                _cached = json.load(_fh) or {}
+            _existing_plan = _cached.get("plan")
+            _existing_trial = (_cached.get("trial_used"), _cached.get("trial_end"))
         if tier is None:
             if _existing_plan is None and not os.path.isfile(_CLOUD_PLAN_CACHE_PATH):
                 return  # already absent; nothing to reconcile
-        elif _existing_plan == tier:
-            return  # cache already matches the live tier; no write, no invalidate
+        elif _existing_plan == tier and _existing_trial == (_trial_used, _trial_end_epoch):
+            # Cache already matches the live tier AND the trial verdict; no
+            # write, no invalidate. The trial pair is part of the comparison
+            # because a lapsing trial does NOT change ``plan`` (it stays
+            # cloud_free) — comparing plan alone would silently skip the write
+            # that arms the paywall.
+            return
     except Exception:
         pass  # any read trouble -> fall through and (re)write below
     try:
@@ -1351,7 +1412,17 @@ def _persist_cloud_plan_to_disk(plan: str | None, trial_days_left=None) -> None:
                     expiry = time.time() + float(trial_days_left) * 86400.0
             except Exception:
                 expiry = None
+            # An authoritative trial_end from the cloud always wins over the
+            # derived days-left countdown: it is the same value Stripe/billing
+            # reconcile against, and it keeps working after the trial lapses
+            # (days_left goes to 0/None but trial_end stays meaningful).
+            if _trial_end_epoch is not None:
+                expiry = _trial_end_epoch
             payload = {"plan": tier, "node_limit": 1, "expiry": expiry}
+            if _trial_used is not None:
+                payload["trial_used"] = _trial_used
+            if _trial_end_epoch is not None:
+                payload["trial_end"] = _trial_end_epoch
             os.makedirs(os.path.dirname(_CLOUD_PLAN_CACHE_PATH), exist_ok=True)
             tmp = _CLOUD_PLAN_CACHE_PATH + ".tmp"
             with open(tmp, "w", encoding="utf-8") as fh:
@@ -1378,6 +1449,12 @@ def _update_trial_state(resp: dict) -> None:
         _TRIAL_STATE["plan"] = resp.get("plan")
     if "trial_days_left" in resp:
         _TRIAL_STATE["trial_days_left"] = resp.get("trial_days_left")
+    # users.trial_end / users.trial_used, mirrored so the resolver can tell a
+    # burnt trial from a never-trialed install (see _persist_cloud_plan_to_disk).
+    if "trial_end" in resp:
+        _TRIAL_STATE["trial_end"] = resp.get("trial_end")
+    if "trial_used" in resp:
+        _TRIAL_STATE["trial_used"] = resp.get("trial_used")
     if resp.get("upgrade_url"):
         _TRIAL_STATE["upgrade_url"] = resp["upgrade_url"]
     if resp.get("checkout_url"):
@@ -1391,9 +1468,17 @@ def _update_trial_state(resp: dict) -> None:
     # so this is cheap, but it self-heals a cache that drifted for any reason
     # (deleted file, a daemon that started while free then the plan upgraded,
     # etc.) and flips paid runtimes on the moment the plan becomes entitled.
-    if "plan" in resp or "trial_days_left" in resp:
+    if (
+        "plan" in resp
+        or "trial_days_left" in resp
+        or "trial_end" in resp
+        or "trial_used" in resp
+    ):
         _persist_cloud_plan_to_disk(
-            _TRIAL_STATE.get("plan"), _TRIAL_STATE.get("trial_days_left")
+            _TRIAL_STATE.get("plan"),
+            _TRIAL_STATE.get("trial_days_left"),
+            trial_end=_TRIAL_STATE.get("trial_end"),
+            trial_used=_TRIAL_STATE.get("trial_used"),
         )
     reason = (resp.get("reason") or "").strip()
     today = datetime.now(timezone.utc).strftime("%Y-%m-%d")

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -19363,6 +19363,32 @@ def run_daemon() -> None:
                 try:
                     _ak = (load_config() or {}).get("api_key", "")
                     if _ak:
+                        # Trial demonstrably lapsed -> REMOVE the pro package
+                        # rather than merely gating it. The entitlement layer
+                        # stops us using the paid adapters, but leaving the
+                        # closed wheel on disk means anyone can import
+                        # clawmetry_pro directly and keep the capability
+                        # without paying. should_deprovision_pro fails OPEN on
+                        # any uncertainty (unresolvable entitlement, offline,
+                        # signed local license, never-trialed, paid) so we
+                        # only ever remove on a positive lapse. Paying
+                        # re-provisions automatically on the next entitled
+                        # heartbeat; DuckDB history is untouched, so the user
+                        # gets their data back rather than a hole.
+                        from clawmetry.license import (
+                            should_deprovision_pro as _sdp,
+                            deprovision_pro as _dpp,
+                        )
+                        if _sdp():
+                            if _pv():
+                                _rm, _rmsg = _dpp("trial lapsed")
+                                log.info(
+                                    "clawmetry-pro removal: %s", _rmsg
+                                ) if _rm else log.warning(
+                                    "clawmetry-pro removal did not complete: %s",
+                                    _rmsg)
+                            _pro_stop.wait(timeout=1800)
+                            continue  # never re-provision on the same tick
                         _was = bool(_pv())
                         _ok, _msg = _wp(_ak, config.get("node_id"))
                         if _ok and not _was:

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -1237,11 +1237,26 @@ _CLOUD_PLAN_CACHE_PATH = os.path.expanduser("~/.clawmetry/cloud_plan.json")
 # Heartbeat ``plan`` strings → entitlement tier codes. Anything not in this map
 # (incl. ``trial_expired`` / None / "") clears the cache so the resolver falls
 # back to OSS-free instead of mistakenly granting an expired Pro plan.
+# Tiers that carry a real subscription. A trial_end must never be stamped onto
+# these as an expiry (see _persist_cloud_plan_to_disk): trial-by-default signup
+# means a paying customer's trial_end is always in the past.
+_PAID_PLAN_TIERS = frozenset({
+    "trial", "cloud_starter", "cloud_pro", "pro", "enterprise",
+})
+
 _HEARTBEAT_PLAN_TO_TIER = {
     "free": "cloud_free",
     "cloud_free": "cloud_free",
     "trial": "trial",
     "cloud_trial": "trial",
+    # A LAPSED trial is cloud_free with a burnt trial, not "unknown". Mapping it
+    # here (instead of falling through to tier=None, which DELETES the cache and
+    # loses the verdict) is what actually arms the paywall for the population
+    # that matters: 2,378 prod accounts sit at plan='trial' with a past
+    # trial_end, vs 40 that have already been flipped to plan='free'. It grants
+    # nothing -- cloud_free has no paid runtimes -- it only carries the
+    # trial_used/trial_end verdict through to the resolver.
+    "trial_expired": "cloud_free",
     "starter": "cloud_starter",
     "cloud_starter": "cloud_starter",
     "pro": "cloud_pro",
@@ -1412,11 +1427,19 @@ def _persist_cloud_plan_to_disk(
                     expiry = time.time() + float(trial_days_left) * 86400.0
             except Exception:
                 expiry = None
-            # An authoritative trial_end from the cloud always wins over the
-            # derived days-left countdown: it is the same value Stripe/billing
-            # reconcile against, and it keeps working after the trial lapses
-            # (days_left goes to 0/None but trial_end stays meaningful).
-            if _trial_end_epoch is not None:
+            # An authoritative trial_end from the cloud wins over the derived
+            # days-left countdown for UNPAID tiers: it is the same value
+            # Stripe/billing reconcile against, and it keeps working after the
+            # trial lapses (days_left goes to 0/None but trial_end stays
+            # meaningful).
+            #
+            # NEVER for a paid tier. Signup is trial-by-default, so essentially
+            # every paying customer carries trial_used=True and a trial_end
+            # that is long past -- stamping that onto their entitlement makes
+            # Entitlement.expired True and hard-blocks a subscriber who is
+            # paying us right now. Their subscription expiry comes from the
+            # plan, not from the trial they took before they bought.
+            if _trial_end_epoch is not None and tier not in _PAID_PLAN_TIERS:
                 expiry = _trial_end_epoch
             payload = {"plan": tier, "node_limit": 1, "expiry": expiry}
             if _trial_used is not None:

--- a/clawmetry/trial_enforcement.py
+++ b/clawmetry/trial_enforcement.py
@@ -234,13 +234,19 @@ def _escape_hatch_active() -> bool:
 
 
 def _resolver_says_unpaid_or_expired(ent: "Entitlement | None") -> bool:
-    """True only when the resolved entitlement WAS on a paid/trial tier and
-    has now passed its ``expiry`` timestamp -- never for an install that was
-    simply never entitled in the first place (plain OSS / cloud_free is the
-    permanent free tier documented in docs/ENTITLEMENTS.md, not a lapsed
-    trial). Fail-closed only on a genuinely unreadable entitlement: we would
-    rather leak into the paywall on an internal error than silently keep
-    serving an install we can't positively classify."""
+    """True only when this install WAS entitled (paid tier, or a trial it has
+    since consumed) and has now passed its ``expiry`` timestamp -- never for
+    an install that was simply never entitled in the first place (plain OSS /
+    cloud_free is the permanent free tier documented in docs/ENTITLEMENTS.md,
+    not a lapsed trial).
+
+    Fail-closed only on a genuinely unreadable entitlement (``ent is None`` or
+    an exception): we would rather leak into the paywall on an internal error
+    than silently keep serving an install we can't positively classify. Note
+    the asymmetry inside the ``trial_used`` branch -- an unparseable expiry
+    there returns False, because a burnt trial with a corrupt date is far more
+    likely to be our bug than a freeloader, and blocking a paying-adjacent
+    user is the costlier mistake."""
     if ent is None:
         return True
     try:
@@ -263,11 +269,33 @@ def _resolver_says_unpaid_or_expired(ent: "Entitlement | None") -> bool:
                 return time.time() > float(expiry)
             except (TypeError, ValueError):
                 return True
-        # Plain OSS / cloud_free: no license, no cloud plan, never paid or
-        # trialed. That's the permanent free tier, not an expired one -- do
-        # NOT block it. (Regression fixed 2026-08-06: this used to fall
-        # through to `return True` here, hard-blocking every fresh
-        # `pip install clawmetry` with no license/trial at all.)
+        # Unpaid tier. Two very different populations land here and only one
+        # of them may be paywalled:
+        #
+        #   (a) never trialed -- a fresh `pip install clawmetry` on the
+        #       permanent free tier (docs/ENTITLEMENTS.md). NEVER block.
+        #       (Regression fixed 2026-08-06: this used to fall through to
+        #       `return True`, hard-blocking every fresh install.)
+        #   (b) trial consumed and its end date passed -- the account saw the
+        #       paid runtimes for 7 days and the window closed. Block, so the
+        #       only ways forward are "upgrade" or "continue on free runtimes".
+        #
+        # ``trial_used`` is what tells them apart; it reaches us from the
+        # cloud heartbeat via ``cloud_plan.json`` (see
+        # ``sync._persist_cloud_plan_to_disk``). Absent that signal the value
+        # is False and we fall through to (a) -- an older daemon, an offline
+        # install, or a cloud that hasn't shipped the field yet all keep
+        # working exactly as before rather than getting a surprise paywall.
+        if getattr(ent, "trial_used", False):
+            expiry = getattr(ent, "expiry", None)
+            if expiry is None:
+                # Trial consumed but no end date known: cannot prove it lapsed,
+                # so do not block on a guess.
+                return False
+            try:
+                return time.time() > float(expiry)
+            except (TypeError, ValueError):
+                return False
         return False
     except Exception as exc:
         logger.warning("trial_enforcement: resolver check failed, defaulting "

--- a/routes/trial.py
+++ b/routes/trial.py
@@ -380,12 +380,29 @@ def api_trial_checkout():
     """
     from clawmetry import trial_enforcement as _te
 
+    # Plan choice from the overlay's picker. Both default conservatively so an
+    # older overlay (or a direct curl) still gets a working monthly Starter
+    # session rather than an error.
+    try:
+        _sel = request.get_json(silent=True) or {}
+    except Exception:
+        _sel = {}
+    _tier = str(_sel.get("tier") or "starter").strip().lower()
+    if _tier not in ("starter", "pro"):
+        _tier = "starter"
+    _plan = "yearly" if str(_sel.get("plan") or "").strip().lower() in (
+        "yearly", "year", "annual", "annually") else "monthly"
+
     api_key = _local_api_key()
     if api_key:
         try:
             from clawmetry import license as _lic
             base = _lic._cloud_base().rstrip("/")
-            body = json.dumps({"context": "trial_hard_block"}).encode("utf-8")
+            body = json.dumps({
+                "context": "trial_hard_block",
+                "tier": _tier,
+                "plan": _plan,
+            }).encode("utf-8")
             req = urllib.request.Request(
                 base + _CHECKOUT_SESSION_PATH,
                 data=body,

--- a/tests/test_pro_deprovision.py
+++ b/tests/test_pro_deprovision.py
@@ -1,0 +1,194 @@
+"""Post-trial, the clawmetry-pro package is REMOVED, not merely gated.
+
+Gating stops ClawMetry from using the paid adapters, but the closed-source
+wheel sitting in site-packages is still importable by hand -- a user can
+`import clawmetry_pro` and keep the paid capability without paying. Removing
+the code is the only version of that boundary that actually holds.
+
+The dangerous direction here is the opposite of the request gate's. A wrongly
+blocked request self-heals on the next heartbeat; a wrongly REMOVED package
+needs a re-download the machine may not be able to make. So
+should_deprovision_pro fails OPEN on every uncertainty and only removes on a
+positive, provable lapse.
+"""
+
+import json
+import os
+import sys
+
+_REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _REPO not in sys.path:
+    sys.path.insert(0, _REPO)
+
+DAY = 86400.0
+
+
+def _ent(monkeypatch, tmp_path, **fields):
+    from clawmetry import entitlements as ent
+    cache = str(tmp_path / ".clawmetry" / "cloud_plan.json")
+    monkeypatch.setattr(ent, "_CLOUD_PLAN_CACHE", cache)
+    monkeypatch.setattr(ent, "_LICENSE_PATH", str(tmp_path / "nope.key"))
+    os.makedirs(os.path.dirname(cache), exist_ok=True)
+    with open(cache, "w") as fh:
+        json.dump(fields, fh)
+    ent.invalidate()
+    return ent.get_entitlement(force=True)
+
+
+# ── the decision ────────────────────────────────────────────────────────────
+
+def test_lapsed_trial_is_removed(monkeypatch, tmp_path):
+    import time
+    from clawmetry.license import should_deprovision_pro
+    e = _ent(monkeypatch, tmp_path, plan="cloud_free", node_limit=1,
+             expiry=time.time() - 2 * DAY, trial_used=True)
+    assert should_deprovision_pro(e) is True
+
+
+def test_paying_customer_is_never_removed(monkeypatch, tmp_path):
+    """Signup is trial-by-default, so a paying customer also has
+    trial_used=True. Removing their adapters would be a self-inflicted outage
+    on a live subscriber."""
+    from clawmetry.license import should_deprovision_pro
+    e = _ent(monkeypatch, tmp_path, plan="cloud_pro", node_limit=5,
+             expiry=None, trial_used=True)
+    assert should_deprovision_pro(e) is False
+
+
+def test_live_trial_is_never_removed(monkeypatch, tmp_path):
+    import time
+    from clawmetry.license import should_deprovision_pro
+    e = _ent(monkeypatch, tmp_path, plan="cloud_free", node_limit=1,
+             expiry=time.time() + 3 * DAY, trial_used=True)
+    assert should_deprovision_pro(e) is False
+
+
+def test_never_trialed_is_never_removed(monkeypatch, tmp_path):
+    from clawmetry.license import should_deprovision_pro
+    e = _ent(monkeypatch, tmp_path, plan="cloud_free", node_limit=1, expiry=None)
+    assert should_deprovision_pro(e) is False
+
+
+def test_unresolvable_entitlement_fails_open():
+    """Offline / cloud outage / corrupt cache. Never remove on uncertainty."""
+    from clawmetry.license import should_deprovision_pro
+    assert should_deprovision_pro(None) is False
+
+
+def test_trial_used_without_expiry_fails_open(monkeypatch, tmp_path):
+    """We know a trial happened but not when it ended -- cannot prove a lapse."""
+    from clawmetry.license import should_deprovision_pro
+    e = _ent(monkeypatch, tmp_path, plan="cloud_free", node_limit=1,
+             expiry=None, trial_used=True)
+    assert should_deprovision_pro(e) is False
+
+
+def test_signed_local_license_is_never_removed(monkeypatch, tmp_path):
+    """A self-hosted key governs locally; the cloud plan does not get to
+    revoke it."""
+    import time
+    from clawmetry import entitlements as ent
+    from clawmetry.license import should_deprovision_pro
+    lic = ent._build(ent.TIER_CLOUD_STARTER, "license", node_limit=1,
+                     expiry=time.time() + 30 * DAY, trial_used=True)
+    assert should_deprovision_pro(lic) is False
+
+
+# ── the removal ─────────────────────────────────────────────────────────────
+
+def _fake_install(root):
+    """Lay down a clawmetry_pro package + dist-info the way the unzip
+    installer does."""
+    pkg = os.path.join(root, "clawmetry_pro")
+    os.makedirs(os.path.join(pkg, "adapters"), exist_ok=True)
+    with open(os.path.join(pkg, "__init__.py"), "w") as fh:
+        fh.write("VALUE = 'paid-adapters'\n")
+    with open(os.path.join(pkg, "adapters", "__init__.py"), "w") as fh:
+        fh.write("\n")
+    di = os.path.join(root, "clawmetry_pro-0.7.6.dist-info")
+    os.makedirs(di, exist_ok=True)
+    with open(os.path.join(di, "METADATA"), "w") as fh:
+        fh.write("Name: clawmetry-pro\nVersion: 0.7.6\n")
+    return pkg, di
+
+
+def test_removal_sweeps_both_install_locations(monkeypatch, tmp_path):
+    """The provisioner writes to site-packages OR the HOME fallback depending
+    on writability. Removing only one leaves the package importable."""
+    from clawmetry import license as lic
+    site = tmp_path / "site-packages"
+    fallback = tmp_path / "pro-packages"
+    site.mkdir()
+    fallback.mkdir()
+    pkg_a, di_a = _fake_install(str(site))
+    pkg_b, di_b = _fake_install(str(fallback))
+
+    monkeypatch.setattr(lic, "_site_packages_target", lambda: (str(site), True))
+    monkeypatch.setattr(lic, "_PRO_FALLBACK_DIR", str(fallback))
+    monkeypatch.setattr(lic, "_PRO_MARKER_PATH", str(tmp_path / "pro_installed.json"))
+    monkeypatch.setattr(lic, "_pip_run", lambda args: (False, "no pip"))
+    monkeypatch.setattr(lic, "_pro_installed_version", lambda: None)
+
+    removed, msg = lic.deprovision_pro("test")
+    assert removed is True, msg
+    for p in (pkg_a, di_a, pkg_b, di_b):
+        assert not os.path.isdir(p), f"{p} survived removal"
+
+
+def test_removal_clears_the_marker(monkeypatch, tmp_path):
+    from clawmetry import license as lic
+    site = tmp_path / "site-packages"
+    site.mkdir()
+    _fake_install(str(site))
+    marker = tmp_path / "pro_installed.json"
+    marker.write_text('{"version": "0.7.6"}')
+
+    monkeypatch.setattr(lic, "_site_packages_target", lambda: (str(site), True))
+    monkeypatch.setattr(lic, "_PRO_FALLBACK_DIR", str(tmp_path / "absent"))
+    monkeypatch.setattr(lic, "_PRO_MARKER_PATH", str(marker))
+    monkeypatch.setattr(lic, "_pip_run", lambda args: (False, "no pip"))
+    monkeypatch.setattr(lic, "_pro_installed_version", lambda: None)
+
+    lic.deprovision_pro("test")
+    assert not marker.exists(), "stale marker would make re-provision skip the download"
+
+
+def test_removal_purges_imported_modules(monkeypatch, tmp_path):
+    """Deleting files is not enough: the daemon already has the adapter classes
+    imported and Python keeps using a module whose file is gone. Without the
+    purge the paid runtimes keep ingesting until the next restart -- exactly
+    the window removal exists to close."""
+    from clawmetry import license as lic
+    import types
+    monkeypatch.setitem(sys.modules, "clawmetry_pro", types.ModuleType("clawmetry_pro"))
+    monkeypatch.setitem(sys.modules, "clawmetry_pro.adapters",
+                        types.ModuleType("clawmetry_pro.adapters"))
+    lic._purge_pro_from_memory()
+    assert "clawmetry_pro" not in sys.modules
+    assert "clawmetry_pro.adapters" not in sys.modules
+
+
+def test_removal_reports_failure_when_still_importable(monkeypatch, tmp_path):
+    """Honest status: if the package survives, say so rather than claim a
+    removal that did not happen."""
+    from clawmetry import license as lic
+    monkeypatch.setattr(lic, "_site_packages_target", lambda: (str(tmp_path), True))
+    monkeypatch.setattr(lic, "_PRO_FALLBACK_DIR", str(tmp_path / "absent"))
+    monkeypatch.setattr(lic, "_PRO_MARKER_PATH", str(tmp_path / "m.json"))
+    monkeypatch.setattr(lic, "_pip_run", lambda args: (False, "no pip"))
+    monkeypatch.setattr(lic, "_pro_installed_version", lambda: "0.7.6")
+    removed, msg = lic.deprovision_pro("test")
+    assert removed is False
+    assert "still importable" in msg
+
+
+def test_removal_is_idempotent_when_absent(monkeypatch, tmp_path):
+    from clawmetry import license as lic
+    monkeypatch.setattr(lic, "_site_packages_target", lambda: (str(tmp_path), True))
+    monkeypatch.setattr(lic, "_PRO_FALLBACK_DIR", str(tmp_path / "absent"))
+    monkeypatch.setattr(lic, "_PRO_MARKER_PATH", str(tmp_path / "m.json"))
+    monkeypatch.setattr(lic, "_pip_run", lambda args: (False, "no pip"))
+    monkeypatch.setattr(lic, "_pro_installed_version", lambda: None)
+    removed, msg = lic.deprovision_pro("test")
+    assert removed is False
+    assert "not installed" in msg

--- a/tests/test_sync_cloud_plan_cache.py
+++ b/tests/test_sync_cloud_plan_cache.py
@@ -78,7 +78,7 @@ def test_persist_maps_known_plan_codes(sync, heartbeat_plan, expected_tier):
     assert payload["plan"] == expected_tier
 
 
-@pytest.mark.parametrize("dead_plan", ["trial_expired", "", None, "unknown_plan"])
+@pytest.mark.parametrize("dead_plan", ["", None, "unknown_plan"])
 def test_persist_removes_cache_for_inactive_plans(sync, dead_plan):
     # Seed an existing cache so the removal path is exercised.
     os.makedirs(os.path.dirname(sync._CLOUD_PLAN_CACHE_PATH), exist_ok=True)
@@ -86,6 +86,34 @@ def test_persist_removes_cache_for_inactive_plans(sync, dead_plan):
         json.dump({"plan": "cloud_pro"}, fh)
     sync._persist_cloud_plan_to_disk(dead_plan)
     assert not os.path.isfile(sync._CLOUD_PLAN_CACHE_PATH)
+
+
+def test_persist_keeps_cache_for_trial_expired(sync):
+    """'trial_expired' used to live in the list above, deleting the cache so the
+    resolver fell back to OSS-free. That threw away the one fact the paywall
+    needs -- that a trial was consumed and has ended -- and left 2,378 prod
+    accounts indistinguishable from a fresh `pip install`, which the resolver
+    (correctly) refuses to block.
+
+    It now maps to cloud_free and the cache is KEPT with the verdict attached.
+    The original safety property is unchanged: cloud_free grants no paid
+    runtimes, so nothing is "mistakenly granted an expired Pro plan" -- the
+    cache carries a denial, not a grant. Asserted below rather than assumed."""
+    os.makedirs(os.path.dirname(sync._CLOUD_PLAN_CACHE_PATH), exist_ok=True)
+    with open(sync._CLOUD_PLAN_CACHE_PATH, "w") as fh:
+        json.dump({"plan": "cloud_pro"}, fh)
+    sync._persist_cloud_plan_to_disk(
+        "trial_expired", None, trial_end="2026-08-13T08:44:45Z", trial_used=True)
+    assert os.path.isfile(sync._CLOUD_PLAN_CACHE_PATH)
+    payload = json.loads(open(sync._CLOUD_PLAN_CACHE_PATH).read())
+    assert payload["plan"] == "cloud_free"
+    assert payload["trial_used"] is True
+
+    import clawmetry.entitlements as e
+    e.invalidate()
+    en = e.get_entitlement(force=True)
+    assert en.allows_runtime("claude_code") is False, "no paid grant survives"
+    assert en.allows_runtime("openclaw") is True, "free runtimes always survive"
 
 
 def test_persist_trial_writes_expiry_from_days_left(sync):
@@ -128,11 +156,20 @@ def test_update_trial_state_persists_pro(sync):
     assert payload["plan"] == "cloud_pro"
 
 
-def test_update_trial_state_clears_cache_on_expiry(sync):
+def test_update_trial_state_downgrades_on_expiry(sync):
+    """A trial_expired heartbeat must DOWNGRADE the cached plan to cloud_free,
+    not delete the cache. Deleting it loses the trial verdict and the paywall
+    can never fire (see test_persist_keeps_cache_for_trial_expired)."""
     sync._update_trial_state({"sync_allowed": True, "plan": "pro"})
     assert os.path.isfile(sync._CLOUD_PLAN_CACHE_PATH)
-    sync._update_trial_state({"sync_allowed": False, "plan": "trial_expired"})
-    assert not os.path.isfile(sync._CLOUD_PLAN_CACHE_PATH)
+    sync._update_trial_state({
+        "sync_allowed": False, "plan": "trial_expired",
+        "trial_end": "2026-08-13T08:44:45Z", "trial_used": True,
+    })
+    assert os.path.isfile(sync._CLOUD_PLAN_CACHE_PATH)
+    payload = json.loads(open(sync._CLOUD_PLAN_CACHE_PATH).read())
+    assert payload["plan"] == "cloud_free", "the Pro grant must be revoked"
+    assert payload["trial_used"] is True
 
 
 def test_update_trial_state_reconciles_persist_each_heartbeat(sync, monkeypatch):
@@ -167,7 +204,12 @@ def test_entitlements_sees_cloud_pro_after_heartbeat(sync, monkeypatch):
     assert en.allows_runtime("claude_code") is True
 
 
-def test_entitlements_falls_back_to_oss_after_trial_expiry(sync, monkeypatch):
+def test_entitlements_revokes_paid_runtimes_after_trial_expiry(sync, monkeypatch):
+    """The substantive property is unchanged: after a trial expires, the paid
+    runtimes are gone. What changed is the tier we land on -- cloud_free rather
+    than oss, so the trial verdict survives and the paywall can fire. Both are
+    equally unpaid; only cloud_free can also be told apart from a fresh
+    install."""
     import clawmetry.entitlements as e
 
     monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
@@ -176,10 +218,15 @@ def test_entitlements_falls_back_to_oss_after_trial_expiry(sync, monkeypatch):
     sync._update_trial_state({"sync_allowed": True, "plan": "pro"})
     assert e.get_entitlement(force=True).tier == e.TIER_CLOUD_PRO
 
-    sync._update_trial_state({"sync_allowed": False, "plan": "trial_expired"})
+    sync._update_trial_state({
+        "sync_allowed": False, "plan": "trial_expired",
+        "trial_end": "2026-08-13T08:44:45Z", "trial_used": True,
+    })
     en = e.get_entitlement(force=True)
-    assert en.tier == e.TIER_OSS
+    assert en.tier == e.TIER_CLOUD_FREE
+    assert en.is_paid is False
     assert en.allows_runtime("claude_code") is False
+    assert en.allows_runtime("openclaw") is True
 
 
 # ── reconcile-every-heartbeat + idempotency (founder ask 2026-06-30) ─────────

--- a/tests/test_sync_cloud_plan_cache.py
+++ b/tests/test_sync_cloud_plan_cache.py
@@ -142,7 +142,7 @@ def test_update_trial_state_reconciles_persist_each_heartbeat(sync, monkeypatch)
     test_persist_is_idempotent_when_tier_unchanged), NOT by skipping the call."""
     calls = {"n": 0}
 
-    def _spy(plan, trial_days_left=None):
+    def _spy(plan, trial_days_left=None, trial_end=None, trial_used=None):
         calls["n"] += 1
 
     monkeypatch.setattr(sync, "_persist_cloud_plan_to_disk", _spy)

--- a/tests/test_trial_hard_block.py
+++ b/tests/test_trial_hard_block.py
@@ -70,6 +70,40 @@ class TrialHardBlockGateTest(unittest.TestCase):
         from clawmetry import entitlements
         entitlements.invalidate()
 
+    def _write_cloud_plan(self, **fields):
+        """Stamp ``$HOME/.clawmetry/cloud_plan.json`` (the cache the daemon
+        writes from the heartbeat) and drop the resolver cache so the next
+        request sees it."""
+        import json
+        d = os.path.join(os.environ["HOME"], ".clawmetry")
+        os.makedirs(d, exist_ok=True)
+        with open(os.path.join(d, "cloud_plan.json"), "w") as fh:
+            json.dump(fields, fh)
+        self._invalidate()
+
+    def _clear_cloud_plan(self):
+        p = os.path.join(os.environ["HOME"], ".clawmetry", "cloud_plan.json")
+        try:
+            os.remove(p)
+        except OSError:
+            pass
+        self._invalidate()
+
+    def test_never_trialed_install_is_never_blocked(self):
+        """A fresh ``pip install clawmetry`` with no license and no trial is
+        the permanent free tier, NOT a lapsed one. Blocking it would brick
+        every new install on day one (the 2026-08-06 regression)."""
+        os.environ["CLAWMETRY_HARD_BLOCK"] = "1"
+        self._clear_cloud_plan()
+        try:
+            resp = self._client.get("/api/sessions")
+            self.assertNotEqual(
+                resp.status_code, 402,
+                "a never-trialed install must NEVER be hard-blocked")
+        finally:
+            os.environ["CLAWMETRY_HARD_BLOCK"] = "0"
+            self._clear_cloud_plan()
+
     def test_default_is_enabled(self):
         """Founder policy: block is default-ON. Only an explicit opt-out
         env value disables it."""
@@ -109,9 +143,22 @@ class TrialHardBlockGateTest(unittest.TestCase):
 
     def test_non_allowlisted_returns_402_with_correct_body(self):
         """A blocked install must 402 non-allowlisted paths with the shape
-        the overlay JS keys off."""
+        the overlay JS keys off.
+
+        "Blocked" means a CONSUMED trial whose end date has passed —
+        ``trial_used`` + a past ``expiry``, exactly what the daemon writes
+        into cloud_plan.json from the heartbeat's users.trial_used /
+        users.trial_end. An empty HOME is a never-trialed install and is
+        deliberately NOT blocked (see
+        test_never_trialed_install_is_never_blocked)."""
+        import time as _t
         os.environ["CLAWMETRY_HARD_BLOCK"] = "1"
-        self._invalidate()
+        self._write_cloud_plan(
+            plan="cloud_free", node_limit=1,
+            expiry=_t.time() - 2 * 86400.0,
+            trial_end=_t.time() - 2 * 86400.0,
+            trial_used=True,
+        )
         try:
             resp = self._client.get("/api/sessions")
             self.assertEqual(
@@ -132,7 +179,9 @@ class TrialHardBlockGateTest(unittest.TestCase):
                           "body.refresh_endpoint must be present")
         finally:
             os.environ["CLAWMETRY_HARD_BLOCK"] = "0"
-            self._invalidate()
+            # Clear the lapsed-trial cache too, or it leaks into every test
+            # that runs after this one in the shared temp HOME.
+            self._clear_cloud_plan()
 
     def test_optout_lets_traffic_through(self):
         """The support opt-out (CLAWMETRY_HARD_BLOCK=0) must bypass the

--- a/tests/test_trial_hard_block.py
+++ b/tests/test_trial_hard_block.py
@@ -70,21 +70,32 @@ class TrialHardBlockGateTest(unittest.TestCase):
         from clawmetry import entitlements
         entitlements.invalidate()
 
+    @staticmethod
+    def _plan_path():
+        """The path the RESOLVER actually reads.
+
+        ``entitlements._CLOUD_PLAN_CACHE`` is expanded at import time, so if
+        any earlier test in the session imported the module under a different
+        HOME it is pinned to that old directory. Deriving the path from
+        ``$HOME`` here instead would write somewhere the resolver never looks
+        — the test then passes alone and fails in the full suite, which is
+        exactly how it behaved before this was fixed."""
+        from clawmetry import entitlements
+        return entitlements._CLOUD_PLAN_CACHE
+
     def _write_cloud_plan(self, **fields):
-        """Stamp ``$HOME/.clawmetry/cloud_plan.json`` (the cache the daemon
-        writes from the heartbeat) and drop the resolver cache so the next
-        request sees it."""
+        """Stamp the cloud-plan cache (what the daemon writes from the
+        heartbeat) and drop the resolver cache so the next request sees it."""
         import json
-        d = os.path.join(os.environ["HOME"], ".clawmetry")
-        os.makedirs(d, exist_ok=True)
-        with open(os.path.join(d, "cloud_plan.json"), "w") as fh:
+        p = self._plan_path()
+        os.makedirs(os.path.dirname(p), exist_ok=True)
+        with open(p, "w") as fh:
             json.dump(fields, fh)
         self._invalidate()
 
     def _clear_cloud_plan(self):
-        p = os.path.join(os.environ["HOME"], ".clawmetry", "cloud_plan.json")
         try:
-            os.remove(p)
+            os.remove(self._plan_path())
         except OSError:
             pass
         self._invalidate()

--- a/tests/test_trial_lapse_blast_radius.py
+++ b/tests/test_trial_lapse_blast_radius.py
@@ -1,0 +1,181 @@
+"""Who the trial paywall may and may not block.
+
+Derived from the real prod population (2026-08-15, users table):
+
+    plan       trial_used  trial_end   count
+    free       f           null         3439   <- never trialed, MUST NOT block
+    trial      t           past         2378   <- lapsed, MUST block
+    trial      t           future        351   <- live trial, MUST NOT block
+    free       t           past           40   <- lapsed, MUST block
+    cloud_pro  f           null           21   <- paying, MUST NOT block
+    cloud_pro  t           past            5   <- paying, once trialed, MUST NOT block
+
+Two bugs this pins, both caught by checking that table before shipping:
+
+1. Stamping trial_end as the entitlement expiry for a PAID tier hard-blocks a
+   paying subscriber. Signup is trial-by-default, so every paying customer has
+   trial_used=True and a trial_end in the past -- the 5 rows above today, and
+   every future one.
+2. plan='trial_expired' (what _effective_plan returns for the 2378 rows) was not
+   in _HEARTBEAT_PLAN_TO_TIER, so the daemon DELETED cloud_plan.json and lost
+   the trial verdict. The paywall would have armed for 40 accounts and missed
+   the 2378 it exists for.
+"""
+
+import json
+import os
+import sys
+import tempfile
+import time
+
+_REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _REPO not in sys.path:
+    sys.path.insert(0, _REPO)
+
+DAY = 86400.0
+
+
+def _resolve(tmp_path, **plan_fields):
+    """Write cloud_plan.json and resolve the entitlement + block verdict."""
+    from clawmetry import entitlements as ent, trial_enforcement as te
+    os.makedirs(os.path.dirname(ent._CLOUD_PLAN_CACHE), exist_ok=True)
+    with open(ent._CLOUD_PLAN_CACHE, "w") as fh:
+        json.dump(plan_fields, fh)
+    ent.invalidate()
+    e = ent.get_entitlement(force=True)
+    return e, te.is_hard_blocked(e, path="/api/sessions")
+
+
+def _isolate(monkeypatch, tmp_path):
+    """Point the resolver's import-time cache path into a tmp dir."""
+    from clawmetry import entitlements as ent
+    monkeypatch.setattr(ent, "_CLOUD_PLAN_CACHE",
+                        str(tmp_path / ".clawmetry" / "cloud_plan.json"))
+    monkeypatch.setattr(ent, "_LICENSE_PATH", str(tmp_path / ".clawmetry" / "nope.key"))
+    monkeypatch.delenv("CLAWMETRY_HARD_BLOCK", raising=False)
+    monkeypatch.delenv("CLAWMETRY_HARD_BLOCK_ESCAPE", raising=False)
+
+
+def test_paying_customer_who_once_trialed_is_never_blocked(monkeypatch, tmp_path):
+    """The 5 cloud_pro rows with a past trial_end. Bricking a live subscriber is
+    the worst failure this system can have.
+
+    Asserts the state the daemon ACTUALLY writes for them: a paid plan whose
+    expiry stays None even though trial_used/trial_end say the trial is long
+    gone. (A paid plan with a genuinely past expiry -- a lapsed subscription --
+    SHOULD still block; that is a different case and stays blocked.)"""
+    _isolate(monkeypatch, tmp_path)
+    past = time.time() - 30 * DAY
+    e, blocked = _resolve(tmp_path, plan="cloud_pro", node_limit=5,
+                          expiry=None, trial_end=past, trial_used=True)
+    assert blocked is False, "a paying subscriber must never be hard-blocked"
+    assert e.expired is False, "a paid tier must not inherit the trial's expiry"
+    assert e.allows_runtime("claude_code") is True
+
+
+def test_paid_starter_who_once_trialed_is_never_blocked(monkeypatch, tmp_path):
+    _isolate(monkeypatch, tmp_path)
+    past = time.time() - 10 * DAY
+    e, blocked = _resolve(tmp_path, plan="cloud_starter", node_limit=1,
+                          expiry=None, trial_end=past, trial_used=True)
+    assert blocked is False
+    assert e.allows_runtime("claude_code") is True
+
+
+def test_genuinely_lapsed_subscription_still_blocks(monkeypatch, tmp_path):
+    """The paid-tier carve-out above is scoped to the TRIAL's date, not a free
+    pass: a paid plan whose own expiry has passed must still block, or a
+    cancelled subscription would keep working forever."""
+    _isolate(monkeypatch, tmp_path)
+    past = time.time() - 5 * DAY
+    e, blocked = _resolve(tmp_path, plan="cloud_pro", node_limit=5,
+                          expiry=past, trial_end=None, trial_used=True)
+    assert blocked is True
+    assert e.allows_runtime("claude_code") is False
+
+
+def test_lapsed_trial_is_blocked(monkeypatch, tmp_path):
+    """The 2378 + 40 rows."""
+    _isolate(monkeypatch, tmp_path)
+    past = time.time() - 2 * DAY
+    e, blocked = _resolve(tmp_path, plan="cloud_free", node_limit=1,
+                          expiry=past, trial_end=past, trial_used=True)
+    assert blocked is True
+    assert e.allows_runtime("claude_code") is False
+    assert e.allows_runtime("openclaw") is True, "free runtimes always survive"
+
+
+def test_live_trial_is_not_blocked(monkeypatch, tmp_path):
+    """The 351 rows mid-trial."""
+    _isolate(monkeypatch, tmp_path)
+    future = time.time() + 3 * DAY
+    e, blocked = _resolve(tmp_path, plan="cloud_free", node_limit=1,
+                          expiry=future, trial_end=future, trial_used=True)
+    assert blocked is False
+    assert e.allows_runtime("claude_code") is True
+
+
+def test_never_trialed_is_not_blocked(monkeypatch, tmp_path):
+    """The 3439 rows. Blocking these bricks every fresh pip install."""
+    _isolate(monkeypatch, tmp_path)
+    e, blocked = _resolve(tmp_path, plan="cloud_free", node_limit=1, expiry=None)
+    assert blocked is False
+    assert e.allows_runtime("claude_code") is True
+
+
+# ── the heartbeat plan mapping ──────────────────────────────────────────────
+
+def test_trial_expired_maps_to_cloud_free_not_none():
+    """_effective_plan returns 'trial_expired' for the 2378. If that is not in
+    the map the daemon deletes cloud_plan.json, the trial verdict is lost, and
+    the paywall silently misses the entire population it was built for."""
+    import clawmetry.sync as s
+    assert s._HEARTBEAT_PLAN_TO_TIER.get("trial_expired") == "cloud_free"
+
+
+def test_persist_writes_lapse_verdict_for_trial_expired(monkeypatch, tmp_path):
+    """End to end through the daemon's own writer: a trial_expired heartbeat
+    must leave a cache that blocks, not an absent file."""
+    import clawmetry.sync as s
+    from clawmetry import entitlements as ent, trial_enforcement as te
+    cache = str(tmp_path / ".clawmetry" / "cloud_plan.json")
+    monkeypatch.setattr(s, "_CLOUD_PLAN_CACHE_PATH", cache)
+    monkeypatch.setattr(ent, "_CLOUD_PLAN_CACHE", cache)
+    monkeypatch.setattr(ent, "_LICENSE_PATH", str(tmp_path / "nope.key"))
+    monkeypatch.delenv("CLAWMETRY_HARD_BLOCK", raising=False)
+
+    past_iso = "2026-08-13T08:44:45.286492Z"
+    s._persist_cloud_plan_to_disk("trial_expired", None,
+                                  trial_end=past_iso, trial_used=True)
+    assert os.path.isfile(cache), "cache must be written, not deleted"
+    written = json.load(open(cache))
+    assert written["plan"] == "cloud_free"
+    assert written["trial_used"] is True
+    assert written["expiry"] is not None
+
+    ent.invalidate()
+    e = ent.get_entitlement(force=True)
+    assert te.is_hard_blocked(e, path="/api/sessions") is True
+    assert e.allows_runtime("claude_code") is False
+
+
+def test_persist_does_not_expire_a_paid_plan_from_trial_end(monkeypatch, tmp_path):
+    """Same path, paid tier: the trial_end must not become the expiry."""
+    import clawmetry.sync as s
+    from clawmetry import entitlements as ent, trial_enforcement as te
+    cache = str(tmp_path / ".clawmetry" / "cloud_plan.json")
+    monkeypatch.setattr(s, "_CLOUD_PLAN_CACHE_PATH", cache)
+    monkeypatch.setattr(ent, "_CLOUD_PLAN_CACHE", cache)
+    monkeypatch.setattr(ent, "_LICENSE_PATH", str(tmp_path / "nope.key"))
+    monkeypatch.delenv("CLAWMETRY_HARD_BLOCK", raising=False)
+
+    s._persist_cloud_plan_to_disk("pro", None,
+                                  trial_end="2026-08-13T08:44:45Z", trial_used=True)
+    written = json.load(open(cache))
+    assert written["plan"] == "cloud_pro"
+    assert written["expiry"] is None, \
+        "a paid plan must not inherit the trial_end as its expiry"
+
+    ent.invalidate()
+    e = ent.get_entitlement(force=True)
+    assert te.is_hard_blocked(e, path="/api/sessions") is False


### PR DESCRIPTION
## Why

The trial paywall has been complete, default-ON, and **firing for nobody**.

Verified against prod: account `vivek+localtest@` has `users.trial_used=t` and `trial_end=2026-08-13`, yet its node was still ingesting and pushing 10 paid runtimes to cloud two days later. 79 cloud session rows, none of them openclaw/nemoclaw.

Root cause is a missing signal, not a missing gate. The cloud only sends `plan="free"` once a trial lapses, which is byte-identical to what a fresh `pip install` sends. `_resolver_says_unpaid_or_expired` correctly refuses to block plain `cloud_free` (that carve-out is the 2026-08-06 fix that stopped us hard-blocking every new install), so with no way to tell "burnt trial" from "never trialed" it declined to block either. `Entitlement.expired` was False for the same reason, which also left the sync-side runtime gate permanently open.

## What

1. **Arm the paywall.** Plumb `users.trial_end` / `users.trial_used` through the heartbeat into `cloud_plan.json` and teach the resolver that `trial_used` + a past expiry means lapsed. Setting expiry from `trial_end` also arms the existing ingest gate for free: `expired` flips True, `allows_runtime()` stops returning the grace-mode True, and paid adapters stop being read at all.

2. **Never expire a paid plan from its trial_end.** Signup is trial-by-default, so **every paying customer carries `trial_used=True` with a long-past `trial_end`**. Stamping that as their expiry hard-blocked live subscribers. Caught by checking the real prod population before shipping, not by any test.

3. **Map `trial_expired`.** `_effective_plan` returns it for the lapsed majority; it was absent from `_HEARTBEAT_PLAN_TO_TIER`, so the daemon deleted `cloud_plan.json` and threw the verdict away. Without this the paywall would arm for 40 accounts and miss the 2,378 it exists for.

4. **Remove clawmetry-pro on lapse, don't just gate it.** The closed wheel sitting in site-packages is importable by hand. `deprovision_pro()` sweeps both install locations, purges `sys.modules` so the running daemon stops immediately, and clears the marker. `should_deprovision_pro()` fails OPEN on every uncertainty.

5. **Pay from inside the dashboard.** The overlay's CTA posted to `/api/billing/checkout-session`, which does not exist in the cloud. It 404'd, a bare `except` swallowed it, and every user fell through to the generic upgrade page. Adds the plan picker (Monthly/Annual x Starter/Pro) and sends the selection. Cloud endpoint in the paired cloud PR.

## The population this touches

| plan | trial_used | trial_end | count | behaviour |
|---|---|---|---|---|
| free | f | null | 3,439 | never blocked |
| trial | t | past | 2,378 | blocked |
| trial | t | future | 351 | never blocked |
| free | t | past | 40 | blocked |
| cloud_pro | f | null | 21 | never blocked |
| cloud_pro | t | past | 5 | **never blocked** |

## Verified

- 6 entitlement scenarios + 9 blast-radius guards + 12 deprovision guards, all revert-proved (red on un-fixed code, green on fixed).
- Real blocked instance in an isolated HOME: `/api/sessions` 402s, allowlist intact, and after "continue free" openclaw serves 200 while claude_code stays 402.
- Overlay rendered and driven headless: Annual/Starter default, Monthly+Pro repaints $90/node/year to $19/node/month, device note hides on monthly.
- `test_trial_hard_block.py::test_non_allowlisted_returns_402_with_correct_body` has been **red on main since 2026-08-06** (it asserted an empty HOME must 402, exactly what the fix stopped doing). Now tests a lapsed trial, which is what should block, plus a new guard pinning that fresh installs are never blocked.

## Rollout note

`_sync_auto_update_with_plan` only enables auto-update for entitled plans, so lapsed-trial nodes will not pull this wheel automatically. The paywall reaches them as they upgrade by hand, over weeks rather than at once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
