### PR TITLE
Built-in monitors: honest delivery channels + mute/pin controls [RELEASE]

### DIFF
--- a/clawmetry/static/css/dashboard.css
+++ b/clawmetry/static/css/dashboard.css
@@ -1316,10 +1316,15 @@
   margin: -4px 0 10px; max-width: 68ch; line-height: 1.5;
 }
 .alerts-rule-row.alerts-builtin-row {
-  grid-template-columns: 24px 1fr auto auto;
+  grid-template-columns: 24px 1fr auto auto auto;
   border-left: 2px solid var(--border-primary);
 }
 .alerts-rule-row.alerts-builtin-row:hover { background: transparent; }
+.alerts-rule-row.alerts-builtin-muted .alerts-rule-main { opacity: 0.55; }
+/* Channel pills on built-in rows are pins: click to add/remove a configured
+   destination. In-app is fixed (not a button). */
+.alerts-chan-pill.alerts-chan-pill-btn { cursor: pointer; }
+.alerts-chan-pill.alerts-chan-pill-btn:hover { border-color: var(--text-muted); opacity: 1; }
 /* Orphan rules: saved but matching no known alert type. Amber left edge marks
    them as needing attention without shouting — they are stale config, not an
    incident. */

--- a/clawmetry/static/js/alerts.js
+++ b/clawmetry/static/js/alerts.js
@@ -513,14 +513,49 @@
   }
 
   // Always-on monitors — the checks that fire without a rule behind them.
-  // Rendered read-only and visibly distinct from the toggleable rules above,
-  // so nobody mistakes them for something they forgot to switch off.
+  // Visibly distinct from the rules above, but NOT read-only: each one can
+  // be muted, and its delivery channels pinned. The channel pills are the
+  // server's live answer (the same resolver _fire_alert uses), so a pill
+  // only appears for a destination this node can actually deliver to.
   const _BUILTIN_ICONS = {
     heartbeat_silent: '💤', agent_down: '📡', anomaly: '📈',
     token_velocity: '⚡', agent_error_rate: '🛠', error_spike: '🔥',
     security_threat: '🛡', numbat_finding: '🛡', security: '🔐',
     threshold: '💰',
   };
+  const _BUILTIN_CHAN_LABEL = { banner: 'In-app', telegram: 'Telegram', slack: 'Slack',
+    discord: 'Discord', webhook: 'Webhook' };
+  let _builtinAvailable = [];
+
+  function builtinToggle(alertType, on) {
+    return '<div class="alerts-toggle-switch" onclick="event.stopPropagation();alertsBuiltinSetEnabled(\'' + alertType + '\', ' + (on ? 'false' : 'true') + ')"'
+      + ' title="' + (on ? 'On — click to mute this monitor' : 'Muted — click to turn it back on') + '"'
+      + ' style="position:relative;width:42px;height:24px;cursor:pointer;flex-shrink:0;">'
+      + '<div style="position:absolute;inset:0;background:' + (on ? '#3b82f6' : '#374151') + ';border-radius:12px;transition:background 0.2s;"></div>'
+      + '<div style="position:absolute;top:3px;left:' + (on ? '21px' : '3px') + ';width:18px;height:18px;background:#fff;border-radius:50%;transition:left 0.2s;box-shadow:0 1px 3px rgba(0,0,0,0.3);"></div>'
+      + '</div>';
+  }
+
+  function builtinChannelPills(m) {
+    const active = new Set(m.channels || ['banner']);
+    const avail = _builtinAvailable.length ? _builtinAvailable : [{ id: 'banner', label: 'In-app' }];
+    const pills = avail.map(c => {
+      const on = active.has(c.id);
+      const isBanner = c.id === 'banner';
+      const title = isBanner
+        ? 'In-app is always on for this monitor. To silence it, use the switch.'
+        : (on ? 'Delivering here — click to stop' : 'Configured but not used by this monitor — click to add')
+          + (c.detail ? ' · ' + c.detail : '');
+      const click = isBanner ? '' : ` onclick="event.stopPropagation();alertsBuiltinToggleChannel('${m.alert_type}','${c.id}')"`;
+      return `<span class="alerts-chan-pill${on ? '' : ' off'}${isBanner ? '' : ' alerts-chan-pill-btn'}" title="${escape(title)}"${click}>${escape(c.label || _BUILTIN_CHAN_LABEL[c.id] || c.id)}</span>`;
+    });
+    // Nothing beyond in-app is configured on this node — say so, and point
+    // at where to fix it, instead of leaving the operator to guess.
+    if (avail.length === 1) {
+      pills.push('<span class="alerts-chan-pill off alerts-chan-pill-btn" title="No external channel is configured on this node. Connect Telegram, Slack, Discord or a webhook in Notifications and it will appear here." onclick="event.stopPropagation();if(typeof showTab===\'function\')showTab(\'notifications\')">+ add channel</span>');
+    }
+    return pills.join('');
+  }
 
   async function renderBuiltinMonitors() {
     const wrap = document.getElementById('alerts-builtins-list');
@@ -529,6 +564,7 @@
     try {
       const d = await fetch('/api/alerts/builtins').then(r => r.json());
       monitors = (d && d.monitors) || [];
+      _builtinAvailable = (d && d.channels_available) || [];
     } catch {
       wrap.innerHTML = '<div class="alerts-loading">Couldn’t load the always-on monitors.</div>';
       return;
@@ -537,19 +573,56 @@
       wrap.innerHTML = '<div class="alerts-loading">No always-on monitors on this build.</div>';
       return;
     }
-    wrap.innerHTML = monitors.map(m => `
-      <div class="alerts-rule-row alerts-builtin-row">
-        <div class="alerts-rule-dot on" title="Always on"></div>
+    wrap.innerHTML = monitors.map(m => {
+      const on = m.enabled !== false;
+      return `
+      <div class="alerts-rule-row alerts-builtin-row${on ? '' : ' alerts-builtin-muted'}" data-builtin="${escape(m.alert_type)}">
+        <div class="alerts-rule-dot ${on ? 'on' : 'off'}" title="${on ? 'Always on' : 'Muted'}"></div>
         <div class="alerts-rule-main">
-          <div class="alerts-rule-title">${_BUILTIN_ICONS[m.alert_type] || '🔔'} ${escape(m.label)}</div>
+          <div class="alerts-rule-title">${_BUILTIN_ICONS[m.alert_type] || '🔔'} ${escape(m.label)}${on ? '' : ' <span class="alerts-builtin-tag" style="margin-left:6px">muted</span>'}</div>
           <div class="alerts-rule-meta">${escape(m.watches)}</div>
         </div>
-        <div class="alerts-rule-chan">${(m.channels || []).map(c =>
-          `<span class="alerts-chan-pill">${escape(c === 'banner' ? 'In-app' : c)}</span>`).join('')}</div>
+        <div class="alerts-rule-chan">${builtinChannelPills(m)}</div>
         <span class="alerts-builtin-tag" title="Built in — fires with no rule of yours behind it">built in</span>
-      </div>
-    `).join('');
+        ${builtinToggle(m.alert_type, on)}
+      </div>`;
+    }).join('');
   }
+
+  async function _patchBuiltin(alertType, body) {
+    try {
+      const r = await fetch('/api/alerts/builtins/' + encodeURIComponent(alertType), {
+        method: 'PATCH', headers: { 'Content-Type': 'application/json' },
+        credentials: 'same-origin', body: JSON.stringify(body),
+      });
+      if (!r.ok) throw new Error('HTTP ' + r.status);
+    } catch (e) {
+      if (typeof showToast === 'function') showToast('Could not save monitor setting');
+    }
+    renderBuiltinMonitors();
+  }
+  // Exposed so the section can refresh independently of the full tab loader
+  // (and so E2E checks can drive it directly).
+  window.alertsRenderBuiltinMonitors = renderBuiltinMonitors;
+  window.alertsBuiltinSetEnabled = function (alertType, enabled) {
+    _patchBuiltin(alertType, { enabled: !!enabled });
+  };
+  window.alertsBuiltinToggleChannel = function (alertType, chan) {
+    const row = document.querySelector('.alerts-builtin-row[data-builtin="' + alertType + '"]');
+    // Current pinned set = the pills rendered as active; flip the clicked one.
+    const active = [];
+    if (row) row.querySelectorAll('.alerts-chan-pill').forEach(p => {
+      if (!p.classList.contains('off')) {
+        const label = p.textContent.trim();
+        const hit = _builtinAvailable.find(c => (c.label || _BUILTIN_CHAN_LABEL[c.id] || c.id) === label);
+        if (hit) active.push(hit.id);
+      }
+    });
+    if (!active.includes('banner')) active.push('banner');
+    const i = active.indexOf(chan);
+    if (i >= 0) active.splice(i, 1); else active.push(chan);
+    _patchBuiltin(alertType, { channels: active });
+  };
 
   function renderChannelsSummary() {
     const wrap = document.getElementById('alerts-channels-summary');

--- a/clawmetry/templates/tabs/alerts.html
+++ b/clawmetry/templates/tabs/alerts.html
@@ -34,7 +34,7 @@
        alert when all of the alerts are disabled?" (founder, 2026-08-15). These
        fire from hardcoded checks, not from the rules above. -->
   <h4 class="alerts-section-h" data-i18n="alerts.builtins_title">Always on</h4>
-  <div class="alerts-builtins-note" data-i18n="alerts.builtins_note">These run whether or not you set up any rules above. They're what raised the red banners at the top of the dashboard.</div>
+  <div class="alerts-builtins-note" data-i18n="alerts.builtins_note">These run without any rules from you. They're what raised the red banners at the top of the dashboard. Each one delivers in-app, plus any channel you've connected in Notifications. Use the switch to mute one, or click a channel pill to change where it goes.</div>
   <div id="alerts-builtins-list" class="alerts-list">
     <div class="alerts-loading" data-i18n="alerts.loading_builtins">Loading monitors…</div>
   </div>

--- a/dashboard.py
+++ b/dashboard.py
@@ -326,7 +326,7 @@ def _otlp_service_name_to_agent_type(service_name):
     return slug or "custom"
 
 
-__version__ = "0.12.726"
+__version__ = "0.12.727"
 
 # Extensions (Phase 2): import the plugin host now, but defer the actual
 # load_plugins() call until after the Flask app is created below so we can
@@ -9953,11 +9953,14 @@ def _send_discord_alert(message, severity="warning", title="ClawMetry Alert"):
     _send_webhook_alert(url, payload, payload_type="generic")
 
 
-def _dispatch_alert(title, message, severity="warning", alert_type=None):
+def _dispatch_alert(title, message, severity="warning", alert_type=None, only=None):
     """Dispatch an alert to all configured channels (Slack, Discord, generic webhook).
 
     Respects the global min_severity filter and per-type toggles.
     Called automatically from _fire_alert() so all alerts reach webhook channels.
+    ``only`` (a set of channel ids) restricts the fan-out to those sinks —
+    built-in monitors pass their resolved channel set so the Alerts tab's
+    pills and the actual delivery are the same list.
     """
     if not _severity_passes_filter(severity):
         return
@@ -9967,6 +9970,13 @@ def _dispatch_alert(title, message, severity="warning", alert_type=None):
     generic_url = str(cfg.get("webhook_url", "")).strip()
     slack_url = str(cfg.get("slack_webhook_url", "")).strip()
     discord_url = str(cfg.get("discord_webhook_url", "")).strip()
+    if only is not None:
+        if "webhook" not in only:
+            generic_url = ""
+        if "slack" not in only:
+            slack_url = ""
+        if "discord" not in only:
+            discord_url = ""
 
     if generic_url:
         payload = {
@@ -9998,10 +10008,161 @@ def _dispatch_configured_webhooks(alert_type, payload):
         _send_webhook_alert(discord_url, payload, payload_type="discord")
 
 
-def _fire_alert(rule_id, alert_type, message, channels=None, severity="warning"):
-    """Fire an alert with cooldown check and dispatch to configured webhook channels."""
+# ── Built-in monitor delivery ──────────────────────────────────────────────
+#
+# Founder 2026-08-17: the Alerts tab showed every always-on monitor with an
+# "In-app · telegram" pill on a node where Telegram was never configured.
+# The pills came from a hardcoded ``channels=["banner", "telegram"]`` on each
+# ``_fire_alert`` call site; delivery then read Telegram creds from a store
+# the Notifications tab never writes and fell back to an undefined gateway
+# helper — so "telegram" delivered nothing and the pill was a fabrication.
+#
+# One resolver now answers "where does this monitor deliver?" for BOTH the
+# Alerts tab (``/api/alerts/builtins``) and ``_fire_alert``. A channel is
+# offered only when this process can actually deliver to it right now, so
+# what the tab shows and what fires cannot drift. Operators can also mute a
+# monitor or pin its channels; prefs live in ~/.clawmetry so they survive
+# upgrades and are not tied to an OpenClaw install.
+_BUILTIN_MONITOR_PREFS_FILE = os.path.expanduser("~/.clawmetry/builtin_monitors.json")
+_BUILTIN_CHANNEL_META = {
+    # In-app is the floor: it is always deliverable and never removable
+    # (to silence a monitor you disable it, not strip its last channel).
+    "banner":   ("In-app",   "Red banner + bell in this dashboard"),
+    "telegram": ("Telegram", "Direct Bot API message"),
+    "slack":    ("Slack",    "Incoming webhook"),
+    "discord":  ("Discord",  "Channel webhook"),
+    "webhook":  ("Webhook",  "POST JSON to your endpoint"),
+}
+
+
+def _builtin_alert_types():
+    try:
+        from routes.alerts import BUILTIN_MONITORS
+        return {m["alert_type"] for m in BUILTIN_MONITORS}
+    except Exception:
+        return set()
+
+
+def _telegram_creds():
+    """(bot_token, chat_id) from either store.
+
+    Legacy budget config (SQLite) came first; the Notifications tab writes
+    the alert-channels file. Delivery must honour both or a user who
+    "connected" Telegram in the tab still gets nothing.
+    """
+    for loader in (_load_alerts_webhook_config, _get_budget_config):
+        try:
+            cfg = loader()
+            tok = str(cfg.get("telegram_bot_token", "") or "").strip()
+            cid = str(cfg.get("telegram_chat_id", "") or "").strip()
+            if tok and cid:
+                return tok, cid
+        except Exception:
+            continue
+    return "", ""
+
+
+def _builtin_channels_available():
+    """Channels a built-in monitor CAN deliver to from this process right now.
+
+    Never advertises a destination that has no working sender behind it:
+    email / phone / WhatsApp are cloud-delivered and have no local sender,
+    so they are absent here even when creds are saved.
+    """
+    out = [{"id": "banner", "label": "In-app",
+            "detail": _BUILTIN_CHANNEL_META["banner"][1], "configured": True}]
+    tok, cid = _telegram_creds()
+    if tok and cid:
+        out.append({"id": "telegram", "label": "Telegram",
+                    "detail": f"Bot API to chat {cid[-4:].rjust(len(cid), '*')}",
+                    "configured": True})
+    try:
+        cfg = _load_alerts_webhook_config()
+    except Exception:
+        cfg = {}
+    for cid_, key in (("slack", "slack_webhook_url"),
+                      ("discord", "discord_webhook_url"),
+                      ("webhook", "webhook_url")):
+        if str(cfg.get(key, "") or "").strip():
+            lbl, det = _BUILTIN_CHANNEL_META[cid_]
+            out.append({"id": cid_, "label": lbl, "detail": det, "configured": True})
+    return out
+
+
+def _load_builtin_monitor_prefs():
+    try:
+        with open(_BUILTIN_MONITOR_PREFS_FILE) as f:
+            data = json.load(f)
+        return data if isinstance(data, dict) else {}
+    except Exception:
+        return {}
+
+
+def _save_builtin_monitor_pref(alert_type, enabled=None, channels=None):
+    """Persist one monitor's prefs. ``channels=None`` keeps the current
+    value; ``channels=[]`` or a list pins them; the string ``"auto"`` clears
+    the pin (back to every available channel)."""
+    prefs = _load_builtin_monitor_prefs()
+    cur = dict(prefs.get(alert_type) or {})
+    if enabled is not None:
+        cur["enabled"] = bool(enabled)
+    if channels == "auto":
+        cur.pop("channels", None)
+    elif isinstance(channels, list):
+        known = set(_BUILTIN_CHANNEL_META)
+        cur["channels"] = sorted({str(c) for c in channels if str(c) in known} | {"banner"})
+    prefs[alert_type] = cur
+    os.makedirs(os.path.dirname(_BUILTIN_MONITOR_PREFS_FILE), exist_ok=True)
+    tmp = _BUILTIN_MONITOR_PREFS_FILE + ".tmp"
+    with open(tmp, "w") as f:
+        json.dump(prefs, f, indent=2)
+    os.replace(tmp, _BUILTIN_MONITOR_PREFS_FILE)
+    return cur
+
+
+def _resolve_builtin_delivery(alert_type):
+    """The single answer for "is this monitor on, and where does it go?".
+
+    Returns ``{"enabled", "channels", "mode"}`` where ``channels`` is the
+    exact list ``_fire_alert`` will deliver to: pinned channels intersected
+    with what is deliverable now (a pinned-but-unconfigured channel is
+    dropped, not shown), or every available channel in ``auto`` mode.
+    """
+    prefs = _load_builtin_monitor_prefs().get(alert_type) or {}
+    available = [c["id"] for c in _builtin_channels_available()]
+    pinned = prefs.get("channels")
+    if isinstance(pinned, list):
+        chans = [c for c in available if c in pinned or c == "banner"]
+        mode = "custom"
+    else:
+        chans, mode = list(available), "auto"
+    return {"enabled": bool(prefs.get("enabled", True)),
+            "channels": chans, "mode": mode}
+
+
+def _fire_alert(rule_id, alert_type, message, channels=None, severity="warning",
+                builtin=None):
+    """Fire an alert with cooldown check and dispatch to configured webhook channels.
+
+    ``builtin`` — True: route through the built-in monitor resolver (mute +
+    channel prefs); False: a user rule, deliver exactly ``channels``; None:
+    auto — built-in iff ``alert_type`` is one of the always-on monitors.
+    """
     global _budget_alert_cooldowns
     now = time.time()
+
+    if builtin is None:
+        builtin = alert_type in _builtin_alert_types()
+    only_sinks = None
+    if builtin:
+        try:
+            resolved = _resolve_builtin_delivery(alert_type)
+        except Exception:
+            resolved = {"enabled": True, "channels": ["banner"], "mode": "auto"}
+        if not resolved["enabled"]:
+            return  # muted by the operator — no history, no banner, no fan-out
+        channels = resolved["channels"]
+        only_sinks = set(channels)
 
     # Check cooldown (default 30 min for budget alerts)
     cooldown_sec = 1800
@@ -10050,51 +10211,47 @@ def _fire_alert(rule_id, alert_type, message, channels=None, severity="warning")
     except Exception:
         pass
 
-    # Always dispatch to configured alert channels (Slack / Discord / generic webhook)
+    # Dispatch to configured alert channels (Slack / Discord / generic webhook).
+    # Built-in monitors pass their resolved channel set so a sink the operator
+    # unpinned is not fanned out to; user rules keep the legacy fan-out.
     _dispatch_alert(
         title=f"ClawMetry Alert [{alert_type}]",
         message=message,
         severity=severity,
         alert_type=alert_type,
+        only=only_sinks,
     )
 
 
 def _send_telegram_alert(message):
-    """Send alert via direct Telegram API (preferred) or gateway fallback."""
-    try:
-        cfg = _get_budget_config()
-        token = str(cfg.get("telegram_bot_token", "")).strip()
-        chat_id = str(cfg.get("telegram_chat_id", "")).strip()
-        if token and chat_id:
-            import urllib.request
+    """Send alert via the direct Telegram Bot API.
 
-            url = f"https://api.telegram.org/bot{token}/sendMessage"
-            payload = json.dumps(
-                {
-                    "chat_id": chat_id,
-                    "text": f"[ClawMetry Alert] {message}",
-                    "parse_mode": "Markdown",
-                }
-            ).encode()
-            req = urllib.request.Request(
-                url,
-                data=payload,
-                headers={"Content-Type": "application/json"},
-            )
-            urllib.request.urlopen(req, timeout=10)
-            return
+    Creds come from either store (see ``_telegram_creds``). With none
+    configured this is a no-op — the old "gateway fallback" called a helper
+    that was never defined, so it silently delivered nothing anyway.
+    """
+    token, chat_id = _telegram_creds()
+    if not (token and chat_id):
+        return
+    try:
+        import urllib.request
+
+        url = f"https://api.telegram.org/bot{token}/sendMessage"
+        payload = json.dumps(
+            {
+                "chat_id": chat_id,
+                "text": f"[ClawMetry Alert] {message}",
+                "parse_mode": "Markdown",
+            }
+        ).encode()
+        req = urllib.request.Request(
+            url,
+            data=payload,
+            headers={"Content-Type": "application/json"},
+        )
+        urllib.request.urlopen(req, timeout=10)
     except Exception as e:
         print(f"Warning: Direct Telegram alert failed: {e}")
-    try:
-        _gw_invoke(
-            "message",
-            {
-                "action": "send",
-                "message": f"[ClawMetry Alert] {message}",
-            },
-        )
-    except Exception:
-        pass
 
 
 # PagerDuty and OpsGenie integration constants. The actual payload

--- a/routes/alerts.py
+++ b/routes/alerts.py
@@ -336,73 +336,80 @@ BUILTIN_MONITORS = [
         "alert_type": "heartbeat_silent",
         "label": "Agent went quiet",
         "watches": "No heartbeat for 1.5x the expected interval",
-        "channels": ["banner", "telegram"],
         "source": "dashboard",
     },
     {
         "alert_type": "agent_down",
         "label": "Telemetry feed stopped",
         "watches": "No OTLP data received for the agent-down window",
-        "channels": ["banner", "telegram"],
         "source": "dashboard",
     },
     {
         "alert_type": "anomaly",
         "label": "Cost spike",
         "watches": "Today's spend above 2x the 7-day average",
-        "channels": ["banner", "telegram"],
         "source": "dashboard",
     },
     {
         "alert_type": "token_velocity",
         "label": "Token burst",
         "watches": "Sustained tokens/min above the built-in ceiling",
-        "channels": ["banner", "telegram"],
         "source": "dashboard",
     },
     {
         "alert_type": "agent_error_rate",
         "label": "Errors climbing",
         "watches": "A runtime's error rate over its recent baseline",
-        "channels": ["banner", "telegram"],
         "source": "dashboard",
     },
     {
         "alert_type": "error_spike",
         "label": "Error spike",
         "watches": "A burst of errors in a short window",
-        "channels": ["banner", "telegram"],
         "source": "dashboard",
     },
     {
         "alert_type": "security_threat",
         "label": "Threat signature matched",
         "watches": "Built-in signatures matching recent agent activity",
-        "channels": ["banner", "telegram"],
         "source": "security-scan",
     },
     {
         "alert_type": "numbat_finding",
         "label": "Security tool finding",
         "watches": "A critical or high finding from a connected scanner",
-        "channels": ["banner", "telegram"],
         "source": "numbat-ingest",
     },
     {
         "alert_type": "security",
         "label": "Security posture changed",
         "watches": "A drop in the node's security posture score",
-        "channels": ["banner", "telegram"],
         "source": "dashboard",
     },
     {
         "alert_type": "threshold",
         "label": "Budget threshold",
         "watches": "Daily spend crossing the budget you configured",
-        "channels": ["banner", "telegram"],
         "source": "dashboard",
     },
 ]
+
+
+def _builtin_monitor_view(m, _d):
+    """One monitor as the Alerts tab renders it: the STATIC catalog entry
+    plus the LIVE delivery answer from the same resolver ``_fire_alert``
+    uses. ``channels`` is what will actually deliver; the hardcoded catalog
+    value is deliberately not exposed (founder 2026-08-17: it advertised
+    Telegram on nodes that never configured it)."""
+    view = {k: v for k, v in m.items() if k != "channels"}
+    try:
+        r = _d._resolve_builtin_delivery(m["alert_type"])
+    except Exception:
+        r = {"enabled": True, "channels": ["banner"], "mode": "auto"}
+    view["enabled"] = r["enabled"]
+    view["channels"] = r["channels"]
+    view["channels_mode"] = r["mode"]
+    return view
 
 
 @bp_alerts.route("/api/alerts/builtins")
@@ -412,9 +419,49 @@ def api_alerts_builtins():
     Read by the Alerts tab so the operator can see WHY a banner appeared
     when every rule on the page is switched off. No ``@gate``: knowing what
     is watching you is not a paid feature.
+
+    ``channels`` on each monitor is the live delivery list (in-app plus any
+    channel this node can actually deliver to right now, minus anything
+    the operator unpinned); ``channels_available`` is the picker menu.
     """
-    return jsonify({"monitors": BUILTIN_MONITORS,
-                    "count": len(BUILTIN_MONITORS)})
+    import dashboard as _d
+    monitors = [_builtin_monitor_view(m, _d) for m in BUILTIN_MONITORS]
+    try:
+        available = _d._builtin_channels_available()
+    except Exception:
+        available = [{"id": "banner", "label": "In-app", "configured": True}]
+    return jsonify({"monitors": monitors,
+                    "count": len(monitors),
+                    "channels_available": available})
+
+
+@bp_alerts.route("/api/alerts/builtins/<alert_type>", methods=["PATCH"])
+def api_alerts_builtin_update(alert_type):
+    """Mute/unmute a built-in monitor or pin its channels.
+
+    Body: ``{"enabled": bool}`` and/or ``{"channels": [...] | "auto"}``.
+    In-app is always kept; to silence a monitor set ``enabled: false``.
+    Local prefs, no ``@gate`` — silencing noise on your own node is not
+    a paid feature.
+    """
+    import dashboard as _d
+    known = {m["alert_type"]: m for m in BUILTIN_MONITORS}
+    if alert_type not in known:
+        return jsonify({"error": "unknown built-in monitor",
+                        "alert_type": alert_type}), 404
+    data = request.get_json(silent=True) or {}
+    enabled = data.get("enabled")
+    channels = data.get("channels", None)
+    if channels is not None and channels != "auto" and not isinstance(channels, list):
+        return jsonify({"error": "channels must be a list or \"auto\""}), 400
+    if enabled is None and channels is None:
+        return jsonify({"error": "nothing to update"}), 400
+    try:
+        _d._save_builtin_monitor_pref(alert_type, enabled=enabled, channels=channels)
+    except Exception as e:
+        return jsonify({"error": f"could not save: {e}"}), 500
+    return jsonify({"ok": True,
+                    "monitor": _builtin_monitor_view(known[alert_type], _d)})
 
 
 # ── Default alert-rule seed list (issue #1707) ─────────────────────────────
@@ -1546,8 +1593,10 @@ def api_harness_inject_cost():
                 continue
             msg = (f"Daily spending ${status['daily_spent']:.2f} exceeded "
                    f"threshold ${rule['threshold']:.2f}")
+            # A USER rule: deliver to exactly the channels it was saved
+            # with, never through the built-in monitor prefs.
             _d._fire_alert(rule_id=rule["id"], alert_type="threshold",
-                           message=msg, channels=channels)
+                           message=msg, channels=channels, builtin=False)
             rules_fired.append(rule["id"])
     history_after = len(_d._get_alert_history(limit=500))
     return jsonify({

--- a/tests/test_builtin_monitor_channels.py
+++ b/tests/test_builtin_monitor_channels.py
@@ -1,0 +1,130 @@
+"""Built-in monitor delivery must be honest and controllable.
+
+Founder-reported 2026-08-17: every always-on monitor showed an
+"In-app · telegram" pill on a node where Telegram was never configured.
+The pill came from a hardcoded ``channels=["banner", "telegram"]`` in the
+catalog; actual delivery read creds from a store the Notifications tab
+never writes, so "telegram" was a fabricated destination.
+
+The fix: one resolver (``_resolve_builtin_delivery``) answers "where does
+this monitor deliver?" for both the API the tab renders and ``_fire_alert``
+itself, and only ever offers channels this process can deliver to right
+now. Operators can mute a monitor or pin its channels. These tests pin
+that contract.
+"""
+
+import json
+
+import pytest
+
+import dashboard as _d
+from routes.alerts import BUILTIN_MONITORS
+
+
+@pytest.fixture
+def isolated(monkeypatch, tmp_path):
+    """No channels configured anywhere, prefs in a temp file."""
+    monkeypatch.setattr(_d, "_BUILTIN_MONITOR_PREFS_FILE",
+                        str(tmp_path / "builtin_monitors.json"))
+    monkeypatch.setattr(_d, "_load_alerts_webhook_config", lambda: {})
+    monkeypatch.setattr(_d, "_get_budget_config", lambda: {})
+    return tmp_path
+
+
+def test_unconfigured_node_gets_banner_only(isolated):
+    """The founder's bug: no Telegram configured -> no telegram channel."""
+    r = _d._resolve_builtin_delivery("heartbeat_silent")
+    assert r["enabled"] is True
+    assert r["channels"] == ["banner"]
+    assert r["mode"] == "auto"
+
+
+def test_catalog_carries_no_hardcoded_channels():
+    """The static catalog must not advertise destinations; only the live
+    resolver may. A ``channels`` key here is exactly the old bug."""
+    for m in BUILTIN_MONITORS:
+        assert "channels" not in m, (
+            f"BUILTIN_MONITORS[{m['alert_type']}] hardcodes channels; "
+            f"delivery is resolved live via _resolve_builtin_delivery"
+        )
+
+
+def test_telegram_offered_once_configured(isolated, monkeypatch):
+    monkeypatch.setattr(_d, "_load_alerts_webhook_config", lambda: {
+        "telegram_bot_token": "123:abc", "telegram_chat_id": "42"})
+    r = _d._resolve_builtin_delivery("anomaly")
+    assert r["channels"] == ["banner", "telegram"]
+
+
+def test_telegram_creds_read_from_legacy_budget_store(isolated, monkeypatch):
+    """Both stores must count — the budget-config store predates the
+    Notifications tab and existing installs still hold creds there."""
+    monkeypatch.setattr(_d, "_get_budget_config", lambda: {
+        "telegram_bot_token": "123:abc", "telegram_chat_id": "42"})
+    assert _d._telegram_creds() == ("123:abc", "42")
+
+
+def test_mute_silences_fire(isolated, monkeypatch):
+    _d._save_builtin_monitor_pref("heartbeat_silent", enabled=False)
+    assert _d._resolve_builtin_delivery("heartbeat_silent")["enabled"] is False
+
+    delivered = []
+    monkeypatch.setattr(_d, "_send_telegram_alert",
+                        lambda msg: delivered.append(("telegram", msg)))
+    monkeypatch.setattr(_d, "_dispatch_alert",
+                        lambda *a, **k: delivered.append(("dispatch", k)))
+    monkeypatch.setattr(_d, "_budget_alert_cooldowns", {})
+    history_calls = []
+    monkeypatch.setattr(_d, "_fleet_db", lambda: history_calls.append(1))
+    _d._fire_alert("heartbeat_gap", "heartbeat_silent", "test message")
+    assert delivered == [] and history_calls == [], (
+        "a muted built-in monitor must not deliver anywhere or write history"
+    )
+
+
+def test_pinned_unconfigured_channel_is_dropped(isolated):
+    """Pinning telegram while it is unconfigured must not advertise it —
+    the pin waits until the channel is deliverable."""
+    _d._save_builtin_monitor_pref("anomaly", channels=["telegram"])
+    r = _d._resolve_builtin_delivery("anomaly")
+    assert r["mode"] == "custom"
+    assert r["channels"] == ["banner"]
+
+
+def test_banner_cannot_be_removed(isolated):
+    _d._save_builtin_monitor_pref("anomaly", channels=[])
+    prefs = json.loads(open(_d._BUILTIN_MONITOR_PREFS_FILE).read())
+    assert "banner" in prefs["anomaly"]["channels"]
+
+
+def test_auto_clears_pin(isolated):
+    _d._save_builtin_monitor_pref("anomaly", channels=["banner"])
+    _d._save_builtin_monitor_pref("anomaly", channels="auto")
+    assert _d._resolve_builtin_delivery("anomaly")["mode"] == "auto"
+
+
+def test_user_rule_channels_untouched(isolated, monkeypatch):
+    """builtin=False must bypass the resolver entirely: a user rule keeps
+    the channels it was saved with even when the same alert_type is also a
+    built-in monitor."""
+    seen = {}
+    monkeypatch.setattr(_d, "_budget_alert_cooldowns", {})
+    monkeypatch.setattr(_d, "_fleet_db_lock", _d._fleet_db_lock)
+
+    class _FakeDb:
+        def execute(self, *a):
+            seen.setdefault("channels", []).append(a[1][3])
+        def commit(self):
+            pass
+        def close(self):
+            pass
+
+    monkeypatch.setattr(_d, "_fleet_db", lambda: _FakeDb())
+    monkeypatch.setattr(_d, "_send_telegram_alert", lambda m: seen.setdefault("tg", True))
+    monkeypatch.setattr(_d, "_dispatch_alert", lambda *a, **k: seen.setdefault("only", k.get("only")))
+    _d._save_builtin_monitor_pref("threshold", enabled=False)  # builtin muted...
+    _d._fire_alert("rule_x", "threshold", "msg", channels=["banner", "telegram"],
+                   builtin=False)  # ...but the user rule still fires
+    assert seen.get("channels") == ["banner", "telegram"]
+    assert seen.get("tg") is True
+    assert seen.get("only") is None

--- a/tests/test_builtin_monitors.py
+++ b/tests/test_builtin_monitors.py
@@ -80,16 +80,23 @@ def test_every_hardcoded_fire_is_documented():
 
 
 def test_monitor_entries_are_well_formed():
-    """The tab renders these fields directly; none may be blank."""
+    """The tab renders these fields directly; none may be blank.
+
+    ``channels`` is deliberately NOT part of the catalog any more — it was a
+    hardcoded lie ("telegram" on nodes with no Telegram). Delivery is
+    resolved live per node (see test_builtin_monitor_channels.py)."""
     from routes.alerts import BUILTIN_MONITORS
 
     seen = set()
     for m in BUILTIN_MONITORS:
-        for field in ("alert_type", "label", "watches", "channels", "source"):
+        for field in ("alert_type", "label", "watches", "source"):
             assert m.get(field), f"{m.get('alert_type')} is missing {field}"
         assert m["alert_type"] not in seen, f"duplicate {m['alert_type']}"
         seen.add(m["alert_type"])
-        assert isinstance(m["channels"], list) and m["channels"]
+        assert "channels" not in m, (
+            f"{m['alert_type']} hardcodes channels — delivery must come "
+            f"from dashboard._resolve_builtin_delivery"
+        )
 
 
 def test_builtins_endpoint_is_not_paywalled():


### PR DESCRIPTION
## What

Founder report (2026-08-17): the Alerts tab's **Always on** section showed every built-in monitor with an **In-app · telegram** pill on a node where Telegram was never configured.

Three defects behind that one pill:
1. `BUILTIN_MONITORS` hardcoded `channels: ["banner", "telegram"]` on all 10 entries — a static claim, not a fact about the node.
2. Delivery (`_send_telegram_alert`) read creds only from the legacy budget store, which the Notifications tab never writes — so even a user who "connected" Telegram in the tab got nothing.
3. Its fallback called `_gw_invoke(...)`, which is not defined anywhere — a silent no-op.

## Fix

- **One resolver** (`dashboard._resolve_builtin_delivery`) answers "where does this monitor deliver?" for both `/api/alerts/builtins` and `_fire_alert` — the pills and the actual fan-out are the same list and cannot drift.
- A channel is offered **only when this node can deliver to it right now**: in-app always; Telegram / Slack / Discord / webhook when configured. Telegram creds are honoured from **both** stores.
- **Mute + pin**: `PATCH /api/alerts/builtins/<alert_type>` with `{"enabled": bool}` and/or `{"channels": [...] | "auto"}`. Prefs live in `~/.clawmetry/builtin_monitors.json`. In-app can't be removed — to silence a monitor you mute it, explicitly.
- **UI**: each Always-on row gets a mute switch and clickable channel pins; unconfigured nodes see `In-app · + add channel` (links to Notifications) instead of a fabricated pill. Muted rows are visibly dimmed.
- User rules are untouched (`builtin=False` bypasses the resolver; delivery to their saved channels verified by test).
- Removed the undefined `_gw_invoke` fallback.

## Verified

- 13 unit tests (`tests/test_builtin_monitor_channels.py` + updated `tests/test_builtin_monitors.py`), all passing.
- Live E2E on an isolated node: unconfigured → `In-app` only; after configuring Telegram creds → `In-app · Telegram`; mute round-trips through the API and survives re-render; unknown type → 404.
- Screenshot: every monitor row with honest pills + working mute toggle.

[RELEASE] bump to 0.12.727

🤖 Generated with [Claude Code](https://claude.com/claude-code)