### PR TITLE
feat(entitlement): has_features_bundle_batch_at + has_runtimes_bundle_batch_at + endpoints

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -7699,6 +7699,307 @@ def has_runtimes_bundle_batch(bundles) -> list[dict]:
     return out
 
 
+def _has_features_bundle_row_at(perspective_tier: str, bundle) -> dict:
+    """Perspective-shaped sibling of :func:`_has_features_bundle_row`.
+
+    Normalises one caller-supplied feature bundle exactly the way the LIVE
+    row helper does (whitespace stripped, lowercased, deduplicated
+    preserving first-seen order; unknown ids bucketed into ``unknown``
+    instead of collapsing the whole fold silently) then folds the known
+    subset through :func:`has_features_at` against ``perspective_tier``
+    so the row reflects the STATIC per-tier grant for that hypothetical
+    tier instead of the LIVE resolver.
+
+    **Grace-independent by construction**: :func:`has_features_at` is
+    backed by :func:`_hypothetical_entitlement` on the feature axis, so
+    the per-row ``has_features_at`` is identical under grace vs enforce
+    for the same ``(perspective, bundle)`` pair. Whole point of the
+    ``_at`` slot: a paywall walkthrough at OSS ("if I were on OSS today,
+    would this whole feature bundle land granted?") sees the would-be-
+    locked state even while the LIVE :func:`has_features_bundle_batch`
+    reports every fully-known bundle granted via grace pass-through.
+
+    Row keys mirror :func:`_has_features_bundle_row` byte-for-byte with
+    the fold slot renamed ``has_features_at`` so a UI wiring both the
+    LIVE and the perspective batches can distinguish the two answers on
+    the same ``(bundle,)`` cell::
+
+        {
+          "features":        ["fleet", "sso"],
+          "unknown":         ["bogus"],
+          "kind":            "features",
+          "count":           2,
+          "has_features_at": <bool>,
+        }
+
+    Fold rule mirrors :func:`_has_features_bundle_row`: unknown or empty
+    known-list collapses the fold to ``False`` (surfacing the typo at
+    callsite instead of silently reporting a fully-granted bundle even
+    at the perspective's would-be tier). Empty / all-unknown bundles
+    surface as a stable row with ``has_features_at=False`` so the batch
+    keeps building. Never raises: a delegate failure returns the empty
+    row shape with ``has_features_at=False``.
+    """
+    known: list[str] = []
+    unknown: list[str] = []
+    seen: set[str] = set()
+    try:
+        raw_items = list(bundle) if bundle is not None else []
+    except TypeError:
+        raw_items = []
+    for token in raw_items:
+        try:
+            fid = str(token).strip().lower()
+        except Exception:
+            continue
+        if not fid or fid in seen:
+            continue
+        seen.add(fid)
+        if fid in ALL_FEATURES:
+            known.append(fid)
+        else:
+            unknown.append(fid)
+    try:
+        if unknown or not known:
+            allowed = False
+        else:
+            allowed = bool(has_features_at(perspective_tier, known))
+    except Exception as exc:
+        logger.warning(
+            "entitlements: _has_features_bundle_row_at(%r) fold failed: %s",
+            perspective_tier,
+            exc,
+        )
+        allowed = False
+    return {
+        "features": known,
+        "unknown": unknown,
+        "kind": "features",
+        "count": len(known),
+        "has_features_at": allowed,
+    }
+
+
+def _has_runtimes_bundle_row_at(perspective_tier: str, bundle) -> dict:
+    """Runtime-axis twin of :func:`_has_features_bundle_row_at`.
+
+    Applies :func:`canonical_runtime` before the :data:`ALL_RUNTIMES`
+    membership check so aliases (``claude-code`` -> ``claude_code``)
+    resolve the same way the LIVE :func:`_has_runtimes_bundle_row`
+    helper does; duplicates that collapse after canonicalisation only
+    contribute one row. Unknown runtime tokens are echoed into
+    ``unknown`` using the raw lowercased id. Same fold semantics as
+    :func:`_has_features_bundle_row_at`: unknown or empty collapses
+    ``has_runtimes_at`` to ``False``. Grace-independent by construction
+    (delegates to :func:`has_runtimes_at`, which reads
+    :func:`_hypothetical_entitlement`). Never raises.
+    """
+    known: list[str] = []
+    unknown: list[str] = []
+    seen: set[str] = set()
+    try:
+        raw_items = list(bundle) if bundle is not None else []
+    except TypeError:
+        raw_items = []
+    for token in raw_items:
+        try:
+            raw = str(token).strip().lower()
+        except Exception:
+            continue
+        if not raw:
+            continue
+        canon = canonical_runtime(raw)
+        if canon and canon in ALL_RUNTIMES:
+            if canon in seen:
+                continue
+            seen.add(canon)
+            known.append(canon)
+        else:
+            if raw in seen:
+                continue
+            seen.add(raw)
+            unknown.append(raw)
+    try:
+        if unknown or not known:
+            allowed = False
+        else:
+            allowed = bool(has_runtimes_at(perspective_tier, known))
+    except Exception as exc:
+        logger.warning(
+            "entitlements: _has_runtimes_bundle_row_at(%r) fold failed: %s",
+            perspective_tier,
+            exc,
+        )
+        allowed = False
+    return {
+        "runtimes": known,
+        "unknown": unknown,
+        "kind": "runtimes",
+        "count": len(known),
+        "has_runtimes_at": allowed,
+    }
+
+
+def has_features_bundle_batch_at(
+    perspective_tier: str, bundles
+) -> list[dict] | None:
+    """Hypothetical-perspective sibling of :func:`has_features_bundle_batch`:
+    per-bundle boolean-fold "would ``perspective_tier`` grant this whole
+    bundle?" for N caller-supplied feature bundles in ONE round-trip.
+
+    Same relationship to :func:`has_features_bundle_batch` that
+    :func:`has_all_bundle_batch_at` has to :func:`has_all_bundle_batch`
+    on the aggregate mixed-axis seat and that :func:`has_features_at`
+    has to :func:`has_features` on the singular scalar seat: the
+    ``perspective_tier`` argument tells the fold which STATIC per-tier
+    grant to reason from so a pricing-matrix walkthrough can hydrate the
+    per-bundle "would <tier> grant this whole feature set?" boolean off
+    ONE call per (perspective, bundles) cell instead of N calls to
+    :func:`has_features_at`.
+
+    **Perspective-shaped (grace-independent by design)**: unlike the
+    LIVE :func:`has_features_bundle_batch` (which passes through
+    :func:`has_features`'s grace answer so every fully-known bundle
+    reports ``True`` while ``ent.grace`` is ``True``), each row's
+    ``has_features_at`` here delegates to :func:`has_features_at`
+    (backed by :func:`_hypothetical_entitlement` on the feature axis),
+    so the row IS shaped by the hypothetical perspective.
+    ``has_features_bundle_batch_at("oss", [["fleet"]])`` reports
+    ``has_features_at=False`` for the fleet row even in grace -- that
+    is the whole point of the ``_at`` slot.
+
+    Row shape mirrors :func:`has_features_bundle_batch` byte-for-byte
+    on the axis echo slots with the fold slot renamed
+    ``has_features_at``::
+
+        {
+          "features":        ["fleet", "sso"],
+          "unknown":         ["bogus"],
+          "kind":            "features",
+          "count":           2,
+          "has_features_at": <bool>,
+        }
+
+    Perspective is validated against :data:`_TIER_ORDER` (including
+    :data:`TIER_TRIAL`); returns ``None`` for empty / unknown /
+    non-string ``perspective_tier`` so the paired endpoint can surface
+    a 404 with ``which=tier``. Matches the ``None`` posture the rest of
+    the ``_at`` bundle-batch family uses (see
+    :func:`has_all_bundle_batch_at`).
+
+    Argument handling on ``bundles`` mirrors
+    :func:`has_features_bundle_batch`:
+
+    * ``bundles is None`` or non-iterable -- returns ``[]`` (perspective
+      valid but nothing to fold).
+    * Each bundle may itself be ``None``, non-iterable, or empty -- the
+      helper emits the empty row shape (``has_features_at=False``)
+      rather than raising.
+    * Non-string tokens inside a bundle are coerced via ``str(...)``
+      (matches the singular endpoint's silent-drop posture for garbage).
+
+    Never raises: a per-bundle failure short-circuits to the empty row
+    shape so the batch keeps building. A perspective-validation failure
+    returns ``None`` so the paired endpoint can surface a 404.
+    """
+    try:
+        p = (perspective_tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if not p or p not in _TIER_ORDER:
+        return None
+    try:
+        if bundles is None:
+            return []
+        items = list(bundles)
+    except TypeError:
+        return []
+    out: list[dict] = []
+    for bundle in items:
+        try:
+            out.append(_has_features_bundle_row_at(p, bundle))
+        except Exception as exc:
+            logger.warning(
+                "entitlements: has_features_bundle_batch_at row failed: %s",
+                exc,
+            )
+            out.append(
+                {
+                    "features": [],
+                    "unknown": [],
+                    "kind": "features",
+                    "count": 0,
+                    "has_features_at": False,
+                }
+            )
+    return out
+
+
+def has_runtimes_bundle_batch_at(
+    perspective_tier: str, bundles
+) -> list[dict] | None:
+    """Runtime-axis twin of :func:`has_features_bundle_batch_at`:
+    per-bundle boolean-fold "would ``perspective_tier`` grant this
+    whole runtime bundle?" for N caller-supplied runtime bundles in
+    ONE round-trip.
+
+    Same relationship to :func:`has_runtimes_bundle_batch` that
+    :func:`has_features_bundle_batch_at` has to
+    :func:`has_features_bundle_batch`. Pairs with
+    :func:`has_features_bundle_batch_at` the same way
+    :func:`has_runtimes_bundle_batch` pairs with
+    :func:`has_features_bundle_batch`: together the two perspective-
+    shaped bundle-batch helpers let a pricing-matrix walkthrough
+    ("from Starter, does {claude_code, cursor} land granted?
+    {openclaw}? {aider, goose}?") hydrate every bundle off TWO calls
+    per perspective instead of 2 * N calls to
+    :func:`has_runtimes_at`.
+
+    Row shape mirrors :func:`has_runtimes_bundle_batch` byte-for-byte
+    on the axis echo slots with the fold slot renamed
+    ``has_runtimes_at``. Runtime aliases (``claude-code`` ->
+    ``claude_code``) canonicalise per bundle via
+    :func:`_has_runtimes_bundle_row_at` before the
+    :data:`ALL_RUNTIMES` membership check, matching the LIVE row
+    helper's alias posture byte-for-byte.
+
+    Perspective validation, ``bundles`` handling, grace-independence
+    and never-raise contract all mirror
+    :func:`has_features_bundle_batch_at` byte-for-byte.
+    """
+    try:
+        p = (perspective_tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if not p or p not in _TIER_ORDER:
+        return None
+    try:
+        if bundles is None:
+            return []
+        items = list(bundles)
+    except TypeError:
+        return []
+    out: list[dict] = []
+    for bundle in items:
+        try:
+            out.append(_has_runtimes_bundle_row_at(p, bundle))
+        except Exception as exc:
+            logger.warning(
+                "entitlements: has_runtimes_bundle_batch_at row failed: %s",
+                exc,
+            )
+            out.append(
+                {
+                    "runtimes": [],
+                    "unknown": [],
+                    "kind": "runtimes",
+                    "count": 0,
+                    "has_runtimes_at": False,
+                }
+            )
+    return out
+
+
 def missing_features(features) -> list:
     """Row-level complement of :func:`has_features`: return the subset of
     ``features`` NOT granted by the resolved entitlement.

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -40919,6 +40919,220 @@ def api_entitlement_has_runtimes_bundle_batch():
         )
 
 
+def _has_bundle_row_at_body(row: dict, list_key: str) -> dict:
+    """Perspective-shaped sibling of :func:`_has_bundle_row_body`.
+
+    Same ``list_key`` / ``unknown`` / ``kind`` / ``count`` axes, but the
+    fold slot is renamed ``has_<axis>_at`` matching the singular scalar
+    ``has_features_at`` / ``has_runtimes_at`` name on
+    :func:`clawmetry.entitlements.has_features_bundle_batch_at` /
+    :func:`clawmetry.entitlements.has_runtimes_bundle_batch_at`. Kept
+    beside :func:`_has_bundle_row_body` so a future per-row envelope
+    tweak (extra keys, coercion) has ONE obvious edit-site per family
+    instead of drifting between the LIVE and the perspective endpoints.
+    Never raises; a missing key surfaces as the empty-row shape with
+    ``has_<axis>_at=False``.
+    """
+    fold_key = f"has_{list_key}_at"
+    return {
+        list_key: list(row.get(list_key) or []),
+        "unknown": list(row.get("unknown") or []),
+        "kind": row.get("kind"),
+        "count": int(row.get("count") or 0),
+        fold_key: bool(row.get(fold_key)),
+    }
+
+
+@bp_entitlement.route(
+    "/api/entitlement/has-features-bundle-batch-at",
+    methods=["POST"],
+)
+def api_entitlement_has_features_bundle_batch_at():
+    """``POST /api/entitlement/has-features-bundle-batch-at?tier=<perspective>``
+    -- hypothetical-perspective sibling of
+    ``/api/entitlement/has-features-bundle-batch``.
+
+    Wraps :func:`clawmetry.entitlements.has_features_bundle_batch_at`
+    so a pricing-matrix walkthrough can call the per-bundle boolean-
+    fold batch on the feature axis from any tier's perspective without
+    first switching the resolver. Fills the ``_at`` slot for the
+    feature-axis bundle-batch family alongside the aggregate
+    ``/has-all-bundle-batch-at`` and the runtime-axis sibling
+    ``/has-runtimes-bundle-batch-at``.
+
+    **Perspective-shaped** (grace-independent by design): each row's
+    ``has_features_at`` delegates to
+    :func:`clawmetry.entitlements.has_features_at` (backed by the
+    static per-tier grant table via
+    :func:`clawmetry.entitlements._hypothetical_entitlement`), so grace
+    vs enforce yields byte-identical row bodies (only the resolver
+    envelope shifts). Whole point of the ``_at`` slot: at
+    ``tier=oss`` a paid-feature bundle reports ``has_features_at=false``
+    even in grace, whereas the LIVE ``/has-features-bundle-batch``
+    reports ``has_features=true`` for the same bundle via grace pass-
+    through.
+
+    Request body is byte-identical to ``/has-features-bundle-batch``.
+    The extra ``tier=<perspective>`` query arg is required.
+
+    Response layers ``perspective_tier`` / ``perspective_tier_label`` /
+    ``perspective_tier_rank`` on top of the bare batch envelope so a
+    caller can render "from <perspective> this bundle would be locked"
+    copy off one call::
+
+        {
+          "perspective_tier":       "cloud_pro",
+          "perspective_tier_label": "Cloud Pro",
+          "perspective_tier_rank":  <int>,
+          "bundles":                [<row>, ...],
+          "count":                  <int>,
+          "current_tier":           "...",
+          "current_tier_rank":      <int>,
+          "grace":                  <bool>,
+          "enforced":               <bool>,
+        }
+
+    Each ``<row>`` mirrors the LIVE ``/has-features-bundle-batch`` row
+    body byte-for-byte on the axis echo slots with the fold slot
+    renamed ``has_features_at``::
+
+        {
+          "features":        ["fleet", "sso"],
+          "unknown":         ["bogus"],
+          "kind":            "features",
+          "count":           2,
+          "has_features_at": <bool>,
+        }
+
+    - **400** when ``tier=`` is missing / blank
+    - **404** when ``tier`` is unknown (body carries ``which=tier`` so a
+      caller can render the right "unknown tier" message)
+    - **400** when ``bundles`` is missing / non-list / empty
+    - **Never 5xxs**: a resolver failure yields the fallback envelope
+      so the paywall matrix keeps rendering.
+    """
+    raw_tier = request.args.get("tier")
+    tier_in = (raw_tier or "").strip().lower()
+    if not tier_in:
+        return jsonify({"error": "missing tier"}), 400
+    body = request.get_json(silent=True) or {}
+    bundles, err = _parse_bundles_body(body)
+    if err == "missing":
+        return jsonify({"error": "missing bundles"}), 400
+    if err == "empty":
+        return jsonify({"error": "empty bundles"}), 400
+    if err == "bundles_must_be_list":
+        return jsonify({"error": "bundles must be a list"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        if tier_in not in _ent._TIER_ORDER:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "tier", "tier": tier_in}
+                ),
+                404,
+            )
+        rows = _ent.has_features_bundle_batch_at(tier_in, bundles) or []
+        out_rows = [_has_bundle_row_at_body(row, "features") for row in rows]
+        env = _perspective_envelope(_ent, tier_in)
+        return jsonify(
+            {
+                **env,
+                "bundles": out_rows,
+                "count": len(out_rows),
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_has_features_bundle_batch_at: error: %s", exc
+        )
+        env = _perspective_fallback(tier_in)
+        return jsonify(
+            {
+                **env,
+                "bundles": [],
+                "count": 0,
+            }
+        )
+
+
+@bp_entitlement.route(
+    "/api/entitlement/has-runtimes-bundle-batch-at",
+    methods=["POST"],
+)
+def api_entitlement_has_runtimes_bundle_batch_at():
+    """``POST /api/entitlement/has-runtimes-bundle-batch-at?tier=<perspective>``
+    -- runtime-axis twin of
+    ``/api/entitlement/has-features-bundle-batch-at``.
+
+    Wraps :func:`clawmetry.entitlements.has_runtimes_bundle_batch_at`
+    so a pricing-matrix walkthrough can call the per-bundle boolean-
+    fold batch on the runtime axis from any tier's perspective without
+    first switching the resolver. Pairs with
+    ``/has-features-bundle-batch-at`` the same way
+    ``/has-runtimes-bundle-batch`` pairs with
+    ``/has-features-bundle-batch`` on the LIVE seat: together the two
+    perspective-scoped bundle-batch endpoints let a caller render "from
+    <perspective>, does this whole runtime set land granted?" copy off
+    ONE call per axis instead of N calls to
+    ``/has-runtime-at`` / ``/has-runtimes-at``.
+
+    Response shape and error paths mirror
+    ``/has-features-bundle-batch-at`` exactly, with ``kind="runtimes"``,
+    a ``runtimes`` list in place of ``features``, and
+    ``has_runtimes_at`` in place of ``has_features_at`` per row.
+    Runtime aliases (``claude-code`` -> ``claude_code``) canonicalise
+    per bundle inside the helper before the ``ALL_RUNTIMES`` membership
+    check, matching the LIVE ``/has-runtimes-bundle-batch`` alias
+    posture byte-for-byte.
+    """
+    raw_tier = request.args.get("tier")
+    tier_in = (raw_tier or "").strip().lower()
+    if not tier_in:
+        return jsonify({"error": "missing tier"}), 400
+    body = request.get_json(silent=True) or {}
+    bundles, err = _parse_bundles_body(body)
+    if err == "missing":
+        return jsonify({"error": "missing bundles"}), 400
+    if err == "empty":
+        return jsonify({"error": "empty bundles"}), 400
+    if err == "bundles_must_be_list":
+        return jsonify({"error": "bundles must be a list"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        if tier_in not in _ent._TIER_ORDER:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "tier", "tier": tier_in}
+                ),
+                404,
+            )
+        rows = _ent.has_runtimes_bundle_batch_at(tier_in, bundles) or []
+        out_rows = [_has_bundle_row_at_body(row, "runtimes") for row in rows]
+        env = _perspective_envelope(_ent, tier_in)
+        return jsonify(
+            {
+                **env,
+                "bundles": out_rows,
+                "count": len(out_rows),
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_has_runtimes_bundle_batch_at: error: %s", exc
+        )
+        env = _perspective_fallback(tier_in)
+        return jsonify(
+            {
+                **env,
+                "bundles": [],
+                "count": 0,
+            }
+        )
+
+
 def _parse_aggregate_bundles_body(body, key: str = "bundles"):
     """Extract a list of aggregate 5-axis bundle dicts from a JSON POST body.
 

--- a/tests/test_entitlement_has_bundle_batch_at.py
+++ b/tests/test_entitlement_has_bundle_batch_at.py
@@ -1,0 +1,569 @@
+"""Tests for the perspective-shaped bundle-batch
+``/api/entitlement/has-features-bundle-batch-at`` and
+``/api/entitlement/has-runtimes-bundle-batch-at`` endpoints.
+
+Hypothetical-perspective sibling of the LIVE
+``/api/entitlement/has-features-bundle-batch`` /
+``/api/entitlement/has-runtimes-bundle-batch`` endpoints (which fold N
+bundles against the resolved entitlement), scoped by a caller-supplied
+``tier=<perspective>`` query arg. Wraps the
+:func:`clawmetry.entitlements.has_features_bundle_batch_at` /
+:func:`clawmetry.entitlements.has_runtimes_bundle_batch_at` helpers.
+
+Fills the ``_at`` slot for the per-axis bundle-batch family alongside
+the aggregate ``/api/entitlement/has-all-bundle-batch-at`` so a caller
+can render the per-axis "would <perspective> grant this whole bundle?"
+column of a pricing matrix off ONE call per axis per perspective
+instead of N calls to ``/has-features-at`` / ``/has-runtimes-at``.
+
+These tests pin:
+
+* helper: perspective validation (empty / non-string / unknown ->
+  ``None``; known tier -> ``list[dict]``)
+* helper: per-bundle normalisation (whitespace, lowercase, dedup
+  preserving first-seen), unknown-id bucketing, runtime alias
+  canonicalisation, empty / all-unknown / ``None`` bundles surface as
+  stable rows with ``has_*_at=False``
+* helper: unknown item collapses the row's fold to ``False`` (typo-
+  catches-at-callsite posture)
+* helper: per-row parity with the singular scalar
+  ``has_features_at`` / ``has_runtimes_at`` on the KNOWN slice
+* helper: ``bundles`` handling (``None`` / non-iterable -> ``[]``;
+  ``None`` bundle -> empty row)
+* helper: **grace-independence** -- the perspective-shaped fold is
+  byte-identical under grace vs enforce (delegates to
+  :func:`has_features_at` / :func:`has_runtimes_at`, both backed by
+  the static per-tier grant tables)
+* helper: perspective divergence -- at ``oss`` a paid-feature bundle
+  reports ``has_features_at=False`` even in grace, whereas the LIVE
+  :func:`has_features_bundle_batch` reports ``has_features=True`` on
+  the same bundle via grace pass-through
+* API: 400 on missing / blank ``tier``; 404 on unknown ``tier``
+  (with ``which=tier`` in the body)
+* API: 400 on missing / non-list / empty ``bundles``
+* API: happy-path envelope layers ``perspective_tier`` /
+  ``perspective_tier_label`` / ``perspective_tier_rank`` on top of the
+  bare batch envelope; each row carries the perspective-shaped
+  ``has_features_at`` / ``has_runtimes_at`` fold slot
+* API: single-list ``{"bundles": ["fleet", "sso"]}`` shorthand
+* API: runtime alias canonicalisation happens through the endpoint
+* API: never-5xxs on a delegate crash (monkey-patched helper raises)
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+# -- Fixtures ----------------------------------------------------------------
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def enforced(monkeypatch, tmp_path):
+    """Enforcement-on fixture. Perspective-shaped ``_at`` answers are
+    intentionally byte-identical in grace and enforce; this fixture
+    pins that invariant against the singular ``_at`` delegates."""
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    importlib.reload(e)
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# -- Helper: perspective validation ------------------------------------------
+
+
+@pytest.mark.parametrize("bad", [None, "", "   ", "bogus", "Pro+", 42, object()])
+def test_helper_features_none_on_bad_perspective(ent, bad):
+    assert ent.has_features_bundle_batch_at(bad, [["fleet"]]) is None
+
+
+@pytest.mark.parametrize("bad", [None, "", "   ", "bogus", 42, object()])
+def test_helper_runtimes_none_on_bad_perspective(ent, bad):
+    assert ent.has_runtimes_bundle_batch_at(bad, [["openclaw"]]) is None
+
+
+def test_helper_features_accepts_all_known_tiers(ent):
+    for tid in ent._TIER_ORDER:
+        rows = ent.has_features_bundle_batch_at(tid, [["fleet"]])
+        assert isinstance(rows, list)
+
+
+# -- Helper: bundle normalisation --------------------------------------------
+
+
+def test_helper_features_dedups_and_lowers(ent):
+    rows = ent.has_features_bundle_batch_at(
+        "enterprise", [["fleet", "", "FLEET", "sso"], ["otel_export"]]
+    )
+    assert len(rows) == 2
+    assert rows[0]["features"] == ["fleet", "sso"]
+    assert rows[0]["unknown"] == []
+    assert rows[0]["count"] == 2
+    assert rows[1]["features"] == ["otel_export"]
+
+
+def test_helper_features_buckets_unknown(ent):
+    rows = ent.has_features_bundle_batch_at("enterprise", [["fleet", "bogus"]])
+    assert rows[0]["features"] == ["fleet"]
+    assert rows[0]["unknown"] == ["bogus"]
+    # Unknown collapses the fold to False even at an admitting tier.
+    assert rows[0]["has_features_at"] is False
+
+
+def test_helper_features_empty_bundle_stable_row(ent):
+    rows = ent.has_features_bundle_batch_at("pro", [[]])
+    assert len(rows) == 1
+    assert rows[0] == {
+        "features": [],
+        "unknown": [],
+        "kind": "features",
+        "count": 0,
+        "has_features_at": False,
+    }
+
+
+def test_helper_features_all_unknown_stable_row(ent):
+    rows = ent.has_features_bundle_batch_at("pro", [["bogus1", "bogus2"]])
+    r = rows[0]
+    assert r["features"] == []
+    assert r["unknown"] == ["bogus1", "bogus2"]
+    assert r["count"] == 0
+    assert r["has_features_at"] is False
+
+
+def test_helper_features_none_bundle_stable_row(ent):
+    rows = ent.has_features_bundle_batch_at("pro", [None, ["fleet"]])
+    assert len(rows) == 2
+    assert rows[0] == {
+        "features": [],
+        "unknown": [],
+        "kind": "features",
+        "count": 0,
+        "has_features_at": False,
+    }
+    assert rows[1]["features"] == ["fleet"]
+
+
+def test_helper_features_non_string_tokens_coerce(ent):
+    rows = ent.has_features_bundle_batch_at("enterprise", [[42, "fleet"]])
+    assert rows[0]["features"] == ["fleet"]
+    assert "42" in rows[0]["unknown"]
+    # Unknown collapses fold to False.
+    assert rows[0]["has_features_at"] is False
+
+
+def test_helper_features_none_bundles_returns_empty(ent):
+    assert ent.has_features_bundle_batch_at("pro", None) == []
+
+
+def test_helper_features_non_iterable_bundles_returns_empty(ent):
+    assert ent.has_features_bundle_batch_at("pro", 42) == []
+
+
+def test_helper_runtimes_canonicalises_aliases(ent):
+    rows = ent.has_runtimes_bundle_batch_at(
+        "pro", [["claude-code", "codex", "claude_code"]]
+    )
+    # Canonicalisation + dedup after canonicalisation.
+    assert rows[0]["runtimes"] == ["claude_code", "codex"]
+    assert rows[0]["unknown"] == []
+
+
+def test_helper_runtimes_buckets_unknown(ent):
+    rows = ent.has_runtimes_bundle_batch_at(
+        "pro", [["claude_code", "bogus_rt"]]
+    )
+    assert rows[0]["runtimes"] == ["claude_code"]
+    assert rows[0]["unknown"] == ["bogus_rt"]
+    assert rows[0]["has_runtimes_at"] is False
+
+
+def test_helper_runtimes_none_bundles_returns_empty(ent):
+    assert ent.has_runtimes_bundle_batch_at("pro", None) == []
+
+
+# -- Helper: per-row parity with the singular scalar --------------------------
+
+
+def test_helper_features_per_row_parity_with_scalar(ent):
+    """Per-row ``has_features_at`` byte-equals :func:`has_features_at`
+    on the KNOWN slice for every (perspective, bundle) pair."""
+    bundles = [
+        ["fleet", "sso"],
+        ["otel_export"],
+        ["fleet"],
+        ["sso"],
+        [],
+    ]
+    for perspective in ("oss", "cloud_starter", "pro", "enterprise"):
+        rows = ent.has_features_bundle_batch_at(perspective, bundles)
+        assert rows is not None
+        for row, bundle in zip(rows, bundles):
+            seen: set[str] = set()
+            known: list[str] = []
+            for tok in bundle:
+                s = tok.strip().lower()
+                if s and s in ent.ALL_FEATURES and s not in seen:
+                    seen.add(s)
+                    known.append(s)
+            singular = (
+                ent.has_features_at(perspective, known) if known else False
+            )
+            assert row["has_features_at"] == singular, (
+                perspective,
+                bundle,
+                singular,
+            )
+
+
+def test_helper_runtimes_per_row_parity_with_scalar(ent):
+    bundles = [
+        ["openclaw"],
+        ["claude-code", "codex"],
+        ["claude_code"],
+        [],
+    ]
+    for perspective in ("oss", "cloud_starter", "pro", "enterprise"):
+        rows = ent.has_runtimes_bundle_batch_at(perspective, bundles)
+        assert rows is not None
+        for row, bundle in zip(rows, bundles):
+            seen: set[str] = set()
+            known: list[str] = []
+            for tok in bundle:
+                c = ent.canonical_runtime(tok.strip().lower())
+                if c and c in ent.ALL_RUNTIMES and c not in seen:
+                    seen.add(c)
+                    known.append(c)
+            singular = (
+                ent.has_runtimes_at(perspective, known) if known else False
+            )
+            assert row["has_runtimes_at"] == singular, (
+                perspective,
+                bundle,
+                singular,
+            )
+
+
+# -- Helper: perspective divergence from LIVE --------------------------------
+
+
+def test_helper_features_oss_diverges_from_live_grace(ent):
+    """At ``oss`` a paid-feature bundle reports False in grace, whereas
+    the LIVE :func:`has_features_bundle_batch` reports True on the same
+    bundle via grace pass-through. That divergence is the whole point
+    of the ``_at`` slot."""
+    live = ent.has_features_bundle_batch([["fleet"]])
+    at_oss = ent.has_features_bundle_batch_at("oss", [["fleet"]])
+    assert live[0]["has_features"] is True  # grace pass-through
+    assert at_oss[0]["has_features_at"] is False  # static per-tier
+
+
+def test_helper_runtimes_oss_diverges_from_live_grace(ent):
+    live = ent.has_runtimes_bundle_batch([["claude_code"]])
+    at_oss = ent.has_runtimes_bundle_batch_at("oss", [["claude_code"]])
+    assert live[0]["has_runtimes"] is True
+    assert at_oss[0]["has_runtimes_at"] is False
+
+
+# -- Helper: grace vs enforce invariance -------------------------------------
+
+
+def test_helper_features_grace_enforce_identical(ent, enforced):
+    """Perspective-shaped fold is byte-identical under grace vs enforce."""
+    bundles = [["fleet", "sso"], ["otel_export"], ["bogus"], []]
+    for perspective in ("oss", "cloud_starter", "pro", "enterprise"):
+        rows_grace = ent.has_features_bundle_batch_at(perspective, bundles)
+        rows_enf = enforced.has_features_bundle_batch_at(perspective, bundles)
+        assert rows_grace == rows_enf, perspective
+
+
+def test_helper_runtimes_grace_enforce_identical(ent, enforced):
+    bundles = [["openclaw"], ["claude_code"], ["bogus_rt"], []]
+    for perspective in ("oss", "cloud_starter", "pro", "enterprise"):
+        rows_grace = ent.has_runtimes_bundle_batch_at(perspective, bundles)
+        rows_enf = enforced.has_runtimes_bundle_batch_at(perspective, bundles)
+        assert rows_grace == rows_enf, perspective
+
+
+# -- API: error paths --------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/api/entitlement/has-features-bundle-batch-at",
+        "/api/entitlement/has-runtimes-bundle-batch-at",
+    ],
+)
+def test_api_missing_tier_400(client, path):
+    r = client.post(path, json={"bundles": [["fleet"]]})
+    assert r.status_code == 400
+    assert r.get_json() == {"error": "missing tier"}
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/api/entitlement/has-features-bundle-batch-at",
+        "/api/entitlement/has-runtimes-bundle-batch-at",
+    ],
+)
+def test_api_blank_tier_400(client, path):
+    r = client.post(f"{path}?tier=   ", json={"bundles": [["fleet"]]})
+    assert r.status_code == 400
+    assert r.get_json() == {"error": "missing tier"}
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/api/entitlement/has-features-bundle-batch-at",
+        "/api/entitlement/has-runtimes-bundle-batch-at",
+    ],
+)
+def test_api_unknown_tier_404(client, path):
+    r = client.post(f"{path}?tier=bogus", json={"bundles": [["fleet"]]})
+    assert r.status_code == 404
+    body = r.get_json()
+    assert body["error"] == "unknown tier"
+    assert body["which"] == "tier"
+    assert body["tier"] == "bogus"
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/api/entitlement/has-features-bundle-batch-at",
+        "/api/entitlement/has-runtimes-bundle-batch-at",
+    ],
+)
+def test_api_missing_bundles_400(client, path):
+    r = client.post(f"{path}?tier=pro", json={})
+    assert r.status_code == 400
+    assert r.get_json() == {"error": "missing bundles"}
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/api/entitlement/has-features-bundle-batch-at",
+        "/api/entitlement/has-runtimes-bundle-batch-at",
+    ],
+)
+def test_api_empty_bundles_400(client, path):
+    r = client.post(f"{path}?tier=pro", json={"bundles": []})
+    assert r.status_code == 400
+    assert r.get_json() == {"error": "empty bundles"}
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/api/entitlement/has-features-bundle-batch-at",
+        "/api/entitlement/has-runtimes-bundle-batch-at",
+    ],
+)
+def test_api_scalar_bundles_400(client, path):
+    r = client.post(f"{path}?tier=pro", json={"bundles": 42})
+    assert r.status_code == 400
+    assert r.get_json() == {"error": "bundles must be a list"}
+
+
+# -- API: happy path envelope shape ------------------------------------------
+
+
+def test_api_features_envelope_shape(client):
+    r = client.post(
+        "/api/entitlement/has-features-bundle-batch-at?tier=enterprise",
+        json={"bundles": [["fleet", "sso"], ["bogus"], []]},
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    expected_keys = {
+        "perspective_tier",
+        "perspective_tier_label",
+        "perspective_tier_rank",
+        "current_tier",
+        "current_tier_rank",
+        "grace",
+        "enforced",
+        "bundles",
+        "count",
+    }
+    assert set(body) == expected_keys
+    assert body["perspective_tier"] == "enterprise"
+    assert body["perspective_tier_label"] == "Enterprise"
+    assert body["perspective_tier_rank"] == 3
+    assert body["count"] == 3
+    row_keys = {"features", "unknown", "kind", "count", "has_features_at"}
+    for row in body["bundles"]:
+        assert set(row) == row_keys
+        assert row["kind"] == "features"
+
+
+def test_api_runtimes_envelope_shape(client):
+    r = client.post(
+        "/api/entitlement/has-runtimes-bundle-batch-at?tier=pro",
+        json={"bundles": [["claude-code"], ["openclaw"]]},
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["perspective_tier"] == "pro"
+    row_keys = {"runtimes", "unknown", "kind", "count", "has_runtimes_at"}
+    for row in body["bundles"]:
+        assert set(row) == row_keys
+        assert row["kind"] == "runtimes"
+
+
+# -- API: fold answers -------------------------------------------------------
+
+
+def test_api_features_enterprise_grants(client):
+    r = client.post(
+        "/api/entitlement/has-features-bundle-batch-at?tier=enterprise",
+        json={"bundles": [["fleet", "sso"]]},
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["bundles"][0]["has_features_at"] is True
+
+
+def test_api_features_oss_denies_paid(client):
+    r = client.post(
+        "/api/entitlement/has-features-bundle-batch-at?tier=oss",
+        json={"bundles": [["fleet"]]},
+    )
+    assert r.status_code == 200
+    assert r.get_json()["bundles"][0]["has_features_at"] is False
+
+
+def test_api_runtimes_alias_canonicalises_through_endpoint(client):
+    r = client.post(
+        "/api/entitlement/has-runtimes-bundle-batch-at?tier=pro",
+        json={"bundles": [["claude-code"]]},
+    )
+    assert r.status_code == 200
+    row = r.get_json()["bundles"][0]
+    assert row["runtimes"] == ["claude_code"]
+    assert row["has_runtimes_at"] is True
+
+
+def test_api_runtimes_oss_free_runtime_grants(client):
+    r = client.post(
+        "/api/entitlement/has-runtimes-bundle-batch-at?tier=oss",
+        json={"bundles": [["openclaw"]]},
+    )
+    assert r.status_code == 200
+    row = r.get_json()["bundles"][0]
+    assert row["runtimes"] == ["openclaw"]
+    assert row["has_runtimes_at"] is True
+
+
+def test_api_runtimes_oss_denies_paid_runtime(client):
+    r = client.post(
+        "/api/entitlement/has-runtimes-bundle-batch-at?tier=oss",
+        json={"bundles": [["claude_code"]]},
+    )
+    assert r.status_code == 200
+    assert r.get_json()["bundles"][0]["has_runtimes_at"] is False
+
+
+# -- API: shorthand ----------------------------------------------------------
+
+
+def test_api_features_bare_list_shorthand_treated_as_one_bundle(client):
+    r = client.post(
+        "/api/entitlement/has-features-bundle-batch-at?tier=enterprise",
+        json={"bundles": ["fleet", "sso"]},
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["count"] == 1
+    assert body["bundles"][0]["features"] == ["fleet", "sso"]
+    assert body["bundles"][0]["has_features_at"] is True
+
+
+# -- API: per-row parity with helper -----------------------------------------
+
+
+def test_api_features_row_parity_with_helper(client, ent):
+    r = client.post(
+        "/api/entitlement/has-features-bundle-batch-at?tier=enterprise",
+        json={"bundles": [["fleet", "sso"], ["bogus"], []]},
+    )
+    assert r.status_code == 200
+    api_rows = r.get_json()["bundles"]
+    helper_rows = ent.has_features_bundle_batch_at(
+        "enterprise", [["fleet", "sso"], ["bogus"], []]
+    )
+    for api_row, helper_row in zip(api_rows, helper_rows):
+        # Envelope helper coerces the shape; per-key equality holds.
+        assert api_row["features"] == helper_row["features"]
+        assert api_row["unknown"] == helper_row["unknown"]
+        assert api_row["kind"] == helper_row["kind"]
+        assert api_row["count"] == helper_row["count"]
+        assert api_row["has_features_at"] == helper_row["has_features_at"]
+
+
+# -- API: never-5xx on delegate crash ----------------------------------------
+
+
+def test_api_features_never_5xx_on_helper_crash(client, monkeypatch, ent):
+    def boom(*_a, **_kw):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(ent, "has_features_bundle_batch_at", boom)
+    r = client.post(
+        "/api/entitlement/has-features-bundle-batch-at?tier=pro",
+        json={"bundles": [["fleet"]]},
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["bundles"] == []
+    assert body["count"] == 0
+    assert body["perspective_tier"] == "pro"
+
+
+def test_api_runtimes_never_5xx_on_helper_crash(client, monkeypatch, ent):
+    def boom(*_a, **_kw):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(ent, "has_runtimes_bundle_batch_at", boom)
+    r = client.post(
+        "/api/entitlement/has-runtimes-bundle-batch-at?tier=pro",
+        json={"bundles": [["claude_code"]]},
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["bundles"] == []
+    assert body["count"] == 0
+    assert body["perspective_tier"] == "pro"


### PR DESCRIPTION
## Summary

Adds the perspective-shaped `_at` sibling of the LIVE per-axis bundle-batch boolean-fold family:

- `clawmetry.entitlements.has_features_bundle_batch_at(perspective_tier, bundles)`
- `clawmetry.entitlements.has_runtimes_bundle_batch_at(perspective_tier, bundles)`
- `POST /api/entitlement/has-features-bundle-batch-at?tier=<perspective>`
- `POST /api/entitlement/has-runtimes-bundle-batch-at?tier=<perspective>`

Fills the same `_at` slot on the feature / runtime axes that `has_all_bundle_batch_at` already fills on the aggregate seat, so a pricing-matrix walkthrough can render the "would `<tier>` grant this whole bundle?" column per axis off ONE call per (perspective, bundles) cell instead of N calls to `/has-features-at` / `/has-runtimes-at`.

## Ships in GRACE — no behavior change

Grace-independent by construction: each row's `has_features_at` / `has_runtimes_at` delegates to the singular scalar (backed by the static per-tier grant tables via `_hypothetical_entitlement`), so the row body is byte-identical under grace vs enforce for the same (perspective, bundle) pair. At `tier=oss` a paid-feature bundle reports `has_features_at=false` even in grace — that is the whole point of the `_at` slot — whereas the LIVE `/has-features-bundle-batch` reports `has_features=true` on the same bundle via grace pass-through. Pinned by the `enforced` fixture in `tests/test_entitlement_has_bundle_batch_at.py`.

## Shape

Row shape mirrors `has_features_bundle_batch` / `has_runtimes_bundle_batch` byte-for-byte on the axis echo slots with the fold slot renamed:

```
{
  "features":        ["fleet", "sso"],
  "unknown":         ["bogus"],
  "kind":            "features",
  "count":           2,
  "has_features_at": <bool>,
}
```

Endpoints layer `perspective_tier` / `perspective_tier_label` / `perspective_tier_rank` on top of the bare batch envelope through the existing `_perspective_envelope` / `_perspective_fallback` helpers. **400** on missing / blank `tier`; **404** on unknown `tier` (`which=tier`); **400** on missing / non-list / empty `bundles`; **never-5xx** via the fallback envelope on any delegate crash.

## Tests

`tests/test_entitlement_has_bundle_batch_at.py` — 54 new tests, all green. Pins:

- perspective validation (empty / non-string / unknown → `None`)
- per-bundle normalisation (dedup, lowercase, whitespace)
- unknown-id bucketing + fold collapses to `False` on any typo
- runtime alias canonicalisation (`claude-code` → `claude_code`)
- empty / all-unknown / `None` bundle stable-row shape
- per-row parity with the singular `has_features_at` / `has_runtimes_at` on the KNOWN slice, across every perspective
- grace-vs-enforce byte-identity via the `enforced` fixture
- LIVE-vs-perspective divergence at OSS (LIVE `True` in grace vs perspective `False`)
- endpoint error paths (400 / 404 shapes)
- endpoint envelope shape
- bare-list bundle shorthand (`{"bundles": ["fleet", "sso"]}`)
- alias canonicalisation through the endpoint
- never-5xx on a monkey-patched helper crash (fallback envelope carries the perspective slot)

Adjacent existing tests (`test_entitlement_has_bundle_batch.py`, `test_entitlement_has_all_bundle_batch.py`, `test_entitlement_missing_all_bundle_batch_at.py`, `test_entitlement_api.py`) still pass (221 tests green).

## Files

- `clawmetry/entitlements.py` — `_has_features_bundle_row_at`, `_has_runtimes_bundle_row_at`, `has_features_bundle_batch_at`, `has_runtimes_bundle_batch_at`
- `routes/entitlement.py` — `_has_bundle_row_at_body`, `api_entitlement_has_features_bundle_batch_at`, `api_entitlement_has_runtimes_bundle_batch_at`
- `tests/test_entitlement_has_bundle_batch_at.py` — new test module

`ruff check` green on all three files; `python3 -m py_compile` green.

No `__version__` bump, no tag, no `[RELEASE]` PR — this stays DRAFT for the local operator to merge and release.

## Local operator verification checklist

Since this session has no access to the local daemon, live cloud snapshot, or a browser, these steps are for the local operator to run before flipping the PR to ready-for-review / merging:

- [ ] `cp clawmetry/entitlements.py routes/entitlement.py ~/.clawmetry/lib/python*/site-packages/clawmetry/` (adjust for the runtime layout — `entitlements.py` under `clawmetry/`, `entitlement.py` under `clawmetry/routes/` or wherever the running install keeps route modules)
- [ ] Clear `__pycache__` under the installed package: `find ~/.clawmetry/lib -name __pycache__ -exec rm -rf {} +`
- [ ] Restart the daemon: `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` (macOS) or the systemd equivalent
- [ ] Confirm the new endpoints respond locally:
  - `curl -sS -X POST 'http://localhost:8900/api/entitlement/has-features-bundle-batch-at?tier=enterprise' -H 'Content-Type: application/json' -d '{"bundles": [["fleet","sso"],["bogus"],[]]}' | jq`
  - `curl -sS -X POST 'http://localhost:8900/api/entitlement/has-runtimes-bundle-batch-at?tier=oss' -H 'Content-Type: application/json' -d '{"bundles": [["openclaw"],["claude_code"]]}' | jq`
- [ ] Confirm the error paths: `?tier=bogus` → 404 `{"error":"unknown tier","which":"tier","tier":"bogus"}`; missing `?tier=` → 400 `{"error":"missing tier"}`; `{}` body → 400 `{"error":"missing bundles"}`
- [ ] Confirm grace-vs-enforce byte-identity locally: `CLAWMETRY_ENFORCE=1` env-flip, hit the same URLs, diff the response bodies (only the resolver-envelope `enforced`/`grace` bits shift; row bodies are identical)
- [ ] Decrypt the live cloud snapshot and confirm the new endpoint bodies render as expected in the browser paywall matrix (if a paywall matrix UI is wired to consume this)
- [ ] `make lint && make test` locally to catch any environment-specific regression the sandbox CI missed
- [ ] Flip the PR from DRAFT to ready, merge on green, and let the release-on-merge flow ship a version bump

---
_Generated by [Claude Code](https://claude.ai/code/session_01QiCgRTdZRcE64WsJDtwRpU)_