### PR TITLE
[RELEASE] Risk chips on legacy audit rows + clean command preview on hook approvals

### DIFF
--- a/routes/policy.py
+++ b/routes/policy.py
@@ -58,6 +58,9 @@ def _arg_preview(args) -> str:
     """Short single-line preview of tool-call arguments — never the full body."""
     if args is None:
         return ""
+    if isinstance(args, dict) and isinstance(args.get("tool_input"), dict) \
+            and str(args.get("source") or "").endswith("-hook"):
+        args = args["tool_input"]
     if isinstance(args, dict):
         for k in ("command", "cmd", "tool", "path", "url"):
             v = args.get(k)
@@ -73,17 +76,28 @@ def _arg_preview(args) -> str:
 
 
 def _row_risk(r) -> "dict | None":
-    """Risk verdict stamped into an approval row's args blob under the
-    namespaced ``_cm_risk`` key (clawmetry/tool_risk.py via the watcher and
-    the pre-tool hook receiver). None for rows written before the risk
-    classifier shipped — the UI simply shows no chip."""
+    """Risk verdict for an approval row.
+
+    Prefers the ``_cm_risk`` verdict stamped at write time (watcher / hook
+    receiver); rows written before the classifier shipped are classified
+    at read time from their recorded tool + args so the whole audit
+    history carries chips, not just new rows. Never raises; None only
+    when there is nothing to classify."""
     args = r.get("args")
     if isinstance(args, dict):
         risk = args.get("_cm_risk")
         if isinstance(risk, dict) and risk.get("level"):
             return {"level": str(risk.get("level")),
                     "reasons": [str(x) for x in (risk.get("reasons") or [])][:4]}
-    return None
+    try:
+        from clawmetry.tool_risk import classify_tool_call
+        tool, raw = _row_tool_and_args(r)
+        if not tool:
+            return None
+        v = classify_tool_call(tool, raw)
+        return {"level": v["level"], "reasons": v["reasons"][:4]}
+    except Exception:
+        return None
 
 
 @bp_policy.route("/api/tool-policy")

--- a/tests/test_tool_risk_remember_flow.py
+++ b/tests/test_tool_risk_remember_flow.py
@@ -199,3 +199,20 @@ def test_watcher_session_allow_short_circuit(harness, monkeypatch):
     auto = next(r for r in rows if r.get("status") == "auto_approved")
     args = auto.get("args") or {}
     assert (args.get("_cm_risk") or {}).get("level") == "high"
+
+
+def test_audit_classifies_legacy_rows_and_previews_hook_command():
+    """Rows written before the classifier shipped still get a risk chip
+    (classified at read time), and hook-receiver rows preview the COMMAND
+    the human must judge, not the internal meta blob."""
+    from routes.policy import _row_risk, _arg_preview
+    legacy = {"id": "l", "action": "Bash: git push --force origin main",
+              "args": {"command": "git push --force origin main"}}
+    assert _row_risk(legacy)["level"] == "high"
+    hook_args = {"source": "pretooluse-hook", "tool_name": "Bash",
+                 "tool_input": {"command": "rm -rf /tmp/x"}, "cwd": "/tmp"}
+    assert _arg_preview(hook_args) == "rm -rf /tmp/x"
+    assert _row_risk({"id": "h", "action": "Bash: rm -rf /tmp/x",
+                      "args": hook_args})["level"] == "high"
+    # Nothing to classify → no chip, no crash.
+    assert _row_risk({"id": "e", "action": "", "args": None}) is None


### PR DESCRIPTION
Follow-up to #4964, found by eyeballing the rendered UI on the released build.

- **Policy tab audit**: rows written before the classifier shipped had no risk pill (risk was only stamped at write time). `_row_risk` now classifies at read time from the row's tool + args when `_cm_risk` is absent — verified on the founder box: 16/16 historical rows now carry chips (all correctly HIGH: `rm -rf`, `--force`).
- **Pending approvals from the PreToolUse hook**: args preview showed the internal meta blob (`{"source":"pretooluse-hook","tool_input":...}`) instead of the command. `_arg_preview` unwraps hook rows to `tool_input`.

Screens (Playwright, released code): risk preset card on Approvals tab, pending row with HIGH RISK chip + Approve-for-session / Always-allow buttons and clean `rm -rf /tmp/demo-canary` preview, rule editor with Minimum risk level select, Brain feed MEDIUM chips inline, Policy tab audit with HIGH pills on every legacy row.

Test added: `test_audit_classifies_legacy_rows_and_previews_hook_command`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)