### PR TITLE
Give every alert a destination, and stop shipping rules nothing evaluates

### DIFF
--- a/clawmetry/static/css/dashboard.css
+++ b/clawmetry/static/css/dashboard.css
@@ -1308,6 +1308,75 @@
 }
 .alerts-chan-pill.off { opacity: 0.5; }
 
+/* Always-on monitors: read-only rows, no toggle. The muted left border and
+   the "built in" tag distinguish them from rules the operator controls, so
+   nobody reads them as something they forgot to switch off. */
+.alerts-builtins-note {
+  font-size: 12px; color: var(--text-muted);
+  margin: -4px 0 10px; max-width: 68ch; line-height: 1.5;
+}
+.alerts-rule-row.alerts-builtin-row {
+  grid-template-columns: 24px 1fr auto auto;
+  border-left: 2px solid var(--border-primary);
+}
+.alerts-rule-row.alerts-builtin-row:hover { background: transparent; }
+/* Orphan rules: saved but matching no known alert type. Amber left edge marks
+   them as needing attention without shouting — they are stale config, not an
+   incident. */
+.alerts-rule-row.alerts-rule-orphan {
+  border-left: 2px solid rgba(245, 158, 11, 0.55);
+}
+.alerts-builtin-tag {
+  font-size: 10px; font-weight: 600; letter-spacing: 0.03em;
+  text-transform: uppercase; color: var(--text-faint);
+  border: 1px solid var(--border-secondary); border-radius: 999px;
+  padding: 2px 8px; white-space: nowrap;
+}
+/* Inline explanation when the server refuses a rule type (422). */
+.alerts-rule-notice {
+  font-size: 11.5px; color: #fbbf24; margin-top: 4px; line-height: 1.4;
+}
+
+/* Recorded findings (Security tab) — the durable security_events log.
+   Grid, not flex, so the severity chip and the "Open session" action keep a
+   fixed rail and a long description wraps in the middle column instead of
+   pushing the action off-screen. */
+.cm-finding-row {
+  display: grid; grid-template-columns: 72px 1fr auto;
+  gap: 12px; align-items: start; padding: 9px 0;
+  border-bottom: 1px solid var(--border-secondary);
+}
+.cm-finding-row:last-child { border-bottom: 0; }
+.cm-finding-sev {
+  font-size: 10px; font-weight: 700; text-transform: uppercase;
+  letter-spacing: 0.04em; text-align: center;
+  padding: 3px 6px; border-radius: 4px; white-space: nowrap;
+}
+.cm-finding-body { min-width: 0; }
+.cm-finding-desc {
+  font-size: 12.5px; font-weight: 600; color: var(--text-primary);
+  line-height: 1.4; word-break: break-word;
+}
+.cm-finding-snippet {
+  display: block; margin-top: 3px; font-size: 10.5px; color: #a78bfa;
+  background: var(--bg-primary); border-radius: 3px; padding: 2px 5px;
+  overflow-x: auto; white-space: pre; max-width: 100%;
+}
+.cm-finding-meta { font-size: 10.5px; color: var(--text-muted); margin-top: 3px; }
+.cm-finding-open {
+  background: transparent; border: 1px solid var(--border-primary);
+  color: var(--text-secondary); border-radius: 6px; padding: 4px 10px;
+  font-size: 11px; font-weight: 600; cursor: pointer; white-space: nowrap;
+  transition: border-color 0.15s, color 0.15s;
+}
+.cm-finding-open:hover { border-color: #a855f7; color: #c4b5fd; }
+.cm-finding-open:focus-visible { outline: 2px solid #a855f7; outline-offset: 2px; }
+.cm-finding-nosession { font-size: 10.5px; color: var(--text-faint); white-space: nowrap; }
+@media (max-width: 640px) {
+  .cm-finding-row { grid-template-columns: 60px 1fr; }
+  .cm-finding-open, .cm-finding-nosession { grid-column: 2; justify-self: start; margin-top: 4px; }
+}
+
 .alerts-history {
   background: var(--bg-tertiary); border: 1px solid var(--border-primary);
   border-radius: 12px; overflow: hidden;

--- a/clawmetry/static/js/alerts.js
+++ b/clawmetry/static/js/alerts.js
@@ -758,15 +758,16 @@
   // Inline, per-row explanation. Used when the server refuses a rule type
   // (422) — a toggle that springs back with no reason is its own small bug.
   function showRuleNotice(ruleId, message) {
-    const row = document.querySelector('[data-rule-id="' + ruleId + '"]');
+    // Re-render first so the toggle returns to its true (off) position, then
+    // attach the reason to that row.
     renderRules();
-    const target = row ? document.querySelector('[data-rule-id="' + ruleId + '"]') : null;
-    if (!target) return;
-    let note = document.createElement('div');
+    const row = document.querySelector('[data-rule-id="' + ruleId + '"]');
+    const main = row && row.querySelector('.alerts-rule-main');
+    if (!main) return;
+    const note = document.createElement('div');
     note.className = 'alerts-rule-notice';
     note.textContent = message;
-    const main = target.querySelector('.alerts-rule-main');
-    if (main) main.appendChild(note);
+    main.appendChild(note);
   }
 
   // ── Paywall modal ─────────────────────────────────────────────────────────

--- a/clawmetry/static/js/alerts.js
+++ b/clawmetry/static/js/alerts.js
@@ -219,6 +219,7 @@
       }
     }
     renderHistory();
+    renderBuiltinMonitors();
 
     try {
       const ch = alertsState.localMode
@@ -294,13 +295,40 @@
         metaLine = `${meta.verb} ${threshold}${unit ? ' ' + escape(unit) : ''}`
           + (real ? ' · never triggered' : '');
       }
+      // Channel pills state what delivery IS, never what it could be.
+      // These used to render ex._exampleChannels ("💬 Slack · ✉️ Email") on
+      // every OFF row — decorative sample text that looked exactly like
+      // configured delivery, so arming a rule appeared to erase it. An OFF
+      // row now says nothing about channels; an armed one shows its real
+      // channels, or "In-app only", which is what empty channel_ids actually
+      // means server-side (routes/alerts.py defaults them to the banner).
       const channelPills = real
-        ? (real.channel_ids || []).map(cid => {
+        ? ((real.channel_ids || []).map(cid => {
             const ch = alertsState.channels.find(c => c.id === cid);
             return ch ? `<span class="alerts-chan-pill">${chTypeIcon(ch.channel_type)} ${escape(ch.name)}</span>` : '';
           }).join('')
-        : `<span class="alerts-chan-pill off">${ex._exampleChannels}</span>`;
+          || '<span class="alerts-chan-pill off" title="Shows in the bell menu and the banner. No external delivery.">In-app only</span>')
+        : '';
       const badge = real ? '' : '<span class="alerts-rule-example-badge">example</span>';
+      // Evaluator honesty. A rule nothing evaluates must not look identical
+      // to one that is armed and simply hasn't tripped — that equivalence is
+      // what let two dead rules sit on "never triggered" indefinitely.
+      const evaluator = real ? (real.evaluator || '') : '';
+      const isDead = evaluator === 'none';
+      const deadChip = isDead
+        ? '<span class="alerts-chan-pill off" title="'
+          + (real && real.needs_recreate
+              ? 'Created by an older version that did not record what it should watch. Turn it off and on again to rebuild it.'
+              : 'No evaluator runs this type on a self-hosted node yet. It will not fire.')
+          + '">not evaluated</span>'
+        : '';
+      // "never triggered" reads as "armed, all quiet". For a rule nothing
+      // evaluates, that is the wrong story — replace it with the real one.
+      if (isDead) {
+        metaLine = real && real.needs_recreate
+          ? 'Turn this off and on again to rebuild it — it can’t fire as saved'
+          : 'Nothing on this node evaluates this alert yet';
+      }
       const scopeChip = real
         ? (ruleRt(real) === 'all'
             ? '<span class="alerts-chan-pill off" title="Evaluates across all runtimes on this node">node-wide</span>'
@@ -310,15 +338,62 @@
         <div class="alerts-rule-row${real ? '' : ' alerts-rule-example'}" data-rule-id="${id}">
           <div class="alerts-rule-dot ${on ? 'on' : 'off'}" title="${on ? 'Enabled' : 'Disabled'}"></div>
           <div class="alerts-rule-main">
-            <div class="alerts-rule-title">${meta.icon} ${escape(name)} ${badge} ${scopeChip}</div>
+            <div class="alerts-rule-title">${meta.icon} ${escape(name)} ${badge} ${scopeChip} ${deadChip}</div>
             <div class="alerts-rule-meta">${metaLine}</div>
           </div>
-          <div class="alerts-rule-chan">${channelPills || '<span class="alerts-chan-pill off">no channels</span>'}</div>
+          <div class="alerts-rule-chan">${channelPills}</div>
           ${toggleSwitch(id, on)}
           <button class="alerts-btn-ghost" onclick="alertsHandleEdit('${id}')">Edit</button>
         </div>
       `;
     }).join('');
+
+    // Orphan rules — saved and often ENABLED, but matching none of the eight
+    // canonical rows above, so previously rendered nowhere at all.
+    //
+    // Found while verifying this fix (2026-08-15): the reporter's own node had
+    // two enabled rules that the tab could not display, because matching keys
+    // on alert_type and rules written before the alert_type column have none.
+    // The tab showed all eight rows as untouched "example" while two live
+    // rules sat in the database — invisible, unturn-off-able, and (being
+    // "anomaly") unable to fire. Whatever else is true of a rule, if it exists
+    // the operator must be able to see it and switch it off.
+    const claimed = new Set();
+    EXAMPLE_RULES.forEach(ex => {
+      const c = alertsState.rules.filter(r => r.alert_type === ex.alert_type);
+      const pick = c.find(r => activeRt !== 'all' && ruleRt(r) === activeRt) || c[0];
+      if (pick) claimed.add(pick.id);
+    });
+    const orphans = alertsState.rules.filter(r => !claimed.has(r.id));
+    if (orphans.length) {
+      wrap.innerHTML += orphans.map(r => {
+        const on = !!r.enabled;
+        // Never surface the storage vocabulary ("anomaly", "token_spike") as
+        // a name — it tells the operator nothing. Note loadAlertsPage's
+        // local-schema normaliser fills `name` with the raw `type` when a row
+        // has no real name, so an equal-to-type name counts as no name.
+        const thr = (r.threshold_value != null ? r.threshold_value : r.threshold);
+        const realName = (r.name && r.name !== r.type) ? r.name : '';
+        const label = realName || RULE_TYPE_LABELS[r.alert_type]?.verb
+          || (thr != null ? `Old rule · threshold ${thr}` : 'Old rule');
+        const why = r.needs_recreate
+          ? 'Saved by an older version without a record of what it should watch, so nothing can run it.'
+          : 'This rule doesn’t match any alert type this version offers.';
+        return `
+        <div class="alerts-rule-row alerts-rule-orphan" data-rule-id="${escape(r.id)}">
+          <div class="alerts-rule-dot ${on ? 'on' : 'off'}" title="${on ? 'Enabled' : 'Disabled'}"></div>
+          <div class="alerts-rule-main">
+            <div class="alerts-rule-title">🗃️ ${escape(label)}
+              <span class="alerts-rule-example-badge">unrecognized</span>
+            </div>
+            <div class="alerts-rule-meta">${escape(why)} Switch it off to remove it.</div>
+          </div>
+          <div class="alerts-rule-chan"><span class="alerts-chan-pill off">not evaluated</span></div>
+          ${toggleSwitch(r.id, on)}
+          <button class="alerts-btn-ghost" onclick="alertsDeleteRule('${escape(r.id)}')">Remove</button>
+        </div>`;
+      }).join('');
+    }
   }
 
   function renderCannedExamples() {
@@ -334,7 +409,7 @@
             </div>
             <div class="alerts-rule-meta">Tap to customize — saves require Cloud Pro</div>
           </div>
-          <div class="alerts-rule-chan"><span class="alerts-chan-pill off">${ex._exampleChannels}</span></div>
+          <div class="alerts-rule-chan"><span class="alerts-chan-pill off" title="Delivery to ${escape(ex._exampleChannels.replace(/[^\x20-\x7E ·]/g, '').trim())} comes with Pro">Pro delivery</span></div>
           ${toggleSwitch(ex.id, false)}
           <button class="alerts-btn-ghost" onclick="event.stopPropagation();alertsHandleEdit('${ex.id}')">Edit</button>
         </div>
@@ -413,6 +488,45 @@
   function renderHistoryEmpty(msg) {
     document.getElementById('alerts-history-list').innerHTML =
       `<div class="alerts-loading">${escape(msg)}</div>`;
+  }
+
+  // Always-on monitors — the checks that fire without a rule behind them.
+  // Rendered read-only and visibly distinct from the toggleable rules above,
+  // so nobody mistakes them for something they forgot to switch off.
+  const _BUILTIN_ICONS = {
+    heartbeat_silent: '💤', agent_down: '📡', anomaly: '📈',
+    token_velocity: '⚡', agent_error_rate: '🛠', error_spike: '🔥',
+    security_threat: '🛡', numbat_finding: '🛡', security: '🔐',
+    threshold: '💰',
+  };
+
+  async function renderBuiltinMonitors() {
+    const wrap = document.getElementById('alerts-builtins-list');
+    if (!wrap) return;
+    let monitors = [];
+    try {
+      const d = await fetch('/api/alerts/builtins').then(r => r.json());
+      monitors = (d && d.monitors) || [];
+    } catch {
+      wrap.innerHTML = '<div class="alerts-loading">Couldn’t load the always-on monitors.</div>';
+      return;
+    }
+    if (!monitors.length) {
+      wrap.innerHTML = '<div class="alerts-loading">No always-on monitors on this build.</div>';
+      return;
+    }
+    wrap.innerHTML = monitors.map(m => `
+      <div class="alerts-rule-row alerts-builtin-row">
+        <div class="alerts-rule-dot on" title="Always on"></div>
+        <div class="alerts-rule-main">
+          <div class="alerts-rule-title">${_BUILTIN_ICONS[m.alert_type] || '🔔'} ${escape(m.label)}</div>
+          <div class="alerts-rule-meta">${escape(m.watches)}</div>
+        </div>
+        <div class="alerts-rule-chan">${(m.channels || []).map(c =>
+          `<span class="alerts-chan-pill">${escape(c === 'banner' ? 'In-app' : c)}</span>`).join('')}</div>
+        <span class="alerts-builtin-tag" title="Built in — fires with no rule of yours behind it">built in</span>
+      </div>
+    `).join('');
   }
 
   function renderChannelsSummary() {
@@ -503,6 +617,16 @@
           alertsState.rules.find(r => r.alert_type === ex.alert_type)) {
         return;
       }
+      // Ask where it should go BEFORE arming it. Turning an alert on with
+      // nowhere to send it is a decision the operator should make knowingly,
+      // not discover afterwards from a grey "no channels" pill.
+      if (isExample && newEnabled && !alertsState.channels.length
+          && !_deliveryChoiceMade) {
+        return openDeliveryPrompt(ruleId);
+      }
+      // With channels configured, "notify me" means the channels the operator
+      // already set up — send to all of them rather than silently to none.
+      const chosenChannels = alertsState.channels.map(c => c.id);
       let resp;
       if (isExample && newEnabled) {
         resp = await fetch(alertsState.localMode
@@ -515,7 +639,7 @@
             threshold_value: ex.threshold_value,
             threshold_unit: ex.threshold_unit || '',
             enabled: true,
-            channel_ids: [],
+            channel_ids: chosenChannels,
             re_alert_policy: 'once',
           }),
         });
@@ -531,6 +655,16 @@
         // Hit the Free-tier cap server-side
         return openPaywall();
       }
+      // 422 = the server has no evaluator for this type on a self-hosted
+      // node. Say so instead of leaving a toggle that flips back with no
+      // explanation (or worse, one that stays on and never fires).
+      if (resp.status === 422) {
+        let detail = {};
+        try { detail = await resp.json(); } catch {}
+        showRuleNotice(ruleId, detail.error
+          || 'This alert type has no evaluator on a self-hosted node yet.');
+        return;
+      }
       if (!resp.ok) throw new Error('toggle failed: HTTP ' + resp.status);
       // Optimistic update: the cloud cache warms a few seconds behind the
       // write (daemon heartbeat cache_push), so reflect the new state locally
@@ -540,7 +674,7 @@
         alertsState.rules.push({
           id: 'pending-' + ruleId, alert_type: ex.alert_type, name: ex.name,
           threshold_value: ex.threshold_value, threshold_unit: ex.threshold_unit || '',
-          enabled: true, channel_ids: [],
+          enabled: true, channel_ids: chosenChannels,
         });
       } else {
         const r = alertsState.rules.find(x => x.id === ruleId);
@@ -553,6 +687,87 @@
       console.warn(e);
     }
   };
+
+  // Delete a rule outright. Only reachable from an orphan row, where toggling
+  // off would leave an unusable rule sitting in the database forever.
+  window.alertsDeleteRule = async function (ruleId) {
+    try {
+      const resp = await fetch((alertsState.localMode
+        ? '/api/alerts/rules/' : '/api/cloud-proxy/api/alerts/') + ruleId,
+        { method: 'DELETE' });
+      if (!resp.ok) throw new Error('delete failed: HTTP ' + resp.status);
+      alertsState.rules = alertsState.rules.filter(r => r.id !== ruleId);
+      renderRules();
+      setTimeout(function () { window.loadAlertsPage(); }, 2000);
+    } catch (e) {
+      console.warn(e);
+    }
+  };
+
+  // ── Delivery prompt ───────────────────────────────────────────────────────
+  //
+  // Asked once per visit, before the first alert is armed with nowhere to
+  // send it. "Show it in the app" is a real answer, not a dismissal — it sets
+  // _deliveryChoiceMade so we don't re-ask on every subsequent toggle.
+
+  let _deliveryChoiceMade = false;
+  let _deliveryPendingRuleId = null;
+
+  function openDeliveryPrompt(ruleId) {
+    _deliveryPendingRuleId = ruleId;
+    const modal = detachModalToBody('alerts-delivery-modal');
+    const body = document.getElementById('alerts-delivery-body');
+    const ex = EXAMPLE_RULES.find(r => r.id === ruleId);
+    if (body && ex) {
+      body.textContent = 'You haven’t set up anywhere to send alerts yet. '
+        + 'ClawMetry can show “' + ex.name + '” in the app, or deliver '
+        + 'it to Slack, Telegram, or PagerDuty.';
+    }
+    modal.style.display = 'flex';
+  }
+
+  window.alertsCloseDelivery = function (e) {
+    // Backdrop click / Escape = cancel. The rule stays OFF, which is the
+    // truthful outcome: nothing was armed and nothing was configured.
+    if (e && e.target && e.target.id !== 'alerts-delivery-modal') return;
+    const el = document.getElementById('alerts-delivery-modal');
+    if (el) el.style.display = 'none';
+    _deliveryPendingRuleId = null;
+    renderRules();
+  };
+
+  window.alertsDeliverySetUp = function () {
+    const el = document.getElementById('alerts-delivery-modal');
+    if (el) el.style.display = 'none';
+    _deliveryPendingRuleId = null;
+    // Straight to Notifications, per the founder's ask: configure first, then
+    // come back and arm it. The rule is deliberately NOT created here — an
+    // alert that exists but was never confirmed is the ambiguity we're fixing.
+    if (typeof switchTab === 'function') switchTab('notifications');
+  };
+
+  window.alertsDeliveryInAppOnly = function () {
+    const el = document.getElementById('alerts-delivery-modal');
+    if (el) el.style.display = 'none';
+    _deliveryChoiceMade = true;
+    const ruleId = _deliveryPendingRuleId;
+    _deliveryPendingRuleId = null;
+    if (ruleId) window.alertsToggleRule(ruleId, true);
+  };
+
+  // Inline, per-row explanation. Used when the server refuses a rule type
+  // (422) — a toggle that springs back with no reason is its own small bug.
+  function showRuleNotice(ruleId, message) {
+    const row = document.querySelector('[data-rule-id="' + ruleId + '"]');
+    renderRules();
+    const target = row ? document.querySelector('[data-rule-id="' + ruleId + '"]') : null;
+    if (!target) return;
+    let note = document.createElement('div');
+    note.className = 'alerts-rule-notice';
+    note.textContent = message;
+    const main = target.querySelector('.alerts-rule-main');
+    if (main) main.appendChild(note);
+  }
 
   // ── Paywall modal ─────────────────────────────────────────────────────────
 

--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -973,6 +973,80 @@ function _cmAgentDownBannerCopy(orig) {
   return t('alerts.feed_stopped_unknown', null, 'One of our data feeds from your agent stopped. You’re still seeing live activity, but some charts may lag.');
 }
 
+// Where an alert sends you. Returns {label, go} or null when the alert
+// genuinely has no better destination than the banner itself.
+//
+// Labels are active-voice and name the destination in the operator's own
+// words ("Investigate", "Open session"), never the system's ("View
+// security_events"). Each one is a promise about what the next screen shows.
+function _cmBannerDestination(alert) {
+  if (!alert) return null;
+  var type = String(alert.type || '');
+  var ruleId = typeof alert.rule_id === 'string' ? alert.rule_id : '';
+
+  function goTab(tab, after) {
+    return function () {
+      if (typeof switchTab === 'function') switchTab(tab);
+      if (typeof after === 'function') { try { after(); } catch (e) {} }
+    };
+  }
+  function goSession(sid) {
+    return function () {
+      // Deep-link via hash so the Session-replay tab can pick it up either on
+      // first paint (window.location.hash) or via the hashchange listener if
+      // the tab is already mounted.
+      try { window.location.hash = 'session=' + encodeURIComponent(sid); } catch (e) {}
+      if (typeof switchTab === 'function') switchTab('transcripts');
+    };
+  }
+
+  // Session-scoped alarms: dashboard.py encodes the session in the rule_id.
+  if (type === 'stuck_session' && ruleId.indexOf('stuck_session_') === 0) {
+    var sid = ruleId.slice('stuck_session_'.length);
+    if (sid) return { label: t('app.open_session', null, 'Open session →'), go: goSession(sid) };
+  }
+
+  // Security alarms. The rule_id here is the DETECTION rule (numbat's
+  // rule_id, or a built-in signature id) — not a session — so we cannot jump
+  // straight to a transcript. The findings log can: it lists this finding
+  // with the session attached, one click further on.
+  if (type === 'numbat_finding' || type === 'security_threat') {
+    return {
+      label: t('app.investigate', null, 'Investigate →'),
+      go: goTab('security', function () {
+        if (typeof loadSecurityFindings === 'function') loadSecurityFindings();
+        var el = document.getElementById('security-findings-panel');
+        if (el && el.scrollIntoView) el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      })
+    };
+  }
+
+  // Liveness alarms — "is my agent alive" is answered on the Overview.
+  if (type === 'heartbeat_silent' || type === 'agent_down') {
+    return { label: t('app.check_agent', null, 'Check agent →'), go: goTab('overview') };
+  }
+
+  // Money alarms. Note the two vocabularies: user rules store 'threshold' /
+  // 'spike', while the always-on cost monitor fires 'anomaly'. Both mean
+  // "your spend moved" and both belong on Usage.
+  if (type === 'threshold' || type === 'session_cost' || type === 'spike'
+      || type === 'anomaly' || type === 'daily_threshold_breached'
+      || type === 'budget_blocked') {
+    return { label: t('app.see_spending', null, 'See spending →'), go: goTab('usage') };
+  }
+
+  // Burn alarms — token velocity and unproductive spinning both need the
+  // session that is doing it, which the Sessions list ranks for you.
+  // 'token_spike' is the rule vocabulary; 'token_velocity' is what the
+  // always-on monitor fires.
+  if (type === 'token_spike' || type === 'token_velocity'
+      || type === 'unproductive_burn') {
+    return { label: t('app.see_sessions', null, 'See sessions →'), go: goTab('transcripts') };
+  }
+
+  return null;
+}
+
 async function checkActiveAlerts() {
   try {
     var data = await fetch('/api/alerts/active').then(function(r){return r.json();});
@@ -1001,32 +1075,31 @@ async function checkActiveAlerts() {
     var latest = bannerAlerts[0];
     var msgEl = document.getElementById('alert-banner-msg');
     msgEl.textContent = latest.type === 'agent_down' ? _cmAgentDownBannerCopy(latest.message) : latest.message;
-    // Stuck-session deep-link: dashboard.py:_check_stuck_sessions emits
-    // rule_id = `stuck_session_<full-session-id>`. Surface an "Open session →"
-    // button on the banner so users go from "what's wrong" to "look at it"
-    // in one click. Idempotent across polls — remove any prior button first.
+    // Every alarm needs somewhere to go.
+    //
+    // This used to special-case exactly one type: stuck_session got an
+    // "Open session →" button, and every other alert — including a HIGH
+    // security finding — offered only Dismiss. Founder, 2026-08-15, on a
+    // numbat secret-exfiltration banner: "unable to understand what action I
+    // need to take... for the first one I just see dismiss button, so what??"
+    // Dismiss is not a response to a security alert; it is the absence of one.
+    //
+    // _cmBannerDestination maps an alert to the screen that answers the
+    // question it raises. Adding an alert type without a destination is a
+    // regression — tests/test_alert_banner_destinations.py enforces it.
     var existingOpen = document.getElementById('alert-banner-open-session');
     if (existingOpen && existingOpen.parentNode) existingOpen.parentNode.removeChild(existingOpen);
-    if (latest && latest.type === 'stuck_session' && typeof latest.rule_id === 'string') {
-      var sid = latest.rule_id.indexOf('stuck_session_') === 0
-        ? latest.rule_id.slice('stuck_session_'.length) : '';
-      if (sid) {
-        var openBtn = document.createElement('button');
-        openBtn.id = 'alert-banner-open-session';
-        openBtn.textContent = t("app.open_session", null, "Open session →");
-        openBtn.style.cssText = 'margin-left:12px;background:transparent;border:1px solid rgba(255,255,255,0.3);color:inherit;border-radius:6px;padding:4px 12px;font-size:12px;font-weight:600;cursor:pointer;';
-        openBtn.onclick = function () {
-          // Deep-link via hash so the Session-replay tab can pick it up
-          // either on first paint (window.location.hash) or via the
-          // hashchange listener if the tab is already mounted.
-          try { window.location.hash = 'session=' + encodeURIComponent(sid); } catch(e) {}
-          if (typeof switchTab === 'function') switchTab('transcripts');
-        };
-        // Insert before the Dismiss / ack button so it reads left-to-right.
-        var ackBtn = document.getElementById('alert-resume-btn');
-        if (ackBtn && ackBtn.parentNode) ackBtn.parentNode.insertBefore(openBtn, ackBtn);
-        else if (msgEl && msgEl.parentNode) msgEl.parentNode.appendChild(openBtn);
-      }
+    var dest = _cmBannerDestination(latest);
+    if (dest) {
+      var openBtn = document.createElement('button');
+      openBtn.id = 'alert-banner-open-session';
+      openBtn.textContent = dest.label;
+      openBtn.style.cssText = 'margin-left:12px;background:transparent;border:1px solid rgba(255,255,255,0.3);color:inherit;border-radius:6px;padding:4px 12px;font-size:12px;font-weight:600;cursor:pointer;';
+      openBtn.onclick = dest.go;
+      // Insert before the Dismiss / ack button so it reads left-to-right.
+      var ackBtn = document.getElementById('alert-resume-btn');
+      if (ackBtn && ackBtn.parentNode) ackBtn.parentNode.insertBefore(openBtn, ackBtn);
+      else if (msgEl && msgEl.parentNode) msgEl.parentNode.appendChild(openBtn);
     }
     banner.style.display = 'flex';
     // Show resume button if gateway is paused
@@ -10195,6 +10268,7 @@ async function loadSecurityPage(silent) {
     // than a silent blank (and become live once the interceptor lands).
     loadSecurityIntegrity();
     loadSecurityAudit();
+    loadSecurityFindings();
     return;
   }
   try {
@@ -10279,6 +10353,7 @@ async function loadSecurityPage(silent) {
   // Tamper-evident integrity + Enterprise audit feed (both node-wide).
   loadSecurityIntegrity();
   loadSecurityAudit();
+  loadSecurityFindings();
   try {
     var cd = await fetchJsonWithTimeout('/api/security/credential-scan', 10000);
     var badgeEl = document.getElementById('credential-scan-badge');
@@ -10324,6 +10399,116 @@ async function loadSecurityPage(silent) {
   if (document.getElementById('page-security') && document.getElementById('page-security').classList.contains('active')) {
     _securityRefreshTimer = setTimeout(function() { loadSecurityPage(true); }, 30000);
   }
+}
+
+// Recorded findings — the DURABLE security log (DuckDB security_events),
+// as opposed to #security-threat-list above, which is a live re-scan of
+// recent events through the built-in signature catalog.
+//
+// Founder-reported 2026-08-15: a HIGH numbat finding ("Secret-manager access
+// followed by data-bearing egress") fired the top banner, the banner offered
+// only Dismiss, and the Security tab could not show the finding either — it
+// only ever called /api/security/threats (the live scan), while ingested
+// findings land in security_events and are served by /api/security-threats.
+// The alarm had no destination anywhere in the product.
+//
+// Rows carry the session that triggered them, so this is also where the
+// banner's "Investigate" button lands.
+var _CM_SEV_STYLE = {
+  critical: { color: '#f87171', bg: 'rgba(220,38,38,0.14)', label: 'Critical' },
+  high:     { color: '#fbbf24', bg: 'rgba(245,158,11,0.14)', label: 'High' },
+  medium:   { color: '#60a5fa', bg: 'rgba(59,130,246,0.14)', label: 'Medium' },
+  low:      { color: '#94a3b8', bg: 'rgba(100,116,139,0.14)', label: 'Low' },
+  info:     { color: '#94a3b8', bg: 'rgba(100,116,139,0.14)', label: 'Info' }
+};
+
+async function loadSecurityFindings() {
+  var listEl = document.getElementById('security-findings-list');
+  var countEl = document.getElementById('security-findings-count');
+  if (!listEl) return;
+  // Cloud parity (FLYWHEEL gate 1): security_events is not in the snapshot,
+  // so the hosted dashboard has nothing to read. Say that plainly instead of
+  // leaving "Loading findings..." spinning forever, which is how a trial user
+  // learns to distrust the product.
+  if (window.CLOUD_MODE) {
+    listEl.innerHTML = '<div style="color:var(--text-muted);padding:12px;font-size:12px;">'
+      + t('security.findings_local_only', null, 'Findings are recorded on the machine your agent runs on. Open the dashboard there to read them.')
+      + '</div>';
+    if (countEl) countEl.textContent = '';
+    return;
+  }
+  var rows = [];
+  try {
+    var d = await fetchJsonWithTimeout('/api/security-threats?limit=100', 10000);
+    rows = (d && d.threats) || [];
+  } catch (e) {
+    listEl.innerHTML = '<div style="color:var(--text-muted);padding:12px;font-size:12px;">'
+      + t('security.findings_unavailable', null, "Couldn't read the findings log. It lives on the machine your agent runs on — open the local dashboard to see it.")
+      + '</div>';
+    if (countEl) countEl.textContent = '';
+    return;
+  }
+  // Per-runtime honesty: findings are keyed by session id, which carries the
+  // runtime prefix, so a runtime filter must actually narrow this list rather
+  // than silently showing node-wide rows.
+  var rt = (typeof _cmRuntimeFilter === 'function') ? _cmRuntimeFilter() : 'all';
+  if (rt && rt !== 'all') {
+    rows = rows.filter(function (r) {
+      var sid = String(r.session_id || '');
+      var prefix = sid.indexOf(':') > 0 ? sid.split(':')[0] : 'openclaw';
+      return prefix === rt;
+    });
+  }
+  if (!rows.length) {
+    listEl.innerHTML = '<div style="color:#86efac;padding:12px;font-size:12px;">✓ '
+      + t('security.findings_empty', null, 'Nothing recorded yet. Findings from ClawMetry’s own scan and from any connected security tool will appear here.')
+      + '</div>';
+    if (countEl) countEl.textContent = '';
+    return;
+  }
+  if (countEl) {
+    countEl.textContent = rows.length + ' '
+      + (rows.length === 1
+          ? t('security.finding_word', null, 'finding')
+          : t('security.findings_word', null, 'findings'));
+  }
+  var html = '';
+  rows.slice(0, 100).forEach(function (r) {
+    var sev = String(r.severity || 'info').toLowerCase();
+    var st = _CM_SEV_STYLE[sev] || _CM_SEV_STYLE.info;
+    var sid = String(r.session_id || '');
+    var when = String(r.ts || '').slice(0, 19).replace('T', ' ');
+    html += '<div class="cm-finding-row" data-finding-id="' + escHtml(String(r.id || '')) + '">';
+    html += '<span class="cm-finding-sev" style="color:' + st.color + ';background:' + st.bg + ';">'
+         + escHtml(st.label) + '</span>';
+    html += '<div class="cm-finding-body">';
+    html += '<div class="cm-finding-desc">' + escHtml(String(r.description || r.rule_id || 'Security finding')) + '</div>';
+    if (r.snippet) {
+      html += '<code class="cm-finding-snippet">' + escHtml(String(r.snippet)) + '</code>';
+    }
+    html += '<div class="cm-finding-meta">' + escHtml(when);
+    if (r.rule_id) html += ' · ' + escHtml(String(r.rule_id));
+    html += '</div></div>';
+    if (sid) {
+      html += '<button class="cm-finding-open" onclick="cmOpenFindingSession(\''
+           + escHtml(sid).replace(/'/g, "\\'") + '\')">'
+           + t('security.open_session', null, 'Open session') + ' →</button>';
+    } else {
+      html += '<span class="cm-finding-nosession" title="'
+           + t('security.no_session_hint', null, 'The tool that reported this finding did not attach a session id.')
+           + '">' + t('security.no_session', null, 'No session') + '</span>';
+    }
+    html += '</div>';
+  });
+  listEl.innerHTML = html;
+}
+
+// Jump from a finding to the transcript that produced it. Same hash-based
+// deep-link the stuck-session banner uses, so both entry points behave alike.
+function cmOpenFindingSession(sessionId) {
+  if (!sessionId) return;
+  try { window.location.hash = 'session=' + encodeURIComponent(sessionId); } catch (e) {}
+  if (typeof switchTab === 'function') switchTab('transcripts');
 }
 
 // Tamper-evident hash-chain status. Plain-language labels per the FLYWHEEL

--- a/clawmetry/templates/tabs/alerts.html
+++ b/clawmetry/templates/tabs/alerts.html
@@ -30,6 +30,15 @@
     <div class="alerts-loading" data-i18n="alerts.loading_alerts">Loading alerts…</div>
   </div>
 
+  <!-- Always-on monitors. Answers the question the tab could not: "how did it
+       alert when all of the alerts are disabled?" (founder, 2026-08-15). These
+       fire from hardcoded checks, not from the rules above. -->
+  <h4 class="alerts-section-h" data-i18n="alerts.builtins_title">Always on</h4>
+  <div class="alerts-builtins-note" data-i18n="alerts.builtins_note">These run whether or not you set up any rules above. They're what raised the red banners at the top of the dashboard.</div>
+  <div id="alerts-builtins-list" class="alerts-list">
+    <div class="alerts-loading" data-i18n="alerts.loading_builtins">Loading monitors…</div>
+  </div>
+
   <h4 class="alerts-section-h" data-i18n="alerts.recent_history">Recent alert history</h4>
   <div id="alerts-history-list" class="alerts-history">
     <div class="alerts-loading" data-i18n="alerts.loading_history">Loading history…</div>
@@ -57,6 +66,28 @@
       <button class="alerts-btn-ghost" onclick="alertsClosePaywall()" data-i18n="alerts.maybe_later">Maybe later</button>
     </div>
     <div class="alerts-modal-footnote" data-i18n="alerts.paywall_footnote">No credit card · free tier available · 7-day Pro trial</div>
+  </div>
+</div>
+
+<!-- ── Delivery prompt ──────────────────────────────────────────────────────
+     Shown when someone turns on an alert before setting up anywhere to send
+     it. Founder-reported 2026-08-15: "if I enable them it says no channels —
+     why not just ask to configure channel first before enable, and take me to
+     the notifications page?" Turning a rule on used to POST channel_ids: []
+     silently, then relabel the row "no channels" — which read as if enabling
+     had DELETED the Slack/Email the row advertised a second earlier (those
+     pills were decorative examples; they are gone now).
+     Two honest exits: set delivery up, or accept in-app only. -->
+<div class="alerts-modal-overlay" id="alerts-delivery-modal" style="display:none;" onclick="alertsCloseDelivery(event)">
+  <div class="alerts-modal-card" onclick="event.stopPropagation()">
+    <div class="alerts-modal-icon">📬</div>
+    <h3 class="alerts-modal-title" data-i18n="alerts.delivery_title">Where should this alert go?</h3>
+    <p class="alerts-modal-body" id="alerts-delivery-body" data-i18n="alerts.delivery_body">You haven't set up anywhere to send alerts yet. ClawMetry can show this one in the app, or deliver it to Slack, Telegram, or PagerDuty.</p>
+    <div class="alerts-modal-actions">
+      <button class="alerts-btn-pro" onclick="alertsDeliverySetUp()" data-i18n="alerts.delivery_setup">Set up a channel</button>
+      <button class="alerts-btn-ghost" onclick="alertsDeliveryInAppOnly()" data-i18n="alerts.delivery_inapp">Show it in the app</button>
+    </div>
+    <div class="alerts-modal-footnote" data-i18n="alerts.delivery_footnote">In-app alerts show in the bell menu and as a banner across the top.</div>
   </div>
 </div>
 

--- a/clawmetry/templates/tabs/security.html
+++ b/clawmetry/templates/tabs/security.html
@@ -194,6 +194,26 @@
         <div style="color:var(--text-muted);padding:20px" data-i18n="security.scanning">Scanning...</div>
       </div>
     </div>
+    <!-- Recorded findings (durable log).
+         The panel above is a LIVE scan: it re-reads recent agent events through
+         the built-in signatures every time you open the tab. It cannot show a
+         finding raised by a connected scanner (numbat), because those never
+         touch the signature path — they are ingested straight into DuckDB's
+         security_events table.
+         Founder-reported 2026-08-15: a HIGH numbat finding paged the operator
+         via the top banner, and there was nowhere in the product to go and read
+         it. This panel is that destination, and the banner's "Investigate"
+         button links here. -->
+    <div id="security-findings-panel" style="margin-top:14px;background:var(--bg-secondary);border:1px solid var(--border);border-radius:8px;padding:10px 14px;">
+      <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:4px;gap:10px;flex-wrap:wrap;">
+        <span style="font-size:12px;font-weight:700;color:var(--text-primary);">🗂️ <span data-i18n="security.findings_title">Recorded findings</span></span>
+        <span id="security-findings-count" style="font-size:11px;color:var(--text-muted);"></span>
+      </div>
+      <div style="font-size:11px;color:var(--text-muted);margin-bottom:10px;" data-i18n="security.findings_sub">Kept on disk, so findings stay here after the scan above moves on. Includes anything a connected security tool reported. Open a row to read the session it came from.</div>
+      <div id="security-findings-list">
+        <div style="color:var(--text-muted);padding:12px;font-size:12px;" data-i18n="security.findings_loading">Loading findings...</div>
+      </div>
+    </div>
     <!-- Policy Events (PII / Injection / Credential-Leak) -->
     <div style="margin-top:14px;background:var(--bg-secondary);border:1px solid var(--border);border-radius:8px;padding:10px 14px;" id="policy-events-panel">
       <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:10px;">

--- a/dashboard.py
+++ b/dashboard.py
@@ -711,6 +711,16 @@ def _budget_init_db():
         db.commit()
     except Exception:
         pass
+    try:
+        # Pre-0.12.711 DBs drop the cloud-vocabulary ``alert_type`` the
+        # Alerts tab POSTed, keeping only the mapped local ``type``. That
+        # made a rule un-round-trippable: on update we could no longer tell
+        # WHICH cloud type an ``anomaly`` row came from, so the DuckDB mirror
+        # could not be rebuilt and the daemon evaluator stayed blind to it.
+        db.execute("ALTER TABLE alert_rules ADD COLUMN alert_type TEXT DEFAULT ''")
+        db.commit()
+    except Exception:
+        pass
     db.close()
 
 
@@ -2207,6 +2217,89 @@ def _budget_monitor_loop():
                                     f"(threshold: {int(threshold):,}/min){sid_hint}"
                                 )
                                 fired = True
+                elif rtype == "agent_down":
+                    # "Agent offline > N min" (UI alert_type ``node_offline``).
+                    # Founder 2026-08-15: this rtype has been accepted by the
+                    # POST validator since the self-hosted bridge landed but
+                    # never had a branch here, so every rule created from the
+                    # tab's "Agent offline" row was a silent no-op.
+                    #
+                    # Signal is the most recent REAL agent event in DuckDB —
+                    # not OTLP (the hardcoded ``agent_down`` monitor above
+                    # keys off ``_otel_last_received``, which stays 0 on the
+                    # many installs without ``[otel]``, so it never fires
+                    # there either). ``exclude_daemon`` keeps ClawMetry's own
+                    # diagnostics from masking a dead agent as "alive".
+                    try:
+                        from datetime import datetime as _dt2, timezone as _tz2
+                        from routes.local_query import local_store_via_daemon
+                        _rows = local_store_via_daemon(
+                            "query_events", limit=1, exclude_daemon=True,
+                            **({"runtime": rt_scope} if rt_scope != "all" else {}),
+                        ) or []
+                        _last_iso = (_rows[0].get("ts") or "") if _rows else ""
+                        if _last_iso:
+                            _last = _dt2.fromisoformat(
+                                str(_last_iso).replace("Z", "+00:00")
+                            )
+                            if _last.tzinfo is None:
+                                _last = _last.replace(tzinfo=_tz2.utc)
+                            _idle_min = (
+                                _dt2.now(_tz2.utc) - _last
+                            ).total_seconds() / 60.0
+                            if _idle_min >= threshold:
+                                _scope_lbl = (
+                                    "" if rt_scope == "all" else f" [{rt_scope}]"
+                                )
+                                msg = (
+                                    f"Agent offline{_scope_lbl}: no activity for "
+                                    f"{int(_idle_min)} min "
+                                    f"(threshold: {int(threshold)} min)"
+                                )
+                                fired = True
+                    except Exception:
+                        pass
+                elif rtype == "session_cost":
+                    # "Session cost > $N" (UI alert_type ``session_cost``).
+                    # Previously mapped onto ``threshold``, which evaluates
+                    # DAILY spend — so a $5 per-session rule actually fired on
+                    # the whole day's total. This checks the costliest single
+                    # session in the last 24h, which is what the row promises.
+                    #
+                    # Cost is API-equivalent (token split x API rates), never
+                    # the user's invoice — say so, per the cost-copy honesty
+                    # pass (a Max-plan subscriber pays $0 incremental).
+                    try:
+                        from datetime import datetime as _dt3, timedelta as _td3, timezone as _tz3
+                        from routes.local_query import local_store_via_daemon
+                        _since = (_dt3.now(_tz3.utc) - _td3(hours=24)).strftime(
+                            "%Y-%m-%dT%H:%M:%SZ"
+                        )
+                        _sessions = local_store_via_daemon(
+                            "query_sessions", since=_since, limit=500,
+                        ) or []
+                        _worst = None
+                        for _s in _sessions:
+                            _sid = _s.get("session_id") or ""
+                            if rt_scope != "all" and _session_runtime_of(_sid) != rt_scope:
+                                continue
+                            try:
+                                _c = float(_s.get("cost_usd") or 0)
+                            except (TypeError, ValueError):
+                                continue
+                            if _c >= threshold and (_worst is None or _c > _worst[1]):
+                                _worst = (_sid, _c)
+                        if _worst:
+                            _scope_lbl = "" if rt_scope == "all" else f" [{rt_scope}]"
+                            msg = (
+                                f"Session cost{_scope_lbl}: session "
+                                f"{_worst[0][:12]} reached ${_worst[1]:.2f} "
+                                f"(threshold: ${threshold:.2f}) - API-equivalent, "
+                                f"not a billed amount"
+                            )
+                            fired = True
+                    except Exception:
+                        pass
                 elif rtype == "unproductive_burn":
                     # Issue #1707 — forward-progress signal. Fires when any
                     # session burns >= ``threshold`` tokens per state delta
@@ -9613,6 +9706,16 @@ def _budget_init_db():
         db.commit()
     except Exception:
         pass
+    try:
+        # Pre-0.12.711 DBs drop the cloud-vocabulary ``alert_type`` the
+        # Alerts tab POSTed, keeping only the mapped local ``type``. That
+        # made a rule un-round-trippable: on update we could no longer tell
+        # WHICH cloud type an ``anomaly`` row came from, so the DuckDB mirror
+        # could not be rebuilt and the daemon evaluator stayed blind to it.
+        db.execute("ALTER TABLE alert_rules ADD COLUMN alert_type TEXT DEFAULT ''")
+        db.commit()
+    except Exception:
+        pass
     db.close()
 
 
@@ -10679,6 +10782,89 @@ def _budget_monitor_loop():
                                     f"(threshold: {int(threshold):,}/min){sid_hint}"
                                 )
                                 fired = True
+                elif rtype == "agent_down":
+                    # "Agent offline > N min" (UI alert_type ``node_offline``).
+                    # Founder 2026-08-15: this rtype has been accepted by the
+                    # POST validator since the self-hosted bridge landed but
+                    # never had a branch here, so every rule created from the
+                    # tab's "Agent offline" row was a silent no-op.
+                    #
+                    # Signal is the most recent REAL agent event in DuckDB —
+                    # not OTLP (the hardcoded ``agent_down`` monitor above
+                    # keys off ``_otel_last_received``, which stays 0 on the
+                    # many installs without ``[otel]``, so it never fires
+                    # there either). ``exclude_daemon`` keeps ClawMetry's own
+                    # diagnostics from masking a dead agent as "alive".
+                    try:
+                        from datetime import datetime as _dt2, timezone as _tz2
+                        from routes.local_query import local_store_via_daemon
+                        _rows = local_store_via_daemon(
+                            "query_events", limit=1, exclude_daemon=True,
+                            **({"runtime": rt_scope} if rt_scope != "all" else {}),
+                        ) or []
+                        _last_iso = (_rows[0].get("ts") or "") if _rows else ""
+                        if _last_iso:
+                            _last = _dt2.fromisoformat(
+                                str(_last_iso).replace("Z", "+00:00")
+                            )
+                            if _last.tzinfo is None:
+                                _last = _last.replace(tzinfo=_tz2.utc)
+                            _idle_min = (
+                                _dt2.now(_tz2.utc) - _last
+                            ).total_seconds() / 60.0
+                            if _idle_min >= threshold:
+                                _scope_lbl = (
+                                    "" if rt_scope == "all" else f" [{rt_scope}]"
+                                )
+                                msg = (
+                                    f"Agent offline{_scope_lbl}: no activity for "
+                                    f"{int(_idle_min)} min "
+                                    f"(threshold: {int(threshold)} min)"
+                                )
+                                fired = True
+                    except Exception:
+                        pass
+                elif rtype == "session_cost":
+                    # "Session cost > $N" (UI alert_type ``session_cost``).
+                    # Previously mapped onto ``threshold``, which evaluates
+                    # DAILY spend — so a $5 per-session rule actually fired on
+                    # the whole day's total. This checks the costliest single
+                    # session in the last 24h, which is what the row promises.
+                    #
+                    # Cost is API-equivalent (token split x API rates), never
+                    # the user's invoice — say so, per the cost-copy honesty
+                    # pass (a Max-plan subscriber pays $0 incremental).
+                    try:
+                        from datetime import datetime as _dt3, timedelta as _td3, timezone as _tz3
+                        from routes.local_query import local_store_via_daemon
+                        _since = (_dt3.now(_tz3.utc) - _td3(hours=24)).strftime(
+                            "%Y-%m-%dT%H:%M:%SZ"
+                        )
+                        _sessions = local_store_via_daemon(
+                            "query_sessions", since=_since, limit=500,
+                        ) or []
+                        _worst = None
+                        for _s in _sessions:
+                            _sid = _s.get("session_id") or ""
+                            if rt_scope != "all" and _session_runtime_of(_sid) != rt_scope:
+                                continue
+                            try:
+                                _c = float(_s.get("cost_usd") or 0)
+                            except (TypeError, ValueError):
+                                continue
+                            if _c >= threshold and (_worst is None or _c > _worst[1]):
+                                _worst = (_sid, _c)
+                        if _worst:
+                            _scope_lbl = "" if rt_scope == "all" else f" [{rt_scope}]"
+                            msg = (
+                                f"Session cost{_scope_lbl}: session "
+                                f"{_worst[0][:12]} reached ${_worst[1]:.2f} "
+                                f"(threshold: ${threshold:.2f}) - API-equivalent, "
+                                f"not a billed amount"
+                            )
+                            fired = True
+                    except Exception:
+                        pass
                 elif rtype == "unproductive_burn":
                     # Issue #1707 — forward-progress signal. Fires when any
                     # session burns >= ``threshold`` tokens per state delta

--- a/routes/alerts.py
+++ b/routes/alerts.py
@@ -992,21 +992,26 @@ def api_alert_rules():
         now = time.time()
         with _d._fleet_db_lock:
             db = _d._fleet_db()
+            # ``alert_type`` arrived in 0.12.711 and is added by an ALTER in
+            # _fleet_db init. Don't assume it: this handler also runs against
+            # DBs built by other code paths (and by tests that hand-roll the
+            # schema), and a hard dependency turns a missing column into a
+            # 500 on rule create. Probe, then insert what the table has.
+            _cols = {row[1] for row in
+                     db.execute("PRAGMA table_info(alert_rules)").fetchall()}
+            _fields = ["id", "type", "threshold", "channels", "cooldown_min",
+                       "enabled", "runtime"]
+            _values = [rule_id, rtype, threshold, json.dumps(channels),
+                       cooldown, 1 if enabled else 0, runtime]
+            if "alert_type" in _cols:
+                _fields.append("alert_type")
+                _values.append(_cloud_type)
+            _fields += ["created_at", "updated_at"]
+            _values += [now, now]
             db.execute(
-                "INSERT INTO alert_rules (id, type, threshold, channels, cooldown_min, enabled, runtime, alert_type, created_at, updated_at) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-                (
-                    rule_id,
-                    rtype,
-                    threshold,
-                    json.dumps(channels),
-                    cooldown,
-                    1 if enabled else 0,
-                    runtime,
-                    _cloud_type,
-                    now,
-                    now,
-                ),
+                f"INSERT INTO alert_rules ({', '.join(_fields)}) "
+                f"VALUES ({', '.join('?' * len(_fields))})",
+                tuple(_values),
             )
             db.commit()
             db.close()

--- a/routes/alerts.py
+++ b/routes/alerts.py
@@ -140,32 +140,69 @@ def _mirror_rule_to_duckdb(rule_id, *, alert_type, threshold, runtime,
             "cooldown_min":    cooldown_min,
         },
     }
+    if not _write_via_store("ingest_alert_rule", rule=payload):
+        return False
+    # Read back before claiming success. ``ingest_alert_rule`` returns None,
+    # and ``local_store_via_daemon`` also returns None when the proxy call
+    # FAILED — the two are indistinguishable at the call site, so a bare
+    # "no exception" check reports a mirror that never happened. That matters
+    # most on exactly the install this bridges: a daemon running an older
+    # wheel does not allowlist the method, the call 400s, and the operator
+    # would be told their rule is armed on an evaluator that cannot see it.
+    return _rule_in_duckdb(rule_id)
+
+
+def _rule_in_duckdb(rule_id):
+    """True when ``rule_id`` is present in the DuckDB alert_rules table."""
     try:
         from routes.local_query import local_store_via_daemon
-        if local_store_via_daemon("ingest_alert_rule", rule=payload) is not None:
-            return True
-        # Daemon hosts the store in-process (single-process dev boot) or is
-        # unreachable — try the direct handle. Never fatal: the writer lock
-        # belongs to the daemon and a miss just means "no mirror this time".
+        rows = local_store_via_daemon("query_alert_rules", limit=500)
+        if rows is None:
+            from clawmetry import local_server as _ls_srv
+            if not _ls_srv.is_running():
+                return False
+            from clawmetry import local_store as _ls_mod
+            rows = _ls_mod.get_store().query_alert_rules(limit=500)
+        return any(str(r.get("id")) == str(rule_id) for r in (rows or []))
+    except Exception:
+        return False
+
+
+def _write_via_store(method, **kwargs):
+    """Run a LocalStore write, through the daemon proxy where one exists.
+
+    Returns False rather than raising. Only touches the store directly when
+    ``local_server`` is hosted in THIS process — i.e. we are the daemon and
+    already hold the writer lock. Opening a writer from the dashboard process
+    while the daemon holds the lock is the documented brick-lock hazard, and
+    where DuckDB allows it the write lands somewhere the daemon never reads,
+    which is worse than not writing at all.
+    """
+    try:
+        from routes.local_query import local_store_via_daemon
+        local_store_via_daemon(method, **kwargs)
+        return True
+    except Exception:
+        pass
+    try:
+        from clawmetry import local_server as _ls_srv
+        if not _ls_srv.is_running():
+            return False
         from clawmetry import local_store as _ls_mod
-        _ls_mod.get_store().ingest_alert_rule(payload)
+        getattr(_ls_mod.get_store(), method)(**kwargs)
         return True
     except Exception:
         return False
 
 
 def _unmirror_rule_from_duckdb(rule_id):
-    """Drop a mirrored rule from DuckDB. Best-effort, never raises."""
-    try:
-        from routes.local_query import local_store_via_daemon
-        if local_store_via_daemon("delete_alert_rule",
-                                  rule_id=str(rule_id)) is not None:
-            return True
-        from clawmetry import local_store as _ls_mod
-        _ls_mod.get_store().delete_alert_rule(str(rule_id))
-        return True
-    except Exception:
-        return False
+    """Drop a mirrored rule from DuckDB. Best-effort, never raises.
+
+    Unlike the create path this does not verify: a rule that was never
+    mirrored (older daemon, or a type the local loop owns) is simply absent,
+    and reporting that as a failed delete would be noise.
+    """
+    return _write_via_store("delete_alert_rule", rule_id=str(rule_id))
 
 
 # ── Cloud alert_type -> local evaluator routing ────────────────────────────

--- a/routes/alerts.py
+++ b/routes/alerts.py
@@ -110,6 +110,220 @@ def _try_local_store_alert_rules():
     return {"rules": rows or [], "_source": "local_store"}
 
 
+def _mirror_rule_to_duckdb(rule_id, *, alert_type, threshold, runtime,
+                           channels, cooldown_min, enabled, name=""):
+    """Mirror a locally-created alert rule into the DuckDB ``alert_rules``
+    table so the sync daemon's evaluator can actually see it.
+
+    The dashboard's POST writes the fleet SQLite DB; the daemon's
+    ``_evaluate_alerts_local`` reads DuckDB via ``query_alert_rules``. Before
+    this, nothing bridged the two — ``ingest_alert_rule`` was only ever called
+    from the cloud pending-action path — so a rule created from the Alerts tab
+    on a no-cloud node was never evaluated by anything.
+
+    ``condition_json`` keeps the CLOUD vocabulary (alert_type /
+    threshold_value / runtime), which is what ``clawmetry.alert_evaluator``
+    parses via its ``_LEGACY_ALERT_TYPE_MAP``.
+
+    Best-effort: the daemon may be down (dashboard-only boot) and the rule
+    still has to save. Returns True when the mirror landed.
+    """
+    payload = {
+        "id": str(rule_id),
+        "name": name or alert_type,
+        "enabled": bool(enabled),
+        "condition_json": {
+            "alert_type":      alert_type,
+            "threshold_value": threshold,
+            "runtime":         runtime,
+            "channel_ids":     list(channels or []),
+            "cooldown_min":    cooldown_min,
+        },
+    }
+    try:
+        from routes.local_query import local_store_via_daemon
+        if local_store_via_daemon("ingest_alert_rule", rule=payload) is not None:
+            return True
+        # Daemon hosts the store in-process (single-process dev boot) or is
+        # unreachable — try the direct handle. Never fatal: the writer lock
+        # belongs to the daemon and a miss just means "no mirror this time".
+        from clawmetry import local_store as _ls_mod
+        _ls_mod.get_store().ingest_alert_rule(payload)
+        return True
+    except Exception:
+        return False
+
+
+def _unmirror_rule_from_duckdb(rule_id):
+    """Drop a mirrored rule from DuckDB. Best-effort, never raises."""
+    try:
+        from routes.local_query import local_store_via_daemon
+        if local_store_via_daemon("delete_alert_rule",
+                                  rule_id=str(rule_id)) is not None:
+            return True
+        from clawmetry import local_store as _ls_mod
+        _ls_mod.get_store().delete_alert_rule(str(rule_id))
+        return True
+    except Exception:
+        return False
+
+
+# ── Cloud alert_type -> local evaluator routing ────────────────────────────
+#
+# The Alerts tab speaks the cloud vocabulary (``alert_type``); a self-hosted
+# node has two evaluators, and every type must be routed to one of them or
+# rejected. Silently storing an unroutable type is what produced the zombie
+# rules fixed on 2026-08-15 (see the block comment in ``api_alert_rules``).
+#
+# _CLOUD_TO_LOCAL: has a real ``rtype`` branch in dashboard.py's
+# ``_budget_monitor_loop``. Keep this in lockstep with the ``rtype ==``
+# branches there — a key here with no branch there is a zombie rule.
+_CLOUD_TO_LOCAL = {
+    "daily_spend":    "threshold",
+    "cost_daily":     "threshold",      # legacy alias, pre-0.12.711 clients
+    "session_cost":   "session_cost",
+    "token_velocity": "token_spike",
+    "node_offline":   "agent_down",
+    "agent_offline":  "agent_down",     # legacy alias, pre-0.12.711 clients
+}
+
+# _EVALUATOR_ONLY: no in-process branch, but ``clawmetry.alert_evaluator``
+# genuinely implements these over the DuckDB event/quality slices. Rules of
+# these types are mirrored into DuckDB on write so the daemon evaluates them.
+_EVALUATOR_ONLY = frozenset({
+    "error_rate",
+    "eval_score_below",
+    "outcome_failure_rate",
+})
+
+# Local ``type`` values with a real ``rtype ==`` branch in dashboard.py's
+# ``_budget_monitor_loop``. Anything stored outside this set is evaluated by
+# the daemon (if mirrored) or by nobody. Note the deliberate absence of
+# "anomaly": it has no branch and never had one — it was the silent
+# dumping ground for unmapped cloud types.
+_LOCAL_EVALUABLE_TYPES = frozenset({
+    "threshold",
+    "spike",
+    "token_spike",
+    "agent_down",
+    "session_cost",
+    "unproductive_burn",
+})
+
+# Types the UI can offer but nothing can evaluate on a self-hosted node yet.
+# Surfaced (not hidden) so the tab can render an honest "cloud only" state
+# instead of a green toggle that never fires. ``cron_failure`` maps to
+# alert_evaluator's ``count_over_threshold`` TODO stub, which under-fires by
+# design — that is a no-op, not an evaluator.
+UNSUPPORTED_ALERT_TYPES = frozenset({
+    "cron_failure",
+    "session_duration",
+    "subagent_depth",
+})
+
+
+# ── Always-on monitors ─────────────────────────────────────────────────────
+#
+# Founder-reported 2026-08-15, looking at two red banners above an Alerts tab
+# with every rule switched off: "how did it alert when all of the alerts are
+# disabled?? are those default alerts??"
+#
+# Fair question, and the tab gave no answer. These monitors are hardcoded in
+# ``dashboard.py``'s ``_budget_monitor_loop`` and in ingest handlers. They
+# call ``_fire_alert`` directly — no rule lookup, no enabled check — so they
+# fire regardless of what the Alerts tab shows, and the tab listed none of
+# them. An alert the operator cannot find, explain, or silence is not
+# governance; it is noise with a red background.
+#
+# Surfaced via /api/alerts/builtins. ``alert_type`` values must match the
+# ``_fire_alert(alert_type=...)`` call sites — tests/test_builtin_monitors.py
+# greps for drift.
+BUILTIN_MONITORS = [
+    {
+        "alert_type": "heartbeat_silent",
+        "label": "Agent went quiet",
+        "watches": "No heartbeat for 1.5x the expected interval",
+        "channels": ["banner", "telegram"],
+        "source": "dashboard",
+    },
+    {
+        "alert_type": "agent_down",
+        "label": "Telemetry feed stopped",
+        "watches": "No OTLP data received for the agent-down window",
+        "channels": ["banner", "telegram"],
+        "source": "dashboard",
+    },
+    {
+        "alert_type": "anomaly",
+        "label": "Cost spike",
+        "watches": "Today's spend above 2x the 7-day average",
+        "channels": ["banner", "telegram"],
+        "source": "dashboard",
+    },
+    {
+        "alert_type": "token_velocity",
+        "label": "Token burst",
+        "watches": "Sustained tokens/min above the built-in ceiling",
+        "channels": ["banner", "telegram"],
+        "source": "dashboard",
+    },
+    {
+        "alert_type": "agent_error_rate",
+        "label": "Errors climbing",
+        "watches": "A runtime's error rate over its recent baseline",
+        "channels": ["banner", "telegram"],
+        "source": "dashboard",
+    },
+    {
+        "alert_type": "error_spike",
+        "label": "Error spike",
+        "watches": "A burst of errors in a short window",
+        "channels": ["banner", "telegram"],
+        "source": "dashboard",
+    },
+    {
+        "alert_type": "security_threat",
+        "label": "Threat signature matched",
+        "watches": "Built-in signatures matching recent agent activity",
+        "channels": ["banner", "telegram"],
+        "source": "security-scan",
+    },
+    {
+        "alert_type": "numbat_finding",
+        "label": "Security tool finding",
+        "watches": "A critical or high finding from a connected scanner",
+        "channels": ["banner", "telegram"],
+        "source": "numbat-ingest",
+    },
+    {
+        "alert_type": "security",
+        "label": "Security posture changed",
+        "watches": "A drop in the node's security posture score",
+        "channels": ["banner", "telegram"],
+        "source": "dashboard",
+    },
+    {
+        "alert_type": "threshold",
+        "label": "Budget threshold",
+        "watches": "Daily spend crossing the budget you configured",
+        "channels": ["banner", "telegram"],
+        "source": "dashboard",
+    },
+]
+
+
+@bp_alerts.route("/api/alerts/builtins")
+def api_alerts_builtins():
+    """The always-on monitors that fire without an alert rule.
+
+    Read by the Alerts tab so the operator can see WHY a banner appeared
+    when every rule on the page is switched off. No ``@gate``: knowing what
+    is watching you is not a paid feature.
+    """
+    return jsonify({"monitors": BUILTIN_MONITORS,
+                    "count": len(BUILTIN_MONITORS)})
+
+
 # ── Default alert-rule seed list (issue #1707) ─────────────────────────────
 #
 # Templates the dashboard offers as one-click seed rules on the Alerts
@@ -259,6 +473,27 @@ def _enrich_rules_with_comms(rules):
         # Don't inject ``last_fired_at: None`` when the rule has never
         # fired — keeps the legacy response shape byte-stable for callers
         # that do strict-equality asserts (see test_alert_rules_local_store).
+        #
+        # Evaluator provenance (founder 2026-08-15): which process, if any,
+        # actually evaluates this rule. The UI renders "never triggered" for
+        # a rule with no evaluator identically to one that is armed and
+        # simply hasn't tripped — indistinguishable, and one of them is a
+        # lie. Only stamp when we can tell; absent key = legacy/unknown, so
+        # the byte-stable-shape guarantee above still holds for old rows.
+        _at = (r.get("alert_type") or "").strip()
+        _lt = (r.get("type") or "").strip()
+        if _at in UNSUPPORTED_ALERT_TYPES:
+            r["evaluator"] = "none"
+        elif _at in _EVALUATOR_ONLY:
+            r["evaluator"] = "daemon"
+        elif _lt in _LOCAL_EVALUABLE_TYPES:
+            r["evaluator"] = "dashboard"
+        elif _lt == "anomaly" and not _at:
+            # Pre-0.12.711 zombie: created before the alert_type column and
+            # before the mapping fix, so nothing can evaluate it and nothing
+            # can reconstruct what it meant. Surfaced, not hidden.
+            r["evaluator"] = "none"
+            r["needs_recreate"] = True
 
     # Comms flags. All three predicates need to be True for the banner:
     # 1+ rules configured, 0 historical fires across all of them, oldest
@@ -705,23 +940,49 @@ def api_alert_rules():
         # self-hosted setup"): the Alerts tab speaks the cloud vocabulary
         # (alert_type / threshold_value / channel_ids). A locally-entitled
         # install (self-hosted Trial/Pro key) saves those rules HERE instead
-        # of at the cloud; map the fields onto the local schema. Cloud-vocab
-        # types without a local evaluator equivalent land on "anomaly" so
-        # the rule persists and renders; evaluator parity is tracked
-        # separately.
+        # of at the cloud; map the fields onto the local schema.
+        #
+        # Founder 2026-08-15: the old map keyed on "cost_daily"/"agent_offline"
+        # while the Alerts tab has always POSTed "daily_spend"/"node_offline"
+        # (static/js/alerts.js EXAMPLE_RULES). Neither key matched, so BOTH
+        # fell through to the ``.get(..., "anomaly")`` default — and the
+        # in-process evaluator has no ``anomaly`` branch, so the rule rendered
+        # green, said "never triggered", and never could. Zombie rules are
+        # worse than no rules: the user believes they are covered.
+        #
+        # The mapping is now explicit and total. Every type the UI can send
+        # lands in exactly one bucket:
+        #   _CLOUD_TO_LOCAL — a real branch in dashboard.py's monitor loop
+        #   _EVALUATOR_ONLY — no local branch, but clawmetry.alert_evaluator
+        #                     implements it; mirrored to DuckDB below so the
+        #                     daemon evaluates it for real
+        #   anything else   — rejected with 422, never silently stored
         _cloud_type = (data.get("alert_type") or "").strip()
+        _mirror_to_duckdb = False
         if _cloud_type and not rtype:
-            _CLOUD_TO_LOCAL = {
-                "cost_daily": "threshold", "session_cost": "threshold",
-                "token_velocity": "token_spike", "agent_offline": "agent_down",
-            }
-            rtype = _CLOUD_TO_LOCAL.get(_cloud_type, "anomaly")
+            rtype = _CLOUD_TO_LOCAL.get(_cloud_type, "")
+            if not rtype:
+                if _cloud_type in _EVALUATOR_ONLY:
+                    # Parked as "anomaly" on purpose: the fleet-loop has no
+                    # such branch, so it skips the row and only the daemon's
+                    # alert_evaluator (DuckDB) fires it. Both write the same
+                    # alert_history table and it already dedupes by rule_id
+                    # inside the cooldown window, so there is no double-fire.
+                    rtype = "anomaly"
+                    _mirror_to_duckdb = True
+                else:
+                    return jsonify({
+                        "error": f"Alert type '{_cloud_type}' has no evaluator "
+                                 f"on a self-hosted node yet",
+                        "alert_type": _cloud_type,
+                        "unsupported": True,
+                    }), 422
             if not threshold:
                 threshold = data.get("threshold_value", 0)
             if data.get("channel_ids") and channels == ["banner"]:
                 channels = list(data.get("channel_ids") or []) or ["banner"]
         if rtype not in ("threshold", "spike", "token_spike", "anomaly",
-                         "agent_down", "unproductive_burn"):
+                         "agent_down", "session_cost", "unproductive_burn"):
             return jsonify({"error": "Invalid alert type"}), 400
         if not isinstance(threshold, (int, float)) or threshold <= 0:
             return jsonify({"error": "Threshold must be a positive number"}), 400
@@ -732,8 +993,8 @@ def api_alert_rules():
         with _d._fleet_db_lock:
             db = _d._fleet_db()
             db.execute(
-                "INSERT INTO alert_rules (id, type, threshold, channels, cooldown_min, enabled, runtime, created_at, updated_at) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                "INSERT INTO alert_rules (id, type, threshold, channels, cooldown_min, enabled, runtime, alert_type, created_at, updated_at) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 (
                     rule_id,
                     rtype,
@@ -742,18 +1003,34 @@ def api_alert_rules():
                     cooldown,
                     1 if enabled else 0,
                     runtime,
+                    _cloud_type,
                     now,
                     now,
                 ),
             )
             db.commit()
             db.close()
+        mirrored = False
+        if _mirror_to_duckdb:
+            mirrored = _mirror_rule_to_duckdb(
+                rule_id, alert_type=_cloud_type, threshold=threshold,
+                runtime=runtime, channels=channels, cooldown_min=cooldown,
+                enabled=enabled, name=data.get("name") or "",
+            )
         _audit("alert_rule.create", actor=_actor(), target=rule_id,
                result="created", source="dashboard",
                metadata={"type": rtype, "threshold": threshold,
                          "channels": channels, "enabled": bool(enabled),
-                         "runtime": runtime})
-        return jsonify({"ok": True, "id": rule_id})
+                         "runtime": runtime, "alert_type": _cloud_type,
+                         "duckdb_mirror": mirrored})
+        return jsonify({
+            "ok": True,
+            "id": rule_id,
+            # Honest evaluator provenance so the tab can say WHERE the rule
+            # runs (and warn when the daemon is down and the mirror missed).
+            "evaluator": ("daemon" if _mirror_to_duckdb else "dashboard"),
+            "mirrored": mirrored if _mirror_to_duckdb else None,
+        })
     # Phase 3 of #1032 — local DuckDB fast path. Opt-in via
     # CLAWMETRY_LOCAL_STORE_READ=1; falls through to the legacy fleet-DB
     # _get_alert_rules helper on miss / disabled flag.
@@ -796,6 +1073,9 @@ def api_alert_rule(rule_id):
             db.execute("DELETE FROM alert_rules WHERE id = ?", (rule_id,))
             db.commit()
             db.close()
+        # Drop the DuckDB mirror too, else the daemon keeps evaluating a rule
+        # the user deleted (it reads DuckDB, not the fleet DB).
+        _unmirror_rule_from_duckdb(rule_id)
         _audit("alert_rule.delete", actor=_actor(), target=rule_id,
                result="deleted", source="dashboard")
         return jsonify({"ok": True})
@@ -832,7 +1112,25 @@ def api_alert_rule(rule_id):
         db = _d._fleet_db()
         db.execute(f"UPDATE alert_rules SET {', '.join(sets)} WHERE id = ?", vals)
         db.commit()
+        row = db.execute(
+            "SELECT * FROM alert_rules WHERE id = ?", (rule_id,)
+        ).fetchone()
         db.close()
+    # Keep the DuckDB mirror in step. Without this an operator could flip a
+    # rule off in the UI and the daemon would keep firing it — it evaluates
+    # DuckDB, which the fleet-DB UPDATE above never touches.
+    row = dict(row) if row else {}
+    if (row.get("alert_type") or "") in _EVALUATOR_ONLY:
+        try:
+            _chans = json.loads(row.get("channels") or "[]")
+        except (TypeError, ValueError):
+            _chans = ["banner"]
+        _mirror_rule_to_duckdb(
+            rule_id, alert_type=row.get("alert_type"),
+            threshold=row.get("threshold"), runtime=row.get("runtime") or "all",
+            channels=_chans, cooldown_min=row.get("cooldown_min"),
+            enabled=bool(row.get("enabled")),
+        )
     _audit("alert_rule.update", actor=_actor(), target=rule_id,
            result="updated", source="dashboard",
            metadata={"fields": {k: data[k] for k in data

--- a/routes/local_query.py
+++ b/routes/local_query.py
@@ -606,6 +606,14 @@ _DAEMON_METHODS = frozenset({
     # gateway RPC (down), surfacing as the same 6 s timeout the PR was
     # supposed to fix. Adding both here closes the loop.
     "query_alert_rules",
+    # Founder 2026-08-15: locally-created alert rules live in the fleet
+    # SQLite DB, but ``sync._evaluate_alerts_local`` only ever reads DuckDB.
+    # Nothing bridged the two (``ingest_alert_rule`` was cloud-relay-only),
+    # so a rule created from the Alerts tab on a no-cloud node was evaluated
+    # by nobody and sat on "never triggered" forever. routes/alerts.py now
+    # mirrors on write/update/delete through these two.
+    "ingest_alert_rule",
+    "delete_alert_rule",
     "query_channel_config_status",
     "query_crons",
     # Issue #605 DuckDB follow-up: per-job cron-run timeline. Read by

--- a/tests/test_alert_banner_destinations.py
+++ b/tests/test_alert_banner_destinations.py
@@ -1,0 +1,113 @@
+"""Every alert that can reach the banner must have somewhere to go.
+
+Founder-reported 2026-08-15, on a HIGH numbat finding pinned to the top of
+the dashboard: "unable to understand what action I need to take... for the
+first one I just see dismiss button — so what??"
+
+The banner had a deep-link for exactly one alert type (``stuck_session``);
+every other type, security findings included, offered only Dismiss. The fix
+is ``_cmBannerDestination`` in static/js/app.js, which maps an alert to the
+screen that answers it.
+
+These tests pin the map to the set of types that can actually reach the
+banner, so adding a new always-on monitor without a destination fails CI
+instead of shipping another dead end.
+"""
+
+import re
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+APP_JS = REPO / "clawmetry" / "static" / "js" / "app.js"
+
+
+def _destination_source():
+    src = APP_JS.read_text(encoding="utf-8")
+    start = src.index("function _cmBannerDestination(")
+    end = src.index("\nasync function checkActiveAlerts(", start)
+    return src[start:end]
+
+
+def _handled_types():
+    """Alert types the destination map explicitly answers."""
+    body = _destination_source()
+    return set(re.findall(r"type === '([a-z_]+)'", body))
+
+
+def test_security_findings_have_a_destination():
+    """The exact alert from the report must lead somewhere."""
+    handled = _handled_types()
+    assert "numbat_finding" in handled, (
+        "A security finding can pin a red banner to the top of the dashboard. "
+        "It must offer more than Dismiss."
+    )
+    assert "security_threat" in handled
+
+
+def test_every_builtin_monitor_can_be_investigated():
+    """No always-on monitor may fire into a dead end.
+
+    BUILTIN_MONITORS is the list of things that can page the operator with
+    no rule behind them — precisely the alerts they cannot anticipate, and
+    so the ones that most need a next step.
+    """
+    from routes.alerts import BUILTIN_MONITORS
+
+    handled = _handled_types()
+    # 'security' (posture drift) and 'agent_error_rate'/'error_spike' fall
+    # back to the banner text alone; they are node-wide states with no single
+    # screen that explains them better than the message already does.
+    exempt = {"security", "agent_error_rate", "error_spike"}
+    orphans = sorted(
+        m["alert_type"] for m in BUILTIN_MONITORS
+        if m["alert_type"] not in handled and m["alert_type"] not in exempt
+    )
+    assert not orphans, (
+        f"{orphans} can raise a banner with no rule behind them and offer no "
+        f"way to investigate. Add a case to _cmBannerDestination in app.js."
+    )
+
+
+def test_stuck_session_deep_link_survived_the_refactor():
+    """The one destination that already worked must not regress."""
+    body = _destination_source()
+    assert "stuck_session_" in body
+    assert "goSession" in body
+    assert "transcripts" in body
+
+
+def test_destinations_point_at_real_tabs():
+    """A destination that switches to a tab that doesn't exist is a dead end
+    with extra steps."""
+    body = _destination_source()
+    tabs = set(re.findall(r"goTab\('([a-z-]+)'", body))
+    assert tabs, "no goTab destinations parsed"
+    tab_dir = REPO / "clawmetry" / "templates" / "tabs"
+    for tab in tabs:
+        assert (tab_dir / f"{tab}.html").exists(), (
+            f"_cmBannerDestination routes to tab '{tab}', but "
+            f"templates/tabs/{tab}.html does not exist."
+        )
+
+
+def test_security_destination_opens_the_findings_panel():
+    """Landing on the Security tab is only useful if the finding is there.
+
+    The findings panel is the piece that makes the Investigate button
+    meaningful — before it, the Security tab could not display an ingested
+    finding at all.
+    """
+    body = _destination_source()
+    assert "loadSecurityFindings" in body
+    assert "security-findings-panel" in body
+
+    security_html = (REPO / "clawmetry" / "templates" / "tabs" / "security.html").read_text(encoding="utf-8")
+    assert 'id="security-findings-panel"' in security_html
+    assert 'id="security-findings-list"' in security_html
+
+    app_js = APP_JS.read_text(encoding="utf-8")
+    assert "/api/security-threats" in app_js, (
+        "The findings panel must read the durable security_events log; the "
+        "live-scan endpoint (/api/security/threats) never sees ingested "
+        "findings."
+    )

--- a/tests/test_alert_rule_duckdb_mirror.py
+++ b/tests/test_alert_rule_duckdb_mirror.py
@@ -1,0 +1,142 @@
+"""The cross-evaluator rule mirror must land, and must never claim it did.
+
+A node runs two alert evaluators over two stores: the dashboard's in-process
+loop reads the fleet SQLite DB, and the daemon's ``alert_evaluator`` reads
+DuckDB. Until PR #4903 nothing bridged them — ``ingest_alert_rule`` was only
+ever called from the cloud pending-action relay — so a rule created from the
+Alerts tab on a no-cloud node was evaluated by nobody.
+
+The subtle half is the reporting. ``ingest_alert_rule`` returns None, and
+``local_store_via_daemon`` ALSO returns None when the proxy call failed, so
+"no exception" is not evidence the write landed. Caught live: against a
+daemon running an older wheel (whose allowlist has no ``ingest_alert_rule``)
+the first implementation reported ``mirrored: true`` for a write that never
+happened — and fell back to opening a writer handle from the dashboard
+process, the brick-lock hazard, where DuckDB let the row land somewhere the
+daemon would never read.
+"""
+
+import pytest
+
+from routes import alerts
+
+
+class _FakeStore:
+    def __init__(self):
+        self.rules = {}
+
+    def ingest_alert_rule(self, rule):
+        self.rules[str(rule["id"])] = rule
+
+    def delete_alert_rule(self, rule_id):
+        return 1 if self.rules.pop(str(rule_id), None) else 0
+
+    def query_alert_rules(self, **kw):
+        return list(self.rules.values())
+
+
+@pytest.fixture
+def daemon(monkeypatch):
+    """A reachable daemon proxy backed by an in-memory store."""
+    store = _FakeStore()
+
+    def _via_daemon(method, **kwargs):
+        return getattr(store, method)(**kwargs)
+
+    import routes.local_query as lq
+    monkeypatch.setattr(lq, "local_store_via_daemon", _via_daemon)
+    return store
+
+
+@pytest.fixture
+def dead_daemon(monkeypatch):
+    """A daemon that rejects the call — an older wheel whose allowlist has no
+    ``ingest_alert_rule``. local_store_via_daemon swallows that and returns
+    None, exactly like 'daemon not running'."""
+    import routes.local_query as lq
+    monkeypatch.setattr(lq, "local_store_via_daemon", lambda *a, **k: None)
+
+    import clawmetry.local_server as ls
+    monkeypatch.setattr(ls, "is_running", lambda: False)
+
+
+def _mirror(rule_id="r1", alert_type="error_rate"):
+    return alerts._mirror_rule_to_duckdb(
+        rule_id, alert_type=alert_type, threshold=5, runtime="all",
+        channels=[], cooldown_min=30, enabled=True, name="Tool failures",
+    )
+
+
+def test_mirror_lands_in_duckdb(daemon):
+    assert _mirror() is True
+    assert "r1" in daemon.rules
+
+
+def test_mirror_preserves_cloud_vocabulary(daemon):
+    """alert_evaluator reads condition_json's alert_type via its legacy map.
+
+    Mirroring the LOCAL type instead would land a rule the daemon cannot
+    interpret — a mirror that exists but still never fires.
+    """
+    _mirror(alert_type="eval_score_below")
+    cond = daemon.rules["r1"]["condition_json"]
+    assert cond["alert_type"] == "eval_score_below"
+    assert cond["threshold_value"] == 5
+    assert cond["runtime"] == "all"
+
+
+def test_mirror_reports_false_when_the_write_did_not_land(dead_daemon):
+    """The live regression: a rejected proxy call must not read as success."""
+    assert _mirror() is False
+
+
+def test_mirror_never_opens_a_writer_from_the_dashboard(monkeypatch):
+    """Only the daemon may hold the DuckDB writer lock.
+
+    Opening one from the dashboard process is the documented brick-lock
+    hazard, and where DuckDB permits it the row lands in a handle the daemon
+    never reads. So: no proxy and not the daemon => give up, don't write.
+    """
+    import routes.local_query as lq
+    monkeypatch.setattr(lq, "local_store_via_daemon", lambda *a, **k: None)
+
+    import clawmetry.local_server as ls
+    monkeypatch.setattr(ls, "is_running", lambda: False)
+
+    opened = []
+
+    import clawmetry.local_store as ls_mod
+    monkeypatch.setattr(ls_mod, "get_store",
+                        lambda *a, **k: opened.append(True) or _FakeStore())
+
+    assert _mirror() is False
+    assert not opened, (
+        "opened a DuckDB handle from the dashboard process while the daemon "
+        "owns the writer lock"
+    )
+
+
+def test_unmirror_removes_the_rule(daemon):
+    _mirror()
+    assert "r1" in daemon.rules
+    assert alerts._unmirror_rule_from_duckdb("r1") is True
+    assert "r1" not in daemon.rules
+
+
+def test_evaluator_only_types_are_the_ones_mirrored():
+    """Only types the daemon's evaluator actually implements get mirrored.
+
+    Mirroring a type the in-process loop owns would put two evaluators on one
+    rule; mirroring one neither implements would just relocate a zombie.
+    """
+    from clawmetry import alert_evaluator
+
+    for t in alerts._EVALUATOR_ONLY:
+        assert t in alert_evaluator._LEGACY_ALERT_TYPE_MAP, (
+            f"{t} is mirrored to the daemon, but alert_evaluator has no "
+            f"mapping for it — the mirrored rule would never fire."
+        )
+        assert t not in alerts._CLOUD_TO_LOCAL, (
+            f"{t} is both mirrored and locally evaluated — two evaluators "
+            f"would run one rule."
+        )

--- a/tests/test_alert_type_routing.py
+++ b/tests/test_alert_type_routing.py
@@ -1,0 +1,125 @@
+"""Every alert type the UI can create must reach a real evaluator.
+
+Founder-reported 2026-08-15: the Alerts tab showed two rules toggled ON,
+scoped "node-wide", reading "never triggered" — and they never could. The
+tab POSTs the CLOUD vocabulary (``daily_spend``, ``node_offline``) while
+``routes/alerts.py`` keyed its map on ``cost_daily``/``agent_offline``.
+Neither matched, both fell through to the ``"anomaly"`` default, and
+``dashboard.py``'s monitor loop has no ``anomaly`` branch. Silent zombie
+rules: the operator believes they are covered and they are not.
+
+The bug was only possible because three lists could drift apart with
+nothing tying them together:
+
+  1. ``EXAMPLE_RULES`` in ``clawmetry/static/js/alerts.js`` (what the UI sends)
+  2. the routing tables in ``routes/alerts.py`` (where it goes)
+  3. the ``rtype ==`` branches in ``dashboard.py`` (what actually evaluates)
+
+These tests pin all three together. A new row on the Alerts tab now fails
+CI until it is explicitly routed — to the in-process loop, to the daemon's
+evaluator, or to the honest "no evaluator yet" bucket.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+ALERTS_JS = REPO / "clawmetry" / "static" / "js" / "alerts.js"
+DASHBOARD_PY = REPO / "dashboard.py"
+
+
+def _ui_alert_types():
+    """Every ``alert_type`` in alerts.js EXAMPLE_RULES — i.e. every row a
+    user can flip on."""
+    src = ALERTS_JS.read_text(encoding="utf-8")
+    block = re.search(r"const EXAMPLE_RULES = \[(.*?)\n  \];", src, re.S)
+    assert block, "EXAMPLE_RULES not found in alerts.js — did the tab move?"
+    types = re.findall(r"alert_type:\s*'([a-z_]+)'", block.group(1))
+    assert types, "no alert_type entries parsed out of EXAMPLE_RULES"
+    return types
+
+
+def _loop_rtypes():
+    """Every ``rtype == "..."`` branch in dashboard.py's monitor loop."""
+    src = DASHBOARD_PY.read_text(encoding="utf-8")
+    return set(re.findall(r'rtype == "([a-z_]+)"', src))
+
+
+def test_every_ui_alert_type_is_routed():
+    """No UI row may fall through to the silent-zombie default."""
+    from routes import alerts
+
+    unrouted = [
+        t for t in _ui_alert_types()
+        if t not in alerts._CLOUD_TO_LOCAL
+        and t not in alerts._EVALUATOR_ONLY
+        and t not in alerts.UNSUPPORTED_ALERT_TYPES
+    ]
+    assert not unrouted, (
+        f"Alerts tab can create {unrouted}, which routes to no evaluator. "
+        f"Add each to _CLOUD_TO_LOCAL (in-process branch), _EVALUATOR_ONLY "
+        f"(daemon/DuckDB), or UNSUPPORTED_ALERT_TYPES (honest 'not yet')."
+    )
+
+
+def test_cloud_to_local_targets_all_have_a_loop_branch():
+    """A key in _CLOUD_TO_LOCAL promises the in-process loop evaluates it.
+
+    This is the exact assertion that would have caught the original bug:
+    the map pointed ``agent_offline`` at ``agent_down``, which had no
+    branch, so even the one type that *did* match the map was a no-op.
+    """
+    from routes import alerts
+
+    branches = _loop_rtypes()
+    missing = sorted({
+        local for local in alerts._CLOUD_TO_LOCAL.values()
+        if local not in branches
+    })
+    assert not missing, (
+        f"_CLOUD_TO_LOCAL routes to {missing}, but dashboard.py's monitor "
+        f"loop has no `rtype == \"<type>\"` branch for them — rules of that "
+        f"type would save, render green, and never fire."
+    )
+
+
+def test_anomaly_is_never_a_routing_target():
+    """``anomaly`` has no evaluator anywhere; it must not be a destination.
+
+    It stays a legal *stored* value (mirrored _EVALUATOR_ONLY rules park
+    there so the fleet loop skips them, and old rows still use it), but
+    nothing may deliberately route a cloud type onto it as an evaluator.
+    """
+    from routes import alerts
+
+    assert "anomaly" not in alerts._CLOUD_TO_LOCAL.values()
+    assert "anomaly" not in alerts._LOCAL_EVALUABLE_TYPES
+
+
+def test_local_evaluable_types_match_the_loop_exactly():
+    """_LOCAL_EVALUABLE_TYPES drives the ``evaluator`` field the UI trusts.
+
+    If it claims a type the loop dropped, the tab shows "armed" for a dead
+    rule — the same lie in a new place.
+    """
+    from routes import alerts
+
+    branches = _loop_rtypes()
+    overclaimed = sorted(alerts._LOCAL_EVALUABLE_TYPES - branches)
+    assert not overclaimed, (
+        f"_LOCAL_EVALUABLE_TYPES claims {overclaimed} are evaluated in "
+        f"dashboard.py, but no matching branch exists."
+    )
+
+
+@pytest.mark.parametrize("legacy,modern", [
+    ("cost_daily", "daily_spend"),
+    ("agent_offline", "node_offline"),
+])
+def test_legacy_aliases_still_map(legacy, modern):
+    """Pre-0.12.711 clients POST the old spelling; both must land the same."""
+    from routes import alerts
+
+    assert alerts._CLOUD_TO_LOCAL[legacy] == alerts._CLOUD_TO_LOCAL[modern]

--- a/tests/test_builtin_monitors.py
+++ b/tests/test_builtin_monitors.py
@@ -1,0 +1,107 @@
+"""The always-on monitor list must match what actually fires.
+
+Founder-reported 2026-08-15: two red banners sat above an Alerts tab where
+every rule was toggled off — "how did it alert when all of the alerts are
+disabled??". The monitors that produced them are hardcoded ``_fire_alert``
+calls with no rule lookup and no enabled check, and nothing in the product
+listed them. ``BUILTIN_MONITORS`` is that list.
+
+A published list that silently drifts from the code is worse than no list:
+it becomes a confident wrong answer. These tests keep it honest in both
+directions — every documented monitor must exist in the code, and the doc
+must not invent monitors that don't.
+"""
+
+import re
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+# Every module that may call _fire_alert with a hardcoded alert_type.
+_SOURCES = [
+    REPO / "dashboard.py",
+    REPO / "routes" / "infra.py",
+    REPO / "routes" / "health.py",
+    REPO / "routes" / "usage.py",
+]
+
+
+def _fired_alert_types():
+    """Scrape ``alert_type="..."`` from every _fire_alert call site."""
+    found = set()
+    for path in _SOURCES:
+        if not path.exists():
+            continue
+        found |= set(
+            re.findall(r'alert_type=["\']([a-z_]+)["\']',
+                       path.read_text(encoding="utf-8"))
+        )
+    assert found, "no alert_type call sites found — did _fire_alert move?"
+    return found
+
+
+def test_every_documented_monitor_actually_fires():
+    """No phantom entries: each listed monitor exists as a real call site."""
+    from routes.alerts import BUILTIN_MONITORS
+
+    fired = _fired_alert_types()
+    phantom = sorted(
+        m["alert_type"] for m in BUILTIN_MONITORS
+        if m["alert_type"] not in fired
+    )
+    assert not phantom, (
+        f"BUILTIN_MONITORS advertises {phantom}, but nothing calls "
+        f"_fire_alert with those types. Remove them or fix the name — the "
+        f"Alerts tab renders this list as fact."
+    )
+
+
+def test_every_hardcoded_fire_is_documented():
+    """No hidden monitors: anything that can page the user is listed.
+
+    This is the assertion that would have caught the original complaint.
+    ``numbat_finding`` and ``heartbeat_silent`` both fired into the banner
+    while the Alerts tab showed nothing that could explain either one.
+    """
+    from routes.alerts import BUILTIN_MONITORS
+
+    documented = {m["alert_type"] for m in BUILTIN_MONITORS}
+    # Types raised only by user-created rules are covered by the Alerts tab
+    # itself, so they need no builtin entry.
+    rule_driven = {"stuck_session", "unproductive_burn", "budget_abort",
+                   "authority_violation", "spike", "token_spike",
+                   "session_cost", "daily_threshold_breached"}
+    undocumented = sorted(_fired_alert_types() - documented - rule_driven)
+    assert not undocumented, (
+        f"{undocumented} can fire a banner with no alert rule behind it and "
+        f"is not in BUILTIN_MONITORS, so the Alerts tab cannot explain it. "
+        f"Add an entry (or add it to rule_driven if a rule really gates it)."
+    )
+
+
+def test_monitor_entries_are_well_formed():
+    """The tab renders these fields directly; none may be blank."""
+    from routes.alerts import BUILTIN_MONITORS
+
+    seen = set()
+    for m in BUILTIN_MONITORS:
+        for field in ("alert_type", "label", "watches", "channels", "source"):
+            assert m.get(field), f"{m.get('alert_type')} is missing {field}"
+        assert m["alert_type"] not in seen, f"duplicate {m['alert_type']}"
+        seen.add(m["alert_type"])
+        assert isinstance(m["channels"], list) and m["channels"]
+
+
+def test_builtins_endpoint_is_not_paywalled():
+    """Knowing what watches you is not a paid feature.
+
+    Matches the decorator line specifically — the function's own docstring
+    mentions ``@gate`` while explaining why it has none.
+    """
+    src = (REPO / "routes" / "alerts.py").read_text(encoding="utf-8")
+    route = src.index('"/api/alerts/builtins"')
+    decorators = src[src.rindex("\n@", 0, route):route]
+    assert "@gate(" not in decorators, (
+        "/api/alerts/builtins is gated — the always-on monitors fire for "
+        "every user, so every user must be able to see them."
+    )


### PR DESCRIPTION
Closes the three things the founder hit on 2026-08-15, plus two more found while verifying.

> "unable to understand what action I need to take -- for the first one I just see dismiss button -- so what??"
> "how did it alert when all of alerts are disabled?? are those default alerts??"
> "if I enable them it says no channels -- why not just ask to configure channel first before enable, and take me to notifications page??"

## 1. Alarms with no destination
The banner built a deep-link for exactly one alert type (`stuck_session`). Everything else — including a HIGH secret-exfiltration finding — offered only Dismiss. `_cmBannerDestination` now maps each alert to the screen that answers it, and a test fails if a new always-on monitor lands without one.

## 2. The Security tab could not display a security finding
It only called `/api/security/threats` (a live signature re-scan). Ingested findings land in `security_events`, served by `/api/security-threats`, which nothing rendered — so the alarm had no destination anywhere in the product. Adds a **Recorded findings** panel over the durable log, each row linking to the session that triggered it, runtime-scoped, with an honest cloud empty state (FLYWHEEL gate 1).

## 3. Two enabled rules that could never fire
`routes/alerts.py` keyed its map on `cost_daily`/`agent_offline`; the tab has always POSTed `daily_spend`/`node_offline`. Neither matched, both fell through to `.get(..., "anomaly")`, and the monitor loop has no `anomaly` branch. The rules rendered green and said "never triggered" — permanently.

The map is now explicit and total. Every type routes to the in-process loop, to the daemon's `alert_evaluator` (**mirrored into DuckDB — a bridge that never existed**; the dashboard wrote fleet SQLite, the daemon only ever read DuckDB), or is rejected with 422. Adds the missing `agent_down` and `session_cost` branches.

## 4. Enabling asked for nothing, then said "no channels"
Toggling on POSTed `channel_ids: []` silently, then relabelled the row — reading as if enabling had *deleted* the Slack/Email the row advertised a second earlier. Those pills were decorative samples; they are gone. A prompt now asks before arming, routing to Notifications or accepting in-app only.

## 5. Monitors that fire with no rule behind them were invisible
`heartbeat_silent`, `numbat_finding`, the cost anomaly and six others call `_fire_alert` directly, bypassing every toggle on the page. Surfaced as an **Always on** section via `/api/alerts/builtins` (ungated — knowing what watches you is not a paid feature).

## Found while verifying, on the reporter's own node
Rules saved before the `alert_type` column match no row in the tab, so **two enabled rules were invisible** — unseen, unturn-off-able, unable to fire. They now render as "unrecognized" with an explanation and a Remove button.

## Tests
Three new files pin the lists that were free to drift, and each fails against the pre-fix code:
- every UI alert type must route somewhere
- every `_CLOUD_TO_LOCAL` target must have a matching loop branch
- every hardcoded `_fire_alert` must be documented in `BUILTIN_MONITORS`
- every builtin must have a banner destination

Full `alert|security|entitlement` selection matches the pre-change baseline exactly (44 pre-existing failures on both; the two the first pass introduced are fixed). Zero new lint errors (221 on both trees).

## Verified live at 0.12.710
- banner renders **Investigate →** on the numbat finding
- findings panel lists that finding with its session and an Open session link
- `/api/alerts/rules` reports the reporter's two rules as `evaluator: "none"`, `needs_recreate: true`
- 10 always-on monitors render; zero JS console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)