### PR TITLE
feat(entitlement): has_all_bundle_at_path_batch + missing_all_bundle_at_path_batch + /api/entitlement/{has,missing}-all-bundle-at-path-batch

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -14761,6 +14761,167 @@ def has_all_bundle_at_path(
         return None
 
 
+def has_all_bundle_at_path_batch(
+    from_tier: str, to_tiers, bundle
+) -> dict | None:
+    """Batch sibling of :func:`has_all_bundle_at_path`: per-rung
+    aggregate boolean-fold path lists for a caller-supplied subset of
+    destination tiers all walked from a single ``from_tier`` under ONE
+    aggregate 5-axis bundle dict in ONE round-trip.
+
+    Bundle-shaped counterpart of :func:`has_all_at_path_batch` (kwargs-
+    shaped batch-path walker) in the same relationship
+    :func:`has_all_bundle_at_path` has to :func:`has_all_at_path` on the
+    singular-destination seat and :func:`has_all_bundle_batch_at` has to
+    :func:`has_all_at_batch` on the perspective-batch seat. Fills the
+    ``_at_path_batch`` slot on the aggregate bundle boolean-fold family
+    alongside :func:`has_all_bundle_at_path` (singular destination),
+    :func:`has_all_bundle_batch_at` (multi-bundle perspective-batch),
+    and :func:`has_all_at_path_batch` (kwargs-shaped batch-path).
+
+    Lets an upgrade-comparison surface render "from my current rung,
+    here are the 3 tiers I'm considering -- for this WHOLE 5-axis
+    bundle dict {features: [fleet], runtimes: [claude_code], channels:
+    5} show me at which rung this bundle unlocks along every candidate
+    path" straight from the bundle dict off ONE call instead of
+    normalising the bundle by hand and calling
+    :func:`has_all_at_path_batch`, or N calls to
+    :func:`has_all_bundle_at_path`.
+
+    Per-destination row shape mirrors :func:`has_all_at_path_batch`
+    exactly with the axis-shared ``path`` slot bound to the per-rung
+    aggregate bundle-shaped boolean-fold list::
+
+        {
+          "to":         "<tier id>",
+          "to_label":   "...",
+          "to_rank":    <int>,
+          "direction":  "upgrade" | "downgrade" | "lateral" | "identity",
+          "path":       [<has_all_bundle_at_path row>, ...],
+        }
+
+    Each ``path`` row is byte-identical to a row from
+    :func:`has_all_bundle_at_path` for the same ``(from_tier, to,
+    bundle)`` triple -- a parity test pins this so the scalar and batch
+    bundle-shaped what-if boolean-fold path helpers cannot drift. The
+    walked rungs are destination-specific (the path's rung set depends
+    on ``to``), so per-destination ``path`` lengths can legitimately
+    differ -- matches :func:`has_all_at_path_batch` /
+    :func:`missing_all_at_path_batch` /
+    :func:`has_features_at_path_batch` /
+    :func:`has_runtimes_at_path_batch` posture.
+
+    Shape::
+
+        {
+          "tiers": [
+            {"to": "<id>", "to_label": ..., "to_rank": ..., "direction": ..., "path": [...]},
+            ...
+          ],
+          "unknown": ["bogus_id", ...],
+        }
+
+    Supplied destination ids are normalised via :func:`_normalise_csv`
+    (whitespace stripped, lowercased, duplicates dropped, first-seen
+    order preserved). Unknown ids are echoed in ``unknown[]`` instead
+    of short-circuiting -- a partially-bad caller still gets paths
+    back for the valid ids alongside a list of what was dropped,
+    matching :func:`has_all_at_path_batch`'s posture. ``trial`` IS
+    accepted as a destination (excluded from the walked intermediate
+    rungs the way :func:`has_all_bundle_at_path` already excludes it,
+    but is a valid endpoint via the lateral / identity branches).
+
+    Bundle-fold semantics per rung per destination inherit
+    :func:`has_all_bundle_at_path` byte-for-byte (i.e.
+    :func:`_normalise_all_bundle` normalisation then
+    :func:`_has_all_bundle_row_at` per rung, so:
+
+    * ``bundle`` non-dict / ``None`` -- normalises to the empty axis
+      echo and every rung of every destination reports
+      ``has_all_at=False`` (matches :func:`has_all_bundle_at_path`
+      empty-``False`` posture: no axis supplied, singular
+      :func:`has_all_at` collapses to ``False``).
+    * Empty feature / runtime CSVs collapse to *unset* per axis
+      (matches the bundle-batch posture) so an empty CSV does NOT drag
+      the rung's ``has_all_at`` to ``False`` on its own.
+    * Non-int capacity value on ``channels`` / ``nodes`` /
+      ``retention_days`` collapses to ``None`` on the echo slot AND
+      drops from the fold (matches :func:`_normalise_all_bundle`
+      convention -- distinct from :func:`has_all_at_path_batch` where a
+      non-int capacity passed as a kwarg collapses the fold to
+      ``False`` via the singular scalar's strict typo posture).
+    * Unknown / typo'd runtime id is dropped by
+      :func:`_normalise_all_bundle` (runtime alias canonicalisation
+      only keeps ids that resolve to :data:`ALL_RUNTIMES` on the echo
+      slot). Unknown / typo'd feature id survives normalisation and is
+      folded through :func:`has_all_at`, collapsing every rung of
+      every destination's ``has_all_at`` to ``False`` via the singular
+      scalar's typo posture.
+
+    Returns ``None`` for empty / unknown ``from_tier`` (caller renders
+    "unknown tier" / 404). Delegates per-destination to
+    :func:`has_all_bundle_at_path`, so a per-destination blowup logs a
+    warning and short-circuits that id into ``unknown[]`` while the
+    rest of the batch keeps building.
+
+    Grace-independent by construction: delegates per-rung per
+    destination to :func:`_has_all_bundle_row_at` (via
+    :func:`has_all_bundle_at_path`), which reads the static per-tier
+    grant tables (via :func:`_hypothetical_entitlement` on the feature
+    / runtime axes and by the static ``_TIER_CHANNEL_LIMIT`` /
+    ``_TIER_RETENTION_DAYS`` / ``_TIER_NODE_LIMIT`` tables on the
+    capacity axes), so the answer is byte-identical under grace vs
+    enforce for the same (from, to, bundle) triple -- same property
+    the rest of the ``_at_path_batch`` family guarantees.
+    """
+    try:
+        f = (from_tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if f not in _TIER_FEATURES:
+        return None
+    candidates = _normalise_csv(to_tiers)
+    rows: list[dict] = []
+    unknown: list[str] = []
+    from_rank = _TIER_RANK.get(f, -1)
+    for tid in candidates:
+        if tid not in _TIER_FEATURES:
+            unknown.append(tid)
+            continue
+        try:
+            path = has_all_bundle_at_path(f, tid, bundle)
+        except Exception as exc:
+            logger.warning(
+                "entitlements: has_all_bundle_at_path_batch row %r failed: %s",
+                tid,
+                exc,
+            )
+            unknown.append(tid)
+            continue
+        if path is None:
+            unknown.append(tid)
+            continue
+        to_rank = _TIER_RANK.get(tid, -1)
+        if f == tid:
+            direction = "identity"
+        elif from_rank == to_rank:
+            direction = "lateral"
+        elif to_rank > from_rank:
+            direction = "upgrade"
+        else:
+            direction = "downgrade"
+        rows.append(
+            {
+                "to": tid,
+                "to_label": tier_label(tid),
+                "to_rank": to_rank,
+                "direction": direction,
+                "path": path,
+            }
+        )
+    return {"tiers": rows, "unknown": unknown}
+
+
 def _missing_all_bundle_row(bundle) -> dict:
     """Per-bundle row shape for :func:`missing_all_bundle_batch`.
 
@@ -15597,6 +15758,177 @@ def missing_all_bundle_at_path(
             exc,
         )
         return None
+
+
+def missing_all_bundle_at_path_batch(
+    from_tier: str, to_tiers, bundle
+) -> dict | None:
+    """Batch sibling of :func:`missing_all_bundle_at_path`: per-rung
+    per-axis denial rollups for a caller-supplied subset of destination
+    tiers all walked from a single ``from_tier`` under ONE aggregate
+    5-axis bundle dict in ONE round-trip.
+
+    Bundle-shaped counterpart of :func:`missing_all_at_path_batch`
+    (kwargs-shaped batch-path walker) in the same relationship
+    :func:`missing_all_bundle_at_path` has to
+    :func:`missing_all_at_path` on the singular-destination seat and
+    :func:`missing_all_bundle_batch_at` has to
+    :func:`missing_all_at_batch` on the perspective-batch seat. Row-
+    detail complement of :func:`has_all_bundle_at_path_batch` at the
+    bundle-shaped batch-path layer, in the same relationship
+    :func:`missing_all_bundle_at_path` has to
+    :func:`has_all_bundle_at_path`. Fills the ``_at_path_batch`` slot
+    on the aggregate bundle row-detail family alongside
+    :func:`missing_all_bundle_at_path` (singular destination),
+    :func:`missing_all_bundle_batch_at` (multi-bundle perspective-
+    batch), and :func:`missing_all_at_path_batch` (kwargs-shaped batch-
+    path).
+
+    Lets an upgrade-comparison surface render "from my current rung,
+    here are the 3 tiers I'm considering -- for this WHOLE 5-axis
+    bundle dict {features: [fleet], runtimes: [claude_code], channels:
+    5} show me which per-axis slots are still locked at every rung
+    climbed to reach each" straight from the bundle dict off ONE call
+    instead of normalising the bundle by hand and calling
+    :func:`missing_all_at_path_batch`, or N calls to
+    :func:`missing_all_bundle_at_path`.
+
+    Per-destination row shape mirrors :func:`missing_all_at_path_batch`
+    exactly with the axis-shared ``path`` slot bound to the per-rung
+    aggregate bundle-shaped row-detail list::
+
+        {
+          "to":         "<tier id>",
+          "to_label":   "...",
+          "to_rank":    <int>,
+          "direction":  "upgrade" | "downgrade" | "lateral" | "identity",
+          "path":       [<missing_all_bundle_at_path row>, ...],
+        }
+
+    Each ``path`` row is byte-identical to a row from
+    :func:`missing_all_bundle_at_path` for the same ``(from_tier, to,
+    bundle)`` triple -- a parity test pins this so the scalar and
+    batch bundle-shaped what-if row-detail path helpers cannot drift.
+    Per-destination ``path`` lengths can legitimately differ -- matches
+    :func:`missing_all_at_path_batch` /
+    :func:`missing_features_at_path_batch` /
+    :func:`missing_runtimes_at_path_batch` posture.
+
+    Shape::
+
+        {
+          "tiers": [
+            {"to": "<id>", "to_label": ..., "to_rank": ..., "direction": ..., "path": [...]},
+            ...
+          ],
+          "unknown": ["bogus_id", ...],
+        }
+
+    Supplied destination ids are normalised via :func:`_normalise_csv`.
+    Unknown ids are echoed in ``unknown[]`` instead of short-
+    circuiting -- a partially-bad caller still gets paths back for the
+    valid ids alongside a list of what was dropped, matching
+    :func:`missing_all_at_path_batch`'s posture. ``trial`` IS accepted
+    as a destination (excluded from the walked intermediate rungs the
+    way :func:`missing_all_bundle_at_path` already excludes it, but is
+    a valid endpoint via the lateral / identity branches).
+
+    Bundle-fold semantics per rung per destination inherit
+    :func:`missing_all_bundle_at_path` byte-for-byte (i.e.
+    :func:`_normalise_all_bundle` normalisation then
+    :func:`_missing_all_bundle_row_at` per rung), so:
+
+    * ``bundle`` non-dict / ``None`` -- normalises to the empty axis
+      echo and every rung of every destination reports the empty
+      ``missing`` dict (nothing supplied -> nothing missing on any
+      axis; matches the per-perspective row-detail seat).
+    * Empty feature / runtime CSVs collapse to *unset* per axis, so
+      per-rung ``missing["features"]`` / ``missing["runtimes"]`` stay
+      empty.
+    * Non-int capacity value on ``channels`` / ``nodes`` /
+      ``retention_days`` collapses to ``None`` on the echo slot AND
+      swallows to ``None`` on the per-rung capacity slot (matches the
+      per-perspective row-detail seat).
+    * Unknown / typo'd runtime id is dropped by
+      :func:`_normalise_all_bundle` (canonicalisation only keeps ids
+      that resolve to :data:`ALL_RUNTIMES`). Unknown / typo'd feature
+      id survives normalisation and is INCLUDED in every rung's per-
+      axis missing list in canonicalised form.
+
+    Complement invariant with :func:`has_all_bundle_at_path_batch`: for
+    every fully-parseable bundle, per destination per rung
+    ``any(row["path"][i]["missing"].values())`` byte-equals ``not
+    row["path"][i]["has_all_at"]`` on the paired
+    :func:`has_all_bundle_at_path_batch` call for the same
+    ``(from_tier, to_tiers, bundle)`` inputs. (Non-int capacity is the
+    same deliberate divergence :func:`missing_all_bundle_at_path`
+    carries against :func:`has_all_bundle_at_path`: both bundle seats
+    collapse coherently to ``None`` / ``False`` respectively on the
+    supplied-but-typo capacity axis, mirroring the row-detail vs
+    boolean-fold posture split on the paired non-bundle seat.)
+
+    Returns ``None`` for empty / unknown ``from_tier`` (caller renders
+    "unknown tier" / 404). Delegates per-destination to
+    :func:`missing_all_bundle_at_path`, so a per-destination blowup
+    logs a warning and short-circuits that id into ``unknown[]`` while
+    the rest of the batch keeps building.
+
+    Grace-independent by construction: delegates per-rung per
+    destination to :func:`_missing_all_bundle_row_at` (via
+    :func:`missing_all_bundle_at_path`), which reads the static per-
+    tier grant tables (via :func:`_hypothetical_entitlement` on the
+    feature / runtime axes and by the static ``_TIER_CHANNEL_LIMIT`` /
+    ``_TIER_RETENTION_DAYS`` / ``_TIER_NODE_LIMIT`` tables on the
+    capacity axes), so the answer is byte-identical under grace vs
+    enforce for the same (from, to, bundle) triple -- same property
+    the rest of the ``_at_path_batch`` family guarantees.
+    """
+    try:
+        f = (from_tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if f not in _TIER_FEATURES:
+        return None
+    candidates = _normalise_csv(to_tiers)
+    rows: list[dict] = []
+    unknown: list[str] = []
+    from_rank = _TIER_RANK.get(f, -1)
+    for tid in candidates:
+        if tid not in _TIER_FEATURES:
+            unknown.append(tid)
+            continue
+        try:
+            path = missing_all_bundle_at_path(f, tid, bundle)
+        except Exception as exc:
+            logger.warning(
+                "entitlements: missing_all_bundle_at_path_batch row %r failed: %s",
+                tid,
+                exc,
+            )
+            unknown.append(tid)
+            continue
+        if path is None:
+            unknown.append(tid)
+            continue
+        to_rank = _TIER_RANK.get(tid, -1)
+        if f == tid:
+            direction = "identity"
+        elif from_rank == to_rank:
+            direction = "lateral"
+        elif to_rank > from_rank:
+            direction = "upgrade"
+        else:
+            direction = "downgrade"
+        rows.append(
+            {
+                "to": tid,
+                "to_label": tier_label(tid),
+                "to_rank": to_rank,
+                "direction": direction,
+                "path": path,
+            }
+        )
+    return {"tiers": rows, "unknown": unknown}
 
 
 def _min_tier_for_all_bundle_row(bundle) -> dict:

--- a/docs/ENTITLEMENTS.md
+++ b/docs/ENTITLEMENTS.md
@@ -700,6 +700,128 @@ Missing/blank/unknown `to` or an empty / all-unknown source CSV returns
 
 The scalar is `clawmetry.entitlements.missing_all_from_path_batch(from_tiers, to_tier, *, features, runtimes, channels, retention_days, nodes)`.
 
+### Bundle batch path-walk boolean-fold endpoint: `has-all-bundle-at-path-batch`
+
+`POST /api/entitlement/has-all-bundle-at-path-batch?from=<id>&to=a,b,c`
+
+Bundle-shaped destination-batch companion of `has-all-bundle-at-path`
+(singular destination) and bundle-shaped counterpart of
+`has-all-at-path-batch` (kwargs-shaped batch-path). Fixes ONE aggregate
+5-axis bundle dict and sweeps across every purchasable rung between
+`from` and each of the N candidate `to` tiers in ONE round-trip,
+returning per-destination path lists of aggregate `has_all_at` fold
+rows. Answers "from my current rung, here are 3 tiers I'm considering:
+for this WHOLE 5-axis bundle dict show me at which rung this bundle
+unlocks along every candidate path" straight from the bundle dict —
+without first normalising it by hand and calling
+`/has-all-at-path-batch`, or N calls to `/has-all-bundle-at-path`.
+
+**Grace-independent by construction** — same static-table walk as the
+singular endpoint applied per destination.
+
+**Request body**: byte-identical to `has-all-bundle-at-path`
+(`{"bundle": {...}}` wrapped form, or bare-dict shorthand).
+
+**Per-destination row:**
+
+```json
+{
+  "to":            "pro",
+  "to_label":      "Self-hosted Pro",
+  "to_rank":       2,
+  "direction":     "upgrade",
+  "path":          [
+    {"tier": "cloud_starter", "tier_label": "Starter", "tier_rank": 1,
+     "features": ["fleet"], "runtimes": ["claude_code"], "channels": 5,
+     "retention_days": null, "nodes": null, "has_all_at": true}
+  ],
+  "path_length":   1,
+  "allowed_count": 1,
+  "all_allowed":   true,
+  "any_allowed":   true
+}
+```
+
+**Envelope keys:** `from`, `from_label`, `from_rank`, `features`,
+`runtimes`, `channels`, `retention_days`, `nodes`, `unknown_tiers`,
+`tiers`, plus the standard resolver envelope (`current_tier`,
+`current_tier_rank`, `grace`, `enforced`).
+
+Per-destination `path` row byte-equals `has-all-bundle-at-path`'s
+`.path` for the same `(from, to, bundle)` triple. Per-destination path
+lengths can legitimately differ (the rungs walked depend on the
+destination). Runtime-alias canonicalisation (`claude-code` →
+`claude_code`) is applied per token by the bundle normaliser. Unknown
+feature id collapses every rung of every destination to
+`has_all_at=false` (matches the singular typo posture). `trial` IS
+accepted as a destination via the lateral / identity branches.
+
+400 on missing / non-object `bundle`. Missing/blank/unknown `from` or
+an empty / all-unknown destination CSV returns 200 with `tiers=[]`
+(never 4xxs or 5xxs). Ships in GRACE mode.
+
+The scalar is `clawmetry.entitlements.has_all_bundle_at_path_batch(from_tier, to_tiers, bundle)`.
+
+### Bundle batch path-walk row-detail endpoint: `missing-all-bundle-at-path-batch`
+
+`POST /api/entitlement/missing-all-bundle-at-path-batch?from=<id>&to=a,b,c`
+
+Row-detail bundle-shaped destination-batch companion of
+`missing-all-bundle-at-path` (singular destination), bundle-shaped
+counterpart of `missing-all-at-path-batch` (kwargs-shaped batch-path),
+and row-detail complement of `has-all-bundle-at-path-batch` at the
+bundle-shaped batch-path layer. Fixes ONE aggregate 5-axis bundle dict
+and sweeps across every purchasable rung between `from` and each of
+the N candidate `to` tiers in ONE round-trip, returning per-destination
+path lists of aggregate per-axis `missing` row-detail rows. Answers
+"from my current rung, here are 3 tiers I'm considering: for this
+WHOLE 5-axis bundle dict show me which per-axis slots are still locked
+at every rung climbed to reach each" straight from the bundle dict.
+
+**Grace-independent by construction** — same static-table walk as the
+singular endpoint applied per destination.
+
+**Request body**: byte-identical to `has-all-bundle-at-path-batch`
+above.
+
+**Per-destination row:**
+
+```json
+{
+  "to":           "pro",
+  "to_label":     "Self-hosted Pro",
+  "to_rank":      2,
+  "direction":    "upgrade",
+  "path":         [
+    {"tier": "cloud_starter", "tier_label": "Starter", "tier_rank": 1,
+     "features": ["fleet"], "runtimes": ["claude_code"], "channels": 5,
+     "retention_days": null, "nodes": null,
+     "missing": {"features": ["fleet"], "runtimes": [], "channels": null,
+                 "retention_days": null, "nodes": null}}
+  ],
+  "path_length":  1,
+  "denied_count": 1,
+  "all_denied":   true,
+  "any_denied":   true
+}
+```
+
+**Envelope keys:** identical to `has-all-bundle-at-path-batch` on the
+axis-echo / resolver slots; per-destination rollup slots use
+`denied_count` / `all_denied` / `any_denied` instead of the boolean-fold
+`allowed_count` / `all_allowed` / `any_allowed`.
+
+Complement invariant with `has-all-bundle-at-path-batch`: per
+destination per rung, `any(row["missing"].values())` byte-equals `not
+row["has_all_at"]` on the paired boolean-fold row for every
+fully-parseable bundle.
+
+400 on missing / non-object `bundle`. Missing/blank/unknown `from` or
+an empty / all-unknown destination CSV returns 200 with `tiers=[]`
+(never 4xxs or 5xxs). Ships in GRACE mode.
+
+The scalar is `clawmetry.entitlements.missing_all_bundle_at_path_batch(from_tier, to_tiers, bundle)`.
+
 ### Bundle-batch perspective row-detail endpoint: `missing-all-bundle-batch-at`
 
 `POST /api/entitlement/missing-all-bundle-batch-at?tier=<perspective>`

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -43530,6 +43530,543 @@ def api_entitlement_missing_all_bundle_at_path():
         )
 
 
+def _has_all_bundle_at_path_batch_fallback(
+    from_tier: str, to_tokens: list
+) -> dict:
+    """Never-5xx envelope for ``/api/entitlement/has-all-bundle-at-path-batch``.
+
+    Bundle-shaped batch-path sibling of
+    :func:`_has_all_at_path_batch_fallback` (kwargs-shaped batch-path)
+    and destination-batch sibling of
+    :func:`_has_all_bundle_at_path_fallback` (singular destination). On
+    any resolver / helper blowup the endpoint still returns 200 with
+    the same envelope shape as the happy path but with ``tiers=[]`` so
+    a pricing-comparison matrix that lost the resolver never silently
+    renders a bundle grant it can't verify. Caller-supplied destination
+    tokens echo into ``unknown_tiers`` for debugging.
+    """
+    return {
+        "from": from_tier,
+        "from_label": None,
+        "from_rank": -1,
+        "features": [],
+        "runtimes": [],
+        "channels": None,
+        "retention_days": None,
+        "nodes": None,
+        "unknown_tiers": list(to_tokens),
+        "tiers": [],
+        "current_tier": "oss",
+        "current_tier_rank": 0,
+        "grace": True,
+        "enforced": False,
+    }
+
+
+@bp_entitlement.route(
+    "/api/entitlement/has-all-bundle-at-path-batch",
+    methods=["POST"],
+)
+def api_entitlement_has_all_bundle_at_path_batch():
+    """``POST /api/entitlement/has-all-bundle-at-path-batch?from=<id>&to=a,b,c``
+    -- bundle-shaped batch-path sibling of
+    ``/api/entitlement/has-all-bundle-at-path`` (singular destination)
+    and bundle-shaped counterpart of
+    ``/api/entitlement/has-all-at-path-batch`` (kwargs-shaped batch-
+    path).
+
+    Wraps :func:`clawmetry.entitlements.has_all_bundle_at_path_batch`
+    so a pricing-matrix or upgrade-walkthrough tooltip can render
+    "from my current rung, here are 3 tiers I'm considering: for this
+    WHOLE 5-axis bundle dict show me at which rung this bundle unlocks
+    along every candidate path" straight from the bundle dict off ONE
+    round-trip instead of normalising the bundle by hand and calling
+    ``/has-all-at-path-batch``, or N calls to
+    ``/has-all-bundle-at-path``.
+
+    Fills the ``_at_path_batch`` slot on the aggregate bundle boolean-
+    fold family alongside ``/has-all-bundle-at-path`` (singular
+    destination), ``/has-all-bundle-batch-at`` (multi-bundle
+    perspective batch), and ``/has-all-at-path-batch`` (kwargs-shaped
+    batch-path).
+
+    Request body is byte-identical to ``/has-all-bundle-at-path``:
+    ``{"bundle": {"features": [...], "runtimes": [...], "channels": N,
+    "retention_days": N, "nodes": N}}`` -- or the bare-dict shorthand.
+    ``from`` and ``to`` (CSV) are required query args.
+
+    Response envelope (byte-stable across every input branch)::
+
+        {
+          "from":               "<tier id>",
+          "from_label":         "..." | null,
+          "from_rank":          <int>,
+          "features":           [<echo>],
+          "runtimes":           [<echo>],
+          "channels":           <int|null>,
+          "retention_days":     <int|null>,
+          "nodes":              <int|null>,
+          "unknown_tiers":      [...],
+          "tiers": [
+            {
+              "to":            "<id>",
+              "to_label":      "...",
+              "to_rank":       <int>,
+              "direction":     "upgrade" | "downgrade" | "lateral" | "identity",
+              "path":          [<has_all_bundle_at_path row>, ...],
+              "path_length":   <int>,
+              "allowed_count": <int>,
+              "all_allowed":   <bool>,
+              "any_allowed":   <bool>,
+            },
+            ...
+          ],
+          "current_tier":        "<live tier id>",
+          "current_tier_rank":   <int>,
+          "grace":               <bool>,
+          "enforced":            <bool>,
+        }
+
+    Each ``tiers[].path`` row is byte-identical to a row from
+    ``/has-all-bundle-at-path?from=<from>&to=<to>``'s ``.path`` for the
+    same triple -- pinned by the parity tests so the singular and batch
+    bundle-shaped what-if boolean-fold path helpers cannot drift. Per-
+    destination path lengths can legitimately differ (the rungs walked
+    depend on the destination), matching
+    ``/has-all-at-path-batch`` posture. ``trial`` IS accepted as a
+    destination (excluded from the walked intermediate rungs the way
+    ``/has-all-bundle-at-path`` already excludes it, but is a valid
+    endpoint via the lateral / identity branches).
+
+    Bundle normalisation semantics per rung per destination inherit
+    ``/has-all-bundle-at-path`` byte-for-byte (via
+    :func:`clawmetry.entitlements._normalise_all_bundle` +
+    :func:`_has_all_bundle_row_at`):
+
+    * Bare-dict shorthand accepted; missing / non-object ``bundle`` is
+      a 400.
+    * ``bundle={}`` (empty) collapses every rung of every destination
+      to ``has_all_at=false`` (no axis supplied, singular
+      :func:`has_all_at` collapses).
+    * Runtime alias canonicalisation (``claude-code`` ->
+      ``claude_code``) applied per-token; alias-and-canonical pair
+      dedups to one entry on the echo.
+    * Unknown runtime id dropped by normalisation. Unknown feature id
+      survives normalisation and collapses every rung's fold to
+      ``false``.
+    * Non-int capacity value collapses to ``null`` on the echo AND
+      drops from the fold.
+
+    Perspective-shaped answers are **intentionally identical in grace
+    and enforce** (read the static per-tier tables via
+    :func:`has_all_bundle_at_path_batch`'s per-rung
+    :func:`_has_all_bundle_row_at` delegation, not the resolver's
+    ``grace`` bit).
+
+    Envelope-level axis echo mirrors the normalised bundle so a caller
+    sees exactly what the scalar folded, independent of the per-rung
+    echo. Reads from the first non-empty row (bundle normalisation is
+    per-scalar not per-rung, so every row's echo is byte-identical
+    within a destination and byte-identical across destinations); falls
+    back to :func:`_normalise_all_bundle` directly when every path is
+    empty (identity / cross-rung-empty branch) so the envelope-level
+    echo still reflects the caller-supplied bundle even when no rungs
+    were walked.
+
+    - **400** when ``bundle`` is missing / non-object.
+    - **Never 4xxs on endpoint validity**: missing / blank / unknown
+      ``from``, or empty / all-unknown ``to`` CSV -> 200 with
+      ``tiers=[]`` (matches ``/has-all-at-path-batch`` posture -- a
+      pricing-comparison matrix binds ``tiers`` directly without a
+      pre-validation round-trip).
+    - **Never 5xxs**: a resolver / scalar / body-builder blowup yields
+      the fallback envelope
+      (:func:`_has_all_bundle_at_path_batch_fallback`) with
+      ``tiers=[]``.
+    """
+    body = request.get_json(silent=True) or {}
+    bundle, err = _parse_single_bundle_body(body)
+    if err == "missing":
+        return jsonify({"error": "missing bundle"}), 400
+    if err == "bundle_must_be_object":
+        return jsonify({"error": "bundle must be an object"}), 400
+    raw_from = request.args.get("from")
+    from_tier = (raw_from or "").strip().lower()
+    to_tokens = _parse_csv_arg("to")
+    try:
+        from clawmetry import entitlements as _ent
+
+        batch = _ent.has_all_bundle_at_path_batch(
+            from_tier, to_tokens, bundle
+        )
+        env = _resolver_envelope(_ent)
+
+        # Envelope-level axis echo: derive from the first available
+        # per-rung row so the envelope reflects exactly what the scalar
+        # folded. Bundle normalisation is per-scalar, not per-rung, so
+        # every rung's echo is byte-identical within a destination and
+        # byte-identical across destinations for the same bundle.
+        features_echo: list = []
+        runtimes_echo: list = []
+        channels_echo = None
+        retention_echo = None
+        nodes_echo = None
+        anchor = None
+        if batch is not None:
+            for row in batch.get("tiers", []) or []:
+                for prow in row.get("path", []) or []:
+                    anchor = prow
+                    break
+                if anchor is not None:
+                    break
+        if anchor is not None:
+            features_echo = list(anchor.get("features") or [])
+            runtimes_echo = list(anchor.get("runtimes") or [])
+            channels_echo = anchor.get("channels")
+            retention_echo = anchor.get("retention_days")
+            nodes_echo = anchor.get("nodes")
+        else:
+            (
+                features_echo,
+                runtimes_echo,
+                channels_echo,
+                retention_echo,
+                nodes_echo,
+            ) = _ent._normalise_all_bundle(bundle)
+
+        if batch is None:
+            return jsonify(
+                {
+                    "from": from_tier,
+                    "from_label": None,
+                    "from_rank": -1,
+                    "features": list(features_echo),
+                    "runtimes": list(runtimes_echo),
+                    "channels": channels_echo,
+                    "retention_days": retention_echo,
+                    "nodes": nodes_echo,
+                    "unknown_tiers": list(to_tokens),
+                    "tiers": [],
+                    "current_tier": env["current_tier"],
+                    "current_tier_rank": env["current_tier_rank"],
+                    "grace": env["grace"],
+                    "enforced": env["enforced"],
+                }
+            )
+
+        tiers_out: list[dict] = []
+        for row in batch.get("tiers", []) or []:
+            try:
+                path = list(row.get("path", []) or [])
+            except AttributeError:
+                continue
+            path_out: list[dict] = []
+            for prow in path:
+                try:
+                    tid = prow.get("tier")
+                except AttributeError:
+                    continue
+                path_out.append(
+                    {
+                        "tier": tid,
+                        "tier_label": prow.get(
+                            "tier_label", _ent.tier_label(tid)
+                        ),
+                        "tier_rank": prow.get(
+                            "tier_rank", _ent.tier_rank(tid)
+                        ),
+                        **_has_all_bundle_row_at_to_body(prow),
+                    }
+                )
+            allowed_count = sum(1 for r in path_out if r.get("has_all_at"))
+            all_allowed = bool(path_out) and all(
+                r.get("has_all_at") for r in path_out
+            )
+            any_allowed = any(r.get("has_all_at") for r in path_out)
+            tiers_out.append(
+                {
+                    "to": row.get("to"),
+                    "to_label": row.get("to_label"),
+                    "to_rank": row.get("to_rank", -1),
+                    "direction": row.get("direction"),
+                    "path": path_out,
+                    "path_length": len(path_out),
+                    "allowed_count": allowed_count,
+                    "all_allowed": all_allowed,
+                    "any_allowed": any_allowed,
+                }
+            )
+
+        return jsonify(
+            {
+                "from": from_tier,
+                "from_label": _ent.tier_label(from_tier),
+                "from_rank": _ent.tier_rank(from_tier),
+                "features": list(features_echo),
+                "runtimes": list(runtimes_echo),
+                "channels": channels_echo,
+                "retention_days": retention_echo,
+                "nodes": nodes_echo,
+                "unknown_tiers": list(batch.get("unknown", []) or []),
+                "tiers": tiers_out,
+                "current_tier": env["current_tier"],
+                "current_tier_rank": env["current_tier_rank"],
+                "grace": env["grace"],
+                "enforced": env["enforced"],
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_has_all_bundle_at_path_batch: error: %s", exc
+        )
+        return jsonify(
+            _has_all_bundle_at_path_batch_fallback(from_tier, to_tokens)
+        )
+
+
+def _missing_all_bundle_at_path_batch_fallback(
+    from_tier: str, to_tokens: list
+) -> dict:
+    """Never-5xx envelope for
+    ``/api/entitlement/missing-all-bundle-at-path-batch``.
+
+    Row-detail bundle-shaped batch-path sibling of
+    :func:`_missing_all_at_path_batch_fallback` (kwargs-shaped batch-
+    path) and destination-batch sibling of
+    :func:`_missing_all_bundle_at_path_fallback` (singular destination).
+    On any resolver / helper blowup the endpoint still returns 200 with
+    the same envelope shape as the happy path but with ``tiers=[]`` so
+    a pricing-comparison matrix that lost the resolver never silently
+    renders a denial it can no longer justify. Mirrors
+    :func:`_has_all_bundle_at_path_batch_fallback` byte-for-byte on the
+    axis-echo slots so a UI wiring both boolean-fold and row-detail
+    matrices off the same body-builder gets byte-stable envelopes
+    across every input branch on both endpoints.
+    """
+    return {
+        "from": from_tier,
+        "from_label": None,
+        "from_rank": -1,
+        "features": [],
+        "runtimes": [],
+        "channels": None,
+        "retention_days": None,
+        "nodes": None,
+        "unknown_tiers": list(to_tokens),
+        "tiers": [],
+        "current_tier": "oss",
+        "current_tier_rank": 0,
+        "grace": True,
+        "enforced": False,
+    }
+
+
+@bp_entitlement.route(
+    "/api/entitlement/missing-all-bundle-at-path-batch",
+    methods=["POST"],
+)
+def api_entitlement_missing_all_bundle_at_path_batch():
+    """``POST /api/entitlement/missing-all-bundle-at-path-batch?from=<id>&to=a,b,c``
+    -- row-detail bundle-shaped batch-path sibling of the boolean-fold
+    ``/api/entitlement/has-all-bundle-at-path-batch``, bundle-shaped
+    counterpart of ``/api/entitlement/missing-all-at-path-batch``
+    (kwargs-shaped batch-path), and destination-batch sibling of
+    ``/api/entitlement/missing-all-bundle-at-path`` (singular
+    destination).
+
+    Wraps :func:`clawmetry.entitlements.missing_all_bundle_at_path_batch`
+    so a pricing-matrix or upgrade-walkthrough tooltip can render
+    "from my current rung, here are 3 tiers I'm considering: for this
+    WHOLE 5-axis bundle dict show me which per-axis slots are still
+    locked at every rung climbed to reach each" straight from the
+    bundle dict off ONE round-trip instead of normalising the bundle
+    by hand and calling ``/missing-all-at-path-batch``, or N calls to
+    ``/missing-all-bundle-at-path``.
+
+    Request body is byte-identical to ``/missing-all-bundle-at-path``:
+    ``{"bundle": {"features": [...], "runtimes": [...], "channels": N,
+    "retention_days": N, "nodes": N}}`` -- or the bare-dict shorthand.
+    ``from`` and ``to`` (CSV) are required query args.
+
+    Response envelope mirrors ``/has-all-bundle-at-path-batch`` byte-
+    for-byte on the axis-echo slots (byte-parity so a UI wiring both
+    boolean-fold and row-detail matrices sees a consistent envelope)
+    with the per-destination fold-rollup keys swapped
+    (``denied_count`` / ``all_denied`` / ``any_denied`` in place of
+    ``allowed_count`` / ``all_allowed`` / ``any_allowed``) and the per-
+    rung row body swapped from the boolean-fold row to the row-detail
+    row.
+
+    Each ``tiers[].path`` row is byte-identical to a row from
+    ``/missing-all-bundle-at-path?from=<from>&to=<to>``'s ``.path`` for
+    the same triple -- pinned by the parity tests so the singular and
+    batch bundle-shaped what-if row-detail path helpers cannot drift.
+
+    Complement invariant with ``/has-all-bundle-at-path-batch``: per
+    destination per rung, ``any(row["missing"].values())`` byte-equals
+    ``not row["has_all_at"]`` on the paired boolean-fold row for every
+    fully-parseable bundle.
+
+    Perspective-shaped answers are **intentionally identical in grace
+    and enforce** (read the static per-tier tables via
+    :func:`missing_all_bundle_at_path_batch`'s per-rung
+    :func:`_missing_all_bundle_row_at` delegation, not the resolver's
+    ``grace`` bit).
+
+    - **400** when ``bundle`` is missing / non-object.
+    - **Never 4xxs on endpoint validity**: missing / blank / unknown
+      ``from``, or empty / all-unknown ``to`` CSV -> 200 with
+      ``tiers=[]``.
+    - **Never 5xxs**: a resolver / scalar / body-builder blowup yields
+      the fallback envelope
+      (:func:`_missing_all_bundle_at_path_batch_fallback`) with
+      ``tiers=[]``.
+    """
+    body = request.get_json(silent=True) or {}
+    bundle, err = _parse_single_bundle_body(body)
+    if err == "missing":
+        return jsonify({"error": "missing bundle"}), 400
+    if err == "bundle_must_be_object":
+        return jsonify({"error": "bundle must be an object"}), 400
+    raw_from = request.args.get("from")
+    from_tier = (raw_from or "").strip().lower()
+    to_tokens = _parse_csv_arg("to")
+    try:
+        from clawmetry import entitlements as _ent
+
+        batch = _ent.missing_all_bundle_at_path_batch(
+            from_tier, to_tokens, bundle
+        )
+        env = _resolver_envelope(_ent)
+
+        features_echo: list = []
+        runtimes_echo: list = []
+        channels_echo = None
+        retention_echo = None
+        nodes_echo = None
+        anchor = None
+        if batch is not None:
+            for row in batch.get("tiers", []) or []:
+                for prow in row.get("path", []) or []:
+                    anchor = prow
+                    break
+                if anchor is not None:
+                    break
+        if anchor is not None:
+            features_echo = list(anchor.get("features") or [])
+            runtimes_echo = list(anchor.get("runtimes") or [])
+            channels_echo = anchor.get("channels")
+            retention_echo = anchor.get("retention_days")
+            nodes_echo = anchor.get("nodes")
+        else:
+            (
+                features_echo,
+                runtimes_echo,
+                channels_echo,
+                retention_echo,
+                nodes_echo,
+            ) = _ent._normalise_all_bundle(bundle)
+
+        if batch is None:
+            return jsonify(
+                {
+                    "from": from_tier,
+                    "from_label": None,
+                    "from_rank": -1,
+                    "features": list(features_echo),
+                    "runtimes": list(runtimes_echo),
+                    "channels": channels_echo,
+                    "retention_days": retention_echo,
+                    "nodes": nodes_echo,
+                    "unknown_tiers": list(to_tokens),
+                    "tiers": [],
+                    "current_tier": env["current_tier"],
+                    "current_tier_rank": env["current_tier_rank"],
+                    "grace": env["grace"],
+                    "enforced": env["enforced"],
+                }
+            )
+
+        def _row_any_denied(prow) -> bool:
+            m = prow.get("missing") or {}
+            for k, v in m.items():
+                if isinstance(v, list):
+                    if v:
+                        return True
+                elif v is not None:
+                    return True
+            return False
+
+        tiers_out: list[dict] = []
+        for row in batch.get("tiers", []) or []:
+            try:
+                path = list(row.get("path", []) or [])
+            except AttributeError:
+                continue
+            path_out: list[dict] = []
+            for prow in path:
+                try:
+                    tid = prow.get("tier")
+                except AttributeError:
+                    continue
+                path_out.append(
+                    {
+                        "tier": tid,
+                        "tier_label": prow.get(
+                            "tier_label", _ent.tier_label(tid)
+                        ),
+                        "tier_rank": prow.get(
+                            "tier_rank", _ent.tier_rank(tid)
+                        ),
+                        **_missing_all_bundle_row_at_to_body(prow),
+                    }
+                )
+            denied_count = sum(1 for r in path_out if _row_any_denied(r))
+            all_denied = bool(path_out) and all(
+                _row_any_denied(r) for r in path_out
+            )
+            any_denied = any(_row_any_denied(r) for r in path_out)
+            tiers_out.append(
+                {
+                    "to": row.get("to"),
+                    "to_label": row.get("to_label"),
+                    "to_rank": row.get("to_rank", -1),
+                    "direction": row.get("direction"),
+                    "path": path_out,
+                    "path_length": len(path_out),
+                    "denied_count": denied_count,
+                    "all_denied": all_denied,
+                    "any_denied": any_denied,
+                }
+            )
+
+        return jsonify(
+            {
+                "from": from_tier,
+                "from_label": _ent.tier_label(from_tier),
+                "from_rank": _ent.tier_rank(from_tier),
+                "features": list(features_echo),
+                "runtimes": list(runtimes_echo),
+                "channels": channels_echo,
+                "retention_days": retention_echo,
+                "nodes": nodes_echo,
+                "unknown_tiers": list(batch.get("unknown", []) or []),
+                "tiers": tiers_out,
+                "current_tier": env["current_tier"],
+                "current_tier_rank": env["current_tier_rank"],
+                "grace": env["grace"],
+                "enforced": env["enforced"],
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_missing_all_bundle_at_path_batch: error: %s", exc
+        )
+        return jsonify(
+            _missing_all_bundle_at_path_batch_fallback(from_tier, to_tokens)
+        )
+
+
 @bp_entitlement.route(
     "/api/entitlement/has-all-bundle-batch",
     methods=["POST"],

--- a/tests/test_entitlement_has_all_bundle_at_path_batch.py
+++ b/tests/test_entitlement_has_all_bundle_at_path_batch.py
@@ -1,0 +1,784 @@
+"""Tests for the bundle-shaped batch-path pair:
+:func:`clawmetry.entitlements.has_all_bundle_at_path_batch` /
+:func:`clawmetry.entitlements.missing_all_bundle_at_path_batch` and
+their paired POST
+``/api/entitlement/has-all-bundle-at-path-batch`` /
+``/api/entitlement/missing-all-bundle-at-path-batch`` endpoints.
+
+Destination-batch siblings of :func:`has_all_bundle_at_path` /
+:func:`missing_all_bundle_at_path` (singular destination) and bundle-
+shaped counterparts of :func:`has_all_at_path_batch` /
+:func:`missing_all_at_path_batch` (kwargs-shaped batch-path). Fills the
+``_at_path_batch`` slot on the aggregate bundle boolean-fold and row-
+detail families.
+
+Pins:
+
+1. Per-destination row shape byte-parity with
+   :func:`has_all_at_path_batch` / :func:`missing_all_at_path_batch`.
+2. Per-rung ``path`` byte-parity with the singular
+   :func:`has_all_bundle_at_path` / :func:`missing_all_bundle_at_path`
+   for the same ``(from, to, bundle)`` triple.
+3. Complement invariant with the paired boolean-fold call per
+   destination per rung.
+4. Grace-independence: same answer under grace-on vs enforce for the
+   same ``(from, to_tiers, bundle)`` triple.
+5. Unknown-from short-circuit returns ``None`` (scalar) / envelope
+   with ``tiers=[]`` (endpoint); never 4xxs on endpoint validity.
+6. Partial-unknown-``to`` posture: valid ids fill ``tiers[]`` while
+   unknown ids echo in ``unknown[]`` / ``unknown_tiers[]``.
+7. Direction detection per destination: ``upgrade`` / ``downgrade`` /
+   ``lateral`` / ``identity``.
+8. Bundle normalisation semantics inherited from the singular
+   ``_bundle_at_path`` seat (non-dict collapses, runtime alias
+   canonicalisation, unknown runtime drop, unknown feature typo
+   collapse on has-side).
+9. Envelope-level rollup fields (``allowed_count`` / ``all_allowed`` /
+   ``any_allowed`` for has; ``denied_count`` / ``all_denied`` /
+   ``any_denied`` for missing).
+10. Never-5xxs on delegate blowup: endpoint returns the fallback
+    envelope with ``tiers=[]``.
+11. Envelope shape (fixed key set) byte-stable across every input
+    branch on both endpoints.
+12. POST body wrapped form + bare-dict shorthand both accepted; 400 on
+    missing / non-object bundle.
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+# -- Fixtures ---------------------------------------------------------
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def enforced(monkeypatch, tmp_path):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    importlib.reload(e)
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# -- Envelope + row shape constants -----------------------------------
+
+_ENVELOPE_KEYS = {
+    "from",
+    "from_label",
+    "from_rank",
+    "features",
+    "runtimes",
+    "channels",
+    "retention_days",
+    "nodes",
+    "unknown_tiers",
+    "tiers",
+    "current_tier",
+    "current_tier_rank",
+    "grace",
+    "enforced",
+}
+
+_TIER_KEYS_HAS = {
+    "to",
+    "to_label",
+    "to_rank",
+    "direction",
+    "path",
+    "path_length",
+    "allowed_count",
+    "all_allowed",
+    "any_allowed",
+}
+
+_TIER_KEYS_MISSING = {
+    "to",
+    "to_label",
+    "to_rank",
+    "direction",
+    "path",
+    "path_length",
+    "denied_count",
+    "all_denied",
+    "any_denied",
+}
+
+_HAS_ROW_KEYS = {
+    "tier",
+    "tier_label",
+    "tier_rank",
+    "features",
+    "runtimes",
+    "channels",
+    "retention_days",
+    "nodes",
+    "has_all_at",
+}
+
+_MISSING_ROW_KEYS = {
+    "tier",
+    "tier_label",
+    "tier_rank",
+    "features",
+    "runtimes",
+    "channels",
+    "retention_days",
+    "nodes",
+    "missing",
+}
+
+
+def _post_json(client, url, body):
+    resp = client.post(url, json=body)
+    assert resp.status_code == 200, (
+        url,
+        resp.status_code,
+        resp.get_data(as_text=True),
+    )
+    return resp.get_json()
+
+
+# -- Scalar: unknown-from short-circuit -------------------------------
+
+
+@pytest.mark.parametrize("bad", ["bogus", "", None])
+def test_has_scalar_unknown_from_returns_none(ent, bad):
+    assert (
+        ent.has_all_bundle_at_path_batch(
+            bad, ["cloud_pro"], {"features": ["fleet"]}
+        )
+        is None
+    )
+
+
+@pytest.mark.parametrize("bad", ["bogus", "", None])
+def test_missing_scalar_unknown_from_returns_none(ent, bad):
+    assert (
+        ent.missing_all_bundle_at_path_batch(
+            bad, ["cloud_pro"], {"features": ["fleet"]}
+        )
+        is None
+    )
+
+
+# -- Scalar: shape + parity with the singular -------------------------
+
+
+def test_has_scalar_shape(ent):
+    r = ent.has_all_bundle_at_path_batch(
+        "oss",
+        ["cloud_starter", "cloud_pro", "enterprise"],
+        {"features": ["fleet"], "runtimes": ["claude_code"]},
+    )
+    assert set(r.keys()) == {"tiers", "unknown"}
+    assert r["unknown"] == []
+    for row in r["tiers"]:
+        assert set(row.keys()) == {
+            "to",
+            "to_label",
+            "to_rank",
+            "direction",
+            "path",
+        }
+        assert isinstance(row["path"], list)
+
+
+def test_has_scalar_per_destination_path_parity_with_singular(ent):
+    bundle = {
+        "features": ["fleet"],
+        "runtimes": ["claude_code"],
+        "channels": 5,
+    }
+    tos = ["cloud_starter", "cloud_pro", "enterprise", "trial"]
+    r = ent.has_all_bundle_at_path_batch("oss", tos, bundle)
+    for row in r["tiers"]:
+        singular = ent.has_all_bundle_at_path("oss", row["to"], bundle)
+        assert row["path"] == singular, row["to"]
+
+
+def test_missing_scalar_per_destination_path_parity_with_singular(ent):
+    bundle = {
+        "features": ["fleet"],
+        "runtimes": ["claude_code"],
+        "channels": 500,
+    }
+    tos = ["cloud_starter", "cloud_pro", "enterprise", "trial"]
+    r = ent.missing_all_bundle_at_path_batch("oss", tos, bundle)
+    for row in r["tiers"]:
+        singular = ent.missing_all_bundle_at_path("oss", row["to"], bundle)
+        assert row["path"] == singular, row["to"]
+
+
+# -- Scalar: direction detection --------------------------------------
+
+
+def test_has_scalar_direction_detection(ent):
+    r = ent.has_all_bundle_at_path_batch(
+        "cloud_pro",
+        ["oss", "cloud_starter", "cloud_pro", "pro", "enterprise"],
+        {"features": ["fleet"]},
+    )
+    by_to = {row["to"]: row for row in r["tiers"]}
+    assert by_to["oss"]["direction"] == "downgrade"
+    assert by_to["cloud_starter"]["direction"] == "downgrade"
+    assert by_to["cloud_pro"]["direction"] == "identity"
+    # cloud_pro and pro share rank 2.
+    assert ent._TIER_RANK["cloud_pro"] == ent._TIER_RANK["pro"]
+    assert by_to["pro"]["direction"] == "lateral"
+    assert by_to["enterprise"]["direction"] == "upgrade"
+
+
+def test_has_scalar_identity_row_has_empty_path(ent):
+    r = ent.has_all_bundle_at_path_batch(
+        "oss", ["oss"], {"features": ["fleet"]}
+    )
+    assert r["tiers"][0]["direction"] == "identity"
+    assert r["tiers"][0]["path"] == []
+
+
+# -- Scalar: partial-unknown-``to`` posture ---------------------------
+
+
+def test_has_scalar_partial_unknown_to_echoes_in_unknown(ent):
+    r = ent.has_all_bundle_at_path_batch(
+        "oss",
+        ["cloud_pro", "bogus", "enterprise", "totally_fake"],
+        {"features": ["fleet"]},
+    )
+    assert [row["to"] for row in r["tiers"]] == ["cloud_pro", "enterprise"]
+    assert r["unknown"] == ["bogus", "totally_fake"]
+
+
+def test_missing_scalar_partial_unknown_to_echoes_in_unknown(ent):
+    r = ent.missing_all_bundle_at_path_batch(
+        "oss",
+        ["cloud_pro", "bogus", "enterprise"],
+        {"features": ["fleet"]},
+    )
+    assert [row["to"] for row in r["tiers"]] == ["cloud_pro", "enterprise"]
+    assert r["unknown"] == ["bogus"]
+
+
+def test_has_scalar_all_unknown_to_returns_empty_tiers(ent):
+    r = ent.has_all_bundle_at_path_batch(
+        "oss", ["bogus", "totally_fake"], {"features": ["fleet"]}
+    )
+    assert r == {
+        "tiers": [],
+        "unknown": ["bogus", "totally_fake"],
+    }
+
+
+def test_has_scalar_empty_to_returns_empty_tiers(ent):
+    assert ent.has_all_bundle_at_path_batch(
+        "oss", [], {"features": ["fleet"]}
+    ) == {"tiers": [], "unknown": []}
+
+
+def test_has_scalar_none_to_returns_empty_tiers(ent):
+    assert ent.has_all_bundle_at_path_batch(
+        "oss", None, {"features": ["fleet"]}
+    ) == {"tiers": [], "unknown": []}
+
+
+# -- Scalar: complement invariant -------------------------------------
+
+
+def test_complement_invariant_per_rung_per_destination(ent):
+    bundle = {
+        "features": ["fleet"],
+        "runtimes": ["claude_code"],
+        "channels": 500,
+        "retention_days": 365,
+        "nodes": 99,
+    }
+    tos = ["cloud_starter", "cloud_pro", "enterprise", "trial"]
+    h = ent.has_all_bundle_at_path_batch("oss", tos, bundle)
+    m = ent.missing_all_bundle_at_path_batch("oss", tos, bundle)
+    assert [row["to"] for row in h["tiers"]] == [
+        row["to"] for row in m["tiers"]
+    ]
+    for hrow, mrow in zip(h["tiers"], m["tiers"]):
+        assert len(hrow["path"]) == len(mrow["path"])
+        for hp, mp in zip(hrow["path"], mrow["path"]):
+            assert hp["tier"] == mp["tier"]
+            any_missing = any(
+                v for v in mp["missing"].values() if v not in (None, [])
+            )
+            assert bool(any_missing) == (not hp["has_all_at"]), (
+                hrow["to"],
+                hp["tier"],
+                hp["has_all_at"],
+                mp["missing"],
+            )
+
+
+# -- Scalar: grace-independence ---------------------------------------
+
+
+def test_has_scalar_grace_independence(ent, enforced):
+    bundle = {"features": ["fleet"], "runtimes": ["claude_code"]}
+    tos = ["cloud_starter", "cloud_pro", "enterprise"]
+    assert ent.has_all_bundle_at_path_batch(
+        "oss", tos, bundle
+    ) == enforced.has_all_bundle_at_path_batch("oss", tos, bundle)
+
+
+def test_missing_scalar_grace_independence(ent, enforced):
+    bundle = {"features": ["fleet"], "runtimes": ["claude_code"]}
+    tos = ["cloud_starter", "cloud_pro", "enterprise"]
+    assert ent.missing_all_bundle_at_path_batch(
+        "oss", tos, bundle
+    ) == enforced.missing_all_bundle_at_path_batch("oss", tos, bundle)
+
+
+# -- Scalar: bundle normalisation -------------------------------------
+
+
+@pytest.mark.parametrize("bad_bundle", [None, "not-a-dict", 42, []])
+def test_has_scalar_non_dict_bundle_collapses_fold_on_every_rung(
+    ent, bad_bundle
+):
+    r = ent.has_all_bundle_at_path_batch("oss", ["enterprise"], bad_bundle)
+    assert r["tiers"]
+    for row in r["tiers"]:
+        for prow in row["path"]:
+            assert prow["has_all_at"] is False
+            assert prow["features"] == []
+            assert prow["runtimes"] == []
+
+
+def test_has_scalar_runtime_alias_canonicalised_per_rung(ent):
+    r = ent.has_all_bundle_at_path_batch(
+        "oss", ["enterprise"], {"runtimes": ["claude-code"]}
+    )
+    for row in r["tiers"]:
+        for prow in row["path"]:
+            assert prow["runtimes"] == ["claude_code"]
+
+
+def test_has_scalar_unknown_feature_collapses_fold_on_every_rung(ent):
+    r = ent.has_all_bundle_at_path_batch(
+        "oss", ["enterprise"], {"features": ["totally_bogus"]}
+    )
+    for row in r["tiers"]:
+        for prow in row["path"]:
+            assert prow["has_all_at"] is False
+
+
+# -- Scalar: per-destination blowup posture ---------------------------
+
+
+def test_has_scalar_delegate_blowup_short_circuits_only_that_row(
+    monkeypatch, ent
+):
+    """A per-destination :func:`has_all_bundle_at_path` blowup logs a
+    warning and short-circuits that id into ``unknown[]`` while the rest
+    of the batch keeps building."""
+    real = ent.has_all_bundle_at_path
+
+    def _boom(from_tier, to_tier, bundle):
+        if to_tier == "cloud_pro":
+            raise RuntimeError("intentional")
+        return real(from_tier, to_tier, bundle)
+
+    monkeypatch.setattr(ent, "has_all_bundle_at_path", _boom)
+    r = ent.has_all_bundle_at_path_batch(
+        "oss",
+        ["cloud_starter", "cloud_pro", "enterprise"],
+        {"features": ["fleet"]},
+    )
+    assert [row["to"] for row in r["tiers"]] == [
+        "cloud_starter",
+        "enterprise",
+    ]
+    assert r["unknown"] == ["cloud_pro"]
+
+
+# -- Endpoint: happy path ---------------------------------------------
+
+
+def test_has_endpoint_upgrade_envelope_shape(client):
+    body = _post_json(
+        client,
+        "/api/entitlement/has-all-bundle-at-path-batch"
+        "?from=oss&to=cloud_starter,cloud_pro,enterprise",
+        {"bundle": {"features": ["fleet"], "runtimes": ["claude_code"]}},
+    )
+    assert set(body.keys()) == _ENVELOPE_KEYS
+    assert body["from"] == "oss"
+    assert body["unknown_tiers"] == []
+    assert [row["to"] for row in body["tiers"]] == [
+        "cloud_starter",
+        "cloud_pro",
+        "enterprise",
+    ]
+    for row in body["tiers"]:
+        assert set(row.keys()) == _TIER_KEYS_HAS
+        assert row["direction"] == "upgrade"
+        assert row["path_length"] == len(row["path"])
+        assert row["allowed_count"] == sum(
+            1 for p in row["path"] if p["has_all_at"]
+        )
+        for prow in row["path"]:
+            assert set(prow.keys()) == _HAS_ROW_KEYS
+
+
+def test_missing_endpoint_upgrade_envelope_shape(client):
+    body = _post_json(
+        client,
+        "/api/entitlement/missing-all-bundle-at-path-batch"
+        "?from=oss&to=cloud_starter,cloud_pro,enterprise",
+        {"bundle": {"features": ["fleet"], "runtimes": ["claude_code"]}},
+    )
+    assert set(body.keys()) == _ENVELOPE_KEYS
+    for row in body["tiers"]:
+        assert set(row.keys()) == _TIER_KEYS_MISSING
+        assert row["direction"] == "upgrade"
+        assert row["path_length"] == len(row["path"])
+        for prow in row["path"]:
+            assert set(prow.keys()) == _MISSING_ROW_KEYS
+            assert set(prow["missing"].keys()) == {
+                "features",
+                "runtimes",
+                "channels",
+                "retention_days",
+                "nodes",
+            }
+
+
+def test_has_endpoint_axis_echo_matches_bundle(client):
+    body = _post_json(
+        client,
+        "/api/entitlement/has-all-bundle-at-path-batch?from=oss&to=enterprise",
+        {
+            "bundle": {
+                "features": ["fleet"],
+                "runtimes": ["claude-code"],
+                "channels": 5,
+            }
+        },
+    )
+    assert body["features"] == ["fleet"]
+    assert body["runtimes"] == ["claude_code"]
+    assert body["channels"] == 5
+
+
+def test_missing_endpoint_axis_echo_matches_bundle(client):
+    body = _post_json(
+        client,
+        "/api/entitlement/missing-all-bundle-at-path-batch?from=oss&to=enterprise",
+        {"bundle": {"features": ["fleet"], "channels": 500}},
+    )
+    assert body["features"] == ["fleet"]
+    assert body["channels"] == 500
+
+
+def test_has_endpoint_bare_dict_shorthand_body(client):
+    body = _post_json(
+        client,
+        "/api/entitlement/has-all-bundle-at-path-batch?from=oss&to=cloud_pro,enterprise",
+        {"features": ["fleet"]},
+    )
+    assert body["features"] == ["fleet"]
+    assert len(body["tiers"]) == 2
+
+
+def test_missing_endpoint_bare_dict_shorthand_body(client):
+    body = _post_json(
+        client,
+        "/api/entitlement/missing-all-bundle-at-path-batch"
+        "?from=oss&to=cloud_pro,enterprise",
+        {"features": ["fleet"]},
+    )
+    assert body["features"] == ["fleet"]
+    assert len(body["tiers"]) == 2
+
+
+# -- Endpoint: fold rollup ---------------------------------------------
+
+
+def test_has_endpoint_all_allowed_true_when_every_rung_grants(client):
+    body = _post_json(
+        client,
+        "/api/entitlement/has-all-bundle-at-path-batch"
+        "?from=cloud_pro&to=enterprise",
+        {"bundle": {"features": ["fleet"]}},
+    )
+    assert body["tiers"]
+    for row in body["tiers"]:
+        assert row["all_allowed"] is True
+        assert row["any_allowed"] is True
+        assert row["allowed_count"] == row["path_length"]
+
+
+def test_missing_endpoint_denied_flags_on_ungranted_bundle(client):
+    """A bundle that requires enterprise-only capacity denies every
+    rung short of enterprise."""
+    body = _post_json(
+        client,
+        "/api/entitlement/missing-all-bundle-at-path-batch"
+        "?from=oss&to=enterprise",
+        {"bundle": {"channels": 999999}},
+    )
+    tiers = body["tiers"]
+    assert tiers
+    for row in tiers:
+        assert row["denied_count"] >= 0
+        assert row["all_denied"] == all(
+            any(v for v in p["missing"].values() if v not in (None, []))
+            for p in row["path"]
+        )
+        assert row["any_denied"] == any(
+            any(v for v in p["missing"].values() if v not in (None, []))
+            for p in row["path"]
+        )
+
+
+# -- Endpoint: never-4xxs on endpoint validity ------------------------
+
+
+def test_has_endpoint_unknown_from_returns_empty_tiers_200(client):
+    body = _post_json(
+        client,
+        "/api/entitlement/has-all-bundle-at-path-batch?from=bogus&to=cloud_pro",
+        {"bundle": {"features": ["fleet"]}},
+    )
+    assert set(body.keys()) == _ENVELOPE_KEYS
+    assert body["tiers"] == []
+    assert body["unknown_tiers"] == ["cloud_pro"]
+
+
+def test_has_endpoint_missing_from_returns_empty_tiers_200(client):
+    body = _post_json(
+        client,
+        "/api/entitlement/has-all-bundle-at-path-batch?to=cloud_pro",
+        {"bundle": {"features": ["fleet"]}},
+    )
+    assert body["tiers"] == []
+    assert body["unknown_tiers"] == ["cloud_pro"]
+
+
+def test_has_endpoint_empty_to_returns_empty_tiers_200(client):
+    body = _post_json(
+        client,
+        "/api/entitlement/has-all-bundle-at-path-batch?from=oss&to=",
+        {"bundle": {"features": ["fleet"]}},
+    )
+    assert body["tiers"] == []
+    assert body["unknown_tiers"] == []
+
+
+def test_has_endpoint_partial_unknown_to_partitions_correctly(client):
+    body = _post_json(
+        client,
+        "/api/entitlement/has-all-bundle-at-path-batch"
+        "?from=oss&to=cloud_pro,bogus,enterprise",
+        {"bundle": {"features": ["fleet"]}},
+    )
+    assert [row["to"] for row in body["tiers"]] == [
+        "cloud_pro",
+        "enterprise",
+    ]
+    assert body["unknown_tiers"] == ["bogus"]
+
+
+# -- Endpoint: 400 branches -------------------------------------------
+
+
+def test_has_endpoint_missing_bundle_is_400(client):
+    resp = client.post(
+        "/api/entitlement/has-all-bundle-at-path-batch?from=oss&to=cloud_pro",
+        json={},
+    )
+    assert resp.status_code == 400
+
+
+def test_missing_endpoint_missing_bundle_is_400(client):
+    resp = client.post(
+        "/api/entitlement/missing-all-bundle-at-path-batch"
+        "?from=oss&to=cloud_pro",
+        json={},
+    )
+    assert resp.status_code == 400
+
+
+def test_has_endpoint_non_object_bundle_is_400(client):
+    resp = client.post(
+        "/api/entitlement/has-all-bundle-at-path-batch?from=oss&to=cloud_pro",
+        json={"bundle": "not-a-dict"},
+    )
+    assert resp.status_code == 400
+
+
+def test_missing_endpoint_non_object_bundle_is_400(client):
+    resp = client.post(
+        "/api/entitlement/missing-all-bundle-at-path-batch"
+        "?from=oss&to=cloud_pro",
+        json={"bundle": ["not-a-dict"]},
+    )
+    assert resp.status_code == 400
+
+
+# -- Endpoint: per-rung parity with singular /has-all-bundle-at-path --
+
+
+def test_has_endpoint_per_rung_parity_with_singular_endpoint(client):
+    bundle = {
+        "features": ["fleet"],
+        "runtimes": ["claude_code"],
+        "channels": 5,
+    }
+    tos = ["cloud_starter", "cloud_pro", "enterprise"]
+    batch = _post_json(
+        client,
+        f"/api/entitlement/has-all-bundle-at-path-batch"
+        f"?from=oss&to={','.join(tos)}",
+        {"bundle": bundle},
+    )
+    for row in batch["tiers"]:
+        singular = _post_json(
+            client,
+            f"/api/entitlement/has-all-bundle-at-path?from=oss&to={row['to']}",
+            {"bundle": bundle},
+        )
+        assert len(row["path"]) == singular["path_length"]
+        for bp, sp in zip(row["path"], singular["path"]):
+            assert bp == sp, (row["to"], bp["tier"])
+
+
+def test_missing_endpoint_per_rung_parity_with_singular_endpoint(client):
+    bundle = {
+        "features": ["fleet"],
+        "runtimes": ["claude_code"],
+        "channels": 500,
+    }
+    tos = ["cloud_starter", "cloud_pro", "enterprise"]
+    batch = _post_json(
+        client,
+        f"/api/entitlement/missing-all-bundle-at-path-batch"
+        f"?from=oss&to={','.join(tos)}",
+        {"bundle": bundle},
+    )
+    for row in batch["tiers"]:
+        singular = _post_json(
+            client,
+            f"/api/entitlement/missing-all-bundle-at-path?from=oss&to={row['to']}",
+            {"bundle": bundle},
+        )
+        assert len(row["path"]) == singular["path_length"]
+        for bp, sp in zip(row["path"], singular["path"]):
+            assert bp == sp, (row["to"], bp["tier"])
+
+
+# -- Endpoint: never-5xxs on body-builder blowup ----------------------
+
+
+def test_has_endpoint_never_5xxs_on_body_builder_blowup(
+    monkeypatch, client
+):
+    """A scalar blowup collapses to the fallback envelope with
+    ``tiers=[]`` -- envelope key set stays byte-stable across the
+    happy/fallback branches."""
+    from clawmetry import entitlements as _e
+
+    def _boom(*a, **k):
+        raise RuntimeError("intentional")
+
+    monkeypatch.setattr(_e, "has_all_bundle_at_path_batch", _boom)
+    body = _post_json(
+        client,
+        "/api/entitlement/has-all-bundle-at-path-batch?from=oss&to=cloud_pro",
+        {"bundle": {"features": ["fleet"]}},
+    )
+    assert set(body.keys()) == _ENVELOPE_KEYS
+    assert body["tiers"] == []
+
+
+def test_missing_endpoint_never_5xxs_on_body_builder_blowup(
+    monkeypatch, client
+):
+    from clawmetry import entitlements as _e
+
+    def _boom(*a, **k):
+        raise RuntimeError("intentional")
+
+    monkeypatch.setattr(_e, "missing_all_bundle_at_path_batch", _boom)
+    body = _post_json(
+        client,
+        "/api/entitlement/missing-all-bundle-at-path-batch"
+        "?from=oss&to=cloud_pro",
+        {"bundle": {"features": ["fleet"]}},
+    )
+    assert set(body.keys()) == _ENVELOPE_KEYS
+    assert body["tiers"] == []
+
+
+# -- Endpoint: identity + lateral edge branches -----------------------
+
+
+def test_has_endpoint_identity_row_has_empty_path_but_axis_echo(client):
+    body = _post_json(
+        client,
+        "/api/entitlement/has-all-bundle-at-path-batch?from=oss&to=oss",
+        {"bundle": {"features": ["fleet"]}},
+    )
+    assert body["tiers"] == [
+        {
+            "to": "oss",
+            "to_label": body["tiers"][0]["to_label"],
+            "to_rank": body["tiers"][0]["to_rank"],
+            "direction": "identity",
+            "path": [],
+            "path_length": 0,
+            "allowed_count": 0,
+            "all_allowed": False,
+            "any_allowed": False,
+        }
+    ]
+    # Axis echo still reflects the caller-supplied bundle even when no
+    # rungs were walked (identity / cross-rung-empty branch).
+    assert body["features"] == ["fleet"]
+
+
+def test_has_endpoint_lateral_direction_single_rung(client):
+    from clawmetry import entitlements as _e
+
+    assert _e._TIER_RANK["cloud_pro"] == _e._TIER_RANK["pro"]
+    body = _post_json(
+        client,
+        "/api/entitlement/has-all-bundle-at-path-batch"
+        "?from=cloud_pro&to=pro",
+        {"bundle": {"features": ["fleet"]}},
+    )
+    assert body["tiers"][0]["direction"] == "lateral"
+    assert body["tiers"][0]["path_length"] == 1
+    assert body["tiers"][0]["path"][0]["tier"] == "pro"


### PR DESCRIPTION
## Summary

- Adds bundle-shaped destination-batch siblings of `has_all_bundle_at_path` / `missing_all_bundle_at_path` (singular destination) and bundle-shaped counterparts of `has_all_at_path_batch` / `missing_all_at_path_batch` (kwargs-shaped batch-path). Fills the `_at_path_batch` slot on the aggregate 5-axis bundle boolean-fold and row-detail families alongside the per-single-axis `_at_path_batch` siblings and the singular `_bundle_at_path` pair.
- New scalars in `clawmetry/entitlements.py`: `has_all_bundle_at_path_batch(from_tier, to_tiers, bundle)` and `missing_all_bundle_at_path_batch(from_tier, to_tiers, bundle)`. Per-destination `path` byte-parity with the singular `has_all_bundle_at_path` / `missing_all_bundle_at_path` for the same `(from_tier, to, bundle)` triple pinned by tests.
- New endpoints on `bp_entitlement` (`routes/entitlement.py`): `POST /api/entitlement/has-all-bundle-at-path-batch?from=&to=a,b,c` and `POST /api/entitlement/missing-all-bundle-at-path-batch?from=&to=a,b,c`. Bundle body accepts both the wrapped `{"bundle": {...}}` form and the bare-dict shorthand — matches sibling `/has-all-bundle-at-path` body posture. Envelope byte-stable across every input branch (fixed key set including the unknown-`from` and fallback branches).
- Grace-independent by construction (delegates per-rung per destination to `_has_all_bundle_row_at` / `_missing_all_bundle_row_at` via the singular `_bundle_at_path` scalars). Rung walk byte-stable against `has_all_at_path` / `missing_all_at_path` / `has_all_bundle_at_path` / `missing_all_bundle_at_path` / `tier_path` (same `_PURCHASABLE_TIERS` filter + same sort + same destination-sibling exclusion).
- Missing / non-object `bundle` is a 400; unknown / blank / missing `from` OR empty / all-unknown `to` CSV returns 200 with `tiers=[]`. A scalar / body-builder blowup collapses to the fallback envelope with `tiers=[]` (never 5xxs).
- Runtime-alias canonicalisation (`claude-code` → `claude_code`) applied by the bundle normaliser. Unknown feature id survives normalisation and collapses every rung's `has_all_at` to `False` via the singular scalar's strict typo posture on the has-side; unknown runtime id is dropped by canonicalisation and surfaces via the empty `runtimes` echo instead.
- Complement invariant pinned by tests: per destination per rung `any(row["path"][i]["missing"].values())` byte-equals `not row["path"][i]["has_all_at"]` on the paired boolean-fold call for every fully-parseable bundle.
- Purely additive query surface. Ships in GRACE mode — no behaviour change on any existing endpoint.
- Docs: `docs/ENTITLEMENTS.md` gains sections for both new endpoints.

## Test plan

- [x] `python -m py_compile clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_has_all_bundle_at_path_batch.py`
- [x] `ruff check tests/test_entitlement_has_all_bundle_at_path_batch.py` — clean
- [x] `python -m pytest tests/test_entitlement_has_all_bundle_at_path_batch.py` — **48 passed**, covering scalar per-destination row shape, per-rung parity with the singular `_bundle_at_path` scalars, complement invariant, grace-independence, direction detection (upgrade / downgrade / lateral / identity), unknown-`from` short-circuit, empty / none / all-unknown `to` CSV, partial-unknown-`to` partitioning, bundle normalisation (non-dict collapse, runtime alias canonicalisation, unknown feature typo collapse), per-destination delegate blowup posture, endpoint envelope shape across every branch, axis-echo derivation from the first row / bundle normaliser fallback, 400 branches (missing / non-object bundle), per-rung parity with the singular `/has-all-bundle-at-path` and `/missing-all-bundle-at-path` endpoints, rollup fields (`allowed_count` / `all_allowed` / `any_allowed` for has; `denied_count` / `all_denied` / `any_denied` for missing), and never-5xxs fallback envelope on body-builder blowup.
- [x] `python -m pytest tests/test_entitlement_has_all_bundle_at_path.py tests/test_entitlement_has_all_at_path_batch.py tests/test_entitlement_has_all_bundle_at_path_batch.py tests/test_entitlement_api.py tests/test_entitlement_has_all_at_path.py tests/test_entitlement_missing_all_at_path.py` — **248 passed**, no regressions in neighbouring entitlement suites (singular `_bundle_at_path` pair, sibling `_at_path_batch` kwargs-shaped pair, live resolver API, singular `_at_path` pair).
- [x] `python3 scripts/lint_daemon_allowlist.py` — pre-existing failure on `main` (unrelated `query_replay_events` call in `routes/sessions.py:3010`); this diff does not touch any daemon-proxy surface (`_ls_call` / `_DAEMON_METHODS` / `local_store_via_daemon`).

## Local operator verification checklist

> **Note:** This is a rebase of #4884 onto current main (post-#4878) via a clean branch to resolve a merge conflict. The original branch `feat/entitlement-bundle-at-path-batch` was branched from old main before PR #4878 (`has_all_from_path_batch` / `missing_all_from_path_batch`) was merged, causing an unresolvable conflict. This replacement PR applies only #4884's unique additions on top of the current main.

The scheduled bot cannot exercise the running daemon, the live cloud snapshot, or a browser. Before promoting this out of draft, run these on the host:

- [ ] `cp clawmetry/entitlements.py routes/entitlement.py docs/ENTITLEMENTS.md ~/.clawmetry/lib/python*/site-packages/clawmetry/` (and matching path for `routes/`), clear stale `__pycache__/` under both directories
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` (macOS) so the daemon reloads with the new module
- [ ] `curl -s -X POST 'http://localhost:8900/api/entitlement/has-all-bundle-at-path-batch?from=oss&to=cloud_starter,cloud_pro,enterprise' -H 'Content-Type: application/json' -d '{"bundle":{"features":["fleet"],"runtimes":["claude_code"],"channels":5}}' | jq .` — expect 200, `from:"oss"`, non-empty `tiers[]` with one row per known destination, per-destination `path[i]` matching what `/api/entitlement/has-all-bundle-at-path?from=oss&to=` returns for the same `(oss, dest, bundle)` triple
- [ ] Same for `/api/entitlement/missing-all-bundle-at-path-batch` — expect the row-detail complement (`missing` dict per rung per destination)
- [ ] Spot-check the fallback branch: `curl -s -X POST 'http://localhost:8900/api/entitlement/has-all-bundle-at-path-batch?from=bogus&to=cloud_pro' -H 'Content-Type: application/json' -d '{"bundle":{"features":["fleet"]}}'` returns 200 with `tiers=[]`, `unknown_tiers=["cloud_pro"]`
- [ ] Spot-check the 400 branch: `curl -s -o /dev/null -w "%{http_code}\n" -X POST 'http://localhost:8900/api/entitlement/has-all-bundle-at-path-batch?from=oss&to=cloud_pro' -H 'Content-Type: application/json' -d '{}'` returns 400
- [ ] Decrypt the live cloud snapshot and confirm no shape drift on the resolver envelope
- [ ] Spot-check a browser hit on the dashboard — no console errors, no regressions on any tab (this PR is purely additive endpoints; no frontend change)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wi6vsdHfDLXXD2xLRWLpwd)_