### PR TITLE
feat(entitlement): missing_features_bundle_batch_at + missing_runtimes_bundle_batch_at + endpoints

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -12206,6 +12206,320 @@ def missing_runtimes_bundle_batch(bundles) -> list[dict]:
     return out
 
 
+def _missing_features_bundle_row_at(perspective_tier: str, bundle) -> dict:
+    """Perspective-shaped sibling of :func:`_missing_features_bundle_row`.
+
+    Normalises one caller-supplied feature bundle exactly the way the LIVE
+    row helper does (whitespace stripped, lowercased, deduplicated
+    preserving first-seen order; unknown ids bucketed into ``unknown``
+    instead of leaking into the ``missing`` walk) then folds the known
+    subset through :func:`missing_features_at` against ``perspective_tier``
+    so the row reflects the STATIC per-tier grant for that hypothetical
+    tier instead of the LIVE resolver.
+
+    **Grace-independent by construction**: :func:`missing_features_at` is
+    backed by :func:`_hypothetical_entitlement` on the feature axis (via
+    the singular :func:`has_feature_at`), so the per-row
+    ``missing_features_at`` list is identical under grace vs enforce for
+    the same ``(perspective, bundle)`` pair. Whole point of the ``_at``
+    slot: a paywall walkthrough at OSS ("if I were on OSS today, WHICH
+    items of this bundle would still be locked?") sees the would-be-
+    denied subset even while the LIVE :func:`missing_features_bundle_batch`
+    reports ``missing=[]`` for every fully-known bundle via grace pass-
+    through.
+
+    Row keys mirror :func:`_missing_features_bundle_row` byte-for-byte on
+    the axis-echo slots with the fold slot renamed ``missing_features_at``
+    (matching the singular scalar :func:`missing_features_at` return-slot
+    name) so a UI wiring both the LIVE and the perspective batches can
+    distinguish the two answers on the same ``(bundle,)`` cell::
+
+        {
+          "features":            ["fleet", "sso"],
+          "unknown":             ["bogus"],
+          "kind":                "features",
+          "count":               2,
+          "missing_features_at": [<subset denied at perspective>],
+        }
+
+    Empty / all-unknown bundles surface as a stable row with
+    ``missing_features_at=[]`` (nothing known to check, nothing missing
+    -- matches :func:`missing_features_at` empty-``[]`` posture). Never
+    raises: a delegate failure returns the empty row shape with
+    ``missing_features_at=[]``.
+    """
+    known: list[str] = []
+    unknown: list[str] = []
+    seen: set[str] = set()
+    try:
+        raw_items = list(bundle) if bundle is not None else []
+    except TypeError:
+        raw_items = []
+    for token in raw_items:
+        try:
+            fid = str(token).strip().lower()
+        except Exception:
+            continue
+        if not fid or fid in seen:
+            continue
+        seen.add(fid)
+        if fid in ALL_FEATURES:
+            known.append(fid)
+        else:
+            unknown.append(fid)
+    try:
+        missing = list(missing_features_at(perspective_tier, known)) if known else []
+    except Exception as exc:
+        logger.warning(
+            "entitlements: _missing_features_bundle_row_at(%r) fold failed: %s",
+            perspective_tier,
+            exc,
+        )
+        missing = []
+    return {
+        "features": known,
+        "unknown": unknown,
+        "kind": "features",
+        "count": len(known),
+        "missing_features_at": missing,
+    }
+
+
+def _missing_runtimes_bundle_row_at(perspective_tier: str, bundle) -> dict:
+    """Runtime-axis twin of :func:`_missing_features_bundle_row_at`.
+
+    Applies :func:`canonical_runtime` before the :data:`ALL_RUNTIMES`
+    membership check so aliases (``claude-code`` -> ``claude_code``)
+    resolve the same way the LIVE :func:`_missing_runtimes_bundle_row`
+    helper does; duplicates that collapse after canonicalisation only
+    contribute one row. Unknown runtime tokens are echoed into
+    ``unknown`` using the raw lowercased id and drop from the ``missing``
+    walk (a typo does NOT silently render as "denied"). Grace-independent
+    by construction (delegates to :func:`missing_runtimes_at`, which
+    reads :func:`_hypothetical_entitlement` via :func:`has_runtime_at`).
+
+    :data:`FREE_RUNTIMES` (``openclaw``, ``nemoclaw``) reports
+    ``missing_runtimes_at=[]`` on every row regardless of perspective
+    (the static per-tier map grants free runtimes at every tier). Never
+    raises.
+    """
+    known: list[str] = []
+    unknown: list[str] = []
+    seen: set[str] = set()
+    try:
+        raw_items = list(bundle) if bundle is not None else []
+    except TypeError:
+        raw_items = []
+    for token in raw_items:
+        try:
+            raw = str(token).strip().lower()
+        except Exception:
+            continue
+        if not raw:
+            continue
+        canon = canonical_runtime(raw)
+        if canon and canon in ALL_RUNTIMES:
+            if canon in seen:
+                continue
+            seen.add(canon)
+            known.append(canon)
+        else:
+            if raw in seen:
+                continue
+            seen.add(raw)
+            unknown.append(raw)
+    try:
+        missing = list(missing_runtimes_at(perspective_tier, known)) if known else []
+    except Exception as exc:
+        logger.warning(
+            "entitlements: _missing_runtimes_bundle_row_at(%r) fold failed: %s",
+            perspective_tier,
+            exc,
+        )
+        missing = []
+    return {
+        "runtimes": known,
+        "unknown": unknown,
+        "kind": "runtimes",
+        "count": len(known),
+        "missing_runtimes_at": missing,
+    }
+
+
+def missing_features_bundle_batch_at(
+    perspective_tier: str, bundles
+) -> list[dict] | None:
+    """Hypothetical-perspective row-detail sibling of
+    :func:`missing_features_bundle_batch`: per-bundle "which subset would
+    ``perspective_tier`` NOT grant?" for N caller-supplied feature bundles
+    in ONE round-trip.
+
+    Same relationship to :func:`missing_features_bundle_batch` that
+    :func:`has_features_bundle_batch_at` has to
+    :func:`has_features_bundle_batch` on the boolean-fold seat and that
+    :func:`missing_features_at` has to :func:`missing_features` on the
+    singular scalar seat: the ``perspective_tier`` argument tells the
+    fold which STATIC per-tier grant to reason from so a pricing-matrix
+    walkthrough can hydrate the per-bundle "which items would be locked
+    at <tier>?" list off ONE call per (perspective, bundles) cell instead
+    of N calls to :func:`missing_features_at`.
+
+    **Perspective-shaped (grace-independent by design)**: unlike the LIVE
+    :func:`missing_features_bundle_batch` (which passes through
+    :func:`missing_features`'s grace answer so every fully-known bundle
+    reports ``missing=[]`` while ``ent.grace`` is ``True``), each row's
+    ``missing_features_at`` here delegates to :func:`missing_features_at`
+    (backed by :func:`_hypothetical_entitlement` on the feature axis), so
+    the row IS shaped by the hypothetical perspective.
+    ``missing_features_bundle_batch_at("oss", [["fleet"]])`` reports
+    ``missing_features_at=["fleet"]`` for the fleet row even in grace --
+    that is the whole point of the ``_at`` slot.
+
+    Row shape mirrors :func:`missing_features_bundle_batch` byte-for-byte
+    on the axis-echo slots with the fold slot renamed
+    ``missing_features_at`` (matching :func:`missing_features_at` return-
+    slot name)::
+
+        {
+          "features":            ["fleet", "sso"],
+          "unknown":             ["bogus"],
+          "kind":                "features",
+          "count":               2,
+          "missing_features_at": [<subset denied at perspective>],
+        }
+
+    Perspective is validated against :data:`_TIER_ORDER` (including
+    :data:`TIER_TRIAL`); returns ``None`` for empty / unknown /
+    non-string ``perspective_tier`` so the paired endpoint can surface a
+    404 with ``which=tier``. Matches the ``None`` posture the rest of the
+    ``_at`` bundle-batch family uses (see
+    :func:`has_features_bundle_batch_at`,
+    :func:`missing_all_bundle_batch_at`).
+
+    Argument handling on ``bundles`` mirrors
+    :func:`missing_features_bundle_batch`:
+
+    * ``bundles is None`` or non-iterable -- returns ``[]`` (perspective
+      valid but nothing to fold).
+    * Each bundle may itself be ``None``, non-iterable, or empty -- the
+      helper emits the empty row shape (``missing_features_at=[]``)
+      rather than raising.
+    * Non-string tokens inside a bundle are coerced via ``str(...)``
+      (matches the singular endpoint's silent-drop posture for garbage).
+
+    Complement invariant with :func:`has_features_bundle_batch_at`: on a
+    valid perspective, for every fully-known bundle,
+    ``bool(row["missing_features_at"]) == (not has_row["has_features_at"])``
+    -- pins the row-detail seat as the exact perspective-shaped negation
+    of the boolean-fold seat.
+
+    Never raises: a per-bundle failure short-circuits to the empty row
+    shape so the batch keeps building. A perspective-validation failure
+    returns ``None`` so the paired endpoint can surface a 404.
+    """
+    try:
+        p = (perspective_tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if not p or p not in _TIER_ORDER:
+        return None
+    try:
+        if bundles is None:
+            return []
+        items = list(bundles)
+    except TypeError:
+        return []
+    out: list[dict] = []
+    for bundle in items:
+        try:
+            out.append(_missing_features_bundle_row_at(p, bundle))
+        except Exception as exc:
+            logger.warning(
+                "entitlements: missing_features_bundle_batch_at row failed: %s",
+                exc,
+            )
+            out.append(
+                {
+                    "features": [],
+                    "unknown": [],
+                    "kind": "features",
+                    "count": 0,
+                    "missing_features_at": [],
+                }
+            )
+    return out
+
+
+def missing_runtimes_bundle_batch_at(
+    perspective_tier: str, bundles
+) -> list[dict] | None:
+    """Runtime-axis twin of :func:`missing_features_bundle_batch_at`:
+    per-bundle "which subset would ``perspective_tier`` NOT grant?" for N
+    caller-supplied runtime bundles in ONE round-trip.
+
+    Same relationship to :func:`missing_runtimes_bundle_batch` that
+    :func:`missing_features_bundle_batch_at` has to
+    :func:`missing_features_bundle_batch`. Pairs with
+    :func:`missing_features_bundle_batch_at` the same way
+    :func:`has_runtimes_bundle_batch_at` pairs with
+    :func:`has_features_bundle_batch_at`: together the two perspective-
+    shaped bundle-batch helpers let a pricing-matrix walkthrough ("from
+    Starter, WHICH items of {claude_code, cursor} would still be locked?
+    {openclaw}? {aider, goose}?") hydrate every bundle's per-item denial
+    list off TWO calls per perspective instead of 2 * N calls to
+    :func:`missing_runtimes_at`.
+
+    Row shape mirrors :func:`missing_runtimes_bundle_batch` byte-for-byte
+    on the axis-echo slots with the fold slot renamed
+    ``missing_runtimes_at``. Runtime aliases (``claude-code`` ->
+    ``claude_code``) canonicalise per bundle via
+    :func:`_missing_runtimes_bundle_row_at` before the
+    :data:`ALL_RUNTIMES` membership check, matching the LIVE row helper's
+    alias posture byte-for-byte -- an alias input surfaces as its
+    canonical id in ``runtimes`` (and, if denied at ``perspective_tier``,
+    in ``missing_runtimes_at``) rather than in ``unknown``.
+
+    :data:`FREE_RUNTIMES` (``openclaw``, ``nemoclaw``) reports
+    ``missing_runtimes_at=[]`` on every row regardless of perspective
+    (the static per-tier map grants free runtimes at every tier).
+
+    Perspective validation, ``bundles`` handling, grace-independence and
+    never-raise contract all mirror
+    :func:`missing_features_bundle_batch_at` byte-for-byte.
+    """
+    try:
+        p = (perspective_tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if not p or p not in _TIER_ORDER:
+        return None
+    try:
+        if bundles is None:
+            return []
+        items = list(bundles)
+    except TypeError:
+        return []
+    out: list[dict] = []
+    for bundle in items:
+        try:
+            out.append(_missing_runtimes_bundle_row_at(p, bundle))
+        except Exception as exc:
+            logger.warning(
+                "entitlements: missing_runtimes_bundle_batch_at row failed: %s",
+                exc,
+            )
+            out.append(
+                {
+                    "runtimes": [],
+                    "unknown": [],
+                    "kind": "runtimes",
+                    "count": 0,
+                    "missing_runtimes_at": [],
+                }
+            )
+    return out
+
+
 def min_tier_for_features_at_batch(
     perspective_tier: str, bundles
 ) -> list[dict] | None:

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -42527,6 +42527,32 @@ def _has_bundle_row_at_body(row: dict, list_key: str) -> dict:
     }
 
 
+def _missing_bundle_row_at_body(row: dict, list_key: str) -> dict:
+    """Row-body helper for the ``/missing-<axis>-bundle-batch-at`` endpoints.
+
+    Perspective-shaped sibling of :func:`_missing_bundle_row_body` on the
+    row-detail complement seat. Row schema mirrors the LIVE helper on the
+    axis-echo slots (``<list_key>`` / ``unknown`` / ``kind`` / ``count``)
+    with the fold slot renamed ``missing_<axis>_at`` matching the
+    singular scalar ``missing_features_at`` / ``missing_runtimes_at`` name
+    on :func:`clawmetry.entitlements.missing_features_bundle_batch_at` /
+    :func:`clawmetry.entitlements.missing_runtimes_bundle_batch_at`. Kept
+    beside :func:`_missing_bundle_row_body` so a future per-row envelope
+    tweak (extra keys, coercion) has ONE obvious edit-site per family
+    instead of drifting between the LIVE and the perspective endpoints.
+    Never raises; a missing key surfaces as the empty-row shape with
+    ``missing_<axis>_at=[]``.
+    """
+    fold_key = f"missing_{list_key}_at"
+    return {
+        list_key: list(row.get(list_key) or []),
+        "unknown": list(row.get("unknown") or []),
+        "kind": row.get("kind"),
+        "count": int(row.get("count") or 0),
+        fold_key: list(row.get(fold_key) or []),
+    }
+
+
 @bp_entitlement.route(
     "/api/entitlement/has-features-bundle-batch-at",
     methods=["POST"],
@@ -42706,6 +42732,204 @@ def api_entitlement_has_runtimes_bundle_batch_at():
     except Exception as exc:
         logger.warning(
             "api_entitlement_has_runtimes_bundle_batch_at: error: %s", exc
+        )
+        env = _perspective_fallback(tier_in)
+        return jsonify(
+            {
+                **env,
+                "bundles": [],
+                "count": 0,
+            }
+        )
+
+
+@bp_entitlement.route(
+    "/api/entitlement/missing-features-bundle-batch-at",
+    methods=["POST"],
+)
+def api_entitlement_missing_features_bundle_batch_at():
+    """``POST /api/entitlement/missing-features-bundle-batch-at?tier=<perspective>``
+    -- hypothetical-perspective row-detail sibling of
+    ``/api/entitlement/missing-features-bundle-batch``.
+
+    Wraps :func:`clawmetry.entitlements.missing_features_bundle_batch_at`
+    so a pricing-matrix walkthrough can call the per-bundle row-detail
+    denial batch on the feature axis from any tier's perspective without
+    first switching the resolver. Fills the ``_at`` slot on the feature-
+    axis row-detail bundle-batch family alongside the aggregate
+    ``/missing-all-bundle-batch-at`` and the runtime-axis sibling
+    ``/missing-runtimes-bundle-batch-at``. Row-detail complement of the
+    boolean-fold ``/has-features-bundle-batch-at`` on the same
+    perspective seat -- the two responses pair on the same ``features``
+    / ``unknown`` / ``kind`` / ``count`` axes so a UI can render "would
+    <perspective> grant this bundle? / which items would still be locked
+    at <perspective>?" side by side per bundle off two calls.
+
+    **Perspective-shaped** (grace-independent by design): each row's
+    ``missing_features_at`` delegates to
+    :func:`clawmetry.entitlements.missing_features_at` (backed by the
+    static per-tier grant table via
+    :func:`clawmetry.entitlements._hypothetical_entitlement`), so grace
+    vs enforce yields byte-identical row bodies (only the resolver
+    envelope shifts). Whole point of the ``_at`` slot: at
+    ``tier=oss`` a paid-feature bundle reports
+    ``missing_features_at=["fleet"]`` even in grace, whereas the LIVE
+    ``/missing-features-bundle-batch`` reports ``missing=[]`` for the
+    same bundle via grace pass-through.
+
+    Request body is byte-identical to ``/missing-features-bundle-batch``.
+    The extra ``tier=<perspective>`` query arg is required.
+
+    Response layers ``perspective_tier`` / ``perspective_tier_label`` /
+    ``perspective_tier_rank`` on top of the bare batch envelope so a
+    caller can render "at <perspective> these items would be locked"
+    copy off one call::
+
+        {
+          "perspective_tier":       "oss",
+          "perspective_tier_label": "OSS",
+          "perspective_tier_rank":  <int>,
+          "bundles":                [<row>, ...],
+          "count":                  <int>,
+          "current_tier":           "...",
+          "current_tier_rank":      <int>,
+          "grace":                  <bool>,
+          "enforced":               <bool>,
+        }
+
+    Each ``<row>`` mirrors the LIVE ``/missing-features-bundle-batch``
+    row body byte-for-byte on the axis-echo slots with the fold slot
+    renamed ``missing_features_at``::
+
+        {
+          "features":            ["fleet", "sso"],
+          "unknown":             ["bogus"],
+          "kind":                "features",
+          "count":               2,
+          "missing_features_at": [<subset denied at perspective>],
+        }
+
+    - **400** when ``tier=`` is missing / blank
+    - **404** when ``tier`` is unknown (body carries ``which=tier`` so a
+      caller can render the right "unknown tier" message)
+    - **400** when ``bundles`` is missing / non-list / empty
+    - **Never 5xxs**: a resolver failure yields the fallback envelope
+      so the paywall matrix keeps rendering.
+    """
+    raw_tier = request.args.get("tier")
+    tier_in = (raw_tier or "").strip().lower()
+    if not tier_in:
+        return jsonify({"error": "missing tier"}), 400
+    body = request.get_json(silent=True) or {}
+    bundles, err = _parse_bundles_body(body)
+    if err == "missing":
+        return jsonify({"error": "missing bundles"}), 400
+    if err == "empty":
+        return jsonify({"error": "empty bundles"}), 400
+    if err == "bundles_must_be_list":
+        return jsonify({"error": "bundles must be a list"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        if tier_in not in _ent._TIER_ORDER:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "tier", "tier": tier_in}
+                ),
+                404,
+            )
+        rows = _ent.missing_features_bundle_batch_at(tier_in, bundles) or []
+        out_rows = [_missing_bundle_row_at_body(row, "features") for row in rows]
+        env = _perspective_envelope(_ent, tier_in)
+        return jsonify(
+            {
+                **env,
+                "bundles": out_rows,
+                "count": len(out_rows),
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_missing_features_bundle_batch_at: error: %s", exc
+        )
+        env = _perspective_fallback(tier_in)
+        return jsonify(
+            {
+                **env,
+                "bundles": [],
+                "count": 0,
+            }
+        )
+
+
+@bp_entitlement.route(
+    "/api/entitlement/missing-runtimes-bundle-batch-at",
+    methods=["POST"],
+)
+def api_entitlement_missing_runtimes_bundle_batch_at():
+    """``POST /api/entitlement/missing-runtimes-bundle-batch-at?tier=<perspective>``
+    -- runtime-axis twin of
+    ``/api/entitlement/missing-features-bundle-batch-at``.
+
+    Wraps :func:`clawmetry.entitlements.missing_runtimes_bundle_batch_at`
+    so a pricing-matrix walkthrough can call the per-bundle row-detail
+    denial batch on the runtime axis from any tier's perspective without
+    first switching the resolver. Pairs with
+    ``/missing-features-bundle-batch-at`` the same way
+    ``/missing-runtimes-bundle-batch`` pairs with
+    ``/missing-features-bundle-batch`` on the LIVE seat: together the
+    two perspective-scoped row-detail bundle-batch endpoints let a
+    caller render "from <perspective>, WHICH items of this whole runtime
+    set would still be locked?" copy off ONE call per axis instead of N
+    calls to ``/missing-runtime-at`` / ``/missing-runtimes-at``.
+
+    Response shape and error paths mirror
+    ``/missing-features-bundle-batch-at`` exactly, with
+    ``kind="runtimes"``, a ``runtimes`` list in place of ``features``,
+    and ``missing_runtimes_at`` in place of ``missing_features_at`` per
+    row. Runtime aliases (``claude-code`` -> ``claude_code``)
+    canonicalise per bundle inside the helper before the
+    ``ALL_RUNTIMES`` membership check, matching the LIVE
+    ``/missing-runtimes-bundle-batch`` alias posture byte-for-byte -- an
+    alias input surfaces as its canonical id in ``runtimes`` (and, if
+    denied at ``perspective_tier``, in ``missing_runtimes_at``) rather
+    than in ``unknown``.
+    """
+    raw_tier = request.args.get("tier")
+    tier_in = (raw_tier or "").strip().lower()
+    if not tier_in:
+        return jsonify({"error": "missing tier"}), 400
+    body = request.get_json(silent=True) or {}
+    bundles, err = _parse_bundles_body(body)
+    if err == "missing":
+        return jsonify({"error": "missing bundles"}), 400
+    if err == "empty":
+        return jsonify({"error": "empty bundles"}), 400
+    if err == "bundles_must_be_list":
+        return jsonify({"error": "bundles must be a list"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        if tier_in not in _ent._TIER_ORDER:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "tier", "tier": tier_in}
+                ),
+                404,
+            )
+        rows = _ent.missing_runtimes_bundle_batch_at(tier_in, bundles) or []
+        out_rows = [_missing_bundle_row_at_body(row, "runtimes") for row in rows]
+        env = _perspective_envelope(_ent, tier_in)
+        return jsonify(
+            {
+                **env,
+                "bundles": out_rows,
+                "count": len(out_rows),
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_missing_runtimes_bundle_batch_at: error: %s", exc
         )
         env = _perspective_fallback(tier_in)
         return jsonify(

--- a/tests/test_entitlement_missing_bundle_batch_at.py
+++ b/tests/test_entitlement_missing_bundle_batch_at.py
@@ -1,0 +1,660 @@
+"""Tests for the perspective-shaped bundle-batch
+``/api/entitlement/missing-features-bundle-batch-at`` and
+``/api/entitlement/missing-runtimes-bundle-batch-at`` endpoints.
+
+Hypothetical-perspective row-detail sibling of the LIVE
+``/api/entitlement/missing-features-bundle-batch`` /
+``/api/entitlement/missing-runtimes-bundle-batch`` endpoints (which fold
+N bundles' per-item denial lists against the resolved entitlement),
+scoped by a caller-supplied ``tier=<perspective>`` query arg. Wraps the
+:func:`clawmetry.entitlements.missing_features_bundle_batch_at` /
+:func:`clawmetry.entitlements.missing_runtimes_bundle_batch_at` helpers.
+
+Fills the ``_at`` slot on the per-axis row-detail bundle-batch family
+alongside the aggregate ``/api/entitlement/missing-all-bundle-batch-at``
+and the boolean-fold ``/api/entitlement/has-{features,runtimes}-bundle-
+batch-at`` so a caller can render the per-axis "which items would
+<perspective> still deny?" column of a pricing matrix off ONE call per
+axis per perspective instead of N calls to ``/missing-features-at`` /
+``/missing-runtimes-at``.
+
+These tests pin:
+
+* helper: perspective validation (empty / non-string / unknown ->
+  ``None``; known tier -> ``list[dict]``)
+* helper: per-bundle normalisation (whitespace, lowercase, dedup
+  preserving first-seen), unknown-id bucketing (surfaces via
+  ``unknown[]`` rather than silently rendering "denied"), runtime
+  alias canonicalisation, empty / all-unknown / ``None`` bundles
+  surface as stable rows with ``missing_*_at=[]``
+* helper: per-row parity with the singular scalar
+  ``missing_features_at`` / ``missing_runtimes_at`` on the KNOWN slice
+* helper: ``bundles`` handling (``None`` / non-iterable -> ``[]``;
+  ``None`` bundle -> empty row)
+* helper: **grace-independence** -- the perspective-shaped fold is
+  byte-identical under grace vs enforce (delegates to
+  :func:`missing_features_at` / :func:`missing_runtimes_at`, both
+  backed by the static per-tier grant tables)
+* helper: perspective divergence -- at ``oss`` a paid-feature bundle
+  reports ``missing_features_at=["fleet"]`` even in grace, whereas
+  the LIVE :func:`missing_features_bundle_batch` reports
+  ``missing=[]`` on the same bundle via grace pass-through
+* helper: **complement invariant** with
+  :func:`has_features_bundle_batch_at` /
+  :func:`has_runtimes_bundle_batch_at` -- for every fully-known bundle,
+  ``bool(row["missing_<axis>_at"]) == (not has_row["has_<axis>_at"])``
+* API: 400 on missing / blank ``tier``; 404 on unknown ``tier``
+  (with ``which=tier`` in the body)
+* API: 400 on missing / non-list / empty ``bundles``
+* API: happy-path envelope layers ``perspective_tier`` /
+  ``perspective_tier_label`` / ``perspective_tier_rank`` on top of the
+  bare batch envelope; each row carries the perspective-shaped
+  ``missing_features_at`` / ``missing_runtimes_at`` fold slot
+* API: single-list ``{"bundles": ["fleet", "sso"]}`` shorthand
+* API: runtime alias canonicalisation happens through the endpoint
+* API: never-5xxs on a delegate crash (monkey-patched helper raises)
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+# -- Fixtures ----------------------------------------------------------------
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def enforced(monkeypatch, tmp_path):
+    """Enforcement-on fixture. Perspective-shaped ``_at`` answers are
+    intentionally byte-identical in grace and enforce; this fixture
+    pins that invariant against the singular ``_at`` delegates."""
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    importlib.reload(e)
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# -- Helper: perspective validation ------------------------------------------
+
+
+@pytest.mark.parametrize("bad", [None, "", "   ", "bogus", "Pro+", 42, object()])
+def test_helper_features_none_on_bad_perspective(ent, bad):
+    assert ent.missing_features_bundle_batch_at(bad, [["fleet"]]) is None
+
+
+@pytest.mark.parametrize("bad", [None, "", "   ", "bogus", 42, object()])
+def test_helper_runtimes_none_on_bad_perspective(ent, bad):
+    assert ent.missing_runtimes_bundle_batch_at(bad, [["openclaw"]]) is None
+
+
+def test_helper_features_accepts_all_known_tiers(ent):
+    for tid in ent._TIER_ORDER:
+        rows = ent.missing_features_bundle_batch_at(tid, [["fleet"]])
+        assert isinstance(rows, list)
+
+
+# -- Helper: bundle normalisation --------------------------------------------
+
+
+def test_helper_features_dedups_and_lowers(ent):
+    rows = ent.missing_features_bundle_batch_at(
+        "enterprise", [["fleet", "", "FLEET", "sso"], ["otel_export"]]
+    )
+    assert len(rows) == 2
+    assert rows[0]["features"] == ["fleet", "sso"]
+    assert rows[0]["unknown"] == []
+    assert rows[0]["count"] == 2
+    assert rows[1]["features"] == ["otel_export"]
+
+
+def test_helper_features_buckets_unknown(ent):
+    """Unknown tokens are echoed via ``unknown[]`` and drop from the
+    ``missing_features_at`` walk -- a typo surfaces at the callsite
+    rather than silently rendering as ``denied``."""
+    rows = ent.missing_features_bundle_batch_at(
+        "enterprise", [["fleet", "bogus"]]
+    )
+    assert rows[0]["features"] == ["fleet"]
+    assert rows[0]["unknown"] == ["bogus"]
+    # Fleet IS granted at enterprise -- KNOWN slice is fully granted -> [].
+    assert rows[0]["missing_features_at"] == []
+
+
+def test_helper_features_empty_bundle_stable_row(ent):
+    rows = ent.missing_features_bundle_batch_at("pro", [[]])
+    assert len(rows) == 1
+    assert rows[0] == {
+        "features": [],
+        "unknown": [],
+        "kind": "features",
+        "count": 0,
+        "missing_features_at": [],
+    }
+
+
+def test_helper_features_all_unknown_stable_row(ent):
+    rows = ent.missing_features_bundle_batch_at("pro", [["bogus1", "bogus2"]])
+    r = rows[0]
+    assert r["features"] == []
+    assert r["unknown"] == ["bogus1", "bogus2"]
+    assert r["count"] == 0
+    # All-unknown -> nothing known to check -> [] (matches
+    # missing_features_at empty-[] posture).
+    assert r["missing_features_at"] == []
+
+
+def test_helper_features_none_bundle_stable_row(ent):
+    rows = ent.missing_features_bundle_batch_at("pro", [None, ["fleet"]])
+    assert len(rows) == 2
+    assert rows[0] == {
+        "features": [],
+        "unknown": [],
+        "kind": "features",
+        "count": 0,
+        "missing_features_at": [],
+    }
+    assert rows[1]["features"] == ["fleet"]
+
+
+def test_helper_features_non_string_tokens_coerce(ent):
+    rows = ent.missing_features_bundle_batch_at("enterprise", [[42, "fleet"]])
+    assert rows[0]["features"] == ["fleet"]
+    assert "42" in rows[0]["unknown"]
+    # Fleet IS granted at enterprise; KNOWN slice fully granted -> [].
+    assert rows[0]["missing_features_at"] == []
+
+
+def test_helper_features_none_bundles_returns_empty(ent):
+    assert ent.missing_features_bundle_batch_at("pro", None) == []
+
+
+def test_helper_features_non_iterable_bundles_returns_empty(ent):
+    assert ent.missing_features_bundle_batch_at("pro", 42) == []
+
+
+def test_helper_runtimes_canonicalises_aliases(ent):
+    rows = ent.missing_runtimes_bundle_batch_at(
+        "pro", [["claude-code", "codex", "claude_code"]]
+    )
+    # Canonicalisation + dedup after canonicalisation.
+    assert rows[0]["runtimes"] == ["claude_code", "codex"]
+    assert rows[0]["unknown"] == []
+
+
+def test_helper_runtimes_buckets_unknown(ent):
+    rows = ent.missing_runtimes_bundle_batch_at(
+        "pro", [["claude_code", "bogus_rt"]]
+    )
+    assert rows[0]["runtimes"] == ["claude_code"]
+    assert rows[0]["unknown"] == ["bogus_rt"]
+    # Pro grants claude_code -> KNOWN slice fully granted -> [].
+    assert rows[0]["missing_runtimes_at"] == []
+
+
+def test_helper_runtimes_none_bundles_returns_empty(ent):
+    assert ent.missing_runtimes_bundle_batch_at("pro", None) == []
+
+
+def test_helper_runtimes_free_runtime_empty_at_every_perspective(ent):
+    """Free runtimes are granted at every tier -- the row's
+    ``missing_runtimes_at`` list is empty regardless of perspective."""
+    for perspective in ent._TIER_ORDER:
+        rows = ent.missing_runtimes_bundle_batch_at(
+            perspective, [["openclaw"]]
+        )
+        assert rows[0]["missing_runtimes_at"] == [], perspective
+
+
+# -- Helper: per-row parity with the singular scalar --------------------------
+
+
+def test_helper_features_per_row_parity_with_scalar(ent):
+    """Per-row ``missing_features_at`` byte-equals
+    :func:`missing_features_at` on the KNOWN slice for every
+    (perspective, bundle) pair."""
+    bundles = [
+        ["fleet", "sso"],
+        ["otel_export"],
+        ["fleet"],
+        ["sso"],
+        [],
+    ]
+    for perspective in ("oss", "cloud_starter", "pro", "enterprise"):
+        rows = ent.missing_features_bundle_batch_at(perspective, bundles)
+        assert rows is not None
+        for row, bundle in zip(rows, bundles):
+            seen: set[str] = set()
+            known: list[str] = []
+            for tok in bundle:
+                s = tok.strip().lower()
+                if s and s in ent.ALL_FEATURES and s not in seen:
+                    seen.add(s)
+                    known.append(s)
+            singular = (
+                list(ent.missing_features_at(perspective, known))
+                if known
+                else []
+            )
+            assert row["missing_features_at"] == singular, (
+                perspective,
+                bundle,
+                singular,
+            )
+
+
+def test_helper_runtimes_per_row_parity_with_scalar(ent):
+    bundles = [
+        ["openclaw"],
+        ["claude-code", "codex"],
+        ["claude_code"],
+        [],
+    ]
+    for perspective in ("oss", "cloud_starter", "pro", "enterprise"):
+        rows = ent.missing_runtimes_bundle_batch_at(perspective, bundles)
+        assert rows is not None
+        for row, bundle in zip(rows, bundles):
+            seen: set[str] = set()
+            known: list[str] = []
+            for tok in bundle:
+                c = ent.canonical_runtime(tok.strip().lower())
+                if c and c in ent.ALL_RUNTIMES and c not in seen:
+                    seen.add(c)
+                    known.append(c)
+            singular = (
+                list(ent.missing_runtimes_at(perspective, known))
+                if known
+                else []
+            )
+            assert row["missing_runtimes_at"] == singular, (
+                perspective,
+                bundle,
+                singular,
+            )
+
+
+# -- Helper: perspective divergence from LIVE --------------------------------
+
+
+def test_helper_features_oss_diverges_from_live_grace(ent):
+    """At ``oss`` a paid-feature bundle reports the item as missing in
+    grace, whereas the LIVE :func:`missing_features_bundle_batch`
+    reports ``missing=[]`` on the same bundle via grace pass-through.
+    That divergence is the whole point of the ``_at`` slot."""
+    live = ent.missing_features_bundle_batch([["fleet"]])
+    at_oss = ent.missing_features_bundle_batch_at("oss", [["fleet"]])
+    assert live[0]["missing"] == []  # grace pass-through
+    assert at_oss[0]["missing_features_at"] == ["fleet"]  # static per-tier
+
+
+def test_helper_runtimes_oss_diverges_from_live_grace(ent):
+    live = ent.missing_runtimes_bundle_batch([["claude_code"]])
+    at_oss = ent.missing_runtimes_bundle_batch_at("oss", [["claude_code"]])
+    assert live[0]["missing"] == []
+    assert at_oss[0]["missing_runtimes_at"] == ["claude_code"]
+
+
+# -- Helper: grace vs enforce invariance -------------------------------------
+
+
+def test_helper_features_grace_enforce_identical(ent, enforced):
+    """Perspective-shaped fold is byte-identical under grace vs enforce."""
+    bundles = [["fleet", "sso"], ["otel_export"], ["bogus"], []]
+    for perspective in ("oss", "cloud_starter", "pro", "enterprise"):
+        rows_grace = ent.missing_features_bundle_batch_at(perspective, bundles)
+        rows_enf = enforced.missing_features_bundle_batch_at(
+            perspective, bundles
+        )
+        assert rows_grace == rows_enf, perspective
+
+
+def test_helper_runtimes_grace_enforce_identical(ent, enforced):
+    bundles = [["openclaw"], ["claude_code"], ["bogus_rt"], []]
+    for perspective in ("oss", "cloud_starter", "pro", "enterprise"):
+        rows_grace = ent.missing_runtimes_bundle_batch_at(perspective, bundles)
+        rows_enf = enforced.missing_runtimes_bundle_batch_at(
+            perspective, bundles
+        )
+        assert rows_grace == rows_enf, perspective
+
+
+# -- Helper: complement invariant with has_...bundle_batch_at ----------------
+
+
+def test_helper_features_complement_invariant_with_has(ent):
+    """For every fully-known bundle,
+    ``bool(missing_features_at) == (not has_features_at)`` -- pins the
+    row-detail seat as the exact perspective-shaped negation of the
+    boolean-fold seat."""
+    bundles = [
+        ["fleet", "sso"],
+        ["otel_export"],
+        ["fleet"],
+        ["sso"],
+    ]
+    for perspective in ("oss", "cloud_starter", "pro", "enterprise"):
+        has_rows = ent.has_features_bundle_batch_at(perspective, bundles)
+        miss_rows = ent.missing_features_bundle_batch_at(perspective, bundles)
+        for h, m in zip(has_rows, miss_rows):
+            # Fully-known bundle -> unknown[] is empty on both sides.
+            assert h["unknown"] == [] and m["unknown"] == []
+            assert bool(m["missing_features_at"]) == (
+                not h["has_features_at"]
+            ), (perspective, h, m)
+
+
+def test_helper_runtimes_complement_invariant_with_has(ent):
+    bundles = [
+        ["openclaw"],
+        ["claude_code"],
+        ["claude_code", "codex"],
+    ]
+    for perspective in ("oss", "cloud_starter", "pro", "enterprise"):
+        has_rows = ent.has_runtimes_bundle_batch_at(perspective, bundles)
+        miss_rows = ent.missing_runtimes_bundle_batch_at(perspective, bundles)
+        for h, m in zip(has_rows, miss_rows):
+            assert h["unknown"] == [] and m["unknown"] == []
+            assert bool(m["missing_runtimes_at"]) == (
+                not h["has_runtimes_at"]
+            ), (perspective, h, m)
+
+
+# -- API: error paths --------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/api/entitlement/missing-features-bundle-batch-at",
+        "/api/entitlement/missing-runtimes-bundle-batch-at",
+    ],
+)
+def test_api_missing_tier_400(client, path):
+    r = client.post(path, json={"bundles": [["fleet"]]})
+    assert r.status_code == 400
+    assert r.get_json() == {"error": "missing tier"}
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/api/entitlement/missing-features-bundle-batch-at",
+        "/api/entitlement/missing-runtimes-bundle-batch-at",
+    ],
+)
+def test_api_blank_tier_400(client, path):
+    r = client.post(f"{path}?tier=   ", json={"bundles": [["fleet"]]})
+    assert r.status_code == 400
+    assert r.get_json() == {"error": "missing tier"}
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/api/entitlement/missing-features-bundle-batch-at",
+        "/api/entitlement/missing-runtimes-bundle-batch-at",
+    ],
+)
+def test_api_unknown_tier_404(client, path):
+    r = client.post(f"{path}?tier=bogus", json={"bundles": [["fleet"]]})
+    assert r.status_code == 404
+    body = r.get_json()
+    assert body["error"] == "unknown tier"
+    assert body["which"] == "tier"
+    assert body["tier"] == "bogus"
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/api/entitlement/missing-features-bundle-batch-at",
+        "/api/entitlement/missing-runtimes-bundle-batch-at",
+    ],
+)
+def test_api_missing_bundles_400(client, path):
+    r = client.post(f"{path}?tier=pro", json={})
+    assert r.status_code == 400
+    assert r.get_json() == {"error": "missing bundles"}
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/api/entitlement/missing-features-bundle-batch-at",
+        "/api/entitlement/missing-runtimes-bundle-batch-at",
+    ],
+)
+def test_api_empty_bundles_400(client, path):
+    r = client.post(f"{path}?tier=pro", json={"bundles": []})
+    assert r.status_code == 400
+    assert r.get_json() == {"error": "empty bundles"}
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/api/entitlement/missing-features-bundle-batch-at",
+        "/api/entitlement/missing-runtimes-bundle-batch-at",
+    ],
+)
+def test_api_scalar_bundles_400(client, path):
+    r = client.post(f"{path}?tier=pro", json={"bundles": 42})
+    assert r.status_code == 400
+    assert r.get_json() == {"error": "bundles must be a list"}
+
+
+# -- API: happy path envelope shape ------------------------------------------
+
+
+def test_api_features_envelope_shape(client):
+    r = client.post(
+        "/api/entitlement/missing-features-bundle-batch-at?tier=enterprise",
+        json={"bundles": [["fleet", "sso"], ["bogus"], []]},
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    expected_keys = {
+        "perspective_tier",
+        "perspective_tier_label",
+        "perspective_tier_rank",
+        "current_tier",
+        "current_tier_rank",
+        "grace",
+        "enforced",
+        "bundles",
+        "count",
+    }
+    assert set(body) == expected_keys
+    assert body["perspective_tier"] == "enterprise"
+    assert body["perspective_tier_label"] == "Enterprise"
+    assert body["perspective_tier_rank"] == 3
+    assert body["count"] == 3
+    row_keys = {
+        "features",
+        "unknown",
+        "kind",
+        "count",
+        "missing_features_at",
+    }
+    for row in body["bundles"]:
+        assert set(row) == row_keys
+        assert row["kind"] == "features"
+
+
+def test_api_runtimes_envelope_shape(client):
+    r = client.post(
+        "/api/entitlement/missing-runtimes-bundle-batch-at?tier=pro",
+        json={"bundles": [["claude-code"], ["openclaw"]]},
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["perspective_tier"] == "pro"
+    row_keys = {
+        "runtimes",
+        "unknown",
+        "kind",
+        "count",
+        "missing_runtimes_at",
+    }
+    for row in body["bundles"]:
+        assert set(row) == row_keys
+        assert row["kind"] == "runtimes"
+
+
+# -- API: fold answers -------------------------------------------------------
+
+
+def test_api_features_enterprise_grants_all(client):
+    r = client.post(
+        "/api/entitlement/missing-features-bundle-batch-at?tier=enterprise",
+        json={"bundles": [["fleet", "sso"]]},
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["bundles"][0]["missing_features_at"] == []
+
+
+def test_api_features_oss_denies_paid(client):
+    r = client.post(
+        "/api/entitlement/missing-features-bundle-batch-at?tier=oss",
+        json={"bundles": [["fleet"]]},
+    )
+    assert r.status_code == 200
+    assert r.get_json()["bundles"][0]["missing_features_at"] == ["fleet"]
+
+
+def test_api_runtimes_alias_canonicalises_through_endpoint(client):
+    r = client.post(
+        "/api/entitlement/missing-runtimes-bundle-batch-at?tier=pro",
+        json={"bundles": [["claude-code"]]},
+    )
+    assert r.status_code == 200
+    row = r.get_json()["bundles"][0]
+    # Alias canonicalises into the row's runtimes list.
+    assert row["runtimes"] == ["claude_code"]
+    # Pro grants claude_code -> nothing missing at this perspective.
+    assert row["missing_runtimes_at"] == []
+
+
+def test_api_runtimes_oss_free_runtime_empty(client):
+    r = client.post(
+        "/api/entitlement/missing-runtimes-bundle-batch-at?tier=oss",
+        json={"bundles": [["openclaw"]]},
+    )
+    assert r.status_code == 200
+    row = r.get_json()["bundles"][0]
+    assert row["runtimes"] == ["openclaw"]
+    assert row["missing_runtimes_at"] == []
+
+
+def test_api_runtimes_oss_denies_paid_runtime(client):
+    r = client.post(
+        "/api/entitlement/missing-runtimes-bundle-batch-at?tier=oss",
+        json={"bundles": [["claude_code"]]},
+    )
+    assert r.status_code == 200
+    assert r.get_json()["bundles"][0]["missing_runtimes_at"] == [
+        "claude_code"
+    ]
+
+
+# -- API: shorthand ----------------------------------------------------------
+
+
+def test_api_features_bare_list_shorthand_treated_as_one_bundle(client):
+    r = client.post(
+        "/api/entitlement/missing-features-bundle-batch-at?tier=oss",
+        json={"bundles": ["fleet", "sso"]},
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["count"] == 1
+    assert body["bundles"][0]["features"] == ["fleet", "sso"]
+    # OSS grants neither.
+    assert set(body["bundles"][0]["missing_features_at"]) == {"fleet", "sso"}
+
+
+# -- API: per-row parity with helper -----------------------------------------
+
+
+def test_api_features_row_parity_with_helper(client, ent):
+    r = client.post(
+        "/api/entitlement/missing-features-bundle-batch-at?tier=oss",
+        json={"bundles": [["fleet", "sso"], ["bogus"], []]},
+    )
+    assert r.status_code == 200
+    api_rows = r.get_json()["bundles"]
+    helper_rows = ent.missing_features_bundle_batch_at(
+        "oss", [["fleet", "sso"], ["bogus"], []]
+    )
+    for api_row, helper_row in zip(api_rows, helper_rows):
+        assert api_row["features"] == helper_row["features"]
+        assert api_row["unknown"] == helper_row["unknown"]
+        assert api_row["kind"] == helper_row["kind"]
+        assert api_row["count"] == helper_row["count"]
+        assert (
+            api_row["missing_features_at"] == helper_row["missing_features_at"]
+        )
+
+
+# -- API: never-5xx on delegate crash ----------------------------------------
+
+
+def test_api_features_never_5xx_on_helper_crash(client, monkeypatch, ent):
+    def boom(*_a, **_kw):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(ent, "missing_features_bundle_batch_at", boom)
+    r = client.post(
+        "/api/entitlement/missing-features-bundle-batch-at?tier=pro",
+        json={"bundles": [["fleet"]]},
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["bundles"] == []
+    assert body["count"] == 0
+    assert body["perspective_tier"] == "pro"
+
+
+def test_api_runtimes_never_5xx_on_helper_crash(client, monkeypatch, ent):
+    def boom(*_a, **_kw):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(ent, "missing_runtimes_bundle_batch_at", boom)
+    r = client.post(
+        "/api/entitlement/missing-runtimes-bundle-batch-at?tier=pro",
+        json={"bundles": [["claude_code"]]},
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["bundles"] == []
+    assert body["count"] == 0
+    assert body["perspective_tier"] == "pro"


### PR DESCRIPTION
## Summary

- Adds `missing_features_bundle_batch_at(perspective_tier, bundles)` and `missing_runtimes_bundle_batch_at(perspective_tier, bundles)` in `clawmetry/entitlements.py` — the perspective-shaped row-detail siblings of `missing_features_bundle_batch` / `missing_runtimes_bundle_batch`. Fills the `_at` slot on the per-axis row-detail bundle-batch family alongside the aggregate `missing_all_bundle_batch_at` and the boolean-fold `has_features_bundle_batch_at` / `has_runtimes_bundle_batch_at` (#4957).
- Wires `POST /api/entitlement/missing-features-bundle-batch-at?tier=<perspective>` and `POST /api/entitlement/missing-runtimes-bundle-batch-at?tier=<perspective>` on `bp_entitlement` (`routes/entitlement.py`), same envelope conventions as the paired `has-*-bundle-batch-at` endpoints.
- Grace-independent by construction (each row delegates to `missing_features_at` / `missing_runtimes_at`, backed by `_hypothetical_entitlement`), so the LIVE resolver and grace posture are unchanged — no behaviour shift.

## Row shape

Byte-parity with `missing_features_bundle_batch` on the axis-echo slots; fold slot renamed `missing_features_at` / `missing_runtimes_at` to match the singular scalar:

```
{
  "features":            ["fleet", "sso"],
  "unknown":             ["bogus"],
  "kind":                "features",
  "count":               2,
  "missing_features_at": [<subset denied at perspective>],
}
```

Response envelope layers `perspective_tier` / `perspective_tier_label` / `perspective_tier_rank` on top of the bare batch envelope. `400` on missing / blank `tier` and missing / non-list / empty `bundles`; `404` with `which=tier` on unknown `tier`; **never 5xxs** (a delegate crash yields the fallback envelope so the paywall matrix keeps rendering).

## Complement invariant

For every fully-known bundle across every perspective tier:

    bool(row["missing_<axis>_at"]) == (not has_row["has_<axis>_at"])

Pinned in the test suite alongside per-row parity with the singular `missing_features_at` / `missing_runtimes_at` scalars.

## Test plan

- [x] `python3 -m py_compile clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_missing_bundle_batch_at.py`
- [x] New tests pass: `pytest tests/test_entitlement_missing_bundle_batch_at.py -q` — 57 passed
- [x] Adjacent siblings still pass: `pytest tests/test_entitlement_has_bundle_batch_at.py tests/test_entitlement_missing_all_bundle_batch_at.py -q` — 153 passed
- [x] Lint delta on the changed files: no new rule classes (existing `S112` / `BLE001` are the module's deliberate never-raise convention; `I001` on the test file matches the sibling `test_entitlement_has_bundle_batch_at.py` layout byte-for-byte)

## Local operator verification checklist

Since the remote sandbox can't reach the daemon, live cloud snapshot, or a browser, the operator should confirm on the host:

- [ ] `cp clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_missing_bundle_batch_at.py` into `~/.clawmetry/lib/python3.X/site-packages/clawmetry/` (and the local `routes/` / `tests/` mirrors)
- [ ] `find ~/.clawmetry -name __pycache__ -type d -exec rm -rf {} +`
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
- [ ] `curl -sS 'http://localhost:8900/api/entitlement/missing-features-bundle-batch-at?tier=oss' -X POST -H 'content-type: application/json' -d '{"bundles":[["fleet"],["sso"],["openclaw"]]}' | jq` — row 1 & 2 report `missing_features_at:["fleet"]` / `["sso"]`; row 3 buckets `openclaw` into `unknown[]` with `missing_features_at:[]`
- [ ] `curl -sS 'http://localhost:8900/api/entitlement/missing-runtimes-bundle-batch-at?tier=oss' -X POST -H 'content-type: application/json' -d '{"bundles":[["claude-code"],["openclaw"]]}' | jq` — alias canonicalises to `claude_code`; free runtime reports `missing_runtimes_at:[]`
- [ ] Decrypt the live snapshot in the browser and confirm no regressions on the existing bundle-batch surfaces

---
_Generated by [Claude Code](https://claude.ai/code/session_014TUdV8w8bkDgv4jbQbNLk7)_