### PR TITLE
fix: only claim "waiting on you" where there is evidence

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -4269,9 +4269,13 @@ function _renderOverviewHero() {
       ? 'It’s working right now.'
       : _working + ' sessions are working right now.';
   } else if (_liveKnown && _waiting > 0) {
+    // Age-based only (last output 2-10 min ago), so it cannot claim "waiting
+    // on you" — that is the needs-you strip's claim, and it has evidence.
+    // Both render on Overview, so a mismatch here is two components
+    // contradicting each other on one screen.
     headline = _waiting === 1
-      ? 'One session is waiting on you.'
-      : _waiting + ' sessions are waiting on you.';
+      ? 'One session has gone quiet.'
+      : _waiting + ' sessions have gone quiet.';
   } else if (!_liveKnown && busy) {
     headline = 'It’s working right now.';
   } else if (!_liveKnown) {
@@ -11864,7 +11868,7 @@ function _invRenderHero(inv) {
     dot = '#22c55e';
     headline = escHtml(wAgents[0].displayName || wAgents[0].agentKey) + ' is working right now.';
     sub = working + (working === 1 ? ' session' : ' sessions') + ' produced output in the last '
-        + 'two minutes' + (waiting ? ', ' + waiting + ' more waiting on you' : '') + '. '
+        + 'two minutes' + (waiting ? ', ' + waiting + ' more gone quiet' : '') + '. '
         + (agents.length - 1) + ' other ' + (agents.length - 1 === 1 ? 'agent is' : 'agents are')
         + ' quiet.';
   } else if (wAgents.length > 1) {
@@ -11872,11 +11876,21 @@ function _invRenderHero(inv) {
     headline = wAgents.length + ' agents are working right now.';
     sub = working + (working === 1 ? ' session' : ' sessions') + ' across '
         + wAgents.map(function (a) { return escHtml(a.displayName || a.agentKey); }).join(', ')
-        + (waiting ? ' · ' + waiting + ' more waiting on you' : '') + '.';
+        + (waiting ? ' · ' + waiting + ' more quiet' : '') + '.';
   } else if (qAgents.length) {
     dot = '#f59e0b';
-    headline = waiting === 1 ? 'One session is waiting on you.'
-                             : waiting + ' sessions are waiting on you.';
+    // "Quiet", not "waiting on you". This bucket is purely age-based — last
+    // output 2-10 minutes ago — which is equally consistent with thinking, a
+    // long-running tool, or a dead process. The sub-line below already said
+    // so ("Nothing has produced output in the last two minutes"); the
+    // headline used to contradict it.
+    //
+    // "Waiting on you" is a claim only the needs-you strip can make, because
+    // only it has evidence: a runtime that reported a prompt, an unanswered
+    // approval, or a tool call that hung. Two components on one page must not
+    // answer the same question differently.
+    headline = waiting === 1 ? 'One session has gone quiet.'
+                             : waiting + ' sessions have gone quiet.';
     sub = 'Open but quiet on '
         + qAgents.map(function (a) { return escHtml(a.displayName || a.agentKey); }).join(', ')
         + '. Nothing has produced output in the last two minutes.';
@@ -12190,7 +12204,7 @@ async function renderInventory() {
     setSub('inv-tile-alive-sub', workingSessions
       ? ('on ' + workingAgents + ' of ' + agents.length + ' agents')
       : (waitingSessions
-          ? (waitingSessions + ' waiting on you')
+          ? (waitingSessions + ' gone quiet')
           : 'nothing in the last 2 min'));
   }
   setTxt('inv-tile-agents', String(agents.length));

--- a/tests/test_overview_claims_are_evidenced.py
+++ b/tests/test_overview_claims_are_evidenced.py
@@ -1,0 +1,72 @@
+"""Only the needs-you strip may claim a session is waiting on you.
+
+The Overview hero had a bucket derived purely from age — last output between
+2 and 10 minutes ago — and rendered it as "One session is waiting on you."
+That state is equally consistent with the agent thinking, running a long
+tool, or being dead. Its own sub-line said so: "Nothing has produced output
+in the last two minutes." The headline contradicted its own subtitle.
+
+Once the needs-you strip shipped, the two rendered on the SAME page, and
+could disagree: "Nothing needs you right now" directly above "1 session is
+waiting on you". Same question, two answers, one screen.
+
+"Waiting on you" is a claim only the strip can make, because only it has
+evidence — a runtime that reported a prompt, an unanswered approval in the
+queue, or a tool call that hung past the dwell threshold. This test keeps the
+claim where the evidence is. The two components sit ~7,500 lines apart in
+app.js, so nothing else would catch it drifting back.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+
+import pytest
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+APP_JS = ROOT / "clawmetry" / "static" / "js" / "app.js"
+
+
+@pytest.fixture(scope="module")
+def app_js() -> str:
+    return APP_JS.read_text(encoding="utf-8")
+
+
+def _claim_lines(js: str, pattern: str):
+    """Non-comment lines matching a claim pattern, with line numbers."""
+    out = []
+    for n, line in enumerate(js.splitlines(), 1):
+        stripped = line.strip()
+        if stripped.startswith("//") or stripped.startswith("*"):
+            continue
+        if re.search(pattern, line):
+            out.append((n, stripped[:100]))
+    return out
+
+
+def test_age_alone_never_claims_waiting_on_you(app_js):
+    """The hero renders from `counts.waiting`, which is an age bucket."""
+    hits = _claim_lines(app_js, r"waiting on you")
+    assert not hits, (
+        "'waiting on you' is asserted outside the needs-you strip:\n"
+        + "\n".join(f"  app.js:{n}  {t}" for n, t in hits)
+        + "\nThat phrasing needs evidence (a reported prompt, a pending "
+          "approval, or a hung tool call). An age bucket has none."
+    )
+
+
+def test_the_strip_still_makes_the_claim(app_js):
+    """The inverse: the component that DOES have evidence must still say it,
+    or this test would pass on a page that never tells anyone anything."""
+    assert "needs.confident" in app_js
+    assert "needs.one_waiting" in app_js and "needs.n_waiting" in app_js
+
+
+def test_quiet_wording_matches_its_own_subtitle(app_js):
+    """The sub-line explains a silence window; the headline must agree."""
+    assert "has gone quiet" in app_js or "have gone quiet" in app_js, (
+        "the age bucket should describe silence, not intent")
+    assert "Nothing has produced output in the last two minutes" in app_js, (
+        "the honest sub-line disappeared — if the window changed, the "
+        "headline wording should be revisited with it")


### PR DESCRIPTION
Found while wiring the needs-you strip: the Overview hero and the new strip can contradict each other on the same screen.

## The bug

The hero renders `counts.waiting` from `/api/live-sessions` as:

> **One session is waiting on you.**

That bucket is purely **age-based** — last output between 2 and 10 minutes ago. It is equally consistent with the agent thinking, running a long tool, or being dead. The hero's own sub-line already admitted this:

> Open but quiet on X. **Nothing has produced output in the last two minutes.**

So the headline contradicted its own subtitle. And now the needs-you strip sits directly above it, so a user can see:

> Nothing needs you right now · 6 agents working
> **1 session is waiting on you.**

Same question, two answers, one screen — and the one with evidence is the one that looks wrong, because it is the smaller number.

## The rule

"Waiting on you" is a claim only the strip can make, because only it has evidence: a runtime that reported a permission prompt, an unanswered approval in the queue, or a tool call that hung past the dwell threshold. An age bucket has none of that.

The hero now says **"has gone quiet"** — what it actually knows, and what its own sub-line already explained.

## Four sites, and the guard found half of them

I fixed two by reading. The other two — the inventory tile and a second hero branch — turned up only because I wrote the guard first. They sit ~7,500 lines apart in `app.js` and nothing else would have caught them.

`tests/test_overview_claims_are_evidenced.py` fails on any non-comment "waiting on you" outside the strip, and asserts the inverse too: that the component **with** evidence still makes the claim, so this can't be "fixed" by making the page tell nobody anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)