### PR TITLE
Re-mirror alert rules stranded by an older daemon

### DIFF
--- a/routes/alerts.py
+++ b/routes/alerts.py
@@ -152,20 +152,76 @@ def _mirror_rule_to_duckdb(rule_id, *, alert_type, threshold, runtime,
     return _rule_in_duckdb(rule_id)
 
 
-def _rule_in_duckdb(rule_id):
-    """True when ``rule_id`` is present in the DuckDB alert_rules table."""
+def _duckdb_rule_ids():
+    """Ids currently in the DuckDB alert_rules table, or None if unreadable."""
     try:
         from routes.local_query import local_store_via_daemon
         rows = local_store_via_daemon("query_alert_rules", limit=500)
         if rows is None:
             from clawmetry import local_server as _ls_srv
             if not _ls_srv.is_running():
-                return False
+                return None
             from clawmetry import local_store as _ls_mod
             rows = _ls_mod.get_store().query_alert_rules(limit=500)
-        return any(str(r.get("id")) == str(rule_id) for r in (rows or []))
+        return {str(r.get("id")) for r in (rows or [])}
     except Exception:
-        return False
+        return None
+
+
+def _rule_in_duckdb(rule_id):
+    """True when ``rule_id`` is present in the DuckDB alert_rules table."""
+    ids = _duckdb_rule_ids()
+    return bool(ids) and str(rule_id) in ids
+
+
+# Rules whose mirror we've already reconciled this process. Bounds the repair
+# below to one attempt per rule per boot — it exists to close an upgrade-skew
+# window, not to run on every page load forever.
+_MIRROR_REPAIRED = set()
+
+
+def _repair_missing_mirrors(rules):
+    """Re-mirror evaluator-owned rules that never reached DuckDB.
+
+    The dashboard and daemon ship in one wheel but restart independently, so
+    there is a window where a NEW dashboard writes a rule that an OLD daemon
+    cannot accept (its method allowlist predates the bridge). Without repair
+    that rule stays stranded after the daemon upgrades: the create path is
+    long over, and nothing else would ever mirror it — the same permanently
+    inert rule this whole change exists to eliminate, just arriving by a
+    different route.
+
+    One DuckDB read, and only when an evaluator-owned rule exists at all.
+    Idempotent upsert, at most one attempt per rule per process.
+    """
+    candidates = [
+        r for r in rules
+        if (r.get("alert_type") or "") in _EVALUATOR_ONLY
+        and str(r.get("id")) not in _MIRROR_REPAIRED
+    ]
+    if not candidates:
+        return
+    present = _duckdb_rule_ids()
+    if present is None:
+        return  # store unreadable; try again next boot rather than guess
+    for r in candidates:
+        rid = str(r.get("id"))
+        _MIRROR_REPAIRED.add(rid)
+        if rid in present:
+            continue
+        try:
+            _chans = json.loads(r.get("channels") or "[]")
+        except (TypeError, ValueError):
+            _chans = []
+        _mirror_rule_to_duckdb(
+            rid, alert_type=r.get("alert_type"),
+            threshold=(r.get("threshold_value")
+                       if r.get("threshold_value") is not None
+                       else r.get("threshold")),
+            runtime=r.get("runtime") or "all", channels=_chans,
+            cooldown_min=r.get("cooldown_min"),
+            enabled=bool(r.get("enabled")), name=r.get("name") or "",
+        )
 
 
 def _write_via_store(method, **kwargs):
@@ -1096,11 +1152,13 @@ def api_alert_rules():
             # Alerts UI can render the PR #1410 "your rules will fire now"
             # banner and per-rule "Last fired" pills.
             enriched, comms = _enrich_rules_with_comms(fast.get("rules") or [])
+            _repair_missing_mirrors(enriched)
             fast = dict(fast)
             fast["rules"] = enriched
             fast["_comms"] = comms
             return jsonify(fast)
     enriched, comms = _enrich_rules_with_comms(_d._get_alert_rules())
+    _repair_missing_mirrors(enriched)
     return jsonify({"rules": enriched, "_comms": comms})
 
 

--- a/tests/test_alert_rule_duckdb_mirror.py
+++ b/tests/test_alert_rule_duckdb_mirror.py
@@ -140,3 +140,61 @@ def test_evaluator_only_types_are_the_ones_mirrored():
             f"{t} is both mirrored and locally evaluated — two evaluators "
             f"would run one rule."
         )
+
+
+def test_repair_remirrors_a_rule_the_old_daemon_rejected(daemon, monkeypatch):
+    """Close the upgrade-skew window.
+
+    A new dashboard can write a rule that an old daemon refuses (its method
+    allowlist predates the bridge). Once the daemon catches up, nothing would
+    otherwise ever mirror that rule — it would stay inert forever, which is
+    the exact defect this change exists to remove, arriving by a later route.
+    """
+    monkeypatch.setattr(alerts, "_MIRROR_REPAIRED", set())
+    assert "stranded" not in daemon.rules
+
+    alerts._repair_missing_mirrors([{
+        "id": "stranded", "alert_type": "error_rate", "threshold": 5,
+        "runtime": "all", "channels": '["banner"]', "cooldown_min": 30,
+        "enabled": 1,
+    }])
+    assert "stranded" in daemon.rules
+
+
+def test_repair_is_attempted_once_per_rule(daemon, monkeypatch):
+    """It repairs an upgrade window, so it must not run on every page load."""
+    monkeypatch.setattr(alerts, "_MIRROR_REPAIRED", set())
+    calls = []
+    real = alerts._mirror_rule_to_duckdb
+    monkeypatch.setattr(alerts, "_mirror_rule_to_duckdb",
+                        lambda *a, **k: calls.append(1) or real(*a, **k))
+    rule = {"id": "once", "alert_type": "error_rate", "threshold": 5,
+            "runtime": "all", "channels": "[]", "cooldown_min": 30,
+            "enabled": 1}
+    alerts._repair_missing_mirrors([rule])
+    alerts._repair_missing_mirrors([rule])
+    assert len(calls) == 1
+
+
+def test_repair_ignores_locally_evaluated_rules(daemon, monkeypatch):
+    """Mirroring a rule the in-process loop owns would double-evaluate it."""
+    monkeypatch.setattr(alerts, "_MIRROR_REPAIRED", set())
+    alerts._repair_missing_mirrors([{
+        "id": "local", "alert_type": "daily_spend", "threshold": 50,
+        "runtime": "all", "channels": "[]", "cooldown_min": 30, "enabled": 1,
+    }])
+    assert "local" not in daemon.rules
+
+
+def test_repair_does_nothing_when_the_store_is_unreadable(monkeypatch):
+    """An unreadable store must not be read as 'nothing is mirrored'."""
+    monkeypatch.setattr(alerts, "_MIRROR_REPAIRED", set())
+    monkeypatch.setattr(alerts, "_duckdb_rule_ids", lambda: None)
+    called = []
+    monkeypatch.setattr(alerts, "_mirror_rule_to_duckdb",
+                        lambda *a, **k: called.append(1))
+    alerts._repair_missing_mirrors([{
+        "id": "x", "alert_type": "error_rate", "threshold": 5,
+        "runtime": "all", "channels": "[]", "cooldown_min": 30, "enabled": 1,
+    }])
+    assert not called


### PR DESCRIPTION
Follow-up to #4903 — this commit raced that PR's auto-merge and did not land with it. Main is self-consistent without it; this closes the remaining hole.

## The gap

The dashboard and daemon ship in one wheel but restart independently. During an upgrade a **new** dashboard can write an evaluator-owned rule that an **old** daemon refuses, because its method allowlist predates the `ingest_alert_rule` bridge #4903 added.

`_mirror_rule_to_duckdb` correctly reports `mirrored: false` in that window (verified live against the 0.12.710 daemon). But nothing would ever mirror that rule afterwards — the create path is long over. Once the daemon caught up, the rule would sit enabled and permanently inert.

That is exactly the defect #4903 exists to remove, arriving by a later route.

## The fix

`_repair_missing_mirrors` runs on the rules GET, on both return paths:

- one DuckDB read, and only when an evaluator-owned rule exists at all
- idempotent upsert, at most one attempt per rule per process
- a no-op when the store is unreadable — absence of evidence is not evidence of a missing mirror
- skips locally-evaluated types, so a rule never ends up with two evaluators

## Tests

Four added to `tests/test_alert_rule_duckdb_mirror.py`: the stranded rule is re-mirrored, the repair is attempted once per rule, locally-evaluated rules are left alone, and an unreadable store triggers no writes. 33 pass across the alert suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)