### PR TITLE
feat(sessions): surface keptLocalPaths in workspace.conflict events (#4907)

### DIFF
--- a/clawmetry/adapters/openclaw.py
+++ b/clawmetry/adapters/openclaw.py
@@ -2916,6 +2916,15 @@ class OpenClawAdapter(AgentAdapter):
                                 _wc_sr = obj.get("stagedRef") or obj.get("staged_ref")
                                 if _wc_sr is not None:
                                     extra["stagedRef"] = _wc_sr
+                                _wc_kept = (
+                                    obj.get("keptLocalPaths")
+                                    or obj.get("kept_local_paths")
+                                    or obj.get("cloudWorkerKeptLocal")
+                                    or obj.get("cloud_worker_kept_local")
+                                    or []
+                                )
+                                if isinstance(_wc_kept, list) and _wc_kept:
+                                    extra["keptLocalPaths"] = _wc_kept
                                 _wc_path_str = (
                                     ", ".join(_wc_paths)
                                     if isinstance(_wc_paths, list) and _wc_paths
@@ -3478,6 +3487,16 @@ class OpenClawAdapter(AgentAdapter):
                 _wc_sr = obj.get("stagedRef") or obj.get("staged_ref")
                 if _wc_sr is not None:
                     wc_attrs["conflict.staged_ref"] = _wc_sr
+                _wc_kept = (
+                    obj.get("keptLocalPaths")
+                    or obj.get("kept_local_paths")
+                    or obj.get("cloudWorkerKeptLocal")
+                    or obj.get("cloud_worker_kept_local")
+                    or []
+                )
+                if isinstance(_wc_kept, list) and _wc_kept:
+                    wc_attrs["conflict.kept_local"] = _wc_kept
+                    wc_attrs["conflict.kept_local_count"] = len(_wc_kept)
                 spans.append({
                     "span_id": _sid("workspace.conflict", session_id, str(raw_ts)),
                     "trace_id": trace_id,

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -3713,17 +3713,28 @@ def _parse_v3_event(
         )
         resolution = obj.get("resolution") or obj.get("resolutionAction") or obj.get("resolution_action")
         staged_ref = obj.get("stagedRef") or obj.get("staged_ref")
+        # Cloud worker results that kept local versions (#4907): OpenClaw surfaces
+        # which paths the cloud worker preserved locally rather than overriding.
+        kept_local = (
+            obj.get("keptLocalPaths")
+            or obj.get("kept_local_paths")
+            or obj.get("cloudWorkerKeptLocal")
+            or obj.get("cloud_worker_kept_local")
+            or []
+        )
         data.update({
             "type": "workspace.conflict",
             "conflictedPaths": paths,
             "resolution": resolution,
             "stagedRef": staged_ref,
+            "keptLocalPaths": kept_local,
             "timestamp": ts,
         })
         inner.update({
             "conflictedPaths": paths,
             "resolution": resolution,
             "stagedRef": staged_ref,
+            "keptLocalPaths": kept_local,
         })
 
     else:

--- a/routes/sessions.py
+++ b/routes/sessions.py
@@ -4397,6 +4397,13 @@ def _expand_openclaw_event(obj: dict, ts_ms):
         paths = obj.get("conflictedPaths") or data.get("conflictedPaths") or []
         resolution = obj.get("resolution") or data.get("resolution") or ""
         staged_ref = obj.get("stagedRef") or data.get("stagedRef") or ""
+        kept_local = (
+            obj.get("keptLocalPaths")
+            or data.get("keptLocalPaths")
+            or obj.get("kept_local_paths")
+            or data.get("kept_local_paths")
+            or []
+        )
         n = len(paths) if isinstance(paths, list) else 0
         parts = [f"⚠ Cloud workspace conflict ({n} conflicted path{'s' if n != 1 else ''})"]
         if resolution:
@@ -4405,6 +4412,12 @@ def _expand_openclaw_event(obj: dict, ts_ms):
             parts.append(f"Staged ref: {staged_ref}")
         if isinstance(paths, list) and paths:
             parts.append("Paths:\n" + "\n".join(f"  • {p}" for p in paths[:20]))
+        if isinstance(kept_local, list) and kept_local:
+            n_kept = len(kept_local)
+            parts.append(
+                f"Kept local ({n_kept} path{'s' if n_kept != 1 else ''}):\n"
+                + "\n".join(f"  • {p}" for p in kept_local[:20])
+            )
         turns.append({"role": "system", "content": "\n".join(parts), "timestamp": ts_ms})
         return turns
 


### PR DESCRIPTION
## Summary

OpenClaw's latest CHANGELOG (Unreleased) adds "cloud worker results that kept local versions" to `workspace.conflict` transcript events. ClawMetry already handles the `conflictedPaths`, `resolution`, and `stagedRef` fields wired in #4747/#4865, but the new `keptLocalPaths` field (which records which paths the cloud worker preserved locally rather than overriding with the cloud version) was not extracted or surfaced anywhere.

This PR fills that gap across all three handling layers.

## Changes

- **`clawmetry/sync.py`**: Extract `keptLocalPaths` / `kept_local_paths` / `cloudWorkerKeptLocal` / `cloud_worker_kept_local` during ingest and persist it in both `data` and `inner` dicts for downstream consumers.
- **`clawmetry/adapters/openclaw.py` (list_events)**: Extract the same field from stored event data so `Event.extra` carries it to transcript callers reading from DuckDB.
- **`clawmetry/adapters/openclaw.py` (tracing spans)**: Add `conflict.kept_local` / `conflict.kept_local_count` span attributes so the Tracing tab reflects the new info.
- **`routes/sessions.py`**: Render a "Kept local (N paths): …" section in the system-role notification block for `workspace.conflict` events.

All field reads are defensive (fallback to `[]`) — no crash if the field is absent in older events.

## Test plan

- [ ] `python3 -c 'import ast; ast.parse(open("routes/sessions.py").read())'` — passes (CI will confirm)
- [ ] Same for `clawmetry/sync.py` and `clawmetry/adapters/openclaw.py`
- [ ] Craft a synthetic `workspace.conflict` JSONL event with `keptLocalPaths: ["src/foo.py", "src/bar.py"]` and verify the transcript renders "Kept local (2 paths): • src/foo.py • src/bar.py"
- [ ] Confirm existing `workspace.conflict` events without `keptLocalPaths` still render identically (backward-compatible)

## Bot meta
<!-- bot-autofix -->
Draft PR opened autonomously based on the plan in #4907. Marked draft for human review — mark Ready for Review once happy.

Closes #4907

---
_Generated by [Claude Code](https://claude.ai/code/session_01MH7Wje4kc8BcP7X65tSQNb)_