### PR TITLE
chore: bump to v0.12.726 [skip ci]

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -326,7 +326,7 @@ def _otlp_service_name_to_agent_type(service_name):
     return slug or "custom"
 
 
-__version__ = "0.12.725"
+__version__ = "0.12.726"
 
 # Extensions (Phase 2): import the plugin host now, but defer the actual
 # load_plugins() call until after the Flask app is created below so we can


### PR DESCRIPTION
Auto-opened after #4949 was left with a merge conflict (caused by #4948 landing and changing the same `__version__` line). This is a clean rebase of the same intent onto current main.

Syncs `__version__` in `dashboard.py` to match `clawmetry==0.12.726` already live on PyPI. Safe to squash-merge as-is.

Closes #4949.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NZFPTbuY1rfGy7vMDwGEzw)_