### PR TITLE
Home: name the sessions that are alive instead of guessing "idle"

### DIFF
--- a/clawmetry/static/css/dashboard.css
+++ b/clawmetry/static/css/dashboard.css
@@ -2555,3 +2555,71 @@ body.has-profile-menu #logout-btn { display: none !important; }
   height: 100vh !important; width: 100vw; max-height: 100vh;
   border-radius: 0 !important; border: none !important;
 }
+
+/* ── Overview hero: live session rows ──────────────────────────────────────
+   One row per session that is alive right now. The age column is deliberately
+   monospaced and right-aligned so "how long since each one moved" reads as a
+   single vertical scan rather than five separate facts. Rows are <button>s,
+   so they are keyboard reachable and announce as actionable. */
+.cm-live-row {
+  display: grid;
+  grid-template-columns: 10px minmax(0, 1fr) auto auto 14px;
+  align-items: center;
+  gap: 11px;
+  width: 100%;
+  padding: 9px 10px;
+  margin: 0 -10px;
+  border: none;
+  border-radius: 10px;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition: background 140ms ease;
+}
+.cm-live-row:hover { background: rgba(255, 255, 255, 0.045); }
+.cm-live-row:focus-visible {
+  outline: 2px solid #3b82f6;
+  outline-offset: 1px;
+  background: rgba(255, 255, 255, 0.045);
+}
+.cm-live-dot {
+  width: 9px; height: 9px; border-radius: 50%;
+  animation: cmLivePulse 2.4s ease-in-out infinite;
+}
+.cm-live-title {
+  font-size: 14.5px; font-weight: 500; color: var(--text-primary);
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.cm-live-rt {
+  font-size: 11px; color: var(--text-muted);
+  padding: 2px 8px; border-radius: 999px;
+  border: 1px solid var(--border-primary);
+  white-space: nowrap;
+}
+.cm-live-age {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11.5px; font-variant-numeric: tabular-nums;
+  color: var(--text-muted); text-align: right; min-width: 62px;
+  white-space: nowrap;
+}
+.cm-live-arrow {
+  color: var(--text-muted); font-size: 13px;
+  opacity: 0; transform: translateX(-3px);
+  transition: opacity 140ms ease, transform 140ms ease;
+}
+.cm-live-row:hover .cm-live-arrow,
+.cm-live-row:focus-visible .cm-live-arrow { opacity: 1; transform: translateX(0); }
+
+@keyframes cmLivePulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.35; } }
+
+@media (prefers-reduced-motion: reduce) {
+  .cm-live-dot { animation: none; }
+  .cm-live-row, .cm-live-arrow { transition: none; }
+}
+
+@media (max-width: 640px) {
+  .cm-live-row { grid-template-columns: 10px minmax(0, 1fr) auto; }
+  .cm-live-rt, .cm-live-arrow { display: none; }
+}

--- a/clawmetry/static/css/dashboard.css
+++ b/clawmetry/static/css/dashboard.css
@@ -2623,3 +2623,11 @@ body.has-profile-menu #logout-btn { display: none !important; }
   .cm-live-row { grid-template-columns: 10px minmax(0, 1fr) auto; }
   .cm-live-rt, .cm-live-arrow { display: none; }
 }
+
+/* Names the boundary between working and waiting rows. A dot colour alone
+   does not teach a first-timer what amber means. */
+.cm-live-group {
+  font-size: 11px; font-weight: 600; letter-spacing: 0.06em;
+  text-transform: uppercase; color: var(--text-muted);
+  padding: 12px 0 5px;
+}

--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -3782,6 +3782,108 @@ function _renderOutLoopSources() {
   }).catch(function(){});
 }
 
+// Status vocabulary. /api/subagents passes the daemon's own classification
+// through VERBATIM, so "in progress" arrives as either 'active' (the
+// age-derived buckets in routes/sessions.py) or 'running' (the daemon's or
+// the gateway registry's explicit label). Matching only the literal 'active'
+// is why 14 genuinely running sub-agents rendered as ✅ complete and the hero
+// said "idle" while five terminals worked (founder report 2026-08-15). Every
+// consumer goes through these helpers — never compare the raw string.
+function _cmIsWorkingStatus(s) {
+  s = String(s == null ? '' : s).trim().toLowerCase();
+  return s === 'active' || s === 'running';
+}
+function _cmIsLiveStatus(s) {
+  return _cmIsWorkingStatus(s) || String(s == null ? '' : s).trim().toLowerCase() === 'idle';
+}
+
+// ── Live sessions ─────────────────────────────────────────────────────────
+// The hero used to answer "is my agent alive?" with one node-wide boolean, so
+// a person driving five terminals read "It's idle right now" while all five
+// were mid-task. /api/live-sessions answers it by NAME instead: which sessions
+// are working, which are parked waiting for you, and how long since each moved.
+//
+// Perf (FLYWHEEL "performance is a feature"): ONE shared cache with a 10s TTL
+// and in-flight dedup, keyed by the runtime filter. The hero repaints far more
+// often than that (two 10s timers plus every subagent poll), and each repaint
+// must reuse the cache rather than issue its own fetch.
+var _CM_LIVE_TTL_MS = 10000;
+function _cmLoadLiveSessions(cb) {
+  var rt = (typeof _cmRuntimeFilter === 'function') ? _cmRuntimeFilter() : 'all';
+  var c = window._cmLive;
+  if (c && c.rt === rt && (Date.now() - c.ts) < _CM_LIVE_TTL_MS) { if (cb) cb(c); return; }
+  if (window._cmLiveWait) return;           // in-flight dedup
+  window._cmLiveWait = true;
+  var url = '/api/live-sessions' + (rt && rt !== 'all' ? '?runtime=' + encodeURIComponent(rt) : '');
+  fetchJsonWithTimeout(url, 6000).then(function (d) {
+    window._cmLive = {
+      rt: rt, ts: Date.now(),
+      sessions: (d && d.sessions) || [],
+      counts: (d && d.counts) || { working: 0, waiting: 0 },
+      // `available:false` means the daemon could not be reached — that is
+      // "we don't know", not "nothing is running", and the hero says so.
+      available: !(d && d.available === false)
+    };
+  }).catch(function () {
+    var old = window._cmLive || {};
+    window._cmLive = { rt: rt, ts: Date.now(), sessions: old.sessions || [],
+                       counts: old.counts || { working: 0, waiting: 0 }, available: false };
+  }).then(function () {
+    window._cmLiveWait = false;
+    if (cb) cb(window._cmLive);
+  });
+}
+
+// "4m" / "just now" — the age column reads as a live clock, so keep it terse
+// and monospaced at the call site.
+function _cmLiveAge(sec) {
+  if (sec == null) return '';
+  if (sec < 15) return 'just now';
+  if (sec < 60) return Math.round(sec) + 's ago';
+  return Math.round(sec / 60) + 'm ago';
+}
+
+// Jump straight from a live row into that session's transcript.
+function cmOpenLiveSession(sessionId) {
+  if (!sessionId) return;
+  if (typeof switchTab === 'function') switchTab('transcripts');
+  setTimeout(function () {
+    if (typeof viewTranscript === 'function') viewTranscript(sessionId);
+  }, 60);
+}
+
+// The signature element: one row per live session. State dot, the session's
+// own title (its name — the thing you actually recognise), the runtime it runs
+// on, and a right-aligned age column so "how long since each one moved" reads
+// as a single vertical scan. Rows are real buttons: keyboard reachable, with a
+// visible focus ring.
+function _cmLiveRowsHtml(live) {
+  var rows = (live && live.sessions) || [];
+  if (!rows.length) return '';
+  var SHOWN = 6;
+  var html = '<div style="margin:16px 0 4px;border-top:1px solid var(--border-primary);padding-top:14px;">';
+  rows.slice(0, SHOWN).forEach(function (s) {
+    var working = s.state === 'working';
+    var col = working ? '#22c55e' : '#f59e0b';
+    var title = (s.title || '').trim() || 'Untitled session';
+    var rtLabel = (typeof _cmRuntimeLabel === 'function' && _cmRuntimeLabel(s.runtime)) || s.runtime || '';
+    html += '<button type="button" class="cm-live-row" onclick="cmOpenLiveSession(' + attrJsStr(s.session_id) + ')"'
+      + ' title="Open this session\'s transcript">'
+      + '<span class="cm-live-dot" style="background:' + col + ';' + (working ? '' : 'animation:none;') + '"></span>'
+      + '<span class="cm-live-title">' + escHtml(title) + '</span>'
+      + '<span class="cm-live-rt">' + escHtml(rtLabel) + '</span>'
+      + '<span class="cm-live-age">' + escHtml(_cmLiveAge(s.age_seconds)) + '</span>'
+      + '<span class="cm-live-arrow">→</span>'
+      + '</button>';
+  });
+  if (rows.length > SHOWN) {
+    html += '<div style="font-size:12px;color:var(--text-muted);padding:8px 10px 2px;">'
+      + (rows.length - SHOWN) + ' more running. Open Sessions to see them all.</div>';
+  }
+  html += '</div>';
+  return html;
+}
+
 // Alive-state truthfulness: /api/subagents only lists SPAWNED children, so a
 // node whose main terminal sessions are hard at work read "It's idle right
 // now" (founder report 2026-08-02). Complement it with per-runtime recency
@@ -3834,8 +3936,42 @@ function _renderOverviewHero() {
       });
     }
   } catch (_e_act) {}
+
+  // Named liveness. This is the primary answer to "is my agent alive?" — the
+  // recency signal above is the fallback for when the session list is not
+  // available (cloud, or the daemon briefly unreachable).
+  var _live = window._cmLive;
+  var _liveRt = (typeof _cmRuntimeFilter === 'function') ? _cmRuntimeFilter() : 'all';
+  if (!_live || _live.rt !== _liveRt || (Date.now() - _live.ts) >= _CM_LIVE_TTL_MS) {
+    _cmLoadLiveSessions(function () { try { _renderOverviewHero(); } catch (e) {} });
+  }
+  var _working = (_live && _live.counts && _live.counts.working) || 0;
+  var _waiting = (_live && _live.counts && _live.counts.waiting) || 0;
+  var _liveKnown = !!(_live && _live.available);
+  if (_working > 0) busy = true;
+
+  // Headline. Say the number and let it carry the news; fall back to the old
+  // single-boolean sentence only when the session list can't be read.
+  var headline;
+  if (_liveKnown && _working > 0) {
+    headline = _working === 1
+      ? 'It’s working right now.'
+      : _working + ' sessions are working right now.';
+  } else if (_liveKnown && _waiting > 0) {
+    headline = _waiting === 1
+      ? 'One session is waiting on you.'
+      : _waiting + ' sessions are waiting on you.';
+  } else if (!_liveKnown && busy) {
+    headline = 'It’s working right now.';
+  } else if (!_liveKnown) {
+    headline = 'Nothing to report yet.';
+  } else {
+    headline = 'It’s idle right now.';
+  }
+
+  var _liveRows = _liveKnown ? _cmLiveRowsHtml(_live) : '';
   var stateWord = busy ? 'working' : 'idle';
-  var dot = busy ? '#22c55e' : '#3b82f6';
+  var dot = busy ? '#22c55e' : (_liveKnown && _waiting > 0 ? '#f59e0b' : '#3b82f6');
   // When a runtime is selected, the hero must mirror the (runtime-scoped) stat
   // cards, not the node-wide overview. _cmRuntimeScope is set by loadMiniWidgets
   // from the v1 API (FLYWHEEL §1c); null = node-wide. Note: prefer the scoped
@@ -3845,8 +3981,14 @@ function _renderOverviewHero() {
   var cost = _scope ? ('$' + _scope.cost.toFixed(2)) : (_txt('cost-today') || '$0.00');
   var model = _scope ? (_txt('model-primary') || _scope.model || '—')
                      : (ov.model || _txt('model-primary') || 'your model');
+  // Node-wide, the chip is labelled "today" below, so it must BE today:
+  // ov.sessionCount is an all-time count with no date predicate and read 89
+  // on a day that had 16. Fall back to the all-time number only on a daemon
+  // too old to send sessionsToday, where the label is dropped instead.
+  var _todayKnown = (typeof ov.sessionsToday === 'number');
   var sessions = _scope ? _scope.sessions
-                        : ((typeof ov.sessionCount === 'number') ? ov.sessionCount : null);
+                        : (_todayKnown ? ov.sessionsToday
+                           : ((typeof ov.sessionCount === 'number') ? ov.sessionCount : null));
   var free = cost === '$0.00' || cost === '$0' ||
              /oauth/i.test((document.getElementById('cost-trend') || {}).textContent || '');
   var say = window._cmLastAgentSay;
@@ -3862,7 +4004,7 @@ function _renderOverviewHero() {
   // (matches the switcher), so don't append "today" — the runtime may have 0
   // sessions today but N on record, and "N sessions today" would be wrong while
   // "0 sessions today" reads as gone. For all-runtimes it stays the live "today".
-  if (sessions != null) stats.push('💬 <strong style="color:var(--text-primary);">' + sessions + (sessions === 1 ? ' session' : ' sessions') + '</strong>' + (_scope ? '' : ' today'));
+  if (sessions != null) stats.push('💬 <strong style="color:var(--text-primary);">' + sessions + (sessions === 1 ? ' session' : ' sessions') + '</strong>' + ((!_scope && _todayKnown) ? ' today' : ''));
   stats.push('💸 <strong style="color:var(--text-primary);">' + escHtml(cost) + '</strong>' + (free ? ' <span style="color:#22c55e;">free on your plan</span>' : ''));
   // Efficiency chip (design spec §1a): grade next to cost answers "what did it
   // cost me, and is that reasonable?" in one read. Renders only when the
@@ -3906,9 +4048,15 @@ function _renderOverviewHero() {
       + '<span style="font-size:12px;font-weight:600;letter-spacing:.06em;text-transform:uppercase;color:var(--text-muted);">' + t('overview.hero_eyebrow', null, 'Your agent') + '</span>'
     + '</div>'
     + '<div style="font-family:Georgia,\'Times New Roman\',serif;font-size:32px;line-height:1.15;font-weight:600;color:var(--text-primary);margin:10px 0 4px;">'
-      + (busy ? 'It’s working right now.' : 'It’s idle right now.') + '</div>'
-    + '<div style="font-size:15px;color:var(--text-secondary);margin-bottom:18px;">' + lastLine + '</div>'
-    + '<div style="display:flex;flex-wrap:wrap;gap:8px 24px;align-items:baseline;font-size:15px;color:var(--text-secondary);">'
+      + headline + '</div>'
+    // When the named rows render they ARE the story; a second "last thing it
+    // did" line underneath just competes with them.
+    + (_liveRows
+        ? ''
+        : '<div style="font-size:15px;color:var(--text-secondary);margin-bottom:18px;">' + lastLine + '</div>')
+    + _liveRows
+    + '<div style="display:flex;flex-wrap:wrap;gap:8px 24px;align-items:baseline;font-size:15px;color:var(--text-secondary);'
+      + (_liveRows ? 'margin-top:16px;' : '') + '">'
       + stats.map(function (s) { return '<span>' + s + '</span>'; }).join('') + '</div>';
   hero.style.display = '';
 
@@ -4080,7 +4228,11 @@ async function loadMiniWidgets(overview, usage) {
   // and it briefly read "0" on a slow/failed fetch. Set synchronously from the
   // value already in hand so the card is never blank and never contradicts the
   // hero. (Card relabeled "Sessions today" in overview.html.)
-  document.getElementById('hot-sessions-count').textContent = overview.sessionCount || 0;
+  // Same honesty fix as the hero chip: the card is LABELLED "Sessions today",
+  // so it must carry today's count, not the all-time sessionCount.
+  document.getElementById('hot-sessions-count').textContent =
+    (typeof overview.sessionsToday === 'number' ? overview.sessionsToday
+                                                : overview.sessionCount) || 0;
 
   // 📈 Runtime scope — when a runtime is selected, the Overview stat cards
   // (sessions / tokens / cost / model) must show ONLY that runtime's data
@@ -4159,7 +4311,10 @@ async function loadMiniWidgets(overview, usage) {
   // switcher) so "today" would be wrong; node-wide stays the live "today".
   try {
     var _slbl = document.getElementById('hot-sessions-label');
-    if (_slbl) _slbl.textContent = window._cmRuntimeScope
+    // A daemon too old to send sessionsToday falls back to the all-time
+    // count, so drop the "today" from the label rather than lie in it.
+    var _ovToday = window._cmOverview && typeof window._cmOverview.sessionsToday === 'number';
+    if (_slbl) _slbl.textContent = (window._cmRuntimeScope || !_ovToday)
       ? t('overview.sessions', null, 'Sessions')
       : t('overview.sessions_today', null, 'Sessions today');
   } catch (e) {}
@@ -5449,10 +5604,10 @@ async function loadSubAgents() {
       previewHtml = '<div style="font-size:11px;color:#666;">No active tasks</div>';
     } else {
       // Show active ones first
-      var activeFirst = subagents.filter(function(a){return a.status==='active';}).concat(subagents.filter(function(a){return a.status!=='active';}));
+      var activeFirst = subagents.filter(function(a){return _cmIsWorkingStatus(a.status);}).concat(subagents.filter(function(a){return !_cmIsWorkingStatus(a.status);}));
       var topAgents = activeFirst.slice(0, 3);
       topAgents.forEach(function(agent) {
-        var icon = agent.status === 'active' ? '🔄' : agent.status === 'idle' ? '✅' : '⬜';
+        var icon = _cmIsWorkingStatus(agent.status) ? '🔄' : agent.status === 'idle' ? '✅' : '⬜';
         var name = cleanTaskName(agent.displayName);
         if (name.length > 40) name = name.substring(0, 37) + '…';
         previewHtml += '<div class="subagent-item">';
@@ -5550,7 +5705,7 @@ async function loadActiveTasks() {
     // Scope to the selected runtime (sub-agent sessionId prefix = runtime).
     var _atRt = (typeof _cmRuntimeFilter === 'function') ? _cmClientFilterRt(_cmRuntimeFilter()) : 'all';
     if (_atRt !== 'all') all = all.filter(function(a) { return _cmRuntimeOf(a) === _atRt; });
-    var live = all.filter(function(a) { return a.status === 'active' || a.status === 'idle'; });
+    var live = all.filter(function(a) { return _cmIsLiveStatus(a.status); });
     var recentFailed = all.filter(function(a) {
       return a.status === 'failed' && (now - (a.updatedAt || 0)) < RECENT_MS;
     });
@@ -5568,7 +5723,7 @@ async function loadActiveTasks() {
     var html = '';
     var badge = document.getElementById('overview-tasks-count-badge');
     if (badge) {
-      var liveCount = agents.filter(function(a) { return a.status === 'active' || a.status === 'idle'; }).length;
+      var liveCount = agents.filter(function(a) { return _cmIsLiveStatus(a.status); }).length;
       badge.textContent = liveCount > 0 ? (liveCount + ' active') : (agents.length + ' recent');
     }
 
@@ -5588,7 +5743,7 @@ async function loadActiveTasks() {
       var st = STATUS_STYLE[agent.status] || STATUS_STYLE.active;
 
       html += '<div class="task-card ' + st.cls + '" style="cursor:pointer;" onclick="openTaskModal(\'' + escHtml(agent.sessionId).replace(/'/g,"\\'") + '\',\'' + escHtml(taskName).replace(/'/g,"\\'") + '\',\'' + escHtml(agent.key || agent.sessionId).replace(/'/g,"\\'") + '\')">';
-      if (agent.status === 'active' || agent.status === 'idle') {
+      if (_cmIsLiveStatus(agent.status)) {
         html += '<div class="task-card-pulse active"></div>';
       }
       html += '<div class="task-card-header">';
@@ -11730,7 +11885,7 @@ async function loadSessions() {
     if (subagents.length > 0) {
       html += '<div style="margin-top:8px;margin-left:16px;border-left:2px solid var(--border-primary);padding-left:12px;">';
       subagents.forEach(function(sa) {
-        var statusIcon = sa.status === 'active' ? '🟢' : sa.status === 'idle' ? '🟡' : '⬜';
+        var statusIcon = _cmIsWorkingStatus(sa.status) ? '🟢' : sa.status === 'idle' ? '🟡' : '⬜';
         html += '<details style="margin-bottom:4px;">';
         html += '<summary style="cursor:pointer;font-size:13px;color:var(--text-secondary);padding:4px 0;">';
         html += statusIcon + ' <strong>' + escHtml(sa.displayName) + '</strong>';
@@ -11793,7 +11948,7 @@ async function loadSessions() {
       chainHtml += ' &bull; <span style="color:var(--text-success);">$' + chain.chain_cost_usd.toFixed(4) + '</span></span>';
       chainHtml += '</div>';
       chain.children.slice(0, 5).forEach(function(child, idx) {
-        var dot = child.status === 'active' ? '#16a34a' : child.status === 'idle' ? '#d97706' : '#6b7280';
+        var dot = _cmIsWorkingStatus(child.status) ? '#16a34a' : child.status === 'idle' ? '#d97706' : '#6b7280';
         chainHtml += '<div style="padding:6px 12px 6px 28px;display:flex;align-items:center;gap:8px;border-bottom:1px solid var(--border-secondary);font-size:12px;">';
         chainHtml += '<span style="width:7px;height:7px;border-radius:50%;background:' + dot + ';flex-shrink:0;"></span>';
         if (idx === 0) chainHtml += '<span style="color:var(--text-muted);font-size:10px;margin-right:-4px;">&#x2514;&#x2500;</span>';
@@ -14653,7 +14808,7 @@ async function loadSystemHealth() {
             chtml += '<span style="font-size:10px;color:var(--text-muted);white-space:nowrap;">' + chain.child_count + ' agents &bull; ' + chainTokStr + ' tok &bull; <span style="color:var(--text-success);">$' + chain.chain_cost_usd.toFixed(4) + '</span></span>';
             chtml += '</div>';
             chain.children.slice(0, 4).forEach(function(child) {
-              var dot = child.status === 'active' ? '#16a34a' : child.status === 'idle' ? '#d97706' : '#6b7280';
+              var dot = _cmIsWorkingStatus(child.status) ? '#16a34a' : child.status === 'idle' ? '#d97706' : '#6b7280';
               var tokStr = child.total_tokens >= 1000 ? (child.total_tokens/1000).toFixed(0)+'K' : child.total_tokens;
               chtml += '<div style="padding:4px 10px 4px 20px;display:flex;align-items:center;gap:6px;border-bottom:1px solid var(--border-secondary);font-size:11px;">';
               chtml += '<span style="width:6px;height:6px;border-radius:50%;background:' + dot + ';flex-shrink:0;"></span>';
@@ -18449,6 +18604,9 @@ async function loadSubagents() {
       }
     });
     function statusDot(status) {
+      // 'running' is the daemon's own word for the same state as 'active';
+      // without this normalise it fell through to the grey "stale" dot.
+      if (_cmIsWorkingStatus(status)) status = 'active';
       var colors = { active: '#16a34a', idle: '#d97706', stale: '#6b7280', failed: '#ef4444', paused: '#7c3aed' };
       var glow = status === 'active' ? 'box-shadow:0 0 6px rgba(22,163,74,0.6);'
                : status === 'failed' ? 'box-shadow:0 0 6px rgba(239,68,68,0.5);'
@@ -21594,7 +21752,7 @@ function _ovTimeLabel(agent) {
   var sec = Math.floor(ms / 1000);
   var min = Math.floor(sec / 60);
   var hr = Math.floor(min / 60);
-  if (agent.status === 'active') {
+  if (_cmIsWorkingStatus(agent.status)) {
     if (min < 1) return 'Running (' + sec + 's)';
     if (min < 60) return 'Running (' + min + ' min)';
     return 'Running (' + hr + 'h ' + (min % 60) + 'm)';
@@ -21619,7 +21777,7 @@ function _ovTimeLabel(agent) {
 
 function _ovRenderCard(agent, idx) {
   var isRealFailure = agent.status === 'stale' && agent.abortedLastRun && (agent.outputTokens || 0) === 0;
-  var sc = agent.status === 'active' ? 'running' : isRealFailure ? 'failed' : 'complete';
+  var sc = _cmIsWorkingStatus(agent.status) ? 'running' : isRealFailure ? 'failed' : 'complete';
   var taskName = cleanTaskName(agent.displayName);
   var badge = detectProjectBadge(agent.displayName);
   var timeLabel = _ovTimeLabel(agent);
@@ -21689,7 +21847,7 @@ async function loadOverviewTasks() {
     var running = [], done = [], failed = [];
     agents.forEach(function(a) {
       var isRealFailure = a.status === 'stale' && a.abortedLastRun && (a.outputTokens || 0) === 0;
-      if (a.status === 'active') running.push(a);
+      if (_cmIsWorkingStatus(a.status)) running.push(a);
       else if (isRealFailure) failed.push(a);
       else done.push(a);
     });
@@ -23544,7 +23702,7 @@ function loadToolData(toolKey, comp, isRefresh) {
     // ─── SESSION MODAL ─────────────────────────────────
     if (toolKey === 'session') {
       var agents = data.subagents || [];
-      var active = agents.filter(function(a){return a.status==='active';}).length;
+      var active = agents.filter(function(a){return _cmIsWorkingStatus(a.status);}).length;
       var idle = agents.filter(function(a){return a.status==='idle';}).length;
       var stale = agents.filter(function(a){return a.status==='stale';}).length;
 
@@ -23559,8 +23717,8 @@ function loadToolData(toolKey, comp, isRefresh) {
         html += '<div style="font-size:12px;font-weight:600;color:var(--text-muted);text-transform:uppercase;letter-spacing:1px;margin-bottom:8px;">Sub-Agents</div>';
         html += '<div style="display:flex;flex-direction:column;gap:6px;max-height:50vh;overflow-y:auto;">';
         agents.forEach(function(a) {
-          var dotColor = a.status==='active' ? '#22c55e' : a.status==='idle' ? '#f59e0b' : '#ef4444';
-          var dotShadow = a.status==='active' ? 'box-shadow:0 0 6px rgba(34,197,94,0.6);' : '';
+          var dotColor = _cmIsWorkingStatus(a.status) ? '#22c55e' : a.status==='idle' ? '#f59e0b' : '#ef4444';
+          var dotShadow = _cmIsWorkingStatus(a.status) ? 'box-shadow:0 0 6px rgba(34,197,94,0.6);' : '';
           html += '<div style="display:flex;align-items:flex-start;gap:10px;padding:10px 12px;background:var(--bg-secondary);border-radius:10px;border:1px solid var(--border-secondary);">';
           html += '<div style="width:10px;height:10px;border-radius:50%;background:'+dotColor+';margin-top:4px;flex-shrink:0;'+dotShadow+'"></div>';
           html += '<div style="flex:1;min-width:0;">';

--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -3862,8 +3862,20 @@ function _cmLiveRowsHtml(live) {
   if (!rows.length) return '';
   var SHOWN = 6;
   var html = '<div style="margin:16px 0 4px;border-top:1px solid var(--border-primary);padding-top:14px;">';
-  rows.slice(0, SHOWN).forEach(function (s) {
+  var shown = rows.slice(0, SHOWN);
+  var sawWaiting = false;
+  shown.forEach(function (s) {
     var working = s.state === 'working';
+    // A colour alone does not teach a first-timer what amber means, and the
+    // headline only ever names one of the two states. Label the boundary once,
+    // in words, the moment the quiet ones start (rows are sorted by age, so
+    // this fires exactly once).
+    if (!working && !sawWaiting) {
+      sawWaiting = true;
+      if (shown[0] && shown[0].state === 'working') {
+        html += '<div class="cm-live-group">Waiting on you</div>';
+      }
+    }
     var col = working ? '#22c55e' : '#f59e0b';
     var title = (s.title || '').trim() || 'Untitled session';
     var rtLabel = (typeof _cmRuntimeLabel === 'function' && _cmRuntimeLabel(s.runtime)) || s.runtime || '';
@@ -3878,7 +3890,7 @@ function _cmLiveRowsHtml(live) {
   });
   if (rows.length > SHOWN) {
     html += '<div style="font-size:12px;color:var(--text-muted);padding:8px 10px 2px;">'
-      + (rows.length - SHOWN) + ' more running. Open Sessions to see them all.</div>';
+      + (rows.length - SHOWN) + ' more. Open Sessions to see them all.</div>';
   }
   html += '</div>';
   return html;

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -11732,6 +11732,17 @@ def sync_session_metadata(config: dict, state: dict = None) -> int:
                 _sk = _sid_to_key.get(sid, "")
                 _sm = _sid_to_meta.get(sid, {})
                 _dn = label or _sm.get("subject") or _sk or sid[:8]
+                # OpenClaw is the one runtime that emits a REAL end signal:
+                # the transcript's ``type=="session"`` frame carries
+                # endReason/end_reason (parsed just above). Honour it — an
+                # explicit end always beats a recency guess. Without one, fall
+                # back to the same recency buckets the family runtimes use, so
+                # a live OpenClaw session stops reporting itself "completed"
+                # from its first turn.
+                if end_reason:
+                    _oc_status, _oc_ended = "completed", updated_at
+                else:
+                    _oc_status, _oc_ended = _session_liveness(updated_at)
                 batch.append(
                     {
                         "session_id": sid,
@@ -11739,7 +11750,8 @@ def sync_session_metadata(config: dict, state: dict = None) -> int:
                         "session_key": _sk,
                         "channel": _sm.get("provider", ""),
                         "chat_type": _sm.get("chatType", ""),
-                        "status": "completed",
+                        "status": _oc_status,
+                        "ended_at": _oc_ended,
                         "end_reason": end_reason,
                         "model": model,
                         "recent_model": last_seen_model or model,
@@ -12426,6 +12438,9 @@ def sync_vm_usage_log(config: dict, state: dict, paths: dict) -> int:
     try:
         store.ingest_many(rows)
         for ns_sess, meta in sessions.items():
+            # One call: evaluating liveness twice could straddle the 120s
+            # boundary and write a status that contradicts its own ended_at.
+            _vm_status, _vm_ended = _session_liveness(meta["last"])
             srow = {
                 "agent_type": "openclaw",
                 "session_id": ns_sess,
@@ -12434,8 +12449,9 @@ def sync_vm_usage_log(config: dict, state: dict, paths: dict) -> int:
                 "title": "Model usage (%s)" % runtime,
                 "started_at": meta["first"],
                 "last_active_at": meta["last"],
-                "ended_at": meta["last"],
-                "status": "ended",
+                # Liveness derived from the newest usage-log line, not assumed.
+                "ended_at": _vm_ended,
+                "status": _vm_status,
                 "total_tokens": int(meta["tokens"]),
                 "cost_usd": None,
                 "message_count": int(meta["n"]),
@@ -12574,6 +12590,61 @@ def _epoch_to_iso(epoch) -> str | None:
         return datetime.fromtimestamp(float(epoch), tz=timezone.utc).isoformat()
     except (ValueError, OSError, OverflowError, TypeError):
         return None
+
+
+# Session liveness buckets. Deliberately the SAME thresholds the subagent
+# reader already derives (routes/sessions.py ``_try_local_store_subagents``:
+# <120s active, <600s idle, else stale) so the two surfaces cannot disagree
+# about what "right now" means.
+_SESSION_ACTIVE_SECS = 120
+_SESSION_IDLE_SECS = 600
+
+
+def _session_liveness(last_activity_iso: str | None) -> tuple[str, str | None]:
+    """Return ``(status, ended_at)`` for a session whose newest event is at
+    ``last_activity_iso``.
+
+    Family runtimes (Claude Code, Codex, Cursor, Antigravity, ...) emit no
+    explicit "session ended" record — the only truth on disk is how long ago
+    the transcript last grew. Every family row used to be stamped
+    ``status="ended"`` with a non-null ``ended_at`` from its very first turn,
+    which made a live session indistinguishable from a dead one and broke
+    every downstream consumer that asks "what is running?":
+
+      * ``routes/overview.py`` ``activeSessions`` counts ``status == "active"``
+        and so reported 0 on a node with six terminals mid-task.
+      * The stuck-session and n-gram loop detectors skip any row carrying
+        ``ended_at``, so they have never fired for a paid runtime despite
+        the comment claiming they cover all of them.
+      * The Overview hero read "It's idle right now" while the agent worked.
+
+    A LIVE session has no end time, so ``ended_at`` comes back ``None`` — that
+    is what puts the row back in front of those consumers (the upsert assigns
+    ``ended_at = excluded.ended_at`` with no COALESCE, so existing poisoned
+    rows heal on the next ingest pass).
+
+    Unparseable or missing timestamps fall back to the historical
+    ``("ended", last_activity_iso)``: a bad clock must never be able to
+    resurrect a dead session.
+    """
+    if not last_activity_iso:
+        return ("ended", last_activity_iso)
+    try:
+        seen = datetime.fromisoformat(str(last_activity_iso).replace("Z", "+00:00"))
+        if seen.tzinfo is None:
+            seen = seen.replace(tzinfo=timezone.utc)
+        age = (datetime.now(timezone.utc) - seen).total_seconds()
+    except (ValueError, TypeError, OSError, OverflowError):
+        return ("ended", last_activity_iso)
+    # A future timestamp means a skewed clock, not a live session. Treat the
+    # skew as "just now" rather than trusting it or discarding the session.
+    if age < 0:
+        age = 0.0
+    if age < _SESSION_ACTIVE_SECS:
+        return ("active", None)
+    if age < _SESSION_IDLE_SECS:
+        return ("idle", None)
+    return ("ended", last_activity_iso)
 
 
 def _session_cost_intel(s) -> dict:
@@ -13042,6 +13113,10 @@ def sync_family_runtimes(config: dict, state: dict, paths: dict) -> int:
                 )
                 if _compactions:
                     metadata["compactionCount"] = _compactions
+                # Liveness: derived from how long ago the transcript last grew,
+                # never hardcoded. Computed once so the local row and the cloud
+                # row below cannot disagree about whether this session is live.
+                _fstatus, _fended = _session_liveness(ended or started)
                 # Local upsert (the sessions list reads this).
                 try:
                     store.ingest_session({
@@ -13052,8 +13127,8 @@ def sync_family_runtimes(config: dict, state: dict, paths: dict) -> int:
                         "title": _row_title,
                         "started_at": started,
                         "last_active_at": ended or started,
-                        "ended_at": ended,
-                        "status": "ended",
+                        "ended_at": _fended,
+                        "status": _fstatus,
                         "total_tokens": int(s.total_tokens or 0),
                         "cost_usd": s.cost_usd,
                         "message_count": int(s.message_count or 0),
@@ -13157,8 +13232,8 @@ def sync_family_runtimes(config: dict, state: dict, paths: dict) -> int:
                     "title": _ftitle,
                     "started_at": started,
                     "last_active_at": ended or started,
-                    "ended_at": ended,
-                    "status": "ended",
+                    "ended_at": _fended,
+                    "status": _fstatus,
                     "total_tokens": int(s.total_tokens or 0),
                     "cost_usd": s.cost_usd,
                     "message_count": int(s.message_count or 0),

--- a/routes/overview.py
+++ b/routes/overview.py
@@ -990,9 +990,18 @@ def _try_local_store_overview():
     user_sessions = [s for s in sessions if _is_user_main(s)]
     main = user_sessions[0] if user_sessions else sessions[0]
 
-    # Active = status=='active' (DuckDB persists status as a free-form string;
-    # 'active' is what sync.py writes for in-progress sessions).
-    active_count = sum(1 for s in sessions if s["status"] == "active")
+    # Active = a session whose transcript grew inside the active window
+    # (sync.py ``_session_liveness``). ``status`` is a free-form string in
+    # DuckDB and different producers spell "in progress" differently
+    # ('active' from the recency buckets, 'running' from the gateway
+    # registry), so match the whole live vocabulary rather than one literal —
+    # counting only 'active' is how this silently read 0 while six terminals
+    # were mid-task. Counted over user_sessions so sub-agents and ClawMetry's
+    # own plumbing sessions can't inflate it.
+    active_count = sum(
+        1 for s in user_sessions
+        if str(s.get("status") or "").strip().lower() in ("active", "running")
+    )
 
     # Model: prefer metadata.model on the main session; fall back to the most
     # recently observed model across events.
@@ -1081,6 +1090,29 @@ def _try_local_store_overview():
     # cloud snapshot's `sessionCount` (clawmetry/sync.py builds the same way).
     user_session_count = len(user_sessions) if user_sessions else len(sessions)
 
+    # `sessionCount` is an ALL-TIME count over the most-recent rows — it has no
+    # date predicate anywhere in its query. The hero rendered it as "N sessions
+    # today", which read 89 on a day that had 16 (founder report 2026-08-15).
+    # Ship the real number rather than dropping the word: "today" next to
+    # today's cost is the comparison a person actually wants. Local calendar
+    # day, because "today" means the user's day, not UTC's.
+    _today = datetime.now().astimezone().date()
+    sessions_today = 0
+    for _s in (user_sessions or sessions):
+        _st = _s.get("started_at") or ""
+        if not _st:
+            continue
+        try:
+            # NB: not `_d` — that name is the `import dashboard as _d` alias in
+            # this module and shadowing it 500s the whole endpoint.
+            _started = datetime.fromisoformat(str(_st).replace("Z", "+00:00"))
+            if _started.tzinfo is None:
+                _started = _started.replace(tzinfo=timezone.utc)
+            if _started.astimezone().date() == _today:
+                sessions_today += 1
+        except (ValueError, TypeError, OSError, OverflowError):
+            continue
+
     # `currentContextTokens` is the right "Context Window Usage" gauge —
     # the most recent assistant turn's live prompt size (input + cache),
     # filtered to exclude clawmetry-* plumbing sessions. `contextWindow`
@@ -1103,6 +1135,7 @@ def _try_local_store_overview():
         "model": model_name,
         "provider": _d._infer_provider_from_model(model_name),
         "sessionCount": user_session_count,
+        "sessionsToday": sessions_today,
         "sessions": user_session_count,  # alias for E2E compatibility
         "activeSessions": active_count,
         "mainSessionUpdated": main.get("last_active_at") or main.get("started_at"),

--- a/routes/sessions.py
+++ b/routes/sessions.py
@@ -333,6 +333,130 @@ def api_sessions():
     return jsonify({"sessions": sessions, "capped_at_24h": capped})
 
 
+# Liveness windows for /api/live-sessions. Mirrors sync.py's
+# ``_SESSION_ACTIVE_SECS`` / ``_SESSION_IDLE_SECS`` so the endpoint and the
+# ingest that feeds it can never disagree about what "right now" means.
+_LIVE_WORKING_SECS = 120
+_LIVE_WAITING_SECS = 600
+
+
+def _live_state(last_active_iso: str, status: str) -> tuple:
+    """Classify one session row into ``(state, age_seconds)``.
+
+    ``state`` is one of:
+      ``working`` — the transcript grew within the last two minutes.
+      ``waiting`` — quiet for under ten minutes; the session is open but the
+                    agent is not producing (usually parked at the prompt).
+      ``ended``   — quiet for longer, or explicitly ended by the runtime.
+
+    An explicit terminal status from the runtime always wins: OpenClaw and
+    Codex can actually assert "this session is over", and a real end signal
+    must never be overridden by a recency guess. Everything else is inferred
+    from silence, which is why the UI labels it as inference rather than fact.
+    """
+    st = str(status or "").strip().lower()
+    # Note the absence of "ended" from this list. Until every daemon in the
+    # fleet has the ``_session_liveness`` ingest fix, rows already in DuckDB
+    # carry the old hardcoded ``status="ended"`` — honouring that literal here
+    # would keep the panel empty on exactly the machines that need it most.
+    # Recency still classifies those rows correctly (a genuinely finished
+    # session is also a quiet one), and once the fix lands they arrive with a
+    # real status anyway. The words below are only ever written when a runtime
+    # ASSERTS an end (OpenClaw's endReason, a failed/aborted run).
+    if st in ("completed", "stopped", "failed", "aborted"):
+        return ("ended", None)
+    if not last_active_iso:
+        return ("ended", None)
+    try:
+        seen = datetime.fromisoformat(str(last_active_iso).replace("Z", "+00:00"))
+        if seen.tzinfo is None:
+            seen = seen.replace(tzinfo=timezone.utc)
+        age = (datetime.now(timezone.utc) - seen).total_seconds()
+    except (ValueError, TypeError, OSError, OverflowError):
+        return ("ended", None)
+    if age < 0:
+        age = 0.0
+    if age < _LIVE_WORKING_SECS:
+        return ("working", age)
+    if age < _LIVE_WAITING_SECS:
+        return ("waiting", age)
+    return ("ended", age)
+
+
+@bp_sessions.route("/api/live-sessions")
+def api_live_sessions():
+    """Which sessions are alive right now, by name, across every runtime.
+
+    The Overview used to answer this with a single node-wide boolean ("It's
+    idle right now") derived from the sub-agent registry — which lists spawned
+    children only, so a person driving five terminals saw "idle" while all
+    five were mid-task (founder report 2026-08-15).
+
+    Response::
+
+        {"sessions": [{session_id, runtime, title, state, age_seconds,
+                       model, cost_usd, message_count, last_active_at}],
+         "counts": {"working": N, "waiting": N},
+         "runtime": "<filter or 'all'>", "_source": "local_store"}
+
+    Ordered most-recently-active first and capped at 20 rows: this feeds a
+    glanceable panel, not a browsing surface (the Sessions tab is that).
+    ``?runtime=<id>`` scopes to one runtime per FLYWHEEL §1c; omitted or
+    ``all`` returns every runtime.
+    """
+    rt_filter = (request.args.get("runtime") or "").strip().lower()
+    if rt_filter in ("all", "undefined", "null"):
+        rt_filter = ""
+
+    rows = _fetch_sessions_table_rows(limit=200)
+    if rows is None:
+        # Honest degradation: the daemon is unreachable and we cannot open
+        # DuckDB. Say "unknown", never an empty list that reads as "nothing
+        # is running".
+        return jsonify({"sessions": [], "counts": {"working": 0, "waiting": 0},
+                        "runtime": rt_filter or "all", "available": False,
+                        "_source": "unavailable"})
+
+    live = []
+    for r in rows or []:
+        if not isinstance(r, dict):
+            continue
+        sid = r.get("session_id") or ""
+        if hide_clawmetry_session(sid):
+            continue
+        low = sid.lower()
+        if "subagent" in low or "sub-agent" in low:
+            continue  # sub-agents are shown under their parent, not as peers
+        meta = r.get("metadata") or {}
+        runtime = (meta.get("runtime") or "").strip() or "openclaw"
+        if rt_filter and runtime.lower() != rt_filter:
+            continue
+        last_active = r.get("last_active_at") or r.get("started_at") or ""
+        state, age = _live_state(last_active, r.get("status"))
+        if state == "ended":
+            continue
+        live.append({
+            "session_id":    sid,
+            "runtime":       runtime,
+            "title":         (r.get("title") or "").strip(),
+            "state":         state,
+            "age_seconds":   int(age) if age is not None else None,
+            "model":         meta.get("recent_model") or meta.get("model") or "",
+            "cost_usd":      round(float(r.get("cost_usd") or 0.0), 4),
+            "message_count": int(r.get("message_count") or 0),
+            "last_active_at": last_active,
+        })
+
+    live.sort(key=lambda s: s.get("age_seconds") if s.get("age_seconds") is not None else 1e9)
+    counts = {
+        "working": sum(1 for s in live if s["state"] == "working"),
+        "waiting": sum(1 for s in live if s["state"] == "waiting"),
+    }
+    return jsonify({"sessions": live[:20], "counts": counts,
+                    "runtime": rt_filter or "all", "available": True,
+                    "_source": "local_store"})
+
+
 def _filter_internal_sessions(rows: list) -> list:
     """Drop ClawMetry's own helper sessions (clawmetry-fix / -selfevolve /
     -mem-probe …) from a session-row list so our plumbing doesn't mix with the
@@ -2082,7 +2206,10 @@ def _try_local_store_subagents(_rows=None):
             "runId":            extra.get("runId") or "",
         })
 
-    _status_rank = {"active": 0, "idle": 1, "stale": 2, "failed": 3}
+    # "running" is the daemon's own word for "active"; without it the
+    # in-progress sub-agents sank to the bottom on rank 9 (the default).
+    _status_rank = {"active": 0, "running": 0, "idle": 1, "stale": 2,
+                    "failed": 3}
     subagents.sort(key=lambda x: (_status_rank.get(x["status"], 9), x["depth"]))
     return {
         "subagents": subagents,
@@ -2328,7 +2455,8 @@ def api_subagents():
         for _sa in subagents:
             if (_sa.get("key") or _sa.get("sessionId") or "") in _paused_agents:
                 _sa["status"] = "paused"
-    _status_rank = {"active": 0, "idle": 1, "stale": 2, "paused": 3, "failed": 4}
+    _status_rank = {"active": 0, "running": 0, "idle": 1, "stale": 2,
+                    "paused": 3, "failed": 4}
     subagents.sort(key=lambda x: (_status_rank.get(x["status"], 9), x["depth"]))
     payload = {"subagents": subagents, "counts": counts}
     if not full_scan:

--- a/tests/test_live_session_truth.py
+++ b/tests/test_live_session_truth.py
@@ -227,6 +227,17 @@ def test_js_hero_reads_named_live_sessions():
     assert "_cmLiveWait" in js and "_CM_LIVE_TTL_MS" in js
 
 
+def test_js_names_the_waiting_group():
+    """A dot colour alone does not teach a first-timer what amber means."""
+    js = open(APP_JS).read()
+    assert "cm-live-group" in js and "Waiting on you</div>" in js, (
+        "the working/waiting boundary lost its written label"
+    )
+    css = open(os.path.join(REPO, "clawmetry", "static", "css",
+                            "dashboard.css")).read()
+    assert ".cm-live-group" in css
+
+
 def test_js_live_rows_are_keyboard_reachable():
     js = open(APP_JS).read()
     assert re.search(r"<button type=\"button\" class=\"cm-live-row\"", js), (

--- a/tests/test_live_session_truth.py
+++ b/tests/test_live_session_truth.py
@@ -1,0 +1,253 @@
+"""Session liveness truthfulness (founder report 2026-08-15).
+
+Every family runtime (Claude Code, Codex, Cursor, Antigravity, ...) used to be
+ingested with ``status="ended"`` and a non-null ``ended_at`` hardcoded from its
+very first turn. A node with six terminals mid-task therefore reported
+``activeSessions: 0`` and the Overview hero read "It's idle right now."
+
+These tests pin the whole chain:
+
+  sync._session_liveness()            -> recency buckets, never a hardcode
+  routes/sessions.py _live_state()    -> the same buckets, explicit end wins
+  GET /api/live-sessions              -> named live sessions, runtime-scoped
+  routes/overview.py activeSessions   -> counts the live vocabulary
+  app.js                              -> 'running' is as live as 'active'
+
+The JS hops are guarded mechanically so a frontend refactor cannot silently
+drop them again.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from flask import Flask
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+APP_JS = os.path.join(REPO, "clawmetry", "static", "js", "app.js")
+
+
+def _iso(delta_secs: float) -> str:
+    """ISO timestamp `delta_secs` in the past."""
+    return (datetime.now(timezone.utc) - timedelta(seconds=delta_secs)).isoformat()
+
+
+# ---------------------------------------------------------------------------
+# 1. Ingest: liveness is derived, never hardcoded
+# ---------------------------------------------------------------------------
+
+def test_session_liveness_buckets():
+    from clawmetry.sync import _session_liveness
+
+    status, ended = _session_liveness(_iso(5))
+    assert status == "active"
+    assert ended is None, "a live session must carry NO end time"
+
+    status, ended = _session_liveness(_iso(300))
+    assert status == "idle"
+    assert ended is None, "an idle-but-open session has not ended"
+
+    last = _iso(4000)
+    status, ended = _session_liveness(last)
+    assert status == "ended"
+    assert ended == last, "an ended session keeps its real end timestamp"
+
+
+def test_session_liveness_never_resurrects_on_bad_input():
+    """A missing or unparseable timestamp must fall back to 'ended'.
+
+    Marking a dead session live is the worse failure: it is what puts a ghost
+    row in front of the user and re-arms the stuck/loop detectors on it.
+    """
+    from clawmetry.sync import _session_liveness
+
+    assert _session_liveness(None)[0] == "ended"
+    assert _session_liveness("")[0] == "ended"
+    assert _session_liveness("not-a-timestamp")[0] == "ended"
+
+
+def test_session_liveness_tolerates_clock_skew():
+    """A future timestamp is a skewed clock, not a live session — but it must
+    not crash or be silently dropped either."""
+    from clawmetry.sync import _session_liveness
+
+    future = (datetime.now(timezone.utc) + timedelta(hours=3)).isoformat()
+    status, ended = _session_liveness(future)
+    assert status == "active"
+    assert ended is None
+
+
+def test_family_ingest_no_longer_hardcodes_ended():
+    """Mechanical guard: the three family/vm ingest sites must not go back to
+    stamping a literal status."""
+    src = open(os.path.join(REPO, "clawmetry", "sync.py")).read()
+    assert '"status": "ended"' not in src, (
+        "a session ingest site is hardcoding status='ended' again — derive it "
+        "from _session_liveness() instead"
+    )
+    assert "_session_liveness(" in src
+
+
+def test_openclaw_end_reason_beats_recency():
+    """OpenClaw emits a REAL end signal; it must win over the recency guess."""
+    src = open(os.path.join(REPO, "clawmetry", "sync.py")).read()
+    assert re.search(
+        r"if end_reason:\s*\n\s*_oc_status, _oc_ended = \"completed\", updated_at",
+        src,
+    ), "OpenClaw's explicit end_reason is no longer honoured"
+
+
+# ---------------------------------------------------------------------------
+# 2. /api/live-sessions
+# ---------------------------------------------------------------------------
+
+def _rows():
+    """Three sessions: one working, one waiting, one long dead."""
+    return [
+        {"session_id": "claude_code:aaa", "title": "Fix the login redirect",
+         "last_active_at": _iso(8), "status": "active", "cost_usd": 1.25,
+         "message_count": 40, "metadata": {"runtime": "claude_code",
+                                           "recent_model": "claude-opus-5"}},
+        {"session_id": "codex:bbb", "title": "Port the parser",
+         "last_active_at": _iso(400), "status": "idle", "cost_usd": 0.5,
+         "message_count": 12, "metadata": {"runtime": "codex"}},
+        {"session_id": "claude_code:ccc", "title": "Ancient history",
+         "last_active_at": _iso(90000), "status": "ended", "cost_usd": 9.0,
+         "message_count": 3, "metadata": {"runtime": "claude_code"}},
+    ]
+
+
+@pytest.fixture
+def client(monkeypatch):
+    import routes.sessions as sessions_mod
+
+    monkeypatch.setattr(sessions_mod, "_fetch_sessions_table_rows",
+                        lambda limit=200: _rows())
+    app = Flask(__name__)
+    app.register_blueprint(sessions_mod.bp_sessions)
+    return app.test_client()
+
+
+def test_live_sessions_names_the_live_ones(client):
+    d = client.get("/api/live-sessions").get_json()
+    assert d["counts"] == {"working": 1, "waiting": 1}
+    titles = [s["title"] for s in d["sessions"]]
+    assert titles == ["Fix the login redirect", "Port the parser"], (
+        "expected most-recently-active first, dead session excluded"
+    )
+    first = d["sessions"][0]
+    assert first["state"] == "working"
+    assert first["runtime"] == "claude_code"
+    assert first["model"] == "claude-opus-5"
+    assert first["age_seconds"] < 120
+
+
+def test_live_sessions_scopes_to_runtime(client):
+    """FLYWHEEL §1c: ?runtime= must actually filter, server-side."""
+    d = client.get("/api/live-sessions?runtime=codex").get_json()
+    assert [s["runtime"] for s in d["sessions"]] == ["codex"]
+    assert d["counts"] == {"working": 0, "waiting": 1}
+
+    d = client.get("/api/live-sessions?runtime=cursor").get_json()
+    assert d["sessions"] == [], "an absent runtime returns nothing, not the node total"
+
+
+def test_live_sessions_says_unknown_when_store_unreachable(monkeypatch):
+    """The daemon being unreachable is 'we don't know', never 'nothing runs'."""
+    import routes.sessions as sessions_mod
+
+    monkeypatch.setattr(sessions_mod, "_fetch_sessions_table_rows",
+                        lambda limit=200: None)
+    app = Flask(__name__)
+    app.register_blueprint(sessions_mod.bp_sessions)
+    d = app.test_client().get("/api/live-sessions").get_json()
+    assert d["available"] is False
+    assert d["sessions"] == []
+
+
+def test_live_sessions_hides_plumbing_and_subagents(monkeypatch):
+    import routes.sessions as sessions_mod
+
+    rows = _rows() + [
+        {"session_id": "clawmetry-selfevolve-1", "title": "our own plumbing",
+         "last_active_at": _iso(5), "status": "active", "metadata": {}},
+        {"session_id": "claude_code:subagent:zzz", "title": "spawned child",
+         "last_active_at": _iso(5), "status": "active", "metadata": {}},
+    ]
+    monkeypatch.setattr(sessions_mod, "_fetch_sessions_table_rows",
+                        lambda limit=200: rows)
+    app = Flask(__name__)
+    app.register_blueprint(sessions_mod.bp_sessions)
+    d = app.test_client().get("/api/live-sessions").get_json()
+    ids = [s["session_id"] for s in d["sessions"]]
+    assert "clawmetry-selfevolve-1" not in ids
+    assert "claude_code:subagent:zzz" not in ids
+
+
+def test_explicit_end_beats_recency():
+    """A runtime that can assert 'this is over' must not be second-guessed by
+    a fresh mtime."""
+    from routes.sessions import _live_state
+
+    assert _live_state(_iso(5), "completed")[0] == "ended"
+    assert _live_state(_iso(5), "failed")[0] == "ended"
+    assert _live_state(_iso(5), "active")[0] == "working"
+
+
+# ---------------------------------------------------------------------------
+# 3. The JS hops (mechanical guards)
+# ---------------------------------------------------------------------------
+
+def test_js_treats_running_as_live():
+    js = open(APP_JS).read()
+    assert "function _cmIsWorkingStatus" in js
+    assert re.search(r"s === 'active' \|\| s === 'running'", js), (
+        "the status helper stopped accepting 'running' — the API emits it"
+    )
+    assert "if (_cmIsWorkingStatus(a.status)) running.push(a);" in js, (
+        "the hero busy gate went back to comparing the raw 'active' literal"
+    )
+    assert not re.search(r"status === 'active' \? 'running'", js), (
+        "_ovRenderCard is labelling running sub-agents 'complete' again"
+    )
+
+
+def test_js_hero_reads_named_live_sessions():
+    js = open(APP_JS).read()
+    assert "/api/live-sessions" in js
+    assert "_cmLiveRowsHtml" in js
+    assert "cmOpenLiveSession" in js, "live rows must stay clickable"
+    assert re.search(r"' sessions are working right now\.'", js), (
+        "the hero lost the counted headline and is back to one boolean"
+    )
+    # Perf: the shared cache + in-flight dedup must survive refactors.
+    assert "_cmLiveWait" in js and "_CM_LIVE_TTL_MS" in js
+
+
+def test_js_live_rows_are_keyboard_reachable():
+    js = open(APP_JS).read()
+    assert re.search(r"<button type=\"button\" class=\"cm-live-row\"", js), (
+        "live rows must be real buttons, not clickable divs"
+    )
+    css = open(os.path.join(REPO, "clawmetry", "static", "css",
+                            "dashboard.css")).read()
+    assert ".cm-live-row:focus-visible" in css, "focus ring lost"
+    assert "prefers-reduced-motion" in css
+
+
+# ---------------------------------------------------------------------------
+# 4. activeSessions
+# ---------------------------------------------------------------------------
+
+def test_overview_active_count_matches_live_vocabulary():
+    src = open(os.path.join(REPO, "routes", "overview.py")).read()
+    assert re.search(
+        r'active_count = sum\(\s*\n\s*1 for s in user_sessions', src
+    ), "activeSessions no longer counts over user_sessions"
+    assert '("active", "running")' in src, (
+        "activeSessions is back to matching a single status literal — that is "
+        "how it read 0 while six terminals were mid-task"
+    )


### PR DESCRIPTION
## The bug

Six Claude Code terminals mid-task. The Home screen:

- `activeSessions: 0`
- every one of 90 sessions in `/api/sessions` had `status: "ended"` — including the one that was running while I read it
- 14 sub-agents with `status: "running"` rendered as ✅ complete
- hero: **"It's idle right now."**

## Root cause

`clawmetry/sync.py` wrote `"status": "ended"` with a non-null `ended_at` for **every** family runtime (all 18 paid ones) from the session's first turn. `ended_at` is set to the last event timestamp, which a live session advances every turn — so a running session and a finished one were byte-identical.

Three consumers were then structurally unable to see running work:

| consumer | why it saw nothing |
|---|---|
| `routes/overview.py` `activeSessions` | counts `status == "active"` → always 0 |
| stuck-session + n-gram loop detectors | skip any row carrying `ended_at` → have never fired for a paid runtime, despite the comment claiming they cover all runtimes |
| the hero | fell back to `/api/subagents`, which lists **spawned children only** — main terminal sessions never appear there |

Separately, `/api/subagents` passes the daemon's status through verbatim and emits `running`, while ~12 JS sites compared against the literal `'active'`. `_ovRenderCard` labelled those running agents `complete`.

## What changed

- **`_session_liveness()`** derives status from how long ago the transcript grew (`<120s` active, `<600s` idle, else ended) and returns `ended_at=None` while live. Reuses the thresholds `routes/sessions.py` already applied to sub-agents so the two surfaces cannot disagree. Unparseable timestamps fall back to `ended` — never resurrect a dead session.
- **OpenClaw's real end signal now wins.** Its `endReason` frame was already parsed, stored as metadata, and then ignored while status was hardcoded `"completed"`.
- **`GET /api/live-sessions`** — which sessions are alive, by name, scoped server-side by `?runtime=` (FLYWHEEL §1c). Returns `available: false` when the daemon is unreachable, because that is "we don't know", not "nothing is running".
- **The hero** leads with the count and lists the sessions: state dot, the session's own title, its runtime, and a right-aligned monospace age column so "how long since each one moved" reads as one vertical scan. Rows are `<button>`s — keyboard reachable, visible focus ring, `prefers-reduced-motion` respected — and jump straight into that session's transcript.
- **`_cmIsWorkingStatus` / `_cmIsLiveStatus`** replace every raw `'active'` comparison; the server-side sort rank stops sinking `running` to the bottom.
- **"N sessions today"** had no date predicate anywhere in its query — it read 89 on a day that had 16. Adds `overview.sessionsToday` (local calendar day). An older daemon drops the word "today" rather than lie in the label.

## Verified live, against six real terminals

`/api/live-sessions` returns the right names and states. The hero renders **"4 sessions are working right now."** with clickable rows. A runtime with nothing live still says **"It's idle right now."** Console clean.

## Consequences worth flagging

The stuck-session and loop detectors will now actually see live family sessions. That is the intended fix (they were silently dead for every paid runtime), but it is a real behaviour change in incident volume — worth watching after release.

`activeSessions` stays 0 until daemons carry the ingest fix, since the poisoned rows are already in DuckDB. `/api/live-sessions` works immediately because it derives from recency and deliberately does not honour the legacy `"ended"` literal (documented inline).

## Testing

14 new tests in `tests/test_live_session_truth.py` covering the recency buckets, the bad-input and clock-skew fallbacks, runtime scoping, the unreachable-daemon state, explicit-end precedence, and mechanical guards on the JS hops so a refactor cannot silently drop them.

The 9 failures across the touched suites and all 221 lint findings reproduce **identically** on an untouched `origin/main` worktree — zero regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)