### PR TITLE
feat(entitlement): has_all_bundle_from_path_batch + missing_all_bundle_from_path_batch + /api/entitlement/{has,missing}-all-bundle-from-path-batch

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -15214,6 +15214,237 @@ def missing_all_bundle_at_path(
         return None
 
 
+def has_all_bundle_from_path_batch(
+    from_tiers, to_tier: str, bundle
+) -> dict | None:
+    """Source-axis batch bundle-shaped sibling of
+    :func:`has_all_bundle_at_path`: per-source aggregate-fold path walk
+    for ONE 5-axis bundle from N candidate sources to a single
+    ``to_tier`` in ONE round-trip.
+
+    Bundle-shaped counterpart of :func:`has_features_from_path_batch` /
+    :func:`has_runtimes_from_path_batch` on the source-batch seat and
+    source-batch complement of the destination-batch
+    :func:`has_all_bundle_at_path_batch` (PR #4884). Same relationship
+    :func:`has_all_bundle_at_path` has to :func:`has_all_at_path` on
+    the singular-path seat: swaps the per-axis kwargs bundle for the
+    5-axis bundle dict so a pricing-page surface can render "for each
+    of the tiers my fleet sits on today, does this whole 5-axis
+    subscription state unlock at every rung climbed toward
+    ``<to_tier>``?" off ONE call instead of N calls to
+    :func:`has_all_bundle_at_path`.
+
+    Per-source row shape mirrors :func:`has_features_from_path_batch`
+    byte-for-byte with the per-rung ``path`` row swapped to the
+    bundle-shape ``has_all_bundle_at_path`` row::
+
+        {
+          "from":       "<tier id>",
+          "from_label": "...",
+          "from_rank":  <int>,
+          "direction":  "upgrade" | "downgrade" | "lateral" | "identity",
+          "path":       [<has_all_bundle_at_path row>, ...],
+        }
+
+    ``direction`` is computed per source relative to the shared
+    ``to_tier`` (a caller can mix upgrades / downgrades / laterals in
+    one batch and each row is labelled from its own perspective). Each
+    ``path`` row is byte-identical to
+    :func:`has_all_bundle_at_path` for the same
+    ``(from, to_tier, bundle)`` triple -- a parity test pins this so
+    the singular and source-batch bundle-shaped path what-if boolean-
+    fold helpers cannot drift.
+
+    Envelope::
+
+        {
+          "tiers": [
+            {"from": "<id>", "from_label": ..., "from_rank": ..., "direction": ..., "path": [...]},
+            ...
+          ],
+          "unknown": ["bogus_id", ...],
+        }
+
+    Supplied source ids are normalised via :func:`_normalise_csv`
+    (whitespace stripped, lowercased, duplicates dropped, first-seen
+    order preserved). Unknown ids are echoed in ``unknown[]`` instead
+    of short-circuiting, matching the kwargs-shape source-batch's
+    posture. ``trial`` IS accepted as a source id (excluded from the
+    walked intermediate rungs the way :func:`has_all_bundle_at_path`
+    already excludes it, but is a valid endpoint via the lateral /
+    identity branches).
+
+    Bundle-fold semantics inherit :func:`has_all_bundle_at_path`
+    byte-for-byte: non-dict / ``None`` bundle normalises to the empty
+    axis echo and every rung of every source reports
+    ``has_all_at=False`` (matches :func:`has_all_bundle` empty-``False``
+    posture). Empty feature / runtime CSVs collapse to *unset* per axis
+    (matches the bundle-batch posture). Non-int capacity value on
+    ``channels`` / ``nodes`` / ``retention_days`` collapses to ``None``
+    on the echo slot AND drops from the fold. Unknown / typo'd runtime
+    id is dropped by :func:`_normalise_all_bundle`; unknown / typo'd
+    feature id survives normalisation and collapses every rung's
+    ``has_all_at`` to ``False`` via the singular scalar's typo posture.
+
+    Returns ``None`` for empty / unknown ``to_tier`` (caller renders
+    "unknown tier" / 404) -- symmetric with :func:`has_features_from_path_batch`'s
+    unknown-``to`` short-circuit.
+
+    Grace-independent by construction: delegates per-source to
+    :func:`has_all_bundle_at_path`, which walks the static
+    :data:`_PURCHASABLE_TIERS` ladder and folds per-rung grants via
+    :func:`_has_all_bundle_row_at` -- so grace vs enforce yields
+    byte-identical rows. Never raises: per-source failures short-
+    circuit that id into ``unknown[]`` and the rest of the batch keeps
+    building; a whole-fold blowup collapses to ``None`` at scalar
+    layer.
+    """
+    try:
+        t = (to_tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if t not in _TIER_FEATURES:
+        return None
+    candidates = _normalise_csv(from_tiers)
+    rows: list[dict] = []
+    unknown: list[str] = []
+    to_rank = _TIER_RANK.get(t, -1)
+    for fid in candidates:
+        if fid not in _TIER_FEATURES:
+            unknown.append(fid)
+            continue
+        try:
+            path = has_all_bundle_at_path(fid, t, bundle)
+        except Exception as exc:
+            logger.warning(
+                "entitlements: has_all_bundle_from_path_batch row %r failed: %s",
+                fid,
+                exc,
+            )
+            unknown.append(fid)
+            continue
+        if path is None:
+            unknown.append(fid)
+            continue
+        from_rank = _TIER_RANK.get(fid, -1)
+        if fid == t:
+            direction = "identity"
+        elif from_rank == to_rank:
+            direction = "lateral"
+        elif to_rank > from_rank:
+            direction = "upgrade"
+        else:
+            direction = "downgrade"
+        rows.append(
+            {
+                "from": fid,
+                "from_label": tier_label(fid),
+                "from_rank": from_rank,
+                "direction": direction,
+                "path": path,
+            }
+        )
+    return {"tiers": rows, "unknown": unknown}
+
+
+def missing_all_bundle_from_path_batch(
+    from_tiers, to_tier: str, bundle
+) -> dict | None:
+    """Row-detail complement of :func:`has_all_bundle_from_path_batch`
+    on the source-axis batch seat: per-source per-rung row-detail path
+    walk for ONE 5-axis bundle from N candidate sources to a single
+    ``to_tier`` in ONE round-trip.
+
+    Bundle-shaped counterpart of :func:`missing_features_from_path_batch` /
+    :func:`missing_runtimes_from_path_batch` on the source-batch seat
+    and source-batch complement of the destination-batch
+    :func:`missing_all_bundle_at_path_batch` (PR #4884). Same
+    relationship :func:`missing_all_bundle_at_path` has to
+    :func:`missing_all_at_path` on the singular-path seat.
+
+    Per-source row shape byte-equals
+    :func:`has_all_bundle_from_path_batch` on the header slots (``from``
+    / ``from_label`` / ``from_rank`` / ``direction``) with the ``path``
+    entries carrying the per-axis missing dict via
+    :func:`missing_all_bundle_at_path` per rung::
+
+        {
+          "from":       "<tier id>",
+          "from_label": "...",
+          "from_rank":  <int>,
+          "direction":  "upgrade" | "downgrade" | "lateral" | "identity",
+          "path":       [<missing_all_bundle_at_path row>, ...],
+        }
+
+    Each ``path`` row byte-equals :func:`missing_all_bundle_at_path`
+    for the same ``(from, to_tier, bundle)`` triple -- a parity test
+    pins this so the singular and source-batch bundle-shaped path
+    what-if row-detail helpers cannot drift.
+
+    Complement invariant with :func:`has_all_bundle_from_path_batch`:
+    for every fully-parseable bundle, per source per rung
+    ``any(row["missing"].values())`` byte-equals ``not row["has_all_at"]``
+    on the paired boolean-fold call. (Same non-int-capacity divergence
+    the singular :func:`missing_all_bundle_at_path` documents applies.)
+
+    Argument handling, source normalisation, and unknown-``to``
+    short-circuit mirror :func:`has_all_bundle_from_path_batch`
+    byte-for-byte so a UI wiring both endpoints sees consistent per-
+    source rollups on the same input.
+
+    Grace-independent by construction. Never raises: per-source
+    failures short-circuit that id into ``unknown[]`` and the rest of
+    the batch keeps building; a whole-fold blowup collapses to ``None``
+    at scalar layer.
+    """
+    try:
+        t = (to_tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if t not in _TIER_FEATURES:
+        return None
+    candidates = _normalise_csv(from_tiers)
+    rows: list[dict] = []
+    unknown: list[str] = []
+    to_rank = _TIER_RANK.get(t, -1)
+    for fid in candidates:
+        if fid not in _TIER_FEATURES:
+            unknown.append(fid)
+            continue
+        try:
+            path = missing_all_bundle_at_path(fid, t, bundle)
+        except Exception as exc:
+            logger.warning(
+                "entitlements: missing_all_bundle_from_path_batch row %r failed: %s",
+                fid,
+                exc,
+            )
+            unknown.append(fid)
+            continue
+        if path is None:
+            unknown.append(fid)
+            continue
+        from_rank = _TIER_RANK.get(fid, -1)
+        if fid == t:
+            direction = "identity"
+        elif from_rank == to_rank:
+            direction = "lateral"
+        elif to_rank > from_rank:
+            direction = "upgrade"
+        else:
+            direction = "downgrade"
+        rows.append(
+            {
+                "from": fid,
+                "from_label": tier_label(fid),
+                "from_rank": from_rank,
+                "direction": direction,
+                "path": path,
+            }
+        )
+    return {"tiers": rows, "unknown": unknown}
+
+
 def _min_tier_for_all_bundle_row(bundle) -> dict:
     """Per-bundle row shape for :func:`min_tier_for_all_batch`.
 

--- a/docs/ENTITLEMENTS.md
+++ b/docs/ENTITLEMENTS.md
@@ -485,6 +485,101 @@ return 200 with `path=[]` (never 4xxs or 5xxs). Ships in GRACE mode.
 
 The scalar is `clawmetry.entitlements.missing_all_bundle_at_path(from_tier, to_tier, bundle)`.
 
+### Source-batch bundle path-walk boolean-fold endpoint: `has-all-bundle-from-path-batch`
+
+`POST /api/entitlement/has-all-bundle-from-path-batch?to=<id>`
+
+Source-axis batch bundle-shaped sibling of `has-all-bundle-at-path`
+(singular source path) and bundle-shape twin of
+`has-features-from-path-batch` / `has-runtimes-from-path-batch` on the
+same source-batch seat. Fixes ONE 5-axis bundle and walks the rungs
+between N candidate SOURCE tiers and one shared `to` in ONE
+round-trip. Answers "for each of the tiers my fleet sits on today,
+does this WHOLE 5-axis subscription state unlock at every rung
+climbed toward `<to>`?" without N calls to `has-all-bundle-at-path`.
+
+**Grace-independent by construction** — same static-table walk as
+the singular `has-all-bundle-at-path` applied per source.
+
+**Request body** (canonical, or bare-axis shorthand alongside
+`from_tiers`):
+
+```json
+{"from_tiers": ["oss", "cloud_starter"],
+ "bundle": {"features": ["fleet"], "runtimes": ["claude_code"],
+            "channels": 5, "retention_days": 30, "nodes": 2}}
+```
+
+**Per-source row:**
+
+```json
+{
+  "from":          "oss",
+  "from_label":    "OSS",
+  "from_rank":     0,
+  "direction":     "upgrade",
+  "path":          [<has-all-bundle-at-path row>, ...],
+  "path_length":   4,
+  "allowed_count": 4,
+  "all_allowed":   true,
+  "any_allowed":   true
+}
+```
+
+Each `path` row byte-equals `has-all-bundle-at-path`'s `.path` for
+the same `(from, to, bundle)` triple. Per-source path lengths can
+differ (the rungs walked depend on the source). Unknown source ids
+echo into `unknown_tiers[]` without short-circuiting the batch.
+
+- **400** on missing / non-object `bundle`.
+- Missing / blank / unknown `to`, or empty / missing `from_tiers` →
+  200 with `tiers=[]` (never 4xxs).
+- Never 5xxs.
+
+Ships in GRACE mode.
+
+The scalar is `clawmetry.entitlements.has_all_bundle_from_path_batch(from_tiers, to_tier, bundle)`.
+
+### Source-batch bundle path-walk row-detail endpoint: `missing-all-bundle-from-path-batch`
+
+`POST /api/entitlement/missing-all-bundle-from-path-batch?to=<id>`
+
+Row-detail complement of `has-all-bundle-from-path-batch` on the
+source-axis batch seat. Same request body; per-source rollups renamed
+for the missing seat (`denied_count` / `all_denied` / `any_denied`)
+and per-rung `path` rows carry the per-axis `missing` dict via
+`missing-all-bundle-at-path`.
+
+**Per-source row:**
+
+```json
+{
+  "from":         "oss",
+  "from_label":   "OSS",
+  "from_rank":    0,
+  "direction":    "upgrade",
+  "path":         [<missing-all-bundle-at-path row>, ...],
+  "path_length":  4,
+  "denied_count": 4,
+  "all_denied":   true,
+  "any_denied":   true
+}
+```
+
+Complement invariant with `has-all-bundle-from-path-batch`: per
+source per rung, `any(row["missing"].values())` byte-equals
+`not row["has_all_at"]` on the paired boolean-fold call for every
+fully-parseable bundle.
+
+- **400** on missing / non-object `bundle`.
+- Missing / blank / unknown `to`, or empty / missing `from_tiers` →
+  200 with `tiers=[]` (never 4xxs).
+- Never 5xxs.
+
+Ships in GRACE mode.
+
+The scalar is `clawmetry.entitlements.missing_all_bundle_from_path_batch(from_tiers, to_tier, bundle)`.
+
 ### Batch path-walk endpoint: `has-all-at-path-batch`
 
 `GET /api/entitlement/has-all-at-path-batch?from=<id>&to=a,b,c&features=x,y&runtimes=p,q&channels=N&retention_days=N&nodes=N`

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -42737,6 +42737,493 @@ def api_entitlement_missing_all_bundle_at_path():
         )
 
 
+def _parse_from_tiers_bundle_body(body):
+    """Extract ``(from_tiers_list, bundle_dict, err)`` from a POST body
+    for the ``/has-all-bundle-from-path-batch`` /
+    ``/missing-all-bundle-from-path-batch`` endpoints.
+
+    Body shape (canonical)::
+
+        {"from_tiers": ["oss", "cloud_starter"],
+         "bundle": {"features": ["fleet"], "runtimes": ["claude_code"],
+                    "channels": 5, "retention_days": 30, "nodes": 2}}
+
+    Also accepts the bare-bundle shorthand where the top-level body
+    carries the bundle axes inline alongside ``from_tiers`` (matches
+    the ``_parse_single_bundle_body`` shorthand posture)::
+
+        {"from_tiers": ["oss"], "features": ["fleet"], "runtimes": [...]}
+
+    Returns ``(from_tiers, bundle, None)`` on success or one of:
+
+    * ``bundle_must_be_object`` -- body is not a dict OR
+      ``body["bundle"]`` is present but not a dict.
+    * ``missing`` -- neither ``body["bundle"]`` nor a bare-axis
+      shorthand is present.
+
+    Missing / non-list ``from_tiers`` normalises to ``[]`` so a
+    caller that forgot the key hits the empty-source branch (the
+    scalar's happy-path posture on empty sources) instead of a 400.
+    ``from_tiers`` may itself be a CSV string (matches
+    ``/has-features-from-path-batch`` GET semantics for a POST
+    caller stitching a CSV).
+    """
+    if not isinstance(body, dict):
+        return [], None, "bundle_must_be_object"
+    raw_from = body.get("from_tiers")
+    if raw_from is None:
+        from_tiers: list = []
+    elif isinstance(raw_from, str):
+        from_tiers = [tok.strip() for tok in raw_from.split(",") if tok.strip()]
+    elif isinstance(raw_from, (list, tuple)):
+        from_tiers = [str(x) for x in raw_from]
+    else:
+        from_tiers = []
+    if "bundle" in body:
+        raw_bundle = body.get("bundle")
+        if raw_bundle is None:
+            return from_tiers, None, "missing"
+        if not isinstance(raw_bundle, dict):
+            return from_tiers, None, "bundle_must_be_object"
+        return from_tiers, dict(raw_bundle), None
+    # Shorthand: bare-axis body IS the bundle alongside from_tiers.
+    known = ("features", "runtimes", "channels", "retention_days", "nodes")
+    if any(axis in body for axis in known):
+        return (
+            from_tiers,
+            {axis: body[axis] for axis in known if axis in body},
+            None,
+        )
+    return from_tiers, None, "missing"
+
+
+def _has_all_bundle_from_path_batch_fallback(
+    to_tier: str, from_tiers: list
+) -> dict:
+    """Never-5xx envelope for
+    ``/api/entitlement/has-all-bundle-from-path-batch``.
+
+    Source-axis batch bundle-shaped sibling of
+    :func:`_has_all_bundle_at_path_fallback` (singular-path bundle)
+    and bundle-shape twin of :func:`_has_bundle_from_path_batch_fallback`
+    (source-batch kwargs). On any resolver / helper blowup the
+    endpoint still returns 200 with the same envelope shape as the
+    happy path but with ``tiers=[]`` / ``count=0`` / axis echoes empty
+    so a source-side pricing surface that lost the resolver never
+    silently renders a grant matrix it can't verify. ``to`` /
+    ``unknown_tiers`` echo the caller's input so a debugging tooltip
+    can still surface the dropped sources.
+    """
+    return {
+        "to": to_tier,
+        "to_label": None,
+        "to_rank": -1,
+        "features": [],
+        "runtimes": [],
+        "channels": None,
+        "retention_days": None,
+        "nodes": None,
+        "unknown_tiers": list(from_tiers),
+        "count": 0,
+        "tiers": [],
+        "current_tier": "oss",
+        "current_tier_rank": 0,
+        "grace": True,
+        "enforced": False,
+    }
+
+
+@bp_entitlement.route(
+    "/api/entitlement/has-all-bundle-from-path-batch",
+    methods=["POST"],
+)
+def api_entitlement_has_all_bundle_from_path_batch():
+    """``POST /api/entitlement/has-all-bundle-from-path-batch?to=<id>``
+    -- source-axis batch bundle-shaped sibling of
+    ``/api/entitlement/has-all-bundle-at-path`` (singular source-path,
+    one bundle) and bundle-shape twin of
+    ``/api/entitlement/has-features-from-path-batch`` /
+    ``/api/entitlement/has-runtimes-from-path-batch`` on the same
+    source-batch seat.
+
+    Wraps :func:`clawmetry.entitlements.has_all_bundle_from_path_batch`
+    so a source-side upgrade-comparison surface can render "for each
+    tier my fleet sits on today, does this whole 5-axis subscription
+    state unlock at every rung climbed toward ``<to_tier>``?" straight
+    from the bundle dict off ONE round-trip instead of N calls to
+    ``/has-all-bundle-at-path``.
+
+    Fills the ``_from_path_batch`` slot on the aggregate bundle
+    boolean-fold family alongside ``/has-all-bundle-at`` (singular
+    perspective), ``/has-all-bundle-batch-at`` (multi-bundle
+    perspective batch), ``/has-all-bundle-at-path`` (singular source-
+    path bundle), and the destination-axis
+    ``/has-all-bundle-at-path-batch`` (PR #4884).
+
+    Request body (canonical)::
+
+        {"from_tiers": ["oss", "cloud_starter"],
+         "bundle": {"features": ["fleet"], "runtimes": ["claude_code"],
+                    "channels": 5, "retention_days": 30, "nodes": 2}}
+
+    Or bare-axis shorthand alongside ``from_tiers``::
+
+        {"from_tiers": ["oss"], "features": ["fleet"]}
+
+    ``to`` is a required query arg. Missing / blank / unknown ``to``
+    returns 200 with ``tiers=[]`` (never 4xxs) -- matches the source-
+    side ``/has-features-from-path-batch`` posture. Missing / empty
+    ``from_tiers`` returns 200 with ``tiers=[]`` (nothing to fold).
+
+    Envelope shape (byte-stable across every input branch)::
+
+        {
+          "to":                 "<tier id>",
+          "to_label":           "...",
+          "to_rank":            <int>,
+          "features":           [<normalised features echo>],
+          "runtimes":           [<normalised runtimes echo>],
+          "channels":           <int|null>,
+          "retention_days":     <int|null>,
+          "nodes":              <int|null>,
+          "unknown_tiers":      [<dropped source ids>],
+          "count":              <int>,               # len(tiers)
+          "tiers": [
+            {
+              "from":          "<id>",
+              "from_label":    "...",
+              "from_rank":     <int>,
+              "direction":     "upgrade" | "downgrade" | "lateral" | "identity",
+              "path":          [<has_all_bundle_at_path row>, ...],
+              "path_length":   <int>,
+              "allowed_count": <int>,                # rungs where fold=True
+              "all_allowed":   <bool>,               # every rung True
+              "any_allowed":   <bool>,               # any rung True
+            },
+            ...
+          ],
+          "current_tier":        "<live tier id>",
+          "current_tier_rank":   <int>,
+          "grace":               <bool>,
+          "enforced":            <bool>,
+        }
+
+    Each ``tiers[].path`` row byte-equals a row from
+    ``/has-all-bundle-at-path?from=<from>&to=<to>``'s ``.path`` for
+    the same ``(from, to, bundle)`` triple -- a parity test pins this
+    so the singular and source-batch bundle-shape path what-if
+    boolean-fold helpers cannot drift.
+
+    Perspective-shaped answers are **intentionally identical in grace
+    and enforce** (read the static per-tier tables via
+    :func:`has_all_bundle_at_path`, not the resolver's ``grace`` bit).
+
+    - **400** when ``bundle`` is missing / non-object (matches
+      ``/has-all-bundle-at-path``'s 400 branch).
+    - **Never 4xxs on endpoint validity**: missing / blank / unknown
+      ``to`` returns 200 with ``tiers=[]`` (same posture as
+      ``/has-features-from-path-batch``).
+    - **Never 5xxs**: a resolver / scalar / body-builder blowup yields
+      the fallback envelope
+      (:func:`_has_all_bundle_from_path_batch_fallback`) with
+      ``tiers=[]``.
+    """
+    body = request.get_json(silent=True) or {}
+    from_tiers, bundle, err = _parse_from_tiers_bundle_body(body)
+    if err == "missing":
+        return jsonify({"error": "missing bundle"}), 400
+    if err == "bundle_must_be_object":
+        return jsonify({"error": "bundle must be an object"}), 400
+    raw_to = request.args.get("to")
+    to_tier = (raw_to or "").strip().lower()
+    try:
+        from clawmetry import entitlements as _ent
+
+        batch = _ent.has_all_bundle_from_path_batch(
+            from_tiers, to_tier, bundle
+        )
+        env = _resolver_envelope(_ent)
+        (
+            features_echo,
+            runtimes_echo,
+            channels_echo,
+            retention_echo,
+            nodes_echo,
+        ) = _ent._normalise_all_bundle(bundle)
+        if batch is None:
+            return jsonify(
+                {
+                    "to": to_tier,
+                    "to_label": None,
+                    "to_rank": -1,
+                    "features": features_echo,
+                    "runtimes": runtimes_echo,
+                    "channels": channels_echo,
+                    "retention_days": retention_echo,
+                    "nodes": nodes_echo,
+                    "unknown_tiers": list(from_tiers),
+                    "count": 0,
+                    "tiers": [],
+                    **env,
+                }
+            )
+        tiers_out: list[dict] = []
+        for row in batch.get("tiers", []) or []:
+            try:
+                path = list(row.get("path", []) or [])
+            except AttributeError:
+                continue
+            allowed_count = sum(1 for r in path if bool(r.get("has_all_at")))
+            path_length = len(path)
+            all_allowed = path_length > 0 and allowed_count == path_length
+            any_allowed = allowed_count > 0
+            tiers_out.append(
+                {
+                    "from": row.get("from"),
+                    "from_label": row.get("from_label"),
+                    "from_rank": row.get("from_rank", -1),
+                    "direction": row.get("direction"),
+                    "path": path,
+                    "path_length": path_length,
+                    "allowed_count": allowed_count,
+                    "all_allowed": all_allowed,
+                    "any_allowed": any_allowed,
+                }
+            )
+        unknown_tiers = list(batch.get("unknown", []) or [])
+        return jsonify(
+            {
+                "to": to_tier,
+                "to_label": _ent.tier_label(to_tier),
+                "to_rank": _ent.tier_rank(to_tier),
+                "features": features_echo,
+                "runtimes": runtimes_echo,
+                "channels": channels_echo,
+                "retention_days": retention_echo,
+                "nodes": nodes_echo,
+                "unknown_tiers": unknown_tiers,
+                "count": len(tiers_out),
+                "tiers": tiers_out,
+                **env,
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_has_all_bundle_from_path_batch: error: %s", exc
+        )
+        return jsonify(
+            _has_all_bundle_from_path_batch_fallback(to_tier, from_tiers)
+        )
+
+
+def _missing_all_bundle_from_path_batch_fallback(
+    to_tier: str, from_tiers: list
+) -> dict:
+    """Never-5xx envelope for
+    ``/api/entitlement/missing-all-bundle-from-path-batch``.
+
+    Row-detail complement of
+    :func:`_has_all_bundle_from_path_batch_fallback`. Same envelope
+    shape with the per-source rollups renamed for the missing seat:
+    ``allowed_count`` / ``all_allowed`` / ``any_allowed`` become
+    ``denied_count`` / ``all_denied`` / ``any_denied`` inside each
+    ``tiers[]`` entry.
+    """
+    return {
+        "to": to_tier,
+        "to_label": None,
+        "to_rank": -1,
+        "features": [],
+        "runtimes": [],
+        "channels": None,
+        "retention_days": None,
+        "nodes": None,
+        "unknown_tiers": list(from_tiers),
+        "count": 0,
+        "tiers": [],
+        "current_tier": "oss",
+        "current_tier_rank": 0,
+        "grace": True,
+        "enforced": False,
+    }
+
+
+@bp_entitlement.route(
+    "/api/entitlement/missing-all-bundle-from-path-batch",
+    methods=["POST"],
+)
+def api_entitlement_missing_all_bundle_from_path_batch():
+    """``POST /api/entitlement/missing-all-bundle-from-path-batch?to=<id>``
+    -- row-detail complement of
+    ``/api/entitlement/has-all-bundle-from-path-batch`` on the source-
+    axis batch seat.
+
+    Bundle-shape twin of ``/api/entitlement/missing-features-from-path-batch``
+    / ``/api/entitlement/missing-runtimes-from-path-batch`` and source-
+    batch complement of the destination-batch
+    ``/api/entitlement/missing-all-bundle-at-path-batch`` (PR #4884).
+
+    Wraps :func:`clawmetry.entitlements.missing_all_bundle_from_path_batch`
+    so a source-side upgrade-comparison surface can render "for each
+    tier my fleet sits on today, WHICH per-axis slots of this 5-axis
+    bundle stay locked at every rung climbed toward ``<to_tier>``?"
+    straight from the bundle dict off ONE round-trip instead of N
+    calls to ``/missing-all-bundle-at-path``.
+
+    Request body is byte-identical to
+    ``/has-all-bundle-from-path-batch``:
+    ``{"from_tiers": [...], "bundle": {...}}`` (or the bare-axis
+    shorthand alongside ``from_tiers``). ``to`` is a required query
+    arg.
+
+    Envelope shape mirrors the boolean-fold sibling exactly on the
+    header slots (``to`` / ``to_label`` / ``to_rank`` / axis echoes /
+    ``unknown_tiers`` / ``count`` / envelope) with the ``tiers[]``
+    entries carrying the row-detail rollups::
+
+        {
+          ...header slots identical to boolean-fold sibling...,
+          "tiers": [
+            {
+              "from":         "<id>",
+              "from_label":   "...",
+              "from_rank":    <int>,
+              "direction":    "upgrade" | ...,
+              "path":         [<missing_all_bundle_at_path row>, ...],
+              "path_length":  <int>,
+              "denied_count": <int>,   # rungs with any missing axis
+              "all_denied":   <bool>,  # every rung has a missing axis
+              "any_denied":   <bool>,  # any rung has a missing axis
+            },
+            ...
+          ],
+          ...envelope tail identical...
+        }
+
+    Each ``tiers[].path`` row byte-equals a row from
+    ``/missing-all-bundle-at-path?from=<from>&to=<to>``'s ``.path`` for
+    the same ``(from, to, bundle)`` triple -- a parity test pins this
+    so the singular and source-batch bundle-shape path what-if row-
+    detail helpers cannot drift.
+
+    Complement invariant with
+    ``/has-all-bundle-from-path-batch``: per source per rung
+    ``any(row["missing"].values())`` byte-equals
+    ``not row["has_all_at"]`` on the paired boolean-fold call for
+    every fully-parseable bundle. (Same non-int-capacity divergence
+    :func:`missing_all_bundle_at_path` documents applies.)
+
+    - **400** when ``bundle`` is missing / non-object.
+    - **Never 4xxs on endpoint validity**: missing / blank / unknown
+      ``to`` returns 200 with ``tiers=[]``.
+    - **Never 5xxs**: a resolver / scalar / body-builder blowup yields
+      the fallback envelope
+      (:func:`_missing_all_bundle_from_path_batch_fallback`) with
+      ``tiers=[]``.
+    """
+    body = request.get_json(silent=True) or {}
+    from_tiers, bundle, err = _parse_from_tiers_bundle_body(body)
+    if err == "missing":
+        return jsonify({"error": "missing bundle"}), 400
+    if err == "bundle_must_be_object":
+        return jsonify({"error": "bundle must be an object"}), 400
+    raw_to = request.args.get("to")
+    to_tier = (raw_to or "").strip().lower()
+    try:
+        from clawmetry import entitlements as _ent
+
+        batch = _ent.missing_all_bundle_from_path_batch(
+            from_tiers, to_tier, bundle
+        )
+        env = _resolver_envelope(_ent)
+        (
+            features_echo,
+            runtimes_echo,
+            channels_echo,
+            retention_echo,
+            nodes_echo,
+        ) = _ent._normalise_all_bundle(bundle)
+        if batch is None:
+            return jsonify(
+                {
+                    "to": to_tier,
+                    "to_label": None,
+                    "to_rank": -1,
+                    "features": features_echo,
+                    "runtimes": runtimes_echo,
+                    "channels": channels_echo,
+                    "retention_days": retention_echo,
+                    "nodes": nodes_echo,
+                    "unknown_tiers": list(from_tiers),
+                    "count": 0,
+                    "tiers": [],
+                    **env,
+                }
+            )
+
+        def _has_missing(row: dict) -> bool:
+            m = row.get("missing") or {}
+            if not isinstance(m, dict):
+                return False
+            for v in m.values():
+                if isinstance(v, list) and v:
+                    return True
+                if isinstance(v, int) and not isinstance(v, bool):
+                    return True
+                if v is not None and not isinstance(v, (list, int)):
+                    return True
+            return False
+
+        tiers_out: list[dict] = []
+        for row in batch.get("tiers", []) or []:
+            try:
+                path = list(row.get("path", []) or [])
+            except AttributeError:
+                continue
+            denied_count = sum(1 for r in path if _has_missing(r))
+            path_length = len(path)
+            all_denied = path_length > 0 and denied_count == path_length
+            any_denied = denied_count > 0
+            tiers_out.append(
+                {
+                    "from": row.get("from"),
+                    "from_label": row.get("from_label"),
+                    "from_rank": row.get("from_rank", -1),
+                    "direction": row.get("direction"),
+                    "path": path,
+                    "path_length": path_length,
+                    "denied_count": denied_count,
+                    "all_denied": all_denied,
+                    "any_denied": any_denied,
+                }
+            )
+        unknown_tiers = list(batch.get("unknown", []) or [])
+        return jsonify(
+            {
+                "to": to_tier,
+                "to_label": _ent.tier_label(to_tier),
+                "to_rank": _ent.tier_rank(to_tier),
+                "features": features_echo,
+                "runtimes": runtimes_echo,
+                "channels": channels_echo,
+                "retention_days": retention_echo,
+                "nodes": nodes_echo,
+                "unknown_tiers": unknown_tiers,
+                "count": len(tiers_out),
+                "tiers": tiers_out,
+                **env,
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_missing_all_bundle_from_path_batch: error: %s",
+            exc,
+        )
+        return jsonify(
+            _missing_all_bundle_from_path_batch_fallback(to_tier, from_tiers)
+        )
+
+
 @bp_entitlement.route(
     "/api/entitlement/has-all-bundle-batch",
     methods=["POST"],

--- a/tests/test_entitlement_has_all_bundle_from_path_batch.py
+++ b/tests/test_entitlement_has_all_bundle_from_path_batch.py
@@ -1,0 +1,671 @@
+"""Tests for the source-axis bundle-shape path-batch scalars
+``has_all_bundle_from_path_batch`` / ``missing_all_bundle_from_path_batch``
+and their paired ``/api/entitlement/has-all-bundle-from-path-batch`` /
+``/api/entitlement/missing-all-bundle-from-path-batch`` endpoints.
+
+Bundle-shape twin of :func:`has_features_from_path_batch` /
+:func:`has_runtimes_from_path_batch` (source-batch on the kwargs
+seat) and source-batch complement of the destination-batch
+:func:`has_all_bundle_at_path_batch` (PR #4884). Where the singular
+:func:`has_all_bundle_at_path` walks one source to one destination
+for one bundle, this fans out over N candidate sources.
+
+Pins:
+
+1. Scalar envelope shape (``{"tiers": [...], "unknown": [...]}``) and
+   per-source row shape (``from`` / ``from_label`` / ``from_rank`` /
+   ``direction`` / ``path``).
+2. Per-source ``path`` byte-parity against the scalar
+   :func:`has_all_bundle_at_path` / :func:`missing_all_bundle_at_path`
+   for the same ``(from, to, bundle)`` triple.
+3. Unknown-``to`` short-circuits: scalar returns ``None``; endpoint
+   returns 200 with ``tiers=[]`` (never 4xxs).
+4. Unknown sources echo into ``unknown[]`` (scalar) /
+   ``unknown_tiers[]`` (endpoint) without short-circuiting the batch.
+5. Direction detection per source (``upgrade`` / ``downgrade`` /
+   ``lateral`` / ``identity``) all computed relative to the shared
+   ``to_tier``.
+6. Grace-independence: same rows under grace on vs enforce for the
+   same ``(from_tiers, to_tier, bundle)`` triple.
+7. Complement invariant per source per rung between the boolean-fold
+   and row-detail scalars.
+8. Endpoint envelope shape (fixed key set) across every branch and
+   per-source rollups (``path_length`` / ``allowed_count`` /
+   ``all_allowed`` / ``any_allowed`` for has;
+   ``denied_count`` / ``all_denied`` / ``any_denied`` for missing).
+9. 400 branches (missing / non-object bundle); never 5xxs (fallback
+   envelope on helper blowup).
+10. Bare-axis body shorthand and CSV ``from_tiers`` acceptance.
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+# ── Fixtures ───────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def enforced(monkeypatch, tmp_path):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    importlib.reload(e)
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# ── Envelope shape constants ───────────────────────────────────────────────
+
+_HAS_ENVELOPE_KEYS = {
+    "to",
+    "to_label",
+    "to_rank",
+    "features",
+    "runtimes",
+    "channels",
+    "retention_days",
+    "nodes",
+    "unknown_tiers",
+    "count",
+    "tiers",
+    "current_tier",
+    "current_tier_rank",
+    "grace",
+    "enforced",
+}
+_MISSING_ENVELOPE_KEYS = set(_HAS_ENVELOPE_KEYS)  # same header shape
+_HAS_ROW_KEYS = {
+    "from",
+    "from_label",
+    "from_rank",
+    "direction",
+    "path",
+    "path_length",
+    "allowed_count",
+    "all_allowed",
+    "any_allowed",
+}
+_MISSING_ROW_KEYS = {
+    "from",
+    "from_label",
+    "from_rank",
+    "direction",
+    "path",
+    "path_length",
+    "denied_count",
+    "all_denied",
+    "any_denied",
+}
+
+
+HAS_URL = "/api/entitlement/has-all-bundle-from-path-batch"
+MISS_URL = "/api/entitlement/missing-all-bundle-from-path-batch"
+
+
+# ── Scalar shape ───────────────────────────────────────────────────────────
+
+
+def test_has_scalar_returns_dict_shape(ent):
+    out = ent.has_all_bundle_from_path_batch(
+        ["oss", "cloud_starter"], "enterprise", {"features": ["fleet"]}
+    )
+    assert isinstance(out, dict)
+    assert set(out.keys()) == {"tiers", "unknown"}
+    assert isinstance(out["tiers"], list)
+    assert isinstance(out["unknown"], list)
+
+
+def test_missing_scalar_returns_dict_shape(ent):
+    out = ent.missing_all_bundle_from_path_batch(
+        ["oss", "cloud_starter"], "enterprise", {"features": ["fleet"]}
+    )
+    assert isinstance(out, dict)
+    assert set(out.keys()) == {"tiers", "unknown"}
+
+
+def test_has_scalar_row_shape(ent):
+    out = ent.has_all_bundle_from_path_batch(
+        ["oss"], "enterprise", {"features": ["fleet"]}
+    )
+    assert out is not None
+    assert len(out["tiers"]) == 1
+    row = out["tiers"][0]
+    assert set(row.keys()) == {
+        "from",
+        "from_label",
+        "from_rank",
+        "direction",
+        "path",
+    }
+    assert row["from"] == "oss"
+    assert isinstance(row["path"], list)
+
+
+def test_missing_scalar_row_shape(ent):
+    out = ent.missing_all_bundle_from_path_batch(
+        ["oss"], "enterprise", {"features": ["fleet"]}
+    )
+    assert out is not None
+    row = out["tiers"][0]
+    assert set(row.keys()) == {
+        "from",
+        "from_label",
+        "from_rank",
+        "direction",
+        "path",
+    }
+
+
+# ── Per-rung parity with singular scalars ──────────────────────────────────
+
+
+def test_has_scalar_per_rung_parity_with_bundle_at_path(ent):
+    bundle = {"features": ["fleet"], "runtimes": ["claude_code"]}
+    from_tiers = ["oss", "cloud_starter", "cloud_pro"]
+    to = "enterprise"
+    out = ent.has_all_bundle_from_path_batch(from_tiers, to, bundle)
+    for row in out["tiers"]:
+        singular = ent.has_all_bundle_at_path(row["from"], to, bundle)
+        assert row["path"] == singular
+
+
+def test_missing_scalar_per_rung_parity_with_bundle_at_path(ent):
+    bundle = {"features": ["fleet"], "channels": 5}
+    from_tiers = ["oss", "cloud_starter"]
+    to = "enterprise"
+    out = ent.missing_all_bundle_from_path_batch(from_tiers, to, bundle)
+    for row in out["tiers"]:
+        singular = ent.missing_all_bundle_at_path(row["from"], to, bundle)
+        assert row["path"] == singular
+
+
+# ── Unknown-``to`` short-circuit ───────────────────────────────────────────
+
+
+def test_has_scalar_unknown_to_returns_none(ent):
+    assert (
+        ent.has_all_bundle_from_path_batch(
+            ["oss"], "bogus", {"features": ["fleet"]}
+        )
+        is None
+    )
+    assert (
+        ent.has_all_bundle_from_path_batch(
+            ["oss"], "", {"features": ["fleet"]}
+        )
+        is None
+    )
+    # noinspection PyTypeChecker
+    assert (
+        ent.has_all_bundle_from_path_batch(
+            ["oss"], None, {"features": ["fleet"]}
+        )
+        is None
+    )
+
+
+def test_missing_scalar_unknown_to_returns_none(ent):
+    assert (
+        ent.missing_all_bundle_from_path_batch(
+            ["oss"], "bogus", {"features": ["fleet"]}
+        )
+        is None
+    )
+
+
+# ── Empty / unknown sources ────────────────────────────────────────────────
+
+
+def test_has_scalar_empty_sources(ent):
+    assert ent.has_all_bundle_from_path_batch(
+        [], "enterprise", {"features": ["fleet"]}
+    ) == {"tiers": [], "unknown": []}
+
+
+def test_has_scalar_unknown_source_echoes(ent):
+    out = ent.has_all_bundle_from_path_batch(
+        ["bogus_id"], "enterprise", {"features": ["fleet"]}
+    )
+    assert out == {"tiers": [], "unknown": ["bogus_id"]}
+
+
+def test_has_scalar_mixed_known_and_unknown_sources(ent):
+    out = ent.has_all_bundle_from_path_batch(
+        ["oss", "bogus", "cloud_starter"],
+        "enterprise",
+        {"features": ["fleet"]},
+    )
+    assert [r["from"] for r in out["tiers"]] == ["oss", "cloud_starter"]
+    assert out["unknown"] == ["bogus"]
+
+
+# ── Direction detection ────────────────────────────────────────────────────
+
+
+def test_has_scalar_direction_per_source(ent):
+    out = ent.has_all_bundle_from_path_batch(
+        ["oss", "enterprise", "cloud_starter", "cloud_pro"],
+        "cloud_pro",
+        {"features": ["fleet"]},
+    )
+    directions = {r["from"]: r["direction"] for r in out["tiers"]}
+    assert directions["oss"] == "upgrade"
+    assert directions["enterprise"] == "downgrade"
+    assert directions["cloud_starter"] == "upgrade"
+    assert directions["cloud_pro"] == "identity"
+
+
+def test_has_scalar_lateral_direction(ent):
+    # cloud_pro and pro share rank 2 (Cloud Pro / Self-hosted Pro).
+    out = ent.has_all_bundle_from_path_batch(
+        ["pro"], "cloud_pro", {"features": ["fleet"]}
+    )
+    assert out["tiers"][0]["direction"] == "lateral"
+
+
+# ── Grace-independence ────────────────────────────────────────────────────
+
+
+def test_has_scalar_same_under_grace_and_enforce(ent, enforced):
+    bundle = {"features": ["fleet"], "runtimes": ["claude_code"]}
+    from_tiers = ["oss", "cloud_starter"]
+    to = "enterprise"
+    grace_out = ent.has_all_bundle_from_path_batch(from_tiers, to, bundle)
+    enforced_out = enforced.has_all_bundle_from_path_batch(
+        from_tiers, to, bundle
+    )
+    assert grace_out == enforced_out
+
+
+# ── Complement invariant ──────────────────────────────────────────────────
+
+
+def _row_has_missing(row):
+    m = row.get("missing") or {}
+    for v in m.values():
+        if isinstance(v, list) and v:
+            return True
+        if isinstance(v, int) and not isinstance(v, bool):
+            return True
+        if v is not None and not isinstance(v, (list, int)):
+            return True
+    return False
+
+
+def test_complement_per_source_per_rung(ent):
+    bundle = {"features": ["fleet"], "runtimes": ["claude_code"]}
+    from_tiers = ["oss", "cloud_starter"]
+    to = "enterprise"
+    hs = ent.has_all_bundle_from_path_batch(from_tiers, to, bundle)
+    mi = ent.missing_all_bundle_from_path_batch(from_tiers, to, bundle)
+    assert [r["from"] for r in hs["tiers"]] == [
+        r["from"] for r in mi["tiers"]
+    ]
+    for h_row, m_row in zip(hs["tiers"], mi["tiers"]):
+        assert len(h_row["path"]) == len(m_row["path"])
+        for h_rung, m_rung in zip(h_row["path"], m_row["path"]):
+            assert h_rung["tier"] == m_rung["tier"]
+            assert h_rung["has_all_at"] is (not _row_has_missing(m_rung))
+
+
+# ── Bundle normalisation posture ──────────────────────────────────────────
+
+
+def test_has_scalar_none_bundle_folds_false_every_rung(ent):
+    out = ent.has_all_bundle_from_path_batch(
+        ["oss"], "enterprise", None
+    )
+    assert out is not None
+    for rung in out["tiers"][0]["path"]:
+        assert rung["has_all_at"] is False
+
+
+def test_has_scalar_non_dict_bundle_folds_false_every_rung(ent):
+    out = ent.has_all_bundle_from_path_batch(
+        ["oss"], "enterprise", "not-a-dict"
+    )
+    assert out is not None
+    for rung in out["tiers"][0]["path"]:
+        assert rung["has_all_at"] is False
+
+
+def test_has_scalar_unknown_feature_folds_false_every_rung(ent):
+    out = ent.has_all_bundle_from_path_batch(
+        ["oss"], "enterprise", {"features": ["typo_feature"]}
+    )
+    assert out is not None
+    for rung in out["tiers"][0]["path"]:
+        assert rung["has_all_at"] is False
+
+
+def test_has_scalar_runtime_alias_canonicalised(ent):
+    out = ent.has_all_bundle_from_path_batch(
+        ["oss"], "enterprise", {"runtimes": ["claude-code"]}
+    )
+    assert out is not None
+    for rung in out["tiers"][0]["path"]:
+        assert rung["runtimes"] == ["claude_code"]
+
+
+# ── CSV ``from_tiers`` acceptance at scalar layer ─────────────────────────
+
+
+def test_has_scalar_accepts_csv_from_tiers(ent):
+    out = ent.has_all_bundle_from_path_batch(
+        "oss,cloud_starter", "enterprise", {"features": ["fleet"]}
+    )
+    assert [r["from"] for r in out["tiers"]] == ["oss", "cloud_starter"]
+
+
+# ── Endpoint envelope shape ───────────────────────────────────────────────
+
+
+def test_endpoint_has_envelope_shape(client):
+    r = client.post(
+        HAS_URL + "?to=enterprise",
+        json={"from_tiers": ["oss"], "bundle": {"features": ["fleet"]}},
+    )
+    assert r.status_code == 200
+    j = r.get_json()
+    assert set(j.keys()) == _HAS_ENVELOPE_KEYS
+    assert j["to"] == "enterprise"
+    assert j["count"] == 1
+    assert len(j["tiers"]) == 1
+    assert set(j["tiers"][0].keys()) == _HAS_ROW_KEYS
+
+
+def test_endpoint_missing_envelope_shape(client):
+    r = client.post(
+        MISS_URL + "?to=enterprise",
+        json={"from_tiers": ["oss"], "bundle": {"features": ["fleet"]}},
+    )
+    assert r.status_code == 200
+    j = r.get_json()
+    assert set(j.keys()) == _MISSING_ENVELOPE_KEYS
+    assert set(j["tiers"][0].keys()) == _MISSING_ROW_KEYS
+
+
+def test_endpoint_axis_echoes_reflect_bundle(client):
+    r = client.post(
+        HAS_URL + "?to=enterprise",
+        json={
+            "from_tiers": ["oss"],
+            "bundle": {
+                "features": ["fleet"],
+                "runtimes": ["claude_code"],
+                "channels": 5,
+                "retention_days": 30,
+                "nodes": 2,
+            },
+        },
+    )
+    j = r.get_json()
+    assert j["features"] == ["fleet"]
+    assert j["runtimes"] == ["claude_code"]
+    assert j["channels"] == 5
+    assert j["retention_days"] == 30
+    assert j["nodes"] == 2
+
+
+def test_endpoint_axis_echoes_reflect_bundle_on_missing(client):
+    r = client.post(
+        MISS_URL + "?to=enterprise",
+        json={
+            "from_tiers": ["oss"],
+            "bundle": {"features": ["fleet"], "channels": 5},
+        },
+    )
+    j = r.get_json()
+    assert j["features"] == ["fleet"]
+    assert j["channels"] == 5
+
+
+# ── Endpoint 400 branches ─────────────────────────────────────────────────
+
+
+def test_endpoint_has_missing_bundle_returns_400(client):
+    r = client.post(HAS_URL + "?to=cloud_pro", json={"from_tiers": ["oss"]})
+    assert r.status_code == 400
+
+
+def test_endpoint_has_non_dict_bundle_returns_400(client):
+    r = client.post(
+        HAS_URL + "?to=cloud_pro",
+        json={"from_tiers": ["oss"], "bundle": "not-a-dict"},
+    )
+    assert r.status_code == 400
+
+
+def test_endpoint_missing_missing_bundle_returns_400(client):
+    r = client.post(MISS_URL + "?to=cloud_pro", json={"from_tiers": ["oss"]})
+    assert r.status_code == 400
+
+
+def test_endpoint_empty_body_returns_400(client):
+    r = client.post(HAS_URL + "?to=cloud_pro", json={})
+    assert r.status_code == 400
+
+
+# ── Endpoint never-4xxs on endpoint validity ──────────────────────────────
+
+
+def test_endpoint_unknown_to_returns_200_empty(client):
+    r = client.post(
+        HAS_URL + "?to=bogus",
+        json={"from_tiers": ["oss"], "bundle": {"features": ["fleet"]}},
+    )
+    assert r.status_code == 200
+    j = r.get_json()
+    assert j["tiers"] == []
+    assert j["count"] == 0
+
+
+def test_endpoint_blank_to_returns_200_empty(client):
+    r = client.post(
+        HAS_URL,
+        json={"from_tiers": ["oss"], "bundle": {"features": ["fleet"]}},
+    )
+    assert r.status_code == 200
+    j = r.get_json()
+    assert j["tiers"] == []
+
+
+def test_endpoint_empty_from_tiers_returns_200_empty(client):
+    r = client.post(
+        HAS_URL + "?to=enterprise",
+        json={"from_tiers": [], "bundle": {"features": ["fleet"]}},
+    )
+    assert r.status_code == 200
+    j = r.get_json()
+    assert j["tiers"] == []
+
+
+def test_endpoint_missing_from_tiers_returns_200_empty(client):
+    r = client.post(
+        HAS_URL + "?to=enterprise",
+        json={"bundle": {"features": ["fleet"]}},
+    )
+    assert r.status_code == 200
+    j = r.get_json()
+    assert j["tiers"] == []
+
+
+def test_endpoint_unknown_source_echoes_unknown_tiers(client):
+    r = client.post(
+        HAS_URL + "?to=enterprise",
+        json={
+            "from_tiers": ["oss", "bogus"],
+            "bundle": {"features": ["fleet"]},
+        },
+    )
+    j = r.get_json()
+    assert j["unknown_tiers"] == ["bogus"]
+    assert [row["from"] for row in j["tiers"]] == ["oss"]
+
+
+# ── Endpoint per-source rollups ──────────────────────────────────────────
+
+
+def test_endpoint_has_per_source_rollups(client):
+    r = client.post(
+        HAS_URL + "?to=enterprise",
+        json={"from_tiers": ["oss"], "bundle": {"features": ["fleet"]}},
+    )
+    j = r.get_json()
+    row = j["tiers"][0]
+    # fleet unlocks at Starter (rank 1) and every rung upward.
+    assert row["path_length"] == len(row["path"])
+    assert row["allowed_count"] == row["path_length"]
+    assert row["all_allowed"] is True
+    assert row["any_allowed"] is True
+
+
+def test_endpoint_missing_per_source_rollups_none_denied(client):
+    r = client.post(
+        MISS_URL + "?to=enterprise",
+        json={"from_tiers": ["oss"], "bundle": {"features": ["fleet"]}},
+    )
+    j = r.get_json()
+    row = j["tiers"][0]
+    assert row["path_length"] == len(row["path"])
+    assert row["denied_count"] == 0
+    assert row["all_denied"] is False
+    assert row["any_denied"] is False
+
+
+def test_endpoint_missing_per_source_rollups_feature_denied(client):
+    # sso stays denied at every rung below Enterprise.
+    r = client.post(
+        MISS_URL + "?to=cloud_pro",
+        json={"from_tiers": ["oss"], "bundle": {"features": ["sso"]}},
+    )
+    j = r.get_json()
+    row = j["tiers"][0]
+    assert row["path_length"] > 0
+    assert row["any_denied"] is True
+    assert row["all_denied"] is True
+    assert row["denied_count"] == row["path_length"]
+
+
+# ── Endpoint bare-axis shorthand ─────────────────────────────────────────
+
+
+def test_endpoint_bare_axis_shorthand(client):
+    r = client.post(
+        HAS_URL + "?to=enterprise",
+        json={"from_tiers": ["oss"], "features": ["fleet"]},
+    )
+    assert r.status_code == 200
+    j = r.get_json()
+    assert j["features"] == ["fleet"]
+    assert j["tiers"][0]["from"] == "oss"
+
+
+def test_endpoint_from_tiers_csv_string(client):
+    r = client.post(
+        HAS_URL + "?to=enterprise",
+        json={
+            "from_tiers": "oss,cloud_starter",
+            "bundle": {"features": ["fleet"]},
+        },
+    )
+    j = r.get_json()
+    assert [row["from"] for row in j["tiers"]] == ["oss", "cloud_starter"]
+
+
+# ── Endpoint path parity with singular ───────────────────────────────────
+
+
+def test_endpoint_path_parity_with_singular_has_all_bundle_at_path(
+    client, ent
+):
+    bundle = {"features": ["fleet"], "runtimes": ["claude_code"]}
+    r = client.post(
+        HAS_URL + "?to=enterprise",
+        json={"from_tiers": ["oss", "cloud_starter"], "bundle": bundle},
+    )
+    j = r.get_json()
+    for row in j["tiers"]:
+        singular = ent.has_all_bundle_at_path(row["from"], "enterprise", bundle)
+        assert row["path"] == singular
+
+
+def test_endpoint_path_parity_with_singular_missing_all_bundle_at_path(
+    client, ent
+):
+    bundle = {"features": ["fleet"], "channels": 5}
+    r = client.post(
+        MISS_URL + "?to=enterprise",
+        json={"from_tiers": ["oss"], "bundle": bundle},
+    )
+    j = r.get_json()
+    for row in j["tiers"]:
+        singular = ent.missing_all_bundle_at_path(
+            row["from"], "enterprise", bundle
+        )
+        assert row["path"] == singular
+
+
+# ── Endpoint fallback never-5xxs ─────────────────────────────────────────
+
+
+def test_endpoint_scalar_blowup_yields_fallback(client, monkeypatch, ent):
+    def _boom(*args, **kwargs):
+        raise RuntimeError("scalar blew up")
+
+    monkeypatch.setattr(ent, "has_all_bundle_from_path_batch", _boom)
+    r = client.post(
+        HAS_URL + "?to=enterprise",
+        json={"from_tiers": ["oss"], "bundle": {"features": ["fleet"]}},
+    )
+    assert r.status_code == 200
+    j = r.get_json()
+    assert set(j.keys()) == _HAS_ENVELOPE_KEYS
+    assert j["tiers"] == []
+    assert j["count"] == 0
+    assert j["unknown_tiers"] == ["oss"]
+
+
+def test_endpoint_missing_scalar_blowup_yields_fallback(
+    client, monkeypatch, ent
+):
+    def _boom(*args, **kwargs):
+        raise RuntimeError("scalar blew up")
+
+    monkeypatch.setattr(ent, "missing_all_bundle_from_path_batch", _boom)
+    r = client.post(
+        MISS_URL + "?to=enterprise",
+        json={"from_tiers": ["oss"], "bundle": {"features": ["fleet"]}},
+    )
+    assert r.status_code == 200
+    j = r.get_json()
+    assert set(j.keys()) == _MISSING_ENVELOPE_KEYS
+    assert j["tiers"] == []


### PR DESCRIPTION
## Summary

- Adds source-axis batch bundle-shape siblings of `has_all_bundle_at_path` / `missing_all_bundle_at_path` (singular source-path bundle) and bundle-shape twins of `has_features_from_path_batch` / `has_runtimes_from_path_batch` on the same source-batch seat. Fills the `_from_path_batch` slot on the aggregate bundle boolean-fold and row-detail families alongside the singular `_bundle_at_path` pair, the perspective-batch `_bundle_batch_at` pair, the singular perspective `_bundle_at` pair, and the destination-batch `_bundle_at_path_batch` pair (PR #4884).
- New scalars in `clawmetry/entitlements.py`: `has_all_bundle_from_path_batch(from_tiers, to_tier, bundle)` and `missing_all_bundle_from_path_batch(from_tiers, to_tier, bundle)`. Fix ONE 5-axis bundle and one destination `to_tier` and fan out over N caller-supplied source tiers, returning one per-source row with its own rung-by-rung path walk delegated to the singular `_bundle_at_path` scalars. Per-source `path` byte-parity with `has_all_bundle_at_path` / `missing_all_bundle_at_path` for the same `(from, to, bundle)` triple pinned by tests.
- New endpoints on `bp_entitlement` (`routes/entitlement.py`): `POST /api/entitlement/has-all-bundle-from-path-batch?to=<id>` and `POST /api/entitlement/missing-all-bundle-from-path-batch?to=<id>`. Body accepts `{"from_tiers": [...], "bundle": {...}}` (canonical) or the bare-axis shorthand alongside `from_tiers` (matches the `_parse_single_bundle_body` shorthand posture). `from_tiers` accepts a list OR a CSV string (matches `/has-features-from-path-batch` GET semantics for a POST caller stitching a CSV). Per-source rollups (`allowed_count` / `all_allowed` / `any_allowed` for has; `denied_count` / `all_denied` / `any_denied` for missing) layered on top of the singular per-rung row shape. Envelope byte-stable across every input branch (fixed key set including the unknown-endpoint and fallback branches).
- Grace-independent by construction (delegates per-source per rung to the singular `_bundle_at_path` scalars, which read the static per-tier grant tables via `_hypothetical_entitlement` on the feature / runtime axes and by the static `_TIER_CHANNEL_LIMIT` / `_TIER_RETENTION_DAYS` / `_TIER_NODE_LIMIT` tables on the capacity axes). Rung walk byte-stable against every other `_path` family helper (same `_PURCHASABLE_TIERS` filter + same sort + same destination-sibling exclusion).
- Missing / non-object `bundle` is a 400; unknown / blank / missing `to` returns 200 with `tiers=[]` / `count=0`; empty / missing `from_tiers` returns 200 with `tiers=[]` (matches `/has-features-from-path-batch`'s never-4xxs posture). A scalar / body-builder blowup collapses to the fallback envelope with `tiers=[]` (never 5xxs).
- Runtime-alias canonicalisation (`claude-code` → `claude_code`) is applied by the bundle normaliser. Unknown feature id survives normalisation and collapses every rung's `has_all_at` to `False` via the singular scalar's typo posture; unknown runtime id is dropped by the bundle normaliser (byte-parity with the singular `has_all_bundle_at_path`).
- Complement invariant pinned by tests: per source per rung `any(row["missing"].values())` byte-equals `not row["has_all_at"]` on the paired boolean-fold call for every fully-parseable bundle.
- Purely additive query surface. Ships in GRACE mode — no behaviour change on any existing endpoint.
- Docs: `docs/ENTITLEMENTS.md` gains sections for both new endpoints.

## Test plan

- [x] `python -m py_compile clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_has_all_bundle_from_path_batch.py`
- [x] `ruff check tests/test_entitlement_has_all_bundle_from_path_batch.py` — clean
- [x] `python -m pytest tests/test_entitlement_has_all_bundle_from_path_batch.py` — **42 passed**, covering scalar dict shape, per-source row shape, per-source `path` byte-parity with the singular `_bundle_at_path` scalars, unknown-`to` short-circuit (both scalar and endpoint), empty / unknown source handling, direction detection (upgrade / downgrade / lateral / identity), grace-independence, complement invariant per source per rung, bundle normalisation (`None`, non-dict, unknown feature, runtime alias canonicalisation), CSV `from_tiers` acceptance at scalar layer, endpoint envelope shape (fixed key set), 400 branches (missing / non-object `bundle`), unknown-endpoint / empty-`from_tiers` 200 posture, per-source rollups (`allowed_count` / `all_allowed` / `any_allowed` for has; `denied_count` / `all_denied` / `any_denied` for missing), bare-axis shorthand and CSV `from_tiers` at endpoint layer, per-path parity through the endpoint layer, and fallback never-5xxs on scalar blowup.
- [x] `python -m pytest tests/test_entitlement_has_all_bundle_from_path_batch.py tests/test_entitlement_has_all_bundle_at_path.py tests/test_entitlement_has_features_runtimes_from_path_batch.py tests/test_entitlement_missing_features_runtimes_from_path_batch.py tests/test_entitlement_api.py` — **202 passed** (with new suite), no regressions in the singular bundle-path seat, the kwargs-shape source-batch families (features / runtimes), or the live resolver API.

## Local operator verification checklist

The scheduled bot cannot exercise the running daemon, the live cloud snapshot, or a browser. Before promoting this out of draft, run these on the host:

- [ ] `cp clawmetry/entitlements.py routes/entitlement.py docs/ENTITLEMENTS.md ~/.clawmetry/lib/python*/site-packages/clawmetry/` (and matching path for `routes/`), clear stale `__pycache__/` under both directories
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` (macOS) so the daemon reloads with the new module
- [ ] `curl -s -X POST 'http://localhost:8900/api/entitlement/has-all-bundle-from-path-batch?to=enterprise' -H 'Content-Type: application/json' -d '{"from_tiers":["oss","cloud_starter"],"bundle":{"features":["fleet"],"runtimes":["claude_code"]}}' | jq .` — expect 200, `to:"enterprise"`, `count:2`, per-source `path[i]` matching what `/api/entitlement/has-all-bundle-at-path?from=<source>&to=enterprise` returns for the same bundle
- [ ] Same for `/api/entitlement/missing-all-bundle-from-path-batch` — expect the row-detail complement (`missing` dict per rung per source) plus `denied_count` / `all_denied` / `any_denied` per source
- [ ] Spot-check bare-axis shorthand: `curl -s -X POST 'http://localhost:8900/api/entitlement/has-all-bundle-from-path-batch?to=enterprise' -H 'Content-Type: application/json' -d '{"from_tiers":["oss"],"features":["fleet"]}' | jq '.count, .tiers[0].from'` returns `1` and `"oss"`
- [ ] Spot-check CSV `from_tiers`: `curl -s -X POST 'http://localhost:8900/api/entitlement/has-all-bundle-from-path-batch?to=enterprise' -H 'Content-Type: application/json' -d '{"from_tiers":"oss,cloud_starter","bundle":{"features":["fleet"]}}' | jq '[.tiers[].from]'` returns `["oss","cloud_starter"]`
- [ ] Spot-check the fallback branch: `curl -s -X POST 'http://localhost:8900/api/entitlement/has-all-bundle-from-path-batch?to=bogus' -H 'Content-Type: application/json' -d '{"from_tiers":["oss"],"bundle":{"features":["fleet"]}}'` returns 200 with `tiers=[]` / `count=0`
- [ ] Spot-check the 400 branches: `curl -s -o /dev/null -w "%{http_code}\n" -X POST 'http://localhost:8900/api/entitlement/has-all-bundle-from-path-batch?to=cloud_pro' -H 'Content-Type: application/json' -d '{"from_tiers":["oss"]}'` returns 400
- [ ] Decrypt the live cloud snapshot and confirm no shape drift on the resolver envelope
- [ ] Spot-check a browser hit on the dashboard — no console errors, no regressions on any tab (this PR is purely additive endpoints; no frontend change)

P3/P4/P6 of the open-core rollout (cloud entitlement fan-out, enterprise fleet, `clawmetry-pro` bootstrap) still require the private `clawmetry-cloud` / `clawmetry-pro` repos this bot has no access to — the local operator owns those.

---
_Generated by [Claude Code](https://claude.ai/code/session_012xBb4DPrjysbx5e35wwZE9)_