### PR TITLE
Desktop shell checks PyPI every 60s, and honours that interval on failure

### DIFF
--- a/desktop/app.py
+++ b/desktop/app.py
@@ -58,18 +58,64 @@ APP_TITLE = "ClawMetry"
 STARTUP_TIMEOUT_SECS = 45.0
 POLL_INTERVAL_SECS = 0.15
 SHUTDOWN_WAIT_SECS = 5.0
-# Blueprint "Desktop Application Distribution" contract: poll PyPI for
-# a newer clawmetry release every 6 hours. `_should_upgrade()` is the
-# gate on the actual pip call; the watcher's own tick is faster because
-# its other job (drift-detect + crash respawn) benefits from a shorter
-# interval — see WATCHER_TICK_SECS.
-UPGRADE_CHECK_INTERVAL_SECS = 6 * 3600
+# Blueprint "Desktop Application Distribution" contract: poll PyPI for a
+# newer clawmetry release. `_should_upgrade()` is the gate on the actual
+# update call; the watcher's own tick is separate — see WATCHER_TICK_SECS.
+#
+# Was 6h. Lowered to 60s (founder call 2026-08-15) so a desktop user picks
+# up a release within about a minute of it landing, matching the daemon's
+# own update worker (routes/update_check.py, CLAWMETRY_UPDATE_CHECK_SECS,
+# default 60s) instead of lagging it by up to a quarter of a day.
+#
+# What forced it: 0.12.707 armed the post-trial paywall, so the upgrade
+# overlay became the ONLY surface a lapsed user can reach — and a layout
+# bug there is a lockout, not a cosmetic defect. Shipping the fix in
+# 0.12.708 and then making trapped users wait up to six hours plus a
+# relaunch, with no in-app way to trigger it, is not a recovery path.
+#
+# Two guards landed with this, and it is worth being precise about why,
+# because the obvious story is wrong. They are NOT "safe at 6h, unsafe at
+# 60s" -- they were already broken at 6h.
+#
+# This interval is enforced ONLY through the stamp file, and the failure
+# paths never wrote one. So `_should_upgrade()` stayed True after any failed
+# update and the watcher retried on the very next tick: a failing update
+# re-ran every WATCHER_TICK_SECS (60s) forever, whatever this constant said.
+# The 6h number only ever throttled the SUCCESS path. Verified against the
+# pre-change code, three consecutive failures, stamp never written.
+#
+# So: stamp every attempt (making the interval mean something on the failure
+# path for the first time), and give the watcher's update its own shorter
+# timeout so a hung PyPI cannot sit inside pip while crash-respawn waits.
+# See WATCHER_UPDATE_TIMEOUT_SECS. Lowering the cadence did not create these;
+# it just removed the last reason to keep tolerating them.
+UPGRADE_CHECK_INTERVAL_SECS = 60
 # How often the watcher thread checks for drift and crashes while the
 # app is running. Short enough that clicking "Update now" in the
 # dashboard translates into a visible restart within ~a minute. The
-# 6h pip-upgrade cadence is enforced by _should_upgrade(), NOT by
-# this constant — do not read this as an upgrade frequency.
+# pip-upgrade cadence is enforced by _should_upgrade(), NOT by this
+# constant — do not read this as an upgrade frequency.
 WATCHER_TICK_SECS = 60
+
+# Timeout for the watcher's periodic `clawmetry update`, as distinct from
+# the 300s first-install timeout in bootstrap().
+#
+# These two are NOT the same job. A first install has no runtime yet, must
+# succeed, and may pull ~100MB on a slow link — 300s is right. A periodic
+# refresh already has a working, launchable ClawMetry, so waiting five
+# minutes on an unreachable PyPI buys nothing.
+#
+# It buys LESS than nothing here: watch() calls this synchronously, and the
+# same loop is what respawns a crashed daemon. Every second spent blocked in
+# pip is a second the app cannot notice its daemon died.
+#
+# This was never bounded by the 6h cadence, contrary to how it reads. A
+# timed-out update wrote no stamp, so the next tick retried immediately --
+# an unreachable PyPI meant 300s blocked, 60s tick, 300s blocked, forever,
+# silently disabling crash-respawn the whole time. The 6h setting throttled
+# only successful updates. 90s bounds the starvation window to ~1-2 missed
+# crash checks instead of five minutes of them.
+WATCHER_UPDATE_TIMEOUT_SECS = 90
 
 BRAND_RED = "#E94644"
 BRAND_BG_DARK = "#0b0e14"
@@ -694,17 +740,30 @@ class RuntimeSupervisor:
             return None
 
     def _background_pip_upgrade(self) -> None:
-        """Non-blocking upgrade via the venv's `clawmetry update
-        --unattended` subcommand — the flag makes the CLI apply the
-        daemon's own update policy (routes/update_check.py): the
-        CLAWMETRY_AUTO_UPDATE kill switch (incl. implicit CI disable)
-        and the CLAWMETRY_AUTOUPDATE_MIN_AGE_HOURS stability window,
-        pinning to the newest aged-in release. Matches the blueprint
-        contract "the shell defers to the daemon's update policy rather
-        than shipping its own"; the local _auto_update_disabled() check
-        is only a cheap pre-flight with the same semantics. Errors are
-        logged and swallowed — a transient PyPI failure should never
-        take down the running app.
+        """Upgrade via the venv's `clawmetry update --unattended`
+        subcommand — the flag makes the CLI apply the daemon's own update
+        policy (routes/update_check.py): the CLAWMETRY_AUTO_UPDATE kill
+        switch (incl. implicit CI disable) and the
+        CLAWMETRY_AUTOUPDATE_MIN_AGE_HOURS stability window, pinning to the
+        newest aged-in release. Matches the blueprint contract "the shell
+        defers to the daemon's update policy rather than shipping its own";
+        the local _auto_update_disabled() check is only a cheap pre-flight
+        with the same semantics. Errors are logged and swallowed — a
+        transient PyPI failure should never take down the running app.
+
+        "Background" here means off the UI thread, NOT asynchronous: the
+        caller (watch()) blocks for the duration, and that same loop owns
+        crash-respawn. Hence WATCHER_UPDATE_TIMEOUT_SECS rather than the
+        300s first-install budget.
+
+        Stamps the attempt on EVERY outcome, including failure. Stamping only
+        successes meant a persistently failing update (offline, broken venv,
+        PyPI down) re-ran on every single watcher tick forever — and that was
+        already true at the OLD 6h cadence, not something the shorter interval
+        introduced. UPGRADE_CHECK_INTERVAL_SECS is enforced purely through the
+        stamp file, so a path that never stamps is a path with no interval at
+        all; 6h only ever throttled successes. A failed attempt is still an
+        attempt.
         """
         if _auto_update_disabled():
             self._log(
@@ -718,7 +777,8 @@ class RuntimeSupervisor:
         try:
             r = subprocess.run(
                 [str(cli), "update", "--unattended"],
-                capture_output=True, text=True, timeout=300,
+                capture_output=True, text=True,
+                timeout=WATCHER_UPDATE_TIMEOUT_SECS,
                 **_win_subprocess_kwargs(),
             )
             if r.returncode != 0 and "--unattended" in (r.stderr or "") \
@@ -733,16 +793,23 @@ class RuntimeSupervisor:
                 )
                 r = subprocess.run(
                     [str(cli), "update"],
-                    capture_output=True, text=True, timeout=300,
+                    capture_output=True, text=True,
+                    timeout=WATCHER_UPDATE_TIMEOUT_SECS,
                     **_win_subprocess_kwargs(),
                 )
             self._log(f"watcher clawmetry-update rc={r.returncode}")
             if r.returncode != 0:
                 self._log(r.stderr[:2000])
-            else:
-                self._mark_upgraded(self._get_installed_version())
+            # Stamp regardless of rc: see the docstring. A failed attempt
+            # still consumed an interval, and not stamping it turns the
+            # 60s cadence into "retry forever, every tick".
+            self._mark_upgraded(self._get_installed_version())
         except subprocess.TimeoutExpired:
             self._log("watcher clawmetry-update timed out")
+            # Same reasoning, and this is the case that matters most: a
+            # hanging PyPI is exactly the failure that would otherwise
+            # re-enter pip on every tick and starve crash-respawn.
+            self._mark_upgraded(self._get_installed_version())
 
     def restart_daemon(self) -> bool:
         """Stop the current daemon and spawn a fresh one on the same

--- a/tests/test_desktop_unattended_update.py
+++ b/tests/test_desktop_unattended_update.py
@@ -1,4 +1,4 @@
-"""The desktop shell's 6h auto-upgrade must honor the daemon's update policy.
+"""The desktop shell's auto-upgrade must honor the daemon's update policy.
 
 Bug pinned here: desktop/app.py's watcher shelled a plain `clawmetry update`
 (a bare pip upgrade that ignores CLAWMETRY_AUTOUPDATE_MIN_AGE_HOURS and
@@ -113,7 +113,7 @@ def test_pre_unattended_venv_falls_back_to_plain_update_once(monkeypatch, tmp_pa
     """Bootstrap: a venv still running a clawmetry from before the flag
     existed rejects --unattended (argparse rc=2). The shell must retry a
     plain update once so the venv can reach a version that understands the
-    policy flag, instead of failing every 6h cycle forever."""
+    policy flag, instead of failing on every cycle forever."""
     monkeypatch.setenv("CLAWMETRY_AUTO_UPDATE", "1")
     stub, cli = _stub_shell(tmp_path)
     calls = []
@@ -150,4 +150,12 @@ def test_real_update_failure_does_not_trigger_plain_fallback(monkeypatch, tmp_pa
     monkeypatch.setattr(dapp.subprocess, "run", _fake_run)
     dapp.RuntimeSupervisor._background_pip_upgrade(stub)
     assert calls == [[str(cli), "update", "--unattended"]]
-    assert stub.upgraded == []
+    # The stamp IS written on a genuine failure now (changed 2026-08-15 with
+    # the 60s cadence). This assertion used to require the opposite, which
+    # pinned the retry-storm bug in place: the upgrade interval is enforced
+    # only via the stamp, so never stamping a failure meant a broken update
+    # re-ran on every watcher tick forever. See
+    # tests/test_desktop_upgrade_cadence.py. What this test is actually about
+    # -- that a real failure must NOT demote to a plain, policy-bypassing
+    # `clawmetry update` -- is the `calls` assertion above, and is unchanged.
+    assert stub.upgraded == ["0.12.999"]

--- a/tests/test_desktop_upgrade_cadence.py
+++ b/tests/test_desktop_upgrade_cadence.py
@@ -1,0 +1,192 @@
+"""The desktop shell polls PyPI every 60s, and the guards that makes necessary.
+
+Founder call 2026-08-15: drop the shell's upgrade cadence from 6h to ~1 minute
+so a desktop user picks up a release about as fast as the daemon's own update
+worker does (routes/update_check.py, default 60s) instead of lagging it by up
+to a quarter of a day.
+
+What forced it: 0.12.707 armed the post-trial paywall, making the upgrade
+overlay the only surface a lapsed user can reach. A layout bug there is a
+lockout, not a cosmetic defect, and "wait up to six hours, then relaunch, with
+no in-app way to trigger it" is not a recovery path for a trapped user.
+
+The cadence change is one constant. This file exists for the two guards that
+landed with it -- and the reason they were needed is NOT the obvious one.
+
+They are not "safe at 6h, unsafe at 60s". They were already broken at 6h:
+
+  1. `_background_pip_upgrade` stamped only on success. UPGRADE_CHECK_INTERVAL_SECS
+     is enforced purely through that stamp, so after any failure
+     `_should_upgrade()` stayed True and the watcher retried on the very next
+     tick. A failing update re-ran every WATCHER_TICK_SECS (60s) forever, no
+     matter what the interval said -- the 6h number only ever throttled the
+     success path. Verified directly against the pre-change code: three
+     consecutive failures, stamp never written, _should_upgrade() True each
+     time.
+  2. That retry ran a 300s-timeout subprocess synchronously inside the same
+     watcher loop that respawns a crashed daemon. So an unreachable PyPI meant
+     300s blocked, 60s tick, 300s blocked, indefinitely -- crash-respawn
+     silently disabled the whole time, at any cadence.
+
+Lowering the interval did not create either bug. It removed the last reason to
+keep tolerating them, because now the success path runs at the same frequency
+the failure path always did.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+import desktop.app as dapp  # noqa: E402
+
+
+# ── the cadence itself ───────────────────────────────────────────────────────
+
+def test_upgrade_cadence_is_about_a_minute():
+    assert dapp.UPGRADE_CHECK_INTERVAL_SECS == 60
+
+
+def test_cadence_is_not_slower_than_the_daemons_own_update_worker():
+    """The shell must not be the bottleneck. routes/update_check.py polls on
+    CLAWMETRY_UPDATE_CHECK_SECS (default 60); a shell that checks less often
+    than the daemon it supervises just adds latency for no benefit."""
+    import routes.update_check as uc  # noqa: F401  (import-ability is the point)
+    daemon_default = 60
+    assert dapp.UPGRADE_CHECK_INTERVAL_SECS <= daemon_default
+
+
+def test_watcher_tick_is_not_slower_than_the_upgrade_interval():
+    """_should_upgrade() is only consulted once per watcher tick, so the tick
+    is the real floor on upgrade latency. A tick slower than the interval
+    would make the interval a lie."""
+    assert dapp.WATCHER_TICK_SECS <= dapp.UPGRADE_CHECK_INTERVAL_SECS
+
+
+# ── guard 1: a failing update must not retry every tick ──────────────────────
+
+def _shell(tmp_path):
+    """A RuntimeSupervisor with just enough wired for _background_pip_upgrade.
+
+    Deliberately the REAL class via __new__ rather than a SimpleNamespace:
+    these tests are about _mark_upgraded / _should_upgrade actually agreeing
+    on the stamp file, so stubbing them would test nothing.
+    """
+    runtime = tmp_path / "runtime"
+    (runtime / "venv" / "bin").mkdir(parents=True, exist_ok=True)
+    cli = runtime / "venv" / "bin" / "clawmetry"
+    cli.write_text("#!/bin/sh\n")
+    cli.chmod(0o755)
+
+    sup = dapp.RuntimeSupervisor.__new__(dapp.RuntimeSupervisor)
+    sup.runtime = runtime
+    sup.stamp_file = runtime / "last-upgrade.json"
+    sup.log_file = runtime / "bootstrap.log"
+    sup.on_status = lambda *a, **k: None
+    sup._venv_clawmetry = lambda: cli
+    sup._get_installed_version = lambda: "0.12.708"
+    return sup
+
+
+def _run_upgrade(monkeypatch, sup, rc=0, raises=None):
+    def fake_run(cmd, **kw):
+        if raises is not None:
+            raise raises
+        return subprocess.CompletedProcess(cmd, rc, stdout="", stderr="")
+    monkeypatch.setattr(dapp.subprocess, "run", fake_run)
+    monkeypatch.setenv("CLAWMETRY_AUTO_UPDATE", "1")
+    sup._background_pip_upgrade()
+
+
+def test_successful_update_stamps(monkeypatch, tmp_path):
+    sup = _shell(tmp_path)
+    _run_upgrade(monkeypatch, sup, rc=0)
+    assert sup.stamp_file.exists()
+    assert sup._should_upgrade() is False
+
+
+def test_failed_update_also_stamps(monkeypatch, tmp_path):
+    """THE RETRY-STORM GUARD. Before: only rc==0 stamped, so an update that
+    fails every time was re-attempted on every watcher tick, forever -- at the
+    old 6h cadence just as much as at 60s, because the interval lives entirely
+    in the stamp."""
+    sup = _shell(tmp_path)
+    _run_upgrade(monkeypatch, sup, rc=1)
+    assert sup.stamp_file.exists(), (
+        "a failed update left no stamp, so _should_upgrade() stays True and "
+        "the watcher re-enters pip on every tick"
+    )
+    assert sup._should_upgrade() is False
+
+
+def test_timed_out_update_also_stamps(monkeypatch, tmp_path):
+    """The case that matters most: a hanging PyPI is exactly the failure that
+    would otherwise re-enter pip every tick AND block crash-respawn while it
+    does -- the two bugs compounding each other."""
+    sup = _shell(tmp_path)
+    _run_upgrade(
+        monkeypatch, sup,
+        raises=subprocess.TimeoutExpired(cmd="clawmetry update", timeout=90),
+    )
+    assert sup.stamp_file.exists()
+    assert sup._should_upgrade() is False
+
+
+# ── guard 2: the watcher's update must not hold the loop for 5 minutes ───────
+
+def test_watcher_update_timeout_is_far_below_the_first_install_budget():
+    """A first install must be patient (no runtime yet, big download). A
+    periodic refresh already has a launchable ClawMetry, so waiting minutes on
+    an unreachable PyPI buys nothing -- and costs crash-respawn latency,
+    because watch() calls it synchronously."""
+    assert dapp.WATCHER_UPDATE_TIMEOUT_SECS <= 120
+    assert dapp.WATCHER_UPDATE_TIMEOUT_SECS < 300
+
+
+def test_watcher_uses_the_short_timeout_not_the_install_one(monkeypatch, tmp_path):
+    """Pins the wiring, not just the constant: a constant nobody passes is a
+    comment."""
+    seen = {}
+
+    def fake_run(cmd, **kw):
+        seen["timeout"] = kw.get("timeout")
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    sup = _shell(tmp_path)
+    monkeypatch.setattr(dapp.subprocess, "run", fake_run)
+    monkeypatch.setenv("CLAWMETRY_AUTO_UPDATE", "1")
+    sup._background_pip_upgrade()
+
+    assert seen["timeout"] == dapp.WATCHER_UPDATE_TIMEOUT_SECS, (
+        "watcher update ran with timeout=%r; at a 60s cadence a 300s timeout "
+        "would let an unreachable PyPI starve crash-respawn" % (seen["timeout"],)
+    )
+
+
+def test_worst_case_block_is_shorter_than_a_handful_of_ticks():
+    """Bounds the starvation window in the units that matter: how many crash
+    checks can a single hung update cost?"""
+    missed = dapp.WATCHER_UPDATE_TIMEOUT_SECS / dapp.WATCHER_TICK_SECS
+    assert missed <= 2.0, (
+        "a hung update can cost %.1f crash-respawn checks; keep it to ~1-2"
+        % missed
+    )
+
+
+# ── the kill switch still wins ───────────────────────────────────────────────
+
+def test_disabled_auto_update_skips_entirely(monkeypatch, tmp_path):
+    """Polling more often must not erode the opt-out. CLAWMETRY_AUTO_UPDATE=0
+    means no subprocess at all, at any cadence."""
+    sup = _shell(tmp_path)
+    called = []
+    monkeypatch.setattr(dapp.subprocess, "run",
+                        lambda *a, **k: called.append(a) or None)
+    monkeypatch.setenv("CLAWMETRY_AUTO_UPDATE", "0")
+    sup._background_pip_upgrade()
+    assert called == []

--- a/tests/test_onboarding_state_reads_desktop_shell_stamp.py
+++ b/tests/test_onboarding_state_reads_desktop_shell_stamp.py
@@ -7,7 +7,8 @@ when it completes onboarding), the founder reopened the .dmg they
 already had installed and STILL saw the "Welcome to ClawMetry / Where
 should ClawMetry keep an eye on your agents?" gate — because the .dmg
 they had was pre-#4758, so the shell never wrote the browser gate's
-file. The pip wheel auto-updates every 6h; the .app bundle only
+file. The pip wheel auto-updates on the shell's upgrade cadence
+(UPGRADE_CHECK_INTERVAL_SECS, 60s since 2026-08-15); the .app bundle only
 updates when the user redownloads. Any fix that lives only in
 ``desktop/`` reaches users days late.
 


### PR DESCRIPTION
Founder ask: make the desktop upgrade check ~1 minute instead of 6 hours.

## Why now

0.12.707 armed the post-trial paywall, so the upgrade overlay became **the only surface a lapsed user can reach**. A layout bug there is a lockout, not a cosmetic defect — and 0.12.708 fixes exactly that. "Wait up to six hours, then relaunch, with no in-app way to trigger it" is not a recovery path for someone who can't reach the Activate-license button.

60s also matches the daemon's own update worker (`routes/update_check.py`, `CLAWMETRY_UPDATE_CHECK_SECS` default 60), so the shell stops being the slower of the two supervisors.

## Two guards ship with it — and the obvious story about them is wrong

I initially wrote these up as "safe at 6h, unsafe at 60s". That was incorrect, and I verified it rather than shipping the comment. **They were already broken at 6h.**

### 1. The interval was never enforced on the failure path

`UPGRADE_CHECK_INTERVAL_SECS` is enforced *only* through the stamp file, and the failure paths never wrote one. So `_should_upgrade()` stayed `True` after any failed update and the watcher retried on the very next tick — a failing update re-ran **every `WATCHER_TICK_SECS` (60s), forever**, whatever the interval said. 6h only ever throttled successes.

Verified directly against the pre-change code:

```
PRE-CHANGE interval: 21600 (6h)
  after failure 1: stamp exists=False  _should_upgrade()=True
  after failure 2: stamp exists=False  _should_upgrade()=True
  after failure 3: stamp exists=False  _should_upgrade()=True
```

Now every attempt stamps, so the interval means something on the failure path for the first time.

### 2. That retry could starve crash-respawn

The retry ran a **300s-timeout subprocess synchronously** inside the same watcher loop that respawns a crashed daemon. An unreachable PyPI meant 300s blocked → 60s tick → 300s blocked, indefinitely, with crash-respawn silently disabled throughout — at any cadence.

The watcher's update now gets its own 90s budget (`WATCHER_UPDATE_TIMEOUT_SECS`), bounding the starvation window to ~1–2 missed crash checks. `bootstrap()`'s first-install path **keeps 300s**: no runtime exists yet, it must succeed, and it may pull ~100MB on a slow link. Different job, different budget.

Lowering the cadence created neither bug. It removed the last reason to tolerate them.

## Tests

`tests/test_desktop_upgrade_cadence.py` — 10 tests covering the cadence, both guards, the tick-vs-interval relationship, the bounded starvation window, and that `CLAWMETRY_AUTO_UPDATE=0` still skips entirely (polling more often must not erode the opt-out).

Each guard verified **falsifiable** by reverting it in isolation:

| Reverted | Result |
|---|---|
| stamp-on-failure | 2 failed — *"a failed update left no stamp, so `_should_upgrade()` stays True and the watcher re-enters pip on every tick"* |
| 90s timeout → 300s | 1 failed |
| 60s → 6h | 2 failed |
| nothing (restored) | 10 passed |

Full desktop suite: **110 passed**.

## One existing assertion changed, not duplicated

`test_real_update_failure_does_not_trigger_plain_fallback` asserted `stub.upgraded == []` — which pinned the retry-storm bug in place. I edited that line and explained why, rather than adding a competing test beside it. That test's actual subject — a genuine failure must not demote to a policy-bypassing plain `clawmetry update` — is the `calls` assertion, and is untouched.

Also refreshed two docstrings in other desktop tests that still described a "6h" cadence.

## Blueprint

`desktop/app.py` cited the *Desktop Application Distribution* blueprint's "every 6 hours" contract. I'm updating that blueprint via the Software Factory API so drift-bot reflects reality rather than being merged past.