### PR TITLE
fix: ask if the daemon is alive, not when it last heartbeated

### DIFF
--- a/routes/attention.py
+++ b/routes/attention.py
@@ -23,9 +23,13 @@ list from a wedged detector must NEVER read as "nothing needs you" -- a badge
 that cries wolf, or a calm all-clear that is wrong, teaches people to stop
 trusting the list, and an ignored list is worth less than no list at all.
 
-Freshness is derived from the daemon's own heartbeat rather than a separate
-attention timestamp, because the honest question is "is the thing that
-computes this alive?" -- and if the daemon is down, we genuinely cannot tell.
+Freshness asks the honest question -- "is the thing that computes this
+alive?" -- and answers it DIRECTLY, by checking the daemon's registered pid.
+An earlier version inferred it from heartbeat age, which a real machine
+disproved: a daemon serving queries normally with a ten-hour-old heartbeat
+row made the page say "can't tell right now" about a node it could have
+answered for. Wrong in the safe direction, but permanently wrong on any node
+whose heartbeat writer has stalled.
 
 Cloud parity: every field here rides the session rows that are already in the
 snapshot, so the cloud interceptor reads the same slice. No new ingest.
@@ -41,9 +45,6 @@ from flask import Blueprint, jsonify, request
 log = logging.getLogger("clawmetry-attention")
 
 bp_attention = Blueprint("attention", __name__)
-
-#: A daemon quieter than this is treated as "no signal", never "all clear".
-_DAEMON_FRESH_SECONDS = 300
 
 #: Signals we KNOW rather than deduce. One definition, so a new source cannot
 #: end up rendering as certain on one surface and hedged on another.
@@ -104,8 +105,39 @@ def _sessions():
         return None
 
 
+def _daemon_is_live() -> bool:
+    """Is the process that computes attention state actually running?
+
+    Checked DIRECTLY — the daemon registers a query server and we confirm its
+    pid is alive — rather than inferred from heartbeat age.
+
+    Heartbeat age was the first implementation and it is a PROXY, which a real
+    machine disproved: a daemon here was serving queries normally while its
+    newest heartbeat row was ten hours old, so the strip reported "can't tell
+    right now" on a node it could perfectly well have answered for. Erring
+    toward "can't tell" is the right direction to be wrong in, but a node with
+    a stalled heartbeat writer would have shown that state permanently, which
+    makes the feature useless exactly where nothing else is obviously broken.
+
+    The attention pass runs on the daemon's own loop, in this process, so
+    "the daemon is alive" is the direct answer to "is this list current".
+    """
+    try:
+        from routes.local_query import _read_discovery
+        # _read_discovery already verifies the recorded pid is alive and
+        # returns None otherwise, which is exactly the question here.
+        return _read_discovery() is not None
+    except Exception:
+        return False
+
+
 def _daemon_age_seconds() -> int:
-    """Seconds since the daemon last checked in; -1 when unknown."""
+    """Seconds since the daemon last wrote a heartbeat; -1 when unknown.
+
+    Retained for the ``daemon_age_seconds`` field (operators asked for the
+    number, and a large value is a genuine signal that the heartbeat writer
+    has stalled) but NO LONGER decides freshness — see :func:`_daemon_is_live`.
+    """
     try:
         from routes.local_query import local_store_via_daemon
         beats = local_store_via_daemon("query_heartbeats", limit=1)
@@ -193,14 +225,17 @@ def build_attention(runtime: str = "") -> dict:
     items.sort(key=lambda i: (i["signal"] not in CONFIRMED_SIGNALS,
                               -i["waiting_seconds"]))
 
+    # Freshness = "is the process that computes this alive", answered
+    # directly. Heartbeat age is reported alongside because a big number is a
+    # real signal, but it does NOT gate the answer — see _daemon_is_live.
+    fresh = _daemon_is_live()
     age = _daemon_age_seconds()
-    fresh = age >= 0 and age <= _DAEMON_FRESH_SECONDS
     return {
         "items":   items if fresh else [],
         "waiting": len(items) if fresh else 0,
         "working": working,
         "fresh":   fresh,
-        "reason":  "" if fresh else ("stale" if age >= 0 else "no_heartbeat"),
+        "reason":  "" if fresh else "daemon_not_running",
         "daemon_age_seconds": age,
         # Surfaced so the UI can say "Pi doesn't ask" rather than implying
         # we checked it and found nothing.

--- a/tests/test_attention_hook_endpoint.py
+++ b/tests/test_attention_hook_endpoint.py
@@ -158,9 +158,9 @@ def test_empty_post_never_500s(client):
 def test_get_attention_reports_the_hooked_session(client, monkeypatch):
     client.post("/api/hooks/attention?runtime=qwen_code",
                 json={"session_id": "abc", "tool_name": "Bash"})
-    # Freshness keys off the daemon heartbeat; force it fresh for the read.
+    # Freshness = the daemon process is alive; force it live for the read.
     import routes.attention as ra
-    monkeypatch.setattr(ra, "_daemon_age_seconds", lambda: 5)
+    monkeypatch.setattr(ra, "_daemon_is_live", lambda: True)
     d = client.get("/api/attention").get_json()
     assert d["fresh"] is True
     assert d["waiting"] == 1
@@ -168,16 +168,16 @@ def test_get_attention_reports_the_hooked_session(client, monkeypatch):
     assert item["signal"] == "hook" and item["tool"] == "Bash"
 
 
-def test_stale_daemon_reports_cant_tell_not_all_clear(client, monkeypatch):
+def test_dead_daemon_reports_cant_tell_not_all_clear(client, monkeypatch):
     """The failure that would destroy trust: a wedged detector rendering as
     a confident 'nothing needs you'."""
     client.post("/api/hooks/attention?runtime=qwen_code",
                 json={"session_id": "abc", "tool_name": "Bash"})
     import routes.attention as ra
-    monkeypatch.setattr(ra, "_daemon_age_seconds", lambda: 99999)
+    monkeypatch.setattr(ra, "_daemon_is_live", lambda: False)
     d = client.get("/api/attention").get_json()
     assert d["fresh"] is False
-    assert d["reason"] == "stale"
+    assert d["reason"] == "daemon_not_running"
     assert d["items"] == []          # withheld, not asserted as empty
 
 
@@ -193,7 +193,7 @@ def test_hook_confirmed_rows_sort_above_guesses(client, monkeypatch):
     client.post("/api/hooks/attention?runtime=qwen_code",
                 json={"session_id": "abc", "tool_name": "Bash"})
     import routes.attention as ra
-    monkeypatch.setattr(ra, "_daemon_age_seconds", lambda: 5)
+    monkeypatch.setattr(ra, "_daemon_is_live", lambda: True)
     items = client.get("/api/attention").get_json()["items"]
     assert [i["signal"] for i in items][0] == "hook"
 
@@ -210,7 +210,7 @@ def test_working_count_excludes_long_idle_sessions(client, monkeypatch):
     """
     import datetime
     import routes.attention as ra
-    monkeypatch.setattr(ra, "_daemon_age_seconds", lambda: 5)
+    monkeypatch.setattr(ra, "_daemon_is_live", lambda: True)
 
     def ago(minutes):
         return (datetime.datetime.now()
@@ -234,7 +234,7 @@ def test_runtime_filter_scopes_the_list(client, monkeypatch):
     client.post("/api/hooks/attention?runtime=gemini_cli",
                 json={"sessionId": "gem-9", "toolName": "sh"})
     import routes.attention as ra
-    monkeypatch.setattr(ra, "_daemon_age_seconds", lambda: 5)
+    monkeypatch.setattr(ra, "_daemon_is_live", lambda: True)
     d = client.get("/api/attention?runtime=qwen_code").get_json()
     assert d["waiting"] == 1
     assert d["items"][0]["runtime"] == "qwen_code"


### PR DESCRIPTION
Follow-up to #4916. Found by live verification on a real machine, which is the only way this one shows up.

## The bug

The needs-you strip gated its answer on **heartbeat age** — if the newest heartbeat row was over five minutes old, it reported "Can't tell right now" instead of an answer.

Heartbeat age is a *proxy* for "is the thing that computes this alive", and the first real machine it met disproved it: a daemon was running and serving queries normally while its newest heartbeat row was **ten hours old**. The strip said it couldn't tell, about a node it could have answered for perfectly well.

Wrong in the safe direction — but *permanently* wrong. Any node whose heartbeat writer has stalled would show that state forever, making the feature useless in exactly the situation where nothing else looks broken.

## The fix

Ask the question directly. The daemon registers a query server and records its pid; `_read_discovery()` already verifies that pid is alive and returns `None` otherwise, which is precisely the question being asked.

The attention pass runs on the daemon's own loop, **in that same process**, so "the daemon is alive" *is* the answer to "is this list current" — no proxy in between.

`daemon_age_seconds` is still reported, because a large value is a genuine signal that the heartbeat writer has stalled. It just no longer decides whether we can answer. `reason` becomes `daemon_not_running`, which is what the state actually means.

## Verified on the machine that exposed it

Same daemon, same ten-hour-stale heartbeat:

| | before | after |
|---|---|---|
| `/api/attention` | `fresh: false, reason: stale` | `fresh: true` |
| the strip | "Can't tell right now" | "Nothing needs you right now · 2 agents working" |

Screenshotted against the real API with no substitution, both themes. 103 tests pass across the attention suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)