### PR TITLE
fix(sync): add missing typing.Any import and narrow bare except

### DIFF
--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -26,6 +26,7 @@ import uuid
 from pathlib import Path
 from datetime import datetime, timezone
 from itertools import islice
+from typing import Any
 
 # Leaf module (typing-only deps) — safe to import at package load, no cycle.
 from clawmetry import error_signal as _error_signal
@@ -15736,7 +15737,7 @@ def _build_tool_stats():
                                     if isinstance(args, str):
                                         try:
                                             args = json.loads(args)
-                                        except:
+                                        except (json.JSONDecodeError, TypeError):
                                             args = {}
 
                                     # Track recent entries for specific tools


### PR DESCRIPTION
## Summary

- Add `from typing import Any` to `clawmetry/sync.py` — `Any` is used in 6 type annotations in the file but was never imported; static type checkers (mypy, pyright) flag this.
- Narrow `except:` to `except (json.JSONDecodeError, TypeError):` in `_build_tool_stats` — the bare clause catches `KeyboardInterrupt` and `SystemExit`, which is unintentional. Only `json.JSONDecodeError` (bad JSON string) and `TypeError` (wrong type passed to `json.loads`) can actually occur at that call site.

Fixes the same issues reported in #4874 by @harshadkhetpal. Applying here on current main because #4874's branch has drifted significantly from the 1,700+ commits that landed since it was opened.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B9HceqAMBF9yMSSMFBkLyD)_