### PR TITLE
fix: drop ghost sessions from the Sessions list, and stop the false heartbeat SILENT banner

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -1356,11 +1356,41 @@ setTimeout(loadAnomalyPanel, 4000);
 visibilitySetInterval(loadAnomalyPanel, 120000);
 
 // === Heartbeat Gap Alerting ===
+// Dismissal is scoped to the current silence EPISODE, not to the tab. The
+// button used to just set display:none inline, which the 30s poller below
+// undid on its next tick, so "Dismiss" bought the user 30 seconds and the
+// banner came back forever. Keyed on last_heartbeat_ts because that value is
+// constant for the whole of one outage and changes the moment the agent
+// checks in again: dismissing silences THIS outage, and a genuinely new one
+// still alerts. Same shape as cm_paused_banner_dismissed.
+var _CM_HB_DISMISS_KEY = 'cm_heartbeat_banner_dismissed_for';
+
+function _cmHeartbeatEpisodeKey(data) {
+  // Falls back when the API can't name a last heartbeat (status "unknown");
+  // anything stable within one episode works.
+  return String((data && data.last_heartbeat_ts) || 'none');
+}
+
+function dismissHeartbeatBanner() {
+  var banner = document.getElementById('heartbeat-banner');
+  if (banner) banner.style.display = 'none';
+  try {
+    localStorage.setItem(_CM_HB_DISMISS_KEY, window._cmHeartbeatEpisode || 'none');
+  } catch(e) { /* private mode: banner just isn't sticky */ }
+}
+
 async function checkHeartbeatStatus() {
   try {
     var data = await fetch('/api/heartbeat-status').then(function(r){return r.json();});
     var banner = document.getElementById('heartbeat-banner');
     if (!banner) return;
+    window._cmHeartbeatEpisode = _cmHeartbeatEpisodeKey(data);
+    var dismissedFor = null;
+    try { dismissedFor = localStorage.getItem(_CM_HB_DISMISS_KEY); } catch(e) {}
+    if (dismissedFor && dismissedFor === window._cmHeartbeatEpisode) {
+      banner.style.display = 'none';
+      return;
+    }
     if (data.status === 'warning' || data.status === 'silent') {
       var gap = data.gap_seconds;
       var gapStr = gap >= 3600 ? Math.floor(gap/3600) + 'h ' + Math.floor((gap%3600)/60) + 'm' : Math.floor(gap/60) + ' minutes';
@@ -18961,6 +18991,18 @@ async function viewTranscript(sessionId) {
       window.CLOUD_MODE ? Promise.resolve(null)
         : fetch('/api/evals/metrics?session_id=' + encodeURIComponent(sessionId) + '&limit=8').then(r => r.json()).catch(() => null)
     ]);
+    // /api/transcript 404s when the session has no renderable turns (a
+    // session_id minted off a gateway log line, or a transcript whose file is
+    // gone). Without this guard the meta card below renders "Session
+    // undefined / Messages undefined" off the error payload.
+    if (!data || data.error) {
+      document.getElementById('transcript-meta').innerHTML = '';
+      document.getElementById('transcript-messages').innerHTML =
+        '<div style="color:#555;padding:16px;">' +
+        t("app.no_messages_in_this_transcript", null, "No messages in this transcript") +
+        '</div>';
+      return;
+    }
     var compactions = compactionsData.compactions || [];
     var evalChips = (evalMetricsData && evalMetricsData.metrics) || [];
     // Family runtimes store metrics under the canonical prefixed id

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -7746,6 +7746,54 @@ def _install_id_for_heartbeat() -> str:
         return ""
 
 
+def record_local_heartbeat(config: dict) -> None:
+    """Persist one liveness row to local DuckDB. Best-effort, never raises.
+
+    ``send_heartbeat`` writes the same row as a side effect of the cloud POST,
+    but it returns early whenever there is no cloud egress (local-only #3281,
+    or self-hosted with no linked account #4329) -- so the write-through that
+    exists "so the dashboard has a per-node liveness history even when
+    offline" never ran for the exact users it was written for. The
+    ``heartbeats`` table then froze at whatever row predated the switch, and
+    ``/api/heartbeat-status`` (which reads the newest row) reported an
+    ever-growing gap: a permanent red "Agent heartbeat SILENT for Nh" banner
+    on a node whose daemon was running fine the whole time.
+
+    Kept deliberately small -- node identity, version, and local-store health.
+    The cloud payload's detection/telemetry fields are irrelevant offline.
+
+    NOTE: this makes the table an honest record of DAEMON liveness. It is
+    still NOT a liveness gate for features -- see the standing rule in
+    ``_daemon_is_live``: ask ``_read_discovery()`` (pid check) instead.
+    """
+    try:
+        from clawmetry import local_store
+        store = local_store.get_store()
+        payload = {
+            "node_id": config.get("node_id"),
+            "ts": datetime.now(timezone.utc).isoformat(),
+            "platform": platform.system(),
+            "version": _get_version(),
+            "e2e": bool(config.get("encryption_key")),
+            "local_only": True,
+        }
+        try:
+            h = store.health()
+            payload["local_store"] = {
+                "engine":       h.get("engine"),
+                "size_bytes":   h.get("size_bytes", 0),
+                "events_total": h.get("events_total", 0),
+                "ring_depth":   h.get("ring_depth", 0),
+            }
+            payload["local_store_size_mb"] = round(
+                (h.get("size_bytes") or 0) / (1024 * 1024), 3)
+        except Exception:
+            pass  # health is a nice-to-have; the liveness row is the point
+        store.ingest_heartbeat(payload)
+    except Exception as _le:
+        log.debug("local-only heartbeat ingest failed (continuing): %s", _le)
+
+
 def send_heartbeat(config: dict) -> bool:
     """Send heartbeat to cloud. Returns True on success, False on failure.
 
@@ -20759,6 +20807,12 @@ def run_daemon() -> None:
                     # agent events from the Brain feed. No-egress must be silent
                     # (found live on the Windows node minutes after 0.12.606:
                     # the 401 wall was replaced by a CRITICAL wall).
+                    #
+                    # Silent to the CLOUD, not to the local store: still record
+                    # the liveness row, or /api/heartbeat-status reads a row
+                    # frozen at the moment egress stopped and paints a
+                    # permanent "heartbeat SILENT" banner on a healthy node.
+                    record_local_heartbeat(config)
                     consecutive_hb_failures = 0
                     last_heartbeat = now
                     heartbeat_interval = HEARTBEAT_INTERVAL_SLOW

--- a/clawmetry/templates/partials/banners.html
+++ b/clawmetry/templates/partials/banners.html
@@ -261,7 +261,7 @@ function dismissDevicePill(){ try{ localStorage.setItem('cm_ab_pill_dismissed','
     margin-right:8px;
     font-weight:600;
     " data-i18n="app.check_agent">Check agent →</a>
-  <button onclick="document.getElementById('heartbeat-banner').style.display='none'" style="
+  <button onclick="dismissHeartbeatBanner()" style="
     background:#92400e;
     color:#fef3c7;
     border:none;

--- a/routes/sessions.py
+++ b/routes/sessions.py
@@ -3900,6 +3900,13 @@ def _first_user_title(fpath: str) -> str:
     return ""
 
 
+# How many transcript rows /api/transcripts returns, and how many session rows
+# we scan to fill them. The gap absorbs sessions dropped for having no
+# renderable turns (see ``_try_local_store_transcripts``).
+_TRANSCRIPT_LIST_LIMIT = 50
+_TRANSCRIPT_LIST_SCAN_LIMIT = 400
+
+
 def _try_local_store_transcripts():
     """Fast path for /api/transcripts. Lists distinct sessions with their
     event counts + most-recent ts, straight from DuckDB.
@@ -3912,7 +3919,12 @@ def _try_local_store_transcripts():
       - the sessions table is empty
       - any unexpected error happens
     """
-    rows = _ls_call("query_sessions", limit=50)
+    # Over-fetch, then trim to _TRANSCRIPT_LIST_LIMIT after dropping the
+    # zero-renderable-turn rows below. Asking for exactly the display count
+    # would return a short list on installs where ghosts are a large share of
+    # the head. ``query_sessions`` applies its LIMIT *after* the GROUP BY, so
+    # a bigger cap costs DuckDB nothing extra.
+    rows = _ls_call("query_sessions", limit=_TRANSCRIPT_LIST_SCAN_LIMIT)
     if not rows:
         return None
     import dashboard as _d
@@ -3962,6 +3974,18 @@ def _try_local_store_transcripts():
         msg_count = r.get("message_count")
         if msg_count is None:
             msg_count = r.get("event_count") or 0
+        # A ``session_id`` is minted for EVERY distinct id the events table has
+        # seen — including ids scraped off gateway log lines, which land as
+        # ``{event_type: "log", data: {kind: "gateway_log"}}`` and carry zero
+        # renderable turns. Those rendered as bare-UUID rows that opened an
+        # empty "Messages 0" detail card (the #1718 count was already correct;
+        # the list just didn't act on it). They also sort to the TOP, because a
+        # log line is newer than the last real turn, so the Sessions tab opened
+        # on a wall of ghosts. If nothing will render in the detail modal, the
+        # row doesn't belong in the list — the detail path drops the same rows
+        # (see ``_try_local_store_transcript``), so list and detail agree.
+        if int(msg_count or 0) <= 0:
+            continue
         transcripts.append({
             "id": sid,
             # Derive the same ChatGPT-style title the legacy path / cloud use, so
@@ -3974,6 +3998,8 @@ def _try_local_store_transcripts():
             "modified": modified_ms,
             "started": started_ms,
         })
+        if len(transcripts) >= _TRANSCRIPT_LIST_LIMIT:
+            break
     _fill_family_titles(transcripts)
     _fill_attention(transcripts)
     return {"transcripts": transcripts, "_source": "local_store"}
@@ -4736,6 +4762,16 @@ def _try_local_store_transcript(session_id: str, _events=None):
             if raw_payload is not None:
                 msg_entry["raw"] = raw_payload
             messages.append(msg_entry)
+    if not messages:
+        # Same contract as the ``if not rows`` guard above, for the case where
+        # rows EXIST but none of them is a transcript turn — e.g. a session_id
+        # scraped off a gateway log line, whose only event is
+        # ``{event_type: "log"}``. Returning the zero-filled shell here served
+        # a 200 that rendered as a detail card with "Messages 0", no model, no
+        # duration and no turns, and it blocked the JSONL fallback that would
+        # have either served the real transcript from disk (#1772) or 404'd.
+        # Falling through is correct in both cases.
+        return None
     duration = None
     if first_ts and last_ts and last_ts > first_ts:
         dur_sec = (last_ts - first_ts) / 1000

--- a/tests/test_ghost_sessions_and_local_only_heartbeat.py
+++ b/tests/test_ghost_sessions_and_local_only_heartbeat.py
@@ -1,0 +1,214 @@
+"""Regressions for two "healthy install looks broken" bugs.
+
+**Ghost sessions.** A ``session_id`` is minted for every distinct id the
+events table has seen — including ids scraped off gateway log lines, which
+land as ``{event_type: "log", data: {kind: "gateway_log"}}`` and carry zero
+renderable turns. Those showed up in the Sessions tab as bare-UUID rows
+(sorted to the TOP, because a log line is newer than the last real turn) and
+opened a detail card reading "Messages 0" with no model, no duration and no
+turns. On a live install 22 of the 50 listed rows were ghosts.
+
+**Local-only heartbeat.** ``send_heartbeat`` returns early when cloud sync is
+off, which also skipped the DuckDB write-through it owns — so the
+``heartbeats`` table froze at whatever row predated the switch to local-only
+and ``/api/heartbeat-status`` reported an ever-growing gap. The dashboard
+painted a permanent red "Agent heartbeat SILENT for Nh" banner on a node
+whose daemon had been running the whole time.
+"""
+
+from __future__ import annotations
+
+import importlib
+import uuid
+
+import pytest
+
+
+# ── ghost sessions ────────────────────────────────────────────────────────
+
+def _session_row(sid, message_count, *, updated="2026-08-16T08:17:21+00:00"):
+    return {
+        "session_id": sid,
+        "agent_id": "main",
+        "started_at": updated,
+        "updated_at": updated,
+        "event_count": max(message_count, 1),
+        "message_count": message_count,
+        "cost_usd": 0,
+        "token_count": 0,
+    }
+
+
+def test_log_only_sessions_are_dropped_from_the_list(monkeypatch):
+    """A session whose only event is a gateway log line has no renderable
+    turn, so it must not appear in /api/transcripts."""
+    import routes.sessions as rs
+
+    rows = [
+        _session_row("1e19a4ce-4025-4375-8422-9f4951a6ec54", 0),  # ghost
+        _session_row("claude_code:real-one", 142),
+        _session_row("b527b4e6-2491-4afc-9d5b-f334258796a9", 0),  # ghost
+    ]
+    monkeypatch.setattr(rs, "_ls_call", lambda *a, **k: rows)
+    monkeypatch.setattr(rs, "_first_user_title", lambda _p: "")
+
+    out = rs._try_local_store_transcripts()
+    ids = [t["id"] for t in out["transcripts"]]
+    assert ids == ["claude_code:real-one"]
+
+
+def test_list_still_fills_to_the_display_limit(monkeypatch):
+    """Ghosts are dropped AFTER the fetch, so a head full of them must not
+    shorten the list — that's what the over-fetch is for."""
+    import routes.sessions as rs
+
+    ghosts = [_session_row(f"ghost-{i}", 0) for i in range(120)]
+    real = [_session_row(f"claude_code:real-{i}", 5) for i in range(80)]
+    monkeypatch.setattr(rs, "_ls_call", lambda *a, **k: ghosts + real)
+    monkeypatch.setattr(rs, "_first_user_title", lambda _p: "")
+
+    out = rs._try_local_store_transcripts()
+    assert len(out["transcripts"]) == rs._TRANSCRIPT_LIST_LIMIT
+    assert all(t["messages"] > 0 for t in out["transcripts"])
+
+
+def test_scan_limit_is_requested_not_the_display_limit(monkeypatch):
+    import routes.sessions as rs
+
+    seen = {}
+
+    def _fake(method, **kwargs):
+        seen[method] = kwargs
+        return [_session_row("claude_code:real", 3)]
+
+    monkeypatch.setattr(rs, "_ls_call", _fake)
+    monkeypatch.setattr(rs, "_first_user_title", lambda _p: "")
+    rs._try_local_store_transcripts()
+    assert seen["query_sessions"]["limit"] == rs._TRANSCRIPT_LIST_SCAN_LIMIT
+    assert rs._TRANSCRIPT_LIST_SCAN_LIMIT > rs._TRANSCRIPT_LIST_LIMIT
+
+
+def test_detail_defers_when_rows_exist_but_none_are_renderable():
+    """The bug: rows existed (one ``log`` row), so the ``if not rows`` guard
+    didn't fire, and the zero-filled shell was served as a 200 — which also
+    blocked the JSONL fallback. It must return None instead."""
+    import routes.sessions as rs
+
+    log_row = {
+        "event_type": "log",
+        "ts": "2026-08-16T08:17:21+00:00",
+        "session_id": "1e19a4ce-4025-4375-8422-9f4951a6ec54",
+        "data": {"kind": "gateway_log", "level": "WARN",
+                 "message": "model fallback decision"},
+    }
+    assert rs._try_local_store_transcript("ghost", _events=[log_row]) is None
+
+
+def test_detail_still_serves_a_real_transcript():
+    """Guard against the fix over-reaching: one renderable turn is enough."""
+    import routes.sessions as rs
+
+    rows = [
+        {"event_type": "log", "ts": "2026-08-16T08:17:20+00:00",
+         "data": {"kind": "gateway_log", "message": "noise"}},
+        {"event_type": "user", "ts": "2026-08-16T08:17:21+00:00",
+         "data": {"role": "user", "content": "hello"}},
+    ]
+    out = rs._try_local_store_transcript("real", _events=rows)
+    assert out is not None
+    assert out["messageCount"] == 1
+    assert out["messages"][0]["content"] == "hello"
+
+
+def test_ghost_session_404s_end_to_end(monkeypatch, tmp_path):
+    """The route must 404 rather than serve an empty card, so the UI can show
+    its "no messages" empty state instead of "Session undefined"."""
+    import dashboard as _d
+    import routes.sessions as rs
+
+    import routes.local_query as lq
+
+    log_row = {
+        "event_type": "log", "ts": "2026-08-16T08:17:21+00:00",
+        "data": {"kind": "gateway_log", "message": "model fallback decision"},
+    }
+    # Feed the real DuckDB detail path the exact shape the live install had:
+    # one non-renderable log row. Nothing is stubbed downstream, so this
+    # exercises the fix rather than asserting on a stub.
+    monkeypatch.setattr(rs, "is_local_store_read_enabled", lambda: True)
+    monkeypatch.setattr(
+        lq, "local_store_via_daemon",
+        lambda method, **kw: [log_row] if method == "query_events" else None)
+    # Point the JSONL fallback at an empty dir so "not found" is the only
+    # possible outcome for an id with no file.
+    monkeypatch.setattr(_d, "SESSIONS_DIR", str(tmp_path), raising=False)
+
+    client = _d.app.test_client()
+    resp = client.get("/api/transcript/ghost")
+    assert resp.status_code == 404
+
+
+# ── local-only heartbeat ──────────────────────────────────────────────────
+
+@pytest.fixture
+def local_store_env(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.02")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "1")
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    # Without this, a dev box with a running daemon hands back a _ProxyStore
+    # pointed at the REAL ~/.clawmetry DB — the assertions below would then
+    # pass on production rows and prove nothing.
+    ls.mark_writer_owner()
+    yield ls
+    try:
+        ls.get_store().stop(flush=True)
+    except Exception:
+        pass
+
+
+def test_local_only_mode_still_records_a_heartbeat_row(local_store_env):
+    """Cloud off must not mean "no liveness history" — that's exactly the
+    case the local write-through was written for."""
+    ls = local_store_env
+    from clawmetry import sync
+
+    node = "agent+test-" + uuid.uuid4().hex[:6]
+    assert not ls.get_store().query_heartbeats(limit=1), "fixture DB not empty"
+
+    sync.record_local_heartbeat({"node_id": node})
+
+    rows = ls.get_store().query_heartbeats(limit=5)
+    assert len(rows) == 1, "local-only heartbeat wrote no row"
+    assert rows[0]["node_id"] == node
+    assert rows[0].get("version")
+
+
+def test_record_local_heartbeat_never_raises(monkeypatch):
+    """Best-effort contract: a broken store must not take down the sync loop."""
+    from clawmetry import sync
+    import clawmetry.local_store as ls
+
+    monkeypatch.setattr(
+        ls, "get_store", lambda *a, **k: (_ for _ in ()).throw(RuntimeError("locked")))
+    sync.record_local_heartbeat({"node_id": "agent+test"})  # must not raise
+
+
+def test_no_egress_branch_records_heartbeat():
+    """Pin the wiring: the no-cloud-egress branch of the sync loop calls the
+    recorder. Without this the fix is a function nobody invokes.
+
+    Anchored on the branch's CODE, not its comment prose, so a reworded
+    comment can't silently un-pin it (the comment has already been rewritten
+    once, when #4329 widened local-only to "no egress").
+    """
+    import inspect
+    from clawmetry import sync
+
+    src = inspect.getsource(sync)
+    start = src.find("if not _hb_egress(config):")
+    assert start > 0, "no-egress branch moved — re-point this test"
+    end = src.find("elif send_heartbeat(config):", start)
+    assert end > start, "branch shape changed — re-point this test"
+    assert "record_local_heartbeat(config)" in src[start:end]

--- a/tests/test_transcript_openclaw_shapes.py
+++ b/tests/test_transcript_openclaw_shapes.py
@@ -158,7 +158,13 @@ def test_trace_artifacts_emits_user_assistant_and_tool(env):
 
 def test_trace_artifacts_empty_data_emits_nothing(env):
     """A trace with no prompt/assistant/tool content should yield zero turns
-    rather than a phantom 'trace.artifacts' message."""
+    rather than a phantom 'trace.artifacts' message.
+
+    "Zero turns" means deferring to the JSONL fallback (None), same as
+    ``test_empty_store_returns_none`` below. Serving a zero-filled shell
+    instead was what put an empty "Messages 0" card on screen and blocked
+    the fallback that could have read the real transcript off disk.
+    """
     store, sessions_mod = env
     sid = "sess-empty-trace"
     _ingest(store, sid, {
@@ -167,9 +173,7 @@ def test_trace_artifacts_empty_data_emits_nothing(env):
         "data": {"finalStatus": "success"},
     })
     _wait(store)
-    result = sessions_mod._try_local_store_transcript(sid)
-    assert result is not None
-    assert result["messages"] == []
+    assert sessions_mod._try_local_store_transcript(sid) is None
 
 
 def test_model_completed_emits_assistant(env):
@@ -232,12 +236,9 @@ def test_plumbing_events_emit_nothing(env):
     for et in ("session.started", "session.ended", "context.compiled", "agent.heartbeat"):
         _ingest(store, sid, {"type": et, "data": {"status": "ok"}})
     _wait(store)
-    result = sessions_mod._try_local_store_transcript(sid)
-    assert result is not None
-    assert result["messages"] == []
-    # And no debug-typed role leaks through.
-    for m in result["messages"]:
-        assert "." not in m["role"]
+    # A session made only of plumbing has nothing to render, so the detail
+    # path defers to the JSONL fallback rather than serving an empty card.
+    assert sessions_mod._try_local_store_transcript(sid) is None
 
 
 def test_unknown_openclaw_event_does_not_emit_garbage(env):
@@ -247,8 +248,7 @@ def test_unknown_openclaw_event_does_not_emit_garbage(env):
     sid = "sess-unknown"
     _ingest(store, sid, {"type": "foo.bar", "data": {"content": "anything"}})
     _wait(store)
-    result = sessions_mod._try_local_store_transcript(sid)
-    assert result["messages"] == []
+    assert sessions_mod._try_local_store_transcript(sid) is None
 
 
 def test_anthropic_shape_still_works(env):

--- a/tests/test_transcripts_list_detail_count_parity.py
+++ b/tests/test_transcripts_list_detail_count_parity.py
@@ -243,7 +243,9 @@ def test_list_count_matches_detail_count_all_sessions(app):
                      "2026-05-19T12:00:02Z"))
 
     # Session B: ONLY non-renderable plumbing (0 renderable, 3 raw).
-    # Pre-fix this would show 3 in the list and 0 in the detail.
+    # #1718 made list and detail agree at 0/0; a session with nothing to
+    # render is now dropped from the list outright and its detail 404s, so
+    # the two still agree, and the user never reaches an empty card.
     store.ingest(_ev("B1", "sess-B", "session.started",
                      {"type": "session.started", "data": {},
                       "timestamp": "2026-05-19T13:00:00Z"},
@@ -287,7 +289,12 @@ def test_list_count_matches_detail_count_all_sessions(app):
     c = a.test_client()
     list_body = c.get("/api/transcripts").get_json()
     transcripts_by_id = {t["id"]: t for t in list_body["transcripts"]}
-    for sid in ("sess-A", "sess-B", "sess-C"):
+
+    # Nothing renderable -> not listed, and not fetchable either.
+    assert "sess-B" not in transcripts_by_id
+    assert c.get("/api/transcript/sess-B").status_code == 404
+
+    for sid in ("sess-A", "sess-C"):
         assert sid in transcripts_by_id, f"missing session {sid} in list"
         list_row = transcripts_by_id[sid]
         detail_body = c.get(f"/api/transcript/{sid}").get_json()


### PR DESCRIPTION
## Why

Two user reports, four bugs. Both are "a healthy install looks broken."

### Ghost sessions (the Sessions tab opened on a wall of UUIDs)

`query_sessions` groups the whole events table by `session_id`, so a session row exists for every id that ever appeared, including ids scraped off **gateway log lines**:

```json
{"event_type": "log", "data": {"kind": "gateway_log", "level": "WARN",
 "message": "model fallback decision"}}
```

Those carry zero renderable turns and sort to the **top**, because a log line is newer than the last real agent turn. On the reporter's install **22 of the 50 listed rows were ghosts**. Clicking one opened a detail card reading "Messages 0" with no model, no duration, no turns.

Three guards were missing. #1718 already made `message_count` correct (0) but nothing acted on it:

1. `_try_local_store_transcripts` drops rows with no renderable turns, and over-fetches 400 to 50 so a ghost-heavy head cannot shorten the list. `query_sessions` applies its LIMIT after the GROUP BY, so the wider scan costs DuckDB nothing.
2. `_try_local_store_transcript`: the `if not rows` guard never fired here, because rows DID exist, they were just all non-renderable. It served a zero-filled **200 shell**, which also blocked the JSONL fallback that could have read the real transcript off disk (#1772). Now returns `None`, so the route 404s.
3. `showTranscript` read `data.name` / `data.messageCount` straight off the payload, so a 404 body would have painted "Session undefined".

### The permanent false "heartbeat SILENT" banner

`send_heartbeat()` returns early when there is no cloud egress (local-only #3281, or self-hosted with no linked account #4329), and the sync loop's no-egress branch never calls it. But the DuckDB write-through lived **inside** `send_heartbeat`. So the `heartbeats` table froze at whatever row predated the switch, and `/api/heartbeat-status` (reads the newest row) reported an ever-growing gap.

Observed live: last row v0.12.712 at 22:16 UTC, daemon running fine on 0.12.715, banner reading **"Agent heartbeat SILENT for 8h 3m"** and climbing. The write-through's own comment says it exists "so the dashboard has a per-node liveness history *even when offline*". It was dead for exactly those users.

4. `record_local_heartbeat(config)`, called from the no-egress branch. I audited the rest of `send_heartbeat`: `ingest_heartbeat` was its **only** local side effect, so the class is closed.

This makes the table an honest daemon-liveness record. It is still **not** a liveness gate, that rule and `_daemon_is_live` stand unchanged.

Separately, **Dismiss on that banner was never sticky**: the button set `display:none` inline and the 30s poller set it straight back to `flex`, so Dismiss bought the user 30 seconds. Now keyed on `last_heartbeat_ts`, which is constant through one outage and changes when the agent checks in, so dismissing silences THIS outage while a genuinely new one still alerts. Same shape as `cm_paused_banner_dismissed`.

## Verification

Against live DuckDB on a real install (not fixtures):

| | before | after |
|---|---|---|
| `/api/transcripts` | 50 rows, 22 with `messages: 0` | 50 rows, **0** ghosts, still a full 50 |
| `/api/transcript/1e19a4ce-...` | `200` + `messageCount: 0`, empty card | **404** `Transcript not found` |
| `/api/transcript/claude_code:1a4185fe-...` | 230 messages | 230 messages (unchanged) |

Heartbeat dismiss driven through the real functions with stubbed DOM/localStorage/fetch: fresh silence shows, Dismiss hides, **two poller ticks keep it hidden** (that was the bug), a new outage re-alerts, recovery hides it.

**Revert-proof** (each guard fails on the un-fixed code, per FLYWHEEL):

```
A. revert list filter    -> 2 failed
B. revert detail guard   -> 4 failed
C. revert heartbeat call -> 1 failed
restored                 -> 24 passed
```

## Tests

New `tests/test_ghost_sessions_and_local_only_heartbeat.py` (9 tests).

Four existing tests pinned the old empty-shell contract as a proxy for "emits nothing"; they now assert the stronger `None`/404 contract, matching their sibling `test_empty_store_returns_none`. Intent preserved, contract corrected.

Full local run, each file in its own process on Python 3.9: `test_ghost_sessions_and_local_only_heartbeat`, `test_transcript_openclaw_shapes`, `test_transcripts_list_detail_count_parity`, `test_query_sessions_message_count`, `test_moat_regression_1129`, `test_heartbeat_local_store`, `test_first_heartbeat_onboarding`, `test_session_deep_dive`, `test_adaptive_heartbeat`, `test_overview_heartbeat`, `test_heartbeat_dispatch` all green.

### Note for future fixtures

`get_store()` hands back a `_ProxyStore` pointed at the **real** `~/.clawmetry` DB whenever a daemon is registered, so store-backed tests pass **vacuously on production rows** on any dev box with a running daemon. One existing test was reading 500 live rows and asserting 6. Call `ls.mark_writer_owner()` in the fixture (this PR's does) or run with a throwaway `HOME`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
