### PR TITLE
fix: add missing typing.Any import and narrow bare except in sync.py

### DIFF
--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -26,6 +26,7 @@ import uuid
 from pathlib import Path
 from datetime import datetime, timezone
 from itertools import islice
+from typing import Any
 
 # Leaf module (typing-only deps) — safe to import at package load, no cycle.
 from clawmetry import error_signal as _error_signal
@@ -16101,7 +16102,7 @@ def _build_tool_stats():
                                     if isinstance(args, str):
                                         try:
                                             args = json.loads(args)
-                                        except:
+                                        except (json.JSONDecodeError, TypeError):
                                             args = {}
 
                                     # Track recent entries for specific tools


### PR DESCRIPTION
## Summary

Two small correctness fixes in `clawmetry/sync.py`:

1. **Missing `Any` import** — `_norm_ts(v: Any)` references `typing.Any`, which is never imported in this module. It doesn't crash at runtime because the file uses `from __future__ import annotations`, but it breaks `typing.get_type_hints()` on this module and trips static analyzers (ruff F821).

2. **Bare `except:` narrowed** — the `json.loads(args)` fallback used a bare `except:`, which also swallows `KeyboardInterrupt`/`SystemExit`. Narrowed to the exceptions `json.loads` can actually raise:

```python
# Before
try:
    args = json.loads(args)
except:
    args = {}

# After
try:
    args = json.loads(args)
except (json.JSONDecodeError, TypeError):
    args = {}
```

## Testing
No behavior change for valid inputs — `python -m py_compile` and `ruff check --select F821,E722` pass on the patched file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)