### PR TITLE
feat: one-line runtime wiring for needs-you (clawmetry hook attention)

### DIFF
--- a/clawmetry/attention_hook.py
+++ b/clawmetry/attention_hook.py
@@ -1,0 +1,94 @@
+"""clawmetry/attention_hook.py — the `clawmetry hook attention` client.
+
+Backs the one line a user adds to a runtime's own hook config to upgrade its
+needs-you badge from "Maybe waiting" (inferred) to "Waiting for you"
+(reported by the runtime):
+
+    clawmetry hook attention --runtime qwen_code
+
+It reads the runtime's hook payload from stdin, forwards it to the local
+dashboard's ``/api/hooks/attention`` receiver, and exits. Replaces a
+multi-line ``curl`` in every wiring snippet, which people get wrong.
+
+Three properties this MUST have, because it runs inside somebody's agent at
+the moment that agent is asking a human for permission:
+
+* **It never fails.** Always exit 0, print nothing. A hook that errors or
+  writes to stdout can change what the runtime does next; a hook that hangs
+  stalls the turn. Nothing about a badge justifies either.
+* **It never blocks for long.** A short timeout, and a failed POST is simply
+  dropped — the daemon's inference pass still covers the session, so the cost
+  of losing this is precision, not the feature.
+* **It never decides anything.** This tells ClawMetry that a prompt is open.
+  It does not answer the prompt, and shares no code path with the approvals
+  gate. Observation and decision stay separate on purpose.
+
+Stdlib only: the hook process starts and dies on every permission prompt, so
+its import cost is paid over and over.
+"""
+from __future__ import annotations
+
+import json
+import sys
+
+#: Deliberately short. The receiver does its own write off-thread, so it
+#: answers immediately; anything slower than this means something is wrong
+#: and waiting longer only makes the agent wait longer too.
+_TIMEOUT_S = 3.0
+
+
+def _arg(argv: list, flag: str, default: str = "") -> str:
+    if flag in argv:
+        try:
+            return argv[argv.index(flag) + 1]
+        except IndexError:
+            return default
+    return default
+
+
+def attention_main(argv: "list | None" = None) -> int:
+    """Entry point for ``clawmetry hook attention``. ALWAYS returns 0.
+
+    Flags:
+      ``--runtime <id>``  which runtime is reporting (required)
+      ``--base <url>``    dashboard base; discovered when omitted
+      ``--event <name>``  ``waiting`` (default) or ``resolved``
+    """
+    argv = list(argv or [])
+    runtime = _arg(argv, "--runtime").strip().lower()
+    if not runtime:
+        return 0  # nothing we can attribute — stay silent, never complain
+
+    event = (_arg(argv, "--event", "waiting") or "waiting").strip().lower()
+
+    base = _arg(argv, "--base").rstrip("/")
+    if not base:
+        try:
+            from clawmetry.claude_code_gate import dashboard_base
+            base = dashboard_base()
+        except Exception:
+            base = "http://127.0.0.1:8900"
+
+    # The runtime's payload, forwarded unmodified — the receiver knows how to
+    # read every spelling of session id and tool name, so this stays dumb.
+    try:
+        raw = sys.stdin.read()
+        body = json.loads(raw) if raw.strip() else {}
+        if not isinstance(body, dict):
+            body = {}
+    except Exception:
+        body = {}
+
+    url = (f"{base}/api/hooks/attention"
+           f"?runtime={runtime}&event={event}")
+    try:
+        import urllib.request
+
+        req = urllib.request.Request(
+            url, data=json.dumps(body).encode("utf-8"),
+            headers={"Content-Type": "application/json"}, method="POST")
+        with urllib.request.urlopen(req, timeout=_TIMEOUT_S):
+            pass
+    except Exception:
+        pass  # dashboard down, wrong port, anything — inference still covers it
+    return 0

--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -6839,6 +6839,14 @@ def main() -> None:
     # JSON. ALWAYS exits 0 — any failure means "no opinion" (fail-open),
     # never a blocked agent. Stdlib-only imports.
     if len(sys.argv) > 1 and sys.argv[1] == "hook":
+        # `clawmetry hook attention --runtime <id>` — the runtime-agnostic
+        # needs-you reporter. Split out from the claude-code gate because it
+        # is a different job: it OBSERVES that a prompt is open and returns,
+        # where the gate DECIDES. Same fail-open, stdlib-only, always-exit-0
+        # contract. See clawmetry/attention_hook.py and docs/NEEDS_YOU.md.
+        if len(sys.argv) > 2 and sys.argv[2] == "attention":
+            from clawmetry.attention_hook import attention_main
+            raise SystemExit(attention_main(sys.argv[3:]))
         from clawmetry.claude_code_gate import hook_main as _hook_cli
         raise SystemExit(_hook_cli(sys.argv[2:]))
     # FAST PATH — agent-facing read CLI (`clawmetry sessions|activity|waste|

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -3940,7 +3940,12 @@ def _first_alias(row: dict, aliases: tuple) -> str | None:
     if not isinstance(row, dict):
         return None
     nests = [row]
-    for key in ("metadata", "extra", "data", "env"):
+    # ``payload`` is not optional politeness: Codex records its working
+    # directory ONLY as ``payload.cwd`` (on its `session_meta` and
+    # `turn_context` lines), so leaving it out silently dropped the location
+    # for an entire runtime. Found by probing the real captured fixtures
+    # rather than trusting the top-level shape.
+    for key in ("payload", "metadata", "extra", "data", "env"):
         sub = row.get(key)
         if isinstance(sub, dict):
             nests.append(sub)

--- a/docs/NEEDS_YOU.md
+++ b/docs/NEEDS_YOU.md
@@ -25,20 +25,32 @@ Two more states exist and are deliberately distinct from "nothing waiting":
 
 ## Wiring a runtime for confirmed signals
 
-Every runtime posts the same way. Send its own hook payload, unmodified, to:
+Every runtime is wired the same way. Point its permission hook at:
 
 ```
-POST http://127.0.0.1:8900/api/hooks/attention?runtime=<runtime>
+clawmetry hook attention --runtime <runtime>
 ```
 
-The receiver reads the session id and tool name from whatever the runtime
-calls them (`session_id`, `sessionId`, `tool_name`, `toolName`, …), so no
-per-runtime translation is needed. Add `&event=resolved` to clear.
+It reads the runtime's own hook payload from stdin and forwards it. The
+receiver reads the session id and tool name from whatever the runtime calls
+them (`session_id`, `sessionId`, `tool_name`, `toolName`, …), so no
+per-runtime translation is needed. Add `--event resolved` to clear.
+
+The command always exits 0 and prints nothing, so it cannot change what your
+runtime does next. If ClawMetry is not running the report is simply dropped
+and inference still covers the session.
+
+Prefer raw HTTP, or wiring a runtime that cannot run a command? The same
+thing over the wire:
+
+```
+POST http://127.0.0.1:8900/api/hooks/attention?runtime=<runtime>&event=waiting
+```
 
 It **observes only**: it records and returns immediately, never answers the
 prompt, never blocks your agent, and cannot return an error that would make a
-runtime hesitate. The response includes `"stored": true|false` so you can
-tell a wired hook from a silent one.
+runtime hesitate. The HTTP response includes `"stored": true|false` so you
+can tell a wired hook from a silent one.
 
 ### Claude Code — already automatic
 
@@ -53,7 +65,7 @@ the only runtime confirmed end to end today.
 
 ```json
 { "hooks": { "PermissionRequest": [ { "hooks": [ { "type": "command",
-  "command": "curl -s -X POST -H 'Content-Type: application/json' --data-binary @- 'http://127.0.0.1:8900/api/hooks/attention?runtime=qwen_code'"
+  "command": "clawmetry hook attention --runtime qwen_code"
 } ] } ] } }
 ```
 
@@ -64,7 +76,7 @@ the agent requires user attention:
 
 ```json
 { "hooks": { "Notification": [ { "hooks": [ { "type": "command",
-  "command": "curl -s -X POST -H 'Content-Type: application/json' --data-binary @- 'http://127.0.0.1:8900/api/hooks/attention?runtime=gemini_cli'"
+  "command": "clawmetry hook attention --runtime gemini_cli"
 } ] } ] } }
 ```
 
@@ -93,7 +105,8 @@ No hooks, but `--notifications-command` runs when the LLM finishes and is
 waiting for you — which is exactly this signal:
 
 ```
-aider --notifications --notifications-command "curl -s -X POST -H 'Content-Type: application/json' -d '{\"session_id\":\"$AIDER_SESSION\",\"tool_name\":\"\"}' 'http://127.0.0.1:8900/api/hooks/attention?runtime=aider'"
+aider --notifications --notifications-command \
+  "echo '{\"session_id\":\"'$AIDER_SESSION'\"}' | clawmetry hook attention --runtime aider"
 ```
 
 ### n8n
@@ -117,7 +130,17 @@ inference — you lose precision, not the feature. Reports welcome.
 
 ## Troubleshooting
 
-**`"stored": false` in the response.** The write did not persist. The usual
+**Checking whether a hook is wired.** `clawmetry hook attention` is silent by
+design, so it tells you nothing either way. To see the answer, send the same
+thing over HTTP once by hand and read `stored`:
+
+```
+echo '{"session_id":"test-1","tool_name":"Bash"}' \
+  | curl -s -X POST -H 'Content-Type: application/json' --data-binary @- \
+    'http://127.0.0.1:8900/api/hooks/attention?runtime=qwen_code'
+```
+
+**`"stored": false` in that response.** The write did not persist. The usual
 cause is a ClawMetry daemon older than this feature: the dashboard cannot
 write to DuckDB while a daemon owns the writer lock, so it proxies, and an
 older daemon's allowlist has no `set_session_attention`. Upgrade and restart

--- a/tests/test_attention_detector.py
+++ b/tests/test_attention_detector.py
@@ -163,6 +163,34 @@ def test_openclaw_v3_model_completed_hosting_tool(store):
     assert rows[0]["tool"] == "shell"
 
 
+def test_real_claude_code_tool_result_clears_the_wait(store):
+    """The REAL resolution shape, and it is not a `tool_result` event.
+
+    Verified against a live transcript: Claude Code returns a tool result as
+    a `user` line whose message.content holds a tool_result block. The
+    synthetic `tool_result` event type elsewhere in this file is a shape our
+    own adapters emit — it is NOT what Claude Code writes. If only that were
+    covered, a regression in the user-role branch would leave every answered
+    prompt showing "waiting" forever, and the tests would stay green.
+    """
+    _session(store, "s-real-res", seconds_idle=300)
+    _event(store, "s-real-res", "assistant", 400, {
+        "role": "assistant",
+        "message": {"role": "assistant", "content": [
+            {"type": "tool_use", "id": "t1", "name": "Bash", "input": {}},
+        ]},
+    }, eid="a")
+    assert len(_detect(store)) == 1, "the pending call should flag first"
+
+    _event(store, "s-real-res", "user", 300, {
+        "role": "user",
+        "message": {"role": "user", "content": [
+            {"type": "tool_result", "tool_use_id": "t1", "content": "ok"},
+        ]},
+    }, eid="b")
+    assert _detect(store) == [], "a real tool result must clear the wait"
+
+
 def test_mixed_text_and_tool_turn_counts_as_reply(store):
     """An assistant turn that both explains and calls a tool has already
     communicated, so it does not read as blocked-and-silent."""

--- a/tests/test_attention_hook_cli.py
+++ b/tests/test_attention_hook_cli.py
@@ -1,0 +1,130 @@
+"""`clawmetry hook attention` — the one-line runtime wiring client.
+
+This runs INSIDE somebody's agent, at the moment that agent is asking a human
+for permission. So the contract under test is mostly about what it must never
+do: never exit non-zero, never write to stdout, never hang, never decide
+anything. A hook that breaks any of those can change what the runtime does
+next, and no badge is worth that.
+
+Losing a report costs precision, not the feature — the daemon's inference
+pass still covers the session. That asymmetry is why every failure path here
+is a silent no-op rather than an error.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import pytest
+
+from clawmetry.attention_hook import attention_main
+
+
+@pytest.fixture()
+def sink():
+    """A local receiver that records what the client sends."""
+    seen = []
+
+    class H(BaseHTTPRequestHandler):
+        def do_POST(self):
+            n = int(self.headers.get("Content-Length") or 0)
+            seen.append({"path": self.path,
+                         "body": self.rfile.read(n).decode()})
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(b'{"ok":true}')
+
+        def log_message(self, *a):
+            pass
+
+    srv = HTTPServer(("127.0.0.1", 0), H)
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    srv.seen = seen
+    srv.base = f"http://127.0.0.1:{srv.server_port}"
+    yield srv
+    srv.shutdown()
+
+
+def _run(monkeypatch, capsys, payload, *args):
+    monkeypatch.setattr("sys.stdin",
+                        __import__("io").StringIO(payload))
+    rc = attention_main(list(args))
+    out = capsys.readouterr()
+    return rc, out
+
+
+# ── it forwards what the runtime said ───────────────────────────────────────
+
+def test_forwards_the_payload_unmodified(sink, monkeypatch, capsys):
+    """The client stays dumb: the receiver knows every spelling of session id
+    and tool name, so translating here would be a second place to get it
+    wrong."""
+    body = '{"session_id":"cli-1","tool_name":"Bash","extra":"kept"}'
+    rc, _ = _run(monkeypatch, capsys, body,
+                 "--runtime", "qwen_code", "--base", sink.base)
+    assert rc == 0
+    assert len(sink.seen) == 1
+    assert json.loads(sink.seen[0]["body"]) == json.loads(body)
+
+
+def test_runtime_and_event_ride_the_query_string(sink, monkeypatch, capsys):
+    _run(monkeypatch, capsys, '{"session_id":"a"}',
+         "--runtime", "gemini_cli", "--base", sink.base)
+    assert "runtime=gemini_cli" in sink.seen[0]["path"]
+    assert "event=waiting" in sink.seen[0]["path"]
+
+
+def test_resolved_event_is_passed_through(sink, monkeypatch, capsys):
+    _run(monkeypatch, capsys, '{"session_id":"a"}',
+         "--runtime", "qwen_code", "--event", "resolved", "--base", sink.base)
+    assert "event=resolved" in sink.seen[0]["path"]
+
+
+# ── it never disturbs the agent ─────────────────────────────────────────────
+
+def test_stdout_stays_empty_on_success(sink, monkeypatch, capsys):
+    """Anything on stdout can be read by the runtime as a hook decision."""
+    _, out = _run(monkeypatch, capsys, '{"session_id":"a"}',
+                  "--runtime", "codex", "--base", sink.base)
+    assert out.out == ""
+    assert out.err == ""
+
+
+def test_missing_runtime_is_a_silent_noop(sink, monkeypatch, capsys):
+    rc, out = _run(monkeypatch, capsys, '{"session_id":"a"}',
+                   "--base", sink.base)
+    assert rc == 0 and out.out == ""
+    assert sink.seen == [], "nothing attributable — must not guess a runtime"
+
+
+@pytest.mark.parametrize("payload", ["", "not json", "[1,2,3]", "null"])
+def test_malformed_stdin_still_exits_zero(sink, monkeypatch, capsys, payload):
+    rc, out = _run(monkeypatch, capsys, payload,
+                   "--runtime", "codex", "--base", sink.base)
+    assert rc == 0 and out.out == ""
+
+
+def test_unreachable_dashboard_exits_zero(monkeypatch, capsys):
+    """Port 9 is reliably closed. Losing the report costs precision; a
+    non-zero exit could cost the user their turn."""
+    rc, out = _run(monkeypatch, capsys, '{"session_id":"a"}',
+                   "--runtime", "codex", "--base", "http://127.0.0.1:9")
+    assert rc == 0 and out.out == ""
+
+
+def test_flag_at_end_of_argv_does_not_crash(sink, monkeypatch, capsys):
+    """`--runtime` with nothing after it is a typo, not a reason to raise."""
+    rc, out = _run(monkeypatch, capsys, '{"session_id":"a"}', "--runtime")
+    assert rc == 0 and out.out == ""
+
+
+def test_it_never_answers_the_prompt(sink, monkeypatch, capsys):
+    """Observation only. If this ever printed a hookSpecificOutput envelope
+    it would be deciding on the user's behalf from the wrong code path."""
+    _, out = _run(monkeypatch, capsys, '{"session_id":"a","tool_name":"Bash"}',
+                  "--runtime", "qwen_code", "--base", sink.base)
+    assert "hookSpecificOutput" not in out.out
+    assert "permissionDecision" not in out.out

--- a/tests/test_session_location_real_fixtures.py
+++ b/tests/test_session_location_real_fixtures.py
@@ -1,0 +1,123 @@
+"""Session-location extraction, measured against each runtime's REAL capture.
+
+"Works across all runtimes" is a claim, and this file is the measurement. It
+runs the shipped extractors over the committed real-capture fixtures, so the
+per-runtime answer is a test result rather than an assumption.
+
+It caught a real bug on first run: Codex records its working directory ONLY
+as ``payload.cwd`` (on its `session_meta` and `turn_context` lines), and the
+nest list did not include ``payload`` — so an entire runtime's location was
+being silently dropped while every synthetic test passed.
+
+Runtimes that genuinely record nothing are asserted as recording nothing, on
+purpose. That is a real answer, and it keeps a future "why is this NULL"
+investigation from starting at zero.
+"""
+
+from __future__ import annotations
+
+import glob
+import json
+import pathlib
+
+import pytest
+
+from clawmetry.sync import _session_cwd, _session_git_branch
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+
+def _scan(pattern: str):
+    """(cwd_hits, branch_hits, first_cwd) across every line of every match."""
+    cwd_hits = branch_hits = 0
+    first = None
+    files = sorted(glob.glob(str(ROOT / pattern), recursive=True))
+    for f in files:
+        for line in open(f, encoding="utf-8", errors="replace"):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                row = json.loads(line)
+            except Exception:
+                continue
+            if not isinstance(row, dict):
+                continue
+            c = _session_cwd(row)
+            if c:
+                cwd_hits += 1
+                first = first or c
+            if _session_git_branch(row):
+                branch_hits += 1
+    return cwd_hits, branch_hits, first, len(files)
+
+
+# ── runtimes whose real captures DO record a working directory ──────────────
+
+@pytest.mark.parametrize("runtime,pattern,expect_cwd", [
+    ("openclaw",    "tests/fixtures/openclaw/*.jsonl",                      "/"),
+    ("claude_code", "tests/fixtures/runtimes/claude_code/**/*.jsonl",       "/"),
+    ("codex",       "tests/fixtures/runtimes/codex/**/*.jsonl",             "/"),
+    ("qwen_code",   "tests/fixtures/runtimes/qwen_code/**/*.jsonl",         "/"),
+    ("antigravity", "tests/fixtures/runtimes/antigravity/**/*.jsonl",       "/"),
+])
+def test_runtime_location_is_extracted(runtime, pattern, expect_cwd):
+    cwd_hits, _, first, nfiles = _scan(pattern)
+    if nfiles == 0:
+        pytest.skip(f"no {runtime} fixtures committed")
+    assert cwd_hits > 0, (
+        f"{runtime}'s real capture records a working directory somewhere and "
+        f"the extractor found none — check where it nests it")
+    assert first.startswith(expect_cwd)
+
+
+def test_codex_cwd_comes_from_payload():
+    """The regression this file exists for.
+
+    Codex puts cwd under `payload`, nowhere else. Before `payload` joined the
+    nest list every Codex session had a NULL location while the synthetic
+    suite stayed green.
+    """
+    row = {"type": "session_meta",
+           "payload": {"cwd": "/workspace/codex-demo", "id": "abc"}}
+    assert _session_cwd(row) == "/workspace/codex-demo"
+
+
+def test_claude_code_is_the_only_branch_source_today():
+    """Documents a real limitation rather than pretending to cover it.
+
+    Only Claude Code writes a git branch into its transcript among the
+    committed captures. If another runtime starts doing so, this test fails
+    and someone gets to widen the claim deliberately.
+    """
+    _, cc_branches, _, n = _scan("tests/fixtures/runtimes/claude_code/**/*.jsonl")
+    if n == 0:
+        pytest.skip("no claude_code fixtures committed")
+    assert cc_branches > 0
+
+    for pattern in ("tests/fixtures/runtimes/codex/**/*.jsonl",
+                    "tests/fixtures/runtimes/qwen_code/**/*.jsonl",
+                    "tests/fixtures/openclaw/*.jsonl"):
+        _, branches, _, nf = _scan(pattern)
+        if nf:
+            assert branches == 0, (
+                f"{pattern} now records a git branch — good news, but the "
+                "coverage claim in docs should be widened to match")
+
+
+# ── runtimes that genuinely record nothing ──────────────────────────────────
+
+@pytest.mark.parametrize("runtime,pattern", [
+    ("copilot",  "tests/fixtures/runtimes/copilot/**/*.jsonl"),
+    ("picoclaw", "tests/fixtures/runtimes/picoclaw/**/*.jsonl"),
+])
+def test_runtime_records_no_location(runtime, pattern):
+    """Asserted, not assumed. These sessions will show no project name, and
+    that is the runtime's doing, not a parsing bug — worth knowing before
+    someone debugs it as one."""
+    cwd_hits, branch_hits, _, nfiles = _scan(pattern)
+    if nfiles == 0:
+        pytest.skip(f"no {runtime} fixtures committed")
+    assert cwd_hits == 0 and branch_hits == 0, (
+        f"{runtime} now records a location — the extractor should be checked "
+        "and the docs updated to say so")


### PR DESCRIPTION
Follow-up to #4916.

Wiring a runtime to report its own permission prompts used to mean pasting a multi-line `curl` into its hook config. Now it is one line:

```
clawmetry hook attention --runtime qwen_code
```

It reads the runtime's own hook payload from stdin and forwards it unmodified — the receiver already knows every spelling of session id and tool name, so translating in the client would only be a second place to get it wrong.

## Why a separate module from claude_code_gate

Different job. This **observes** that a prompt is open and returns; the gate **decides**. Keeping the two apart is the same discipline opencode's plugin follows by deliberately staying out of `permission.ask` — nothing an observability feature does should be able to delay a decision a human is being asked to make.

## The contract is mostly about what it must not do

It runs inside somebody's agent, at the moment that agent is asking for permission:

- **Always exits 0**, and never writes to stdout — a runtime can read stdout as a hook decision.
- **3s timeout**, stdlib-only imports: the process starts and dies on every prompt.
- **Every failure is a silent no-op.** Losing a report costs precision, not the feature; the daemon's inference pass still covers the session. A non-zero exit could cost the user their turn.

## Verified on the wire, not by exit code

Exit 0 proves nothing here — it is also what failure looks like, by design. A capture server confirms the real client sends the correct path, query string and unmodified body for both the waiting and resolved cases, with empty stdout:

```
/api/hooks/attention?runtime=qwen_code&event=waiting   {"session_id": "cli-1", "tool_name": "Bash"}
/api/hooks/attention?runtime=gemini_cli&event=waiting  {"sessionId": "g-1", "toolName": "sh"}
/api/hooks/attention?runtime=qwen_code&event=resolved  {"session_id": "cli-1"}
```

The documented Aider one-liner was run verbatim through a real shell — its quoting is the fiddliest thing in the doc — and interpolates the session id correctly.

12 tests covering the forwarding shape and every failure path.

## Docs

`docs/NEEDS_YOU.md` shows the shim for every runtime, keeps the raw HTTP form for anything that cannot run a command, and its troubleshooting section no longer tells people to read a `stored` field that the deliberately-silent shim swallows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)