### PR TITLE
fix(desktop): supervisor died mid-upgrade and froze every tab for 6h39m

### DIFF
--- a/clawmetry/static/js/auth-bootstrap.js
+++ b/clawmetry/static/js/auth-bootstrap.js
@@ -312,19 +312,146 @@ function clawmetryLocalSignin(){
       if(err) err.style.display='block';
     });
 }
-// Inject auth header into all fetch calls
+// Inject auth header into all fetch calls, and notice when the backend
+// stops answering at all.
+//
+// A dead local backend rejects every fetch with a network-level TypeError
+// ("Load failed" in WebKit, "Failed to fetch" in Chromium) -- no status, no
+// response. Each panel used to absorb that on its own, so a machine-wide
+// outage rendered as a dozen unrelated "Loading..." spinners and one
+// unhelpful per-panel Retry. On 2026-08-17 a desktop user sat in front of
+// that for over six hours with nothing telling them the backend was gone.
+// This is the one place every /api/ call passes through, so the global
+// outage signal belongs here.
 (function(){
   var _origFetch=window.fetch;
+  var _netFail=0;
+  // One transient failure means nothing (a restart, a sleep/wake, a
+  // navigation racing an in-flight request). Three in a row is an outage.
+  var FAIL_THRESHOLD=3;
+
+  function _isNetworkError(e){
+    // Never treat an HTTP error status as an outage -- those resolve.
+    return !!e && (e.name==='TypeError' || e instanceof TypeError);
+  }
+
   window.fetch=function(url,opts){
     var tok=localStorage.getItem('clawmetry-token');
-    if(tok && typeof url==='string' && url.startsWith('/api/')){
+    var isApi=(typeof url==='string' && url.startsWith('/api/'));
+    if(tok && isApi){
       opts=opts||{};
       opts.headers=opts.headers||{};
       if(opts.headers instanceof Headers){opts.headers.set('Authorization','Bearer '+tok);}
       else{opts.headers['Authorization']='Bearer '+tok;}
     }
-    return _origFetch.call(this,url,opts);
+    if(!isApi) return _origFetch.call(this,url,opts);
+    return _origFetch.call(this,url,opts).then(function(r){
+      // Any answer at all -- even a 500 -- means the backend is reachable.
+      if(_netFail!==0){
+        _netFail=0;
+        window.dispatchEvent(new CustomEvent('cm:backend-reachable'));
+      }
+      return r;
+    },function(e){
+      if(_isNetworkError(e)){
+        _netFail++;
+        if(_netFail===FAIL_THRESHOLD){
+          window.dispatchEvent(new CustomEvent('cm:backend-unreachable',
+            {detail:{url:String(url)}}));
+        }
+      }
+      throw e;
+    });
   };
+  window.cmBackendFailures=function(){return _netFail;};
+})();
+
+// ── Global "backend unreachable" overlay ──
+// The recovery surface of last resort. Rendered on top of every tab, so it
+// cannot be missed the way a per-panel spinner can, and it always offers an
+// action. Inside the desktop shell the pywebview JS bridge still works when
+// the HTTP origin does not, so prefer it; in a browser tab, reload.
+(function(){
+  var BAR_ID='cm-backend-outage';
+
+  function _bridge(){
+    try{
+      return (window.pywebview && window.pywebview.api) ? window.pywebview.api : null;
+    }catch(e){ return null; }
+  }
+
+  function _dismiss(){
+    var el=document.getElementById(BAR_ID);
+    if(el && el.parentNode) el.parentNode.removeChild(el);
+  }
+
+  function _show(){
+    if(document.getElementById(BAR_ID)) return;
+    var api=_bridge();
+    var el=document.createElement('div');
+    el.id=BAR_ID;
+    el.setAttribute('role','alert');
+    el.style.cssText=[
+      'position:fixed','left:50%','transform:translateX(-50%)','bottom:24px',
+      'z-index:2147483000','max-width:min(640px,92vw)',
+      'display:flex','align-items:center','gap:14px','flex-wrap:wrap',
+      'padding:14px 18px','border-radius:12px',
+      'background:#2a1215','border:1px solid #7f1d1d','color:#fecaca',
+      'box-shadow:0 12px 32px rgba(0,0,0,.45)',
+      'font:14px/1.45 -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif'
+    ].join(';');
+
+    var msg=document.createElement('div');
+    msg.style.cssText='flex:1 1 260px;min-width:220px';
+    msg.innerHTML='<strong style="color:#fca5a5">Cannot reach the ClawMetry '
+      +'backend on this machine.</strong><br>'
+      +'<span style="color:#f3b5b5">Numbers on every tab are frozen at their '
+      +'last known values.</span>';
+    el.appendChild(msg);
+
+    var btn=document.createElement('button');
+    btn.type='button';
+    btn.style.cssText=[
+      'cursor:pointer','white-space:nowrap','padding:8px 16px',
+      'border-radius:8px','border:1px solid #ef4444','background:#ef4444',
+      'color:#fff','font-weight:600','font-size:13px'
+    ].join(';');
+    btn.textContent=(api&&api.restart_backend)?'Restart backend':'Reload';
+    btn.onclick=function(){
+      btn.disabled=true;
+      btn.textContent='Restarting…';
+      if(api&&api.restart_backend){
+        try{
+          api.restart_backend();
+          // The shell reloads the window itself once the daemon answers.
+          // If it cannot, re-enable so the user can try again.
+          setTimeout(function(){
+            btn.disabled=false;
+            btn.textContent='Restart backend';
+          },20000);
+          return;
+        }catch(e){}
+      }
+      location.reload();
+    };
+    el.appendChild(btn);
+
+    // Honest fallback for the case the shell cannot fix itself.
+    if(!(api&&api.restart_backend)){
+      var hint=document.createElement('div');
+      hint.style.cssText='flex-basis:100%;font-size:12px;color:#e7a3a3';
+      hint.textContent='If reloading does not help, quit ClawMetry and open '
+        +'it again.';
+      el.appendChild(hint);
+    }
+    (document.body||document.documentElement).appendChild(el);
+  }
+
+  window.addEventListener('cm:backend-unreachable',_show);
+  window.addEventListener('cm:backend-reachable',_dismiss);
+  // Exposed for tests and for panels that want to raise it directly.
+  window.cmShowBackendOutage=_show;
+  window.cmHideBackendOutage=_dismiss;
 })();
 
 // ── Version badge + one-click update ──

--- a/desktop/app.py
+++ b/desktop/app.py
@@ -42,6 +42,7 @@ import subprocess
 import sys
 import threading
 import time
+import traceback
 import urllib.request
 from pathlib import Path
 from typing import Callable, Optional
@@ -90,6 +91,12 @@ SHUTDOWN_WAIT_SECS = 5.0
 # See WATCHER_UPDATE_TIMEOUT_SECS. Lowering the cadence did not create these;
 # it just removed the last reason to keep tolerating them.
 UPGRADE_CHECK_INTERVAL_SECS = 60
+# Hard bound on any pywebview call made from a background thread. The
+# Cocoa backend's evaluate_js/load_url block the caller on an UNBOUNDED
+# Semaphore.acquire() (webview/platforms/cocoa.py:916) that a wedged or
+# dead WebContent process never releases. Nothing on the supervision
+# path may wait on the GUI indefinitely. See _gui_call().
+GUI_CALL_TIMEOUT_SECS = 8.0
 # How often the watcher thread checks for drift and crashes while the
 # app is running. Short enough that clicking "Update now" in the
 # dashboard translates into a visible restart within ~a minute. The
@@ -449,6 +456,16 @@ class RuntimeSupervisor:
         # Set to True by main() when the user closes the window so the
         # watcher stops trying to respawn the daemon on the way out.
         self.shutting_down = threading.Event()
+        # Version seen drifting on the PREVIOUS tick. A pip upgrade writes
+        # its dist-info ~4s before the console script exists, so a single
+        # tick's reading can describe an install that is still in flight.
+        # Acting on it killed a healthy daemon and could not respawn it
+        # (2026-08-17 freeze). Require two consecutive ticks to agree.
+        self._pending_drift: Optional[str] = None
+        # Wall-clock of the last completed watcher tick. The watchdog
+        # thread reads this to detect a stalled (not merely dead) watcher.
+        self._last_tick = 0.0
+        self._tick_count = 0
 
     def _venv_python(self) -> Path:
         return self.venv / ("Scripts" if platform.system() == "Windows" else "bin") / (
@@ -515,6 +532,13 @@ class RuntimeSupervisor:
                 for g in sp_globs
                 for d in self.venv.glob(f"{g}/clawmetry-*.dist-info")
                 if d.is_dir()
+                # An install is only COMPLETE once pip has written RECORD.
+                # pip creates the dist-info dir and METADATA seconds before
+                # it re-creates `bin/clawmetry`; reading the version off the
+                # bare directory name reports a release that cannot yet be
+                # launched. On 2026-08-17 that made the watcher stop a
+                # healthy daemon 548ms before its replacement existed.
+                and (d / "RECORD").exists()
             ]
             if infos:
                 newest = max(infos, key=_ver_key)
@@ -658,9 +682,32 @@ class RuntimeSupervisor:
         except OSError:
             pass
 
-    def start_daemon(self) -> None:
+    def entrypoint_ready(self) -> bool:
+        """True when the venv's clawmetry launcher exists and is
+        executable. pip DELETES this file and re-creates it ~4s later
+        during an upgrade; spawning inside that window raises
+        FileNotFoundError. Probe before every spawn."""
+        try:
+            cli = self._venv_clawmetry()
+            return cli.exists() and os.access(str(cli), os.X_OK)
+        except OSError:
+            return False
+
+    def start_daemon(self) -> bool:
+        """Spawn the dashboard child. Returns True if a process was
+        launched. NEVER raises — a failed spawn must cost one watcher
+        tick, not the supervisor thread (2026-08-17: an unguarded Popen
+        here killed the watcher and stranded the window for 6.5 hours)."""
+        cli = self._venv_clawmetry()
+        if not self.entrypoint_ready():
+            self._log(
+                f"start_daemon: {cli} missing or not executable "
+                "(pip upgrade in flight?); will retry"
+            )
+            self.proc = None
+            return False
         argv = [
-            str(self._venv_clawmetry()),
+            str(cli),
             "--no-debug",
             "--port", str(self.port),
         ]
@@ -668,6 +715,13 @@ class RuntimeSupervisor:
         # WERKZEUG_RUN_MAIN handled by --no-debug (waitress path).
         env.pop("PYTHONHOME", None)
         env.pop("PYTHONPATH", None)
+        # The shell owns pip AND the restart for its own child. Leaving the
+        # daemon's in-process updater armed gave one venv two independent
+        # updaters: the child pip-upgrades, calls os._exit(0) expecting a
+        # supervisor, and races the shell's own upgrade over the same files.
+        # Mutate the COPY only — _auto_update_disabled() reads os.environ
+        # and would otherwise disable the shell's updater too.
+        env["CLAWMETRY_AUTO_UPDATE"] = "0"
         kwargs: dict = {
             "stdout": subprocess.DEVNULL,
             "stderr": subprocess.DEVNULL,
@@ -685,8 +739,17 @@ class RuntimeSupervisor:
             )
         else:
             kwargs["start_new_session"] = True
-        self.proc = subprocess.Popen(argv, **kwargs)
+        try:
+            self.proc = subprocess.Popen(argv, **kwargs)
+        except OSError as exc:
+            # FileNotFoundError (script unlinked mid-upgrade),
+            # PermissionError (written but not yet chmod +x), ENOEXEC...
+            self._log(f"start_daemon: Popen failed: {exc!r}")
+            self.proc = None
+            return False
+        self._log(f"start_daemon: spawned pid={self.proc.pid} port={self.port}")
         self._write_instance_file()
+        return True
 
     def wait_ready(self, deadline_secs: float = STARTUP_TIMEOUT_SECS) -> bool:
         url = f"http://127.0.0.1:{self.port}/"
@@ -707,6 +770,7 @@ class RuntimeSupervisor:
         p = self.proc
         if not p:
             return
+        self._log(f"stop: terminating daemon pid={p.pid}")
         try:
             if os.name == "nt":
                 p.send_signal(signal.CTRL_BREAK_EVENT)  # type: ignore[attr-defined]
@@ -814,13 +878,34 @@ class RuntimeSupervisor:
     def restart_daemon(self) -> bool:
         """Stop the current daemon and spawn a fresh one on the same
         port. Returns True if the new daemon binds and answers before
-        the startup timeout. Idempotent; safe to call repeatedly."""
+        the startup timeout. Idempotent; safe to call repeatedly.
+
+        Never raises, and never destroys a working backend it cannot
+        replace: the entrypoint is probed BEFORE stop(), so a half-written
+        venv leaves the current daemon serving instead of stranding the
+        window on a dead port."""
+        if not self.entrypoint_ready():
+            self._log(
+                "restart_daemon: venv entrypoint not ready; deferring restart "
+                "(current daemon left running)"
+            )
+            return False
         self.stop()
         # Give TCP TIME_WAIT a moment on the freed port; on most systems
         # SO_REUSEADDR handles this, but on macOS a bare Popen can lose.
         time.sleep(0.5)
-        self.start_daemon()
-        return self.wait_ready()
+        for attempt in (1, 2, 3):
+            if self.shutting_down.is_set():
+                return False
+            if self.start_daemon() and self.wait_ready():
+                self._log(f"restart_daemon: ready (attempt {attempt})")
+                return True
+            self._log(f"restart_daemon: attempt {attempt} failed")
+            # Back off so a still-running pip has time to finish.
+            if self.shutting_down.wait(2.0 * attempt):
+                return False
+        self._log("restart_daemon: giving up after 3 attempts")
+        return False
 
     def watch(self, on_restart: Callable[[], None]) -> None:
         """Blocking watcher loop, meant to run in a daemon thread.
@@ -841,35 +926,85 @@ class RuntimeSupervisor:
              so users who never quit still get PyPI releases on the
              blueprint's 6h cadence. Any resulting version change is
              caught by step 2 on the next tick.
+
+        The loop body is wrapped: a raising tick logs a traceback and
+        the loop continues. Before that guard existed, one unguarded
+        FileNotFoundError out of Popen ended supervision permanently and
+        silently (2026-08-17) — the .app has no stderr, so the thread
+        simply vanished and the window sat on a dead port for 6.5 hours.
         """
-        while not self.shutting_down.is_set():
-            if self.shutting_down.wait(WATCHER_TICK_SECS):
-                return
+        self._log("watcher: started")
+        try:
+            while not self.shutting_down.is_set():
+                if self.shutting_down.wait(WATCHER_TICK_SECS):
+                    return
+                try:
+                    self._tick(on_restart)
+                except BaseException:
+                    # Deliberately BaseException: supervision must outlive
+                    # anything short of interpreter teardown.
+                    self._log(
+                        "watcher tick raised (supervision continues):\n"
+                        + traceback.format_exc()
+                    )
+                finally:
+                    self._last_tick = time.time()
+                    self._tick_count += 1
+                    if self._tick_count % 10 == 1:
+                        self._log(
+                            f"watcher: heartbeat tick={self._tick_count} "
+                            f"daemon_pid={getattr(self.proc, 'pid', None)}"
+                        )
+        finally:
+            self._log("watcher: thread exiting")
 
-            if self.proc is not None and self.proc.poll() is not None:
-                self._log(f"daemon exited with code {self.proc.returncode}; respawning")
-                if self.restart_daemon():
-                    on_restart()
-                continue
+    def _tick(self, on_restart: Callable[[], None]) -> None:
+        """One watcher iteration. May raise; watch() contains the damage."""
+        if self.proc is not None and self.proc.poll() is not None:
+            self._log(f"daemon exited with code {self.proc.returncode}; respawning")
+            ok = self.restart_daemon()
+            self._log(f"respawn after exit -> {ok}")
+            if ok:
+                on_restart()
+            return
 
-            # Heal the sync/ingest daemon too — same contract as the
-            # dashboard child: the shell owns it while the app runs.
-            self.ensure_sync_daemon()
+        # Heal the sync/ingest daemon too — same contract as the
+        # dashboard child: the shell owns it while the app runs.
+        self.ensure_sync_daemon()
 
-            installed = self._get_installed_version()
-            running = self._get_running_daemon_version()
-            if installed and running and installed != running:
+        installed = self._get_installed_version()
+        running = self._get_running_daemon_version()
+        if installed and running and installed != running:
+            # Debounce: a pip upgrade is visible in site-packages for
+            # seconds before it is launchable. Requiring two consecutive
+            # ticks to agree means we only ever restart onto a settled
+            # install. pip finishes in ~4s; the tick is 60s.
+            if self._pending_drift != installed:
+                self._pending_drift = installed
                 self._log(
-                    f"version drift: venv={installed} running={running}; restarting"
+                    f"version drift seen: venv={installed} running={running}; "
+                    "confirming on next tick"
                 )
-                self.on_status(f"Applying update to v{installed}")
-                if self.restart_daemon():
-                    on_restart()
-                continue
+                return
+            self._log(
+                f"version drift: venv={installed} running={running}; restarting"
+            )
+            # Recovery FIRST, status second. A status call is a synchronous
+            # RPC into the webview; it must never gate the restart.
+            ok = self.restart_daemon()
+            self._log(f"restart after drift -> {ok}")
+            self._pending_drift = None
+            if ok:
+                on_restart()
+            else:
+                self.on_status(f"Update to v{installed} pending; will retry")
+            return
 
-            if self._should_upgrade():
-                self._log("watcher: 6h elapsed, running clawmetry update")
-                self._background_pip_upgrade()
+        self._pending_drift = None
+
+        if self._should_upgrade():
+            self._log("watcher: upgrade interval elapsed, running clawmetry update")
+            self._background_pip_upgrade()
 
 
 def _ensure_user_path_windows(bin_dir: str, log: Callable[[str], None]) -> None:
@@ -1051,6 +1186,44 @@ class DesktopAPI:
         self._captured_email: str = ""
         self._captured_provider: str = ""
         self._captured_mode: str = ""
+        # Injected by main() once the window exists. The JS bridge is the
+        # only channel that still works when the HTTP origin is dead, so
+        # the page's outage overlay reaches recovery through here.
+        self._recover_backend: Optional[Callable[[], None]] = None
+        self._reload_window: Optional[Callable[[], None]] = None
+
+    # ── Recovery (reachable from a page whose backend is gone) ────────────
+    def backend_state(self) -> dict:
+        """Cheap liveness probe the page can poll without HTTP."""
+        proc = self._sup.proc
+        return {
+            "ok": True,
+            "port": self._sup.port,
+            "daemon_pid": getattr(proc, "pid", None) if proc else None,
+            "daemon_running": bool(proc and proc.poll() is None),
+            "last_tick": self._sup._last_tick,
+            "alive": _dashboard_alive(self._sup.port),
+        }
+
+    def restart_backend(self) -> dict:
+        """Restart the dashboard child and reload the window onto it.
+
+        Returns immediately — the restart can take up to
+        STARTUP_TIMEOUT_SECS and pywebview marshals this call on a worker
+        thread we must not hold."""
+        fn = self._recover_backend
+        if fn is None:
+            return {"ok": False, "error": "recovery not wired"}
+        threading.Thread(target=fn, daemon=True).start()
+        return {"ok": True}
+
+    def reload_dashboard(self) -> dict:
+        """Re-navigate the window to the dashboard URL."""
+        fn = self._reload_window
+        if fn is None:
+            return {"ok": False, "error": "reload not wired"}
+        threading.Thread(target=fn, daemon=True).start()
+        return {"ok": True}
 
     # ── OAuth (GitHub / Google) ────────────────────────────────────────────
     def start_oauth(self, provider: str) -> dict:
@@ -1354,15 +1527,43 @@ def main() -> int:
         background_color=BRAND_BG_DARK,
     )
 
+    def _gui_call(fn: Callable, *args, timeout: float = GUI_CALL_TIMEOUT_SECS) -> None:
+        """Run a pywebview call with a hard wall-clock bound.
+
+        pywebview's Cocoa backend blocks the CALLING thread on an
+        unbounded `Semaphore.acquire()` (webview/platforms/cocoa.py:916)
+        until the WebView's completion handler fires. If the WebContent
+        process is wedged or gone, that handler never fires and the
+        caller is parked forever. The supervisor thread must never take
+        that risk, so the call is pushed onto a throwaway thread and we
+        wait a bounded time for it. A hung webview then costs one leaked
+        thread instead of all supervision."""
+        done = threading.Event()
+
+        def _run() -> None:
+            try:
+                fn(*args)
+            except Exception:
+                pass
+            finally:
+                done.set()
+
+        threading.Thread(target=_run, daemon=True).start()
+        if not done.wait(timeout):
+            sup._log(
+                f"gui call {getattr(fn, '__name__', fn)!r} did not return "
+                f"within {timeout}s; continuing without it"
+            )
+
     def _set_status(msg: str) -> None:
         """Push a progress line into the carousel's top bar. When the
         pane isn't the carousel (e.g. we've swapped to the auth pane),
-        the JS call is a no-op and we swallow the exception — status
-        messages are hints, not load-bearing."""
-        try:
-            window.evaluate_js(f"window.set_status && window.set_status({json.dumps(msg)});")
-        except Exception:
-            pass
+        the JS call is a no-op. Bounded: status messages are hints, and
+        must never be able to stall the caller (see _gui_call)."""
+        _gui_call(
+            window.evaluate_js,
+            f"window.set_status && window.set_status({json.dumps(msg)});",
+        )
 
     # Late-bind the real status hook now that window exists.
     sup.on_status = _set_status
@@ -1373,11 +1574,11 @@ def main() -> int:
         """Callback the watcher fires after a successful daemon
         restart. Reloading the same URL is enough — the WebView picks
         up whatever the fresh daemon serves, so users see the new
-        version immediately without having to quit and relaunch."""
-        try:
-            window.load_url(dashboard_url)
-        except Exception:
-            pass
+        version immediately without having to quit and relaunch.
+
+        Bounded for the same reason as _set_status: this runs on the
+        supervisor thread."""
+        _gui_call(window.load_url, dashboard_url)
 
     def _do_uninstall_flow() -> None:
         """Menu handler — confirm, then shell out to
@@ -1438,19 +1639,56 @@ def main() -> int:
         # off it so evaluate_js and subprocess don't block the main loop.
         threading.Thread(target=_do_uninstall_flow, daemon=True).start()
 
+    def _on_menu_reload() -> None:
+        """Re-navigate to the dashboard. The window has no browser chrome
+        and pywebview's Cocoa backend swallows Cmd-R, so without this the
+        user has literally no way to retry a page whose backend blipped."""
+        threading.Thread(target=_reload_window, daemon=True).start()
+
+    def _recover_backend() -> None:
+        """Restart the child daemon, then reload the page onto it."""
+        sup._log("manual recovery requested")
+        if sup.restart_daemon():
+            _reload_window()
+        else:
+            _set_status("Could not restart the backend. See bootstrap.log.")
+
+    def _on_menu_restart_backend() -> None:
+        # restart_daemon blocks for up to STARTUP_TIMEOUT_SECS; menu
+        # callbacks run on the GUI thread, so never inline it.
+        threading.Thread(target=_recover_backend, daemon=True).start()
+
+    # Give the API object the recovery hook so a stranded PAGE can call it.
+    # When the HTTP origin is dead the JS bridge is the only channel left.
+    api._recover_backend = _recover_backend  # type: ignore[attr-defined]
+    api._reload_window = _reload_window  # type: ignore[attr-defined]
+
     # Build the menu — tolerant of pywebview versions without a menu API.
     # macOS shows this alongside the standard app menu; the item name uses
     # the platform convention "Uninstall ClawMetry…" (ellipsis = confirms).
     menu_items: list = []
     try:
-        from webview.menu import Menu, MenuAction  # type: ignore
+        from webview.menu import Menu, MenuAction, MenuSeparator  # type: ignore
         menu_items = [
             Menu(APP_TITLE, [
+                MenuAction("Reload Dashboard", _on_menu_reload),
+                MenuAction("Restart Backend", _on_menu_restart_backend),
+                MenuSeparator(),
                 MenuAction("Uninstall ClawMetry…", _on_menu_uninstall),
             ]),
         ]
     except Exception:
-        menu_items = []
+        try:
+            from webview.menu import Menu, MenuAction  # type: ignore
+            menu_items = [
+                Menu(APP_TITLE, [
+                    MenuAction("Reload Dashboard", _on_menu_reload),
+                    MenuAction("Restart Backend", _on_menu_restart_backend),
+                    MenuAction("Uninstall ClawMetry…", _on_menu_uninstall),
+                ]),
+            ]
+        except Exception:
+            menu_items = []
 
     def _boot():
         # Phase 1: bootstrap the runtime venv.
@@ -1579,9 +1817,40 @@ def main() -> int:
         # Start the watcher after wait_ready so the initial startup exit
         # is never mistaken for a crash. Handles version drift ("Update
         # now") and unexpected exits by restarting + reloading the WebView.
+        sup._last_tick = time.time()
         threading.Thread(
             target=sup.watch, args=(_reload_window,), daemon=True
         ).start()
+
+        def _supervise_the_supervisor() -> None:
+            """Watch the watcher.
+
+            watch() now contains its own exceptions, but a thread can
+            still be lost to something it cannot catch — a wedged GUI
+            call, a hung subprocess, an interpreter-level kill. Nothing
+            noticed on 2026-08-17 because nothing was looking. A stale
+            _last_tick is the one signal that distinguishes "supervising"
+            from "gone", and re-arming is cheap and idempotent."""
+            stale_after = 3 * WATCHER_TICK_SECS
+            while not sup.shutting_down.wait(WATCHER_TICK_SECS):
+                try:
+                    last = sup._last_tick
+                    if not last or (time.time() - last) <= stale_after:
+                        continue
+                    sup._log(
+                        f"WATCHER STALLED: {time.time() - last:.0f}s since last "
+                        "tick; re-arming supervision"
+                    )
+                    # Re-arm first so a still-parked old thread cannot make
+                    # us spawn a new one every tick.
+                    sup._last_tick = time.time()
+                    threading.Thread(
+                        target=sup.watch, args=(_reload_window,), daemon=True
+                    ).start()
+                except Exception:
+                    sup._log("watchdog raised:\n" + traceback.format_exc())
+
+        threading.Thread(target=_supervise_the_supervisor, daemon=True).start()
 
         # Phase 5: load the ready-gate spinner, poll /api/overview
         # from Python (avoids CORS from a load_html origin), then load

--- a/tests/test_backend_outage_overlay.js
+++ b/tests/test_backend_outage_overlay.js
@@ -1,0 +1,280 @@
+/**
+ * Behavioural tests for the global "backend unreachable" detector + overlay
+ * in clawmetry/static/js/auth-bootstrap.js.
+ *
+ * Why this exists: on 2026-08-17 a desktop user's backend died and every tab
+ * froze -- Activity showed "Failed to load: TypeError: Load failed", Cost sat
+ * on "Loading..." forever, Agents claimed "No agents yet". Each panel handled
+ * the failure privately, so nothing said "the backend is gone" and nothing
+ * offered a way back. The user's words: there is no refresh button when it
+ * gets into this state.
+ *
+ * The two IIFEs under test are extracted from the shipped source and run
+ * against a minimal DOM/window stub -- no jsdom dependency, and it fails if
+ * the shipped file stops containing them.
+ */
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const SRC = path.join(__dirname, '..', 'clawmetry', 'static', 'js', 'auth-bootstrap.js');
+
+let failures = 0;
+const pending = [];
+function check(name, fn) {
+  const record = function (e) {
+    if (e) {
+      failures++;
+      console.log('  FAIL ' + name + ' -- ' + (e && e.message ? e.message : e));
+    } else {
+      console.log('  ok   ' + name);
+    }
+  };
+  let out;
+  try {
+    out = fn();
+  } catch (e) {
+    record(e);
+    return;
+  }
+  if (out && typeof out.then === 'function') {
+    pending.push(out.then(function () { record(null); }, record));
+  } else {
+    record(null);
+  }
+}
+function assert(cond, msg) { if (!cond) throw new Error(msg || 'assertion failed'); }
+function eq(a, b, msg) {
+  if (a !== b) throw new Error((msg || 'not equal') + ': ' + JSON.stringify(a) + ' !== ' + JSON.stringify(b));
+}
+
+// ── extract the two IIFEs from the shipped file ──────────────────────────────
+const source = fs.readFileSync(SRC, 'utf8');
+
+function sliceBlock(startMarker, label) {
+  const at = source.indexOf(startMarker);
+  assert(at !== -1, 'shipped auth-bootstrap.js no longer contains ' + label +
+    ' (looked for: ' + startMarker + ')');
+  // Walk forward to the IIFE that follows, then brace-match it.
+  const open = source.indexOf('(function(){', at);
+  assert(open !== -1, 'no IIFE after ' + label);
+  let depth = 0, i = open;
+  for (; i < source.length; i++) {
+    const c = source[i];
+    if (c === '{') depth++;
+    else if (c === '}') { depth--; if (depth === 0) break; }
+  }
+  // i is the IIFE body's closing brace. Take through the invoking "()" --
+  // stopping at the first ")" yields a function expression that is never
+  // called, and every assertion then silently sees an undefined global.
+  const call = source.indexOf('()', i);
+  assert(call !== -1 && call - i <= 3,
+    'expected "})();" to close ' + label + ', got: ' + JSON.stringify(source.slice(i, i + 8)));
+  return source.slice(open, call + 2) + ';';
+}
+
+const fetchBlock = sliceBlock('// Inject auth header into all fetch calls', 'the fetch wrapper');
+const overlayBlock = sliceBlock('// ── Global "backend unreachable" overlay ──', 'the outage overlay');
+
+// ── a small DOM/window stub ──────────────────────────────────────────────────
+function makeElement(tag) {
+  return {
+    tagName: tag, id: '', style: { cssText: '' }, textContent: '', innerHTML: '',
+    type: '', disabled: false, onclick: null, children: [], parentNode: null,
+    _attrs: {},
+    setAttribute(k, v) { this._attrs[k] = v; },
+    appendChild(c) { c.parentNode = this; this.children.push(c); return c; },
+    removeChild(c) {
+      const i = this.children.indexOf(c);
+      if (i >= 0) this.children.splice(i, 1);
+      c.parentNode = null;
+    },
+  };
+}
+
+function makeEnv(opts) {
+  opts = opts || {};
+  const body = makeElement('body');
+  const byId = {};
+  const listeners = {};
+  const timers = [];
+
+  function collect(el, out) {
+    out.push(el);
+    el.children.forEach(function (c) { collect(c, out); });
+    return out;
+  }
+
+  const win = {
+    localStorage: { getItem() { return null; }, setItem() {}, removeItem() {} },
+    fetch: opts.fetch,
+    CustomEvent: function (type, init) { this.type = type; this.detail = init && init.detail; },
+    addEventListener(type, fn) { (listeners[type] = listeners[type] || []).push(fn); },
+    dispatchEvent(ev) { (listeners[ev.type] || []).forEach(function (f) { f(ev); }); return true; },
+    setTimeout(fn, ms) { timers.push({ fn: fn, ms: ms }); return timers.length; },
+    location: { reload() { win.__reloaded = (win.__reloaded || 0) + 1; } },
+    document: {
+      body: body,
+      documentElement: body,
+      getElementById(id) {
+        const all = collect(body, []);
+        for (const el of all) if (el.id === id) return el;
+        return byId[id] || null;
+      },
+      createElement: makeElement,
+    },
+    __timers: timers,
+    __body: body,
+  };
+  if (opts.pywebview) win.pywebview = opts.pywebview;
+  win.window = win;
+  return win;
+}
+
+function run(env, blocks) {
+  const ctx = vm.createContext(env);
+  // The blocks reference bare `window`, `document`, `localStorage`.
+  ctx.document = env.document;
+  ctx.localStorage = env.localStorage;
+  blocks.forEach(function (b) { vm.runInContext(b, ctx); });
+  return ctx;
+}
+
+function netError() {
+  const e = new TypeError('Load failed');
+  return e;
+}
+
+function overlay(env) { return env.document.getElementById('cm-backend-outage'); }
+
+// ── tests ────────────────────────────────────────────────────────────────────
+console.log('backend outage overlay');
+
+check('a single network failure does NOT raise the overlay', function () {
+  const env = makeEnv({ fetch: function () { return Promise.reject(netError()); } });
+  run(env, [fetchBlock, overlayBlock]);
+  return env.fetch('/api/overview').catch(function () {}).then(function () {
+    eq(overlay(env), null, 'overlay appeared on the first failure');
+  });
+});
+
+check('three consecutive network failures raise the overlay', function () {
+  const env = makeEnv({ fetch: function () { return Promise.reject(netError()); } });
+  run(env, [fetchBlock, overlayBlock]);
+  let p = Promise.resolve();
+  for (let i = 0; i < 3; i++) {
+    p = p.then(function () { return env.fetch('/api/overview').catch(function () {}); });
+  }
+  return p.then(function () {
+    assert(overlay(env), 'overlay never appeared after 3 network failures');
+    const text = JSON.stringify(overlay(env).children.map(function (c) {
+      return c.innerHTML || c.textContent;
+    }));
+    assert(/Cannot reach the ClawMetry backend/.test(text),
+      'overlay does not name the problem: ' + text);
+  });
+});
+
+check('an HTTP error status is NOT an outage (the server answered)', function () {
+  const env = makeEnv({
+    fetch: function () { return Promise.resolve({ status: 500, ok: false }); },
+  });
+  run(env, [fetchBlock, overlayBlock]);
+  let p = Promise.resolve();
+  for (let i = 0; i < 5; i++) p = p.then(function () { return env.fetch('/api/overview'); });
+  return p.then(function () {
+    eq(overlay(env), null, '500s were mistaken for an outage');
+  });
+});
+
+check('recovery dismisses the overlay', function () {
+  let dead = true;
+  const env = makeEnv({
+    fetch: function () {
+      return dead ? Promise.reject(netError()) : Promise.resolve({ status: 200, ok: true });
+    },
+  });
+  run(env, [fetchBlock, overlayBlock]);
+  let p = Promise.resolve();
+  for (let i = 0; i < 3; i++) {
+    p = p.then(function () { return env.fetch('/api/overview').catch(function () {}); });
+  }
+  return p.then(function () {
+    assert(overlay(env), 'overlay never appeared');
+    dead = false;
+    return env.fetch('/api/overview');
+  }).then(function () {
+    eq(overlay(env), null, 'overlay survived the backend coming back');
+  });
+});
+
+check('the overlay always carries an actionable button', function () {
+  const env = makeEnv({ fetch: function () { return Promise.reject(netError()); } });
+  run(env, [fetchBlock, overlayBlock]);
+  env.window.cmShowBackendOutage();
+  const el = overlay(env);
+  assert(el, 'overlay missing');
+  const btn = el.children.filter(function (c) { return c.tagName === 'button'; })[0];
+  assert(btn, 'no button in the outage overlay -- this is the whole point');
+  assert(typeof btn.onclick === 'function', 'button has no click handler');
+  eq(btn.textContent, 'Reload', 'browser fallback should offer Reload');
+});
+
+check('in a browser the button reloads the page', function () {
+  const env = makeEnv({ fetch: function () { return Promise.reject(netError()); } });
+  run(env, [fetchBlock, overlayBlock]);
+  env.window.cmShowBackendOutage();
+  const btn = overlay(env).children.filter(function (c) { return c.tagName === 'button'; })[0];
+  btn.onclick();
+  eq(env.__reloaded, 1, 'Reload did not reload');
+});
+
+check('in the desktop shell the button restarts the backend via the bridge', function () {
+  let restarted = 0;
+  const env = makeEnv({
+    fetch: function () { return Promise.reject(netError()); },
+    pywebview: { api: { restart_backend: function () { restarted++; return { ok: true }; } } },
+  });
+  run(env, [fetchBlock, overlayBlock]);
+  env.window.cmShowBackendOutage();
+  const el = overlay(env);
+  const btn = el.children.filter(function (c) { return c.tagName === 'button'; })[0];
+  eq(btn.textContent, 'Restart backend', 'desktop should offer a real restart');
+  btn.onclick();
+  eq(restarted, 1, 'bridge restart_backend was not called');
+  eq(env.__reloaded, undefined, 'should not fall back to reload when the bridge works');
+});
+
+check('a browser outage tells the user what else to try', function () {
+  const env = makeEnv({ fetch: function () { return Promise.reject(netError()); } });
+  run(env, [fetchBlock, overlayBlock]);
+  env.window.cmShowBackendOutage();
+  const text = overlay(env).children.map(function (c) {
+    return c.textContent || c.innerHTML;
+  }).join(' ');
+  assert(/quit ClawMetry and open it again/i.test(text),
+    'no fallback guidance when the shell cannot self-heal: ' + text);
+});
+
+check('non-/api/ requests are not counted toward an outage', function () {
+  const env = makeEnv({ fetch: function () { return Promise.reject(netError()); } });
+  run(env, [fetchBlock, overlayBlock]);
+  let p = Promise.resolve();
+  for (let i = 0; i < 5; i++) {
+    p = p.then(function () { return env.fetch('/static/js/app.js').catch(function () {}); });
+  }
+  return p.then(function () {
+    eq(overlay(env), null, 'a static-asset failure raised a backend outage');
+  });
+});
+
+// Several checks are async; drain them before reporting.
+Promise.all(pending).then(function () {
+  if (failures) {
+    console.log('\nFAIL: ' + failures + ' check(s) failed');
+    process.exit(1);
+  }
+  console.log('\nPASS');
+});

--- a/tests/test_backend_outage_overlay.py
+++ b/tests/test_backend_outage_overlay.py
@@ -1,0 +1,46 @@
+"""Global "backend unreachable" overlay -- the affordance that was missing.
+
+2026-08-17: a desktop user's backend died and every tab froze. Activity said
+"Failed to load: TypeError: Load failed", Cost sat on "Loading..." forever,
+Agents claimed "No agents yet". Each panel swallowed the failure privately,
+so a machine-wide outage rendered as a dozen unrelated spinners and nothing
+that named the actual problem or offered a way out. The user's report: there
+is no refresh button when it gets into this state.
+
+The fix adds one global detector at the single chokepoint every /api/ call
+already passes through (the auth-header fetch wrapper in auth-bootstrap.js)
+and one overlay that always carries an action -- a real backend restart over
+the pywebview JS bridge inside the desktop shell, a reload in a browser tab.
+
+Runs the Node suite in ``test_backend_outage_overlay.js``, which extracts the
+shipped IIFEs from auth-bootstrap.js and exercises them against a DOM stub.
+Skipped (not failed) when ``node`` is not on PATH.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+
+import pytest
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_JS_TEST = os.path.join(_HERE, "test_backend_outage_overlay.js")
+
+
+@pytest.mark.skipif(
+    shutil.which("node") is None,
+    reason="node not on PATH; JS unit tests only run when Node is available",
+)
+def test_backend_outage_overlay_suite() -> None:
+    """Run the Node-based behavioural tests for the outage detector."""
+    proc = subprocess.run(
+        ["node", _JS_TEST],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    output = (proc.stdout or "") + (proc.stderr or "")
+    assert proc.returncode == 0, "backend outage overlay tests failed:\n" + output
+    assert "PASS" in output, "no PASS line in output:\n" + output

--- a/tests/test_desktop_supervisor_resilience.py
+++ b/tests/test_desktop_supervisor_resilience.py
@@ -36,9 +36,7 @@ Three properties are load-bearing and each test below fails if one regresses:
 """
 from __future__ import annotations
 
-import json
 import os
-import subprocess
 import sys
 import threading
 import time
@@ -307,7 +305,9 @@ def test_sustained_drift_still_restarts(tmp_path, monkeypatch):
         lambda: (restarts.__setitem__("n", restarts["n"] + 1), True)[1],
     )
 
-    on_restart = lambda: reloaded.__setitem__("n", reloaded["n"] + 1)
+    def on_restart():
+        reloaded["n"] += 1
+
     sup._tick(on_restart)
     assert restarts["n"] == 0
     sup._tick(on_restart)

--- a/tests/test_desktop_supervisor_resilience.py
+++ b/tests/test_desktop_supervisor_resilience.py
@@ -1,0 +1,405 @@
+"""The desktop shell's supervisor must outlive anything its child can do.
+
+Incident 2026-08-17, reconstructed from the live machine. The user's window
+sat frozen for 6h39m across every tab: "Failed to load: TypeError: Load
+failed", "Connection lost. Reconnecting...", Cost panels stuck on
+"Loading...". The app process was alive and responsive; it simply had no
+backend and no way to say so.
+
+What happened, to the millisecond:
+
+  16:51:41.518  pip (the daemon's OWN in-process updater, not the shell's)
+                creates clawmetry-0.12.730.dist-info/ in the shared runtime
+                venv and unlinks the old dist -- taking venv/bin/clawmetry
+                with it.
+  16:51:44.345  The watcher tick reads "0.12.730" off the dist-info
+                DIRECTORY NAME of a still-in-flight install, compares it to
+                the running daemon's 0.12.729, and declares version drift.
+  16:51:44.532  restart_daemon() -> stop() SIGTERMs a perfectly healthy,
+                serving daemon and unlinks app-instance.json.
+  16:51:45.032  start_daemon() -> subprocess.Popen([venv/bin/clawmetry, ...])
+                raises FileNotFoundError. The script does not exist yet.
+  16:51:45.580  pip re-creates venv/bin/clawmetry -- 548ms too late.
+
+The Popen was unguarded, watch() had no try/except, and the thread was a
+bare daemon thread in a PyInstaller windowed .app with no stderr sink. So
+the exception vanished, the watcher thread died, and nothing was left to
+respawn the daemon, reload the window, or even write a log line. The last
+line in bootstrap.log is the drift message.
+
+Three properties are load-bearing and each test below fails if one regresses:
+
+  1. A spawn that cannot happen costs one tick, not the supervisor.
+  2. A healthy daemon is never destroyed to make way for a replacement that
+     was never proven launchable.
+  3. Version drift is only acted on once the install has settled.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+import desktop.app as dapp  # noqa: E402
+
+
+def _sup(tmp_path, *, with_entrypoint: bool = True):
+    """A real RuntimeSupervisor over a temp runtime dir.
+
+    Built via __new__ rather than a stub: these tests are about the actual
+    interplay of entrypoint_ready / start_daemon / restart_daemon / _tick,
+    so replacing any of them would test nothing.
+    """
+    runtime = tmp_path / "runtime"
+    (runtime / "venv" / "bin").mkdir(parents=True, exist_ok=True)
+    cli = runtime / "venv" / "bin" / "clawmetry"
+    if with_entrypoint:
+        cli.write_text("#!/bin/sh\nsleep 300\n")
+        cli.chmod(0o755)
+
+    sup = dapp.RuntimeSupervisor.__new__(dapp.RuntimeSupervisor)
+    sup.port = 8999
+    sup.on_status = lambda *a, **k: None
+    sup.proc = None
+    sup.runtime = runtime
+    sup.venv = runtime / "venv"
+    sup.stamp_file = runtime / "last-upgrade.json"
+    sup.log_file = runtime / "bootstrap.log"
+    sup.instance_file = runtime / "app-instance.json"
+    sup._last_sync_start = 0.0
+    sup.shutting_down = threading.Event()
+    sup._pending_drift = None
+    sup._last_tick = 0.0
+    sup._tick_count = 0
+    return sup
+
+
+def _log_text(sup) -> str:
+    try:
+        return sup.log_file.read_text()
+    except OSError:
+        return ""
+
+
+# ── property 1: a failed spawn costs one tick, never the supervisor ──────────
+
+def test_start_daemon_returns_false_when_entrypoint_is_missing(tmp_path):
+    """The exact 548ms hole: pip has deleted bin/clawmetry and not yet
+    written it back."""
+    sup = _sup(tmp_path, with_entrypoint=False)
+    assert sup.entrypoint_ready() is False
+    assert sup.start_daemon() is False
+    assert sup.proc is None
+    assert "start_daemon:" in _log_text(sup)
+
+
+def test_start_daemon_swallows_oserror_from_popen(tmp_path, monkeypatch):
+    """Even if the probe passes, the exec can still lose the race. Popen
+    must never propagate -- that raise is what killed the watcher."""
+    sup = _sup(tmp_path)
+
+    def _boom(*a, **k):
+        raise FileNotFoundError(2, "No such file or directory")
+
+    monkeypatch.setattr(dapp.subprocess, "Popen", _boom)
+    assert sup.start_daemon() is False
+    assert sup.proc is None
+    assert "Popen failed" in _log_text(sup)
+
+
+def test_start_daemon_does_not_raise_on_permission_error(tmp_path, monkeypatch):
+    """The written-but-not-yet-chmod+x variant of the same race."""
+    sup = _sup(tmp_path)
+    monkeypatch.setattr(
+        dapp.subprocess, "Popen",
+        lambda *a, **k: (_ for _ in ()).throw(PermissionError(13, "denied")),
+    )
+    assert sup.start_daemon() is False
+
+
+def test_instance_file_exists_only_alongside_a_live_proc(tmp_path, monkeypatch):
+    """app-instance.json's absence is what proved Popen raised. Keep that
+    signal honest: a failed spawn must not leave a stale instance file, and
+    must not be mistaken for a clean shutdown."""
+    sup = _sup(tmp_path)
+    monkeypatch.setattr(
+        dapp.subprocess, "Popen",
+        lambda *a, **k: (_ for _ in ()).throw(FileNotFoundError(2, "gone")),
+    )
+    assert sup.start_daemon() is False
+    assert not sup.instance_file.exists()
+    assert sup.proc is None
+
+
+def _quiet_tick(sup, monkeypatch, *, drift: bool = False):
+    """Neutralise every collaborator a tick touches so a test can make
+    exactly one of them misbehave. Without this the tick shells out for
+    real (ensure_sync_daemon, _background_pip_upgrade) and the timing
+    assertions measure pip, not the loop."""
+    monkeypatch.setattr(sup, "ensure_sync_daemon", lambda: None)
+    monkeypatch.setattr(sup, "_should_upgrade", lambda: False)
+    monkeypatch.setattr(sup, "_background_pip_upgrade", lambda: None)
+    monkeypatch.setattr(
+        sup, "_get_installed_version", lambda: "9.9.9" if drift else "0.12.729",
+    )
+    monkeypatch.setattr(sup, "_get_running_daemon_version", lambda: "0.12.729")
+    if drift:
+        # Pre-arm the debounce so the very first tick reaches restart_daemon.
+        sup._pending_drift = "9.9.9"
+
+
+@pytest.mark.parametrize(
+    "victim",
+    [
+        "_get_installed_version",
+        "_get_running_daemon_version",
+        "ensure_sync_daemon",
+        "restart_daemon",
+        "_should_upgrade",
+    ],
+)
+def test_watch_survives_a_raising_tick(tmp_path, monkeypatch, victim):
+    """Whatever blows up inside a tick, supervision continues. This is the
+    guard that turns a 6h39m outage into a 60s one."""
+    sup = _sup(tmp_path)
+    monkeypatch.setattr(dapp, "WATCHER_TICK_SECS", 0.05)
+    # restart_daemon is only reached on the drift path.
+    _quiet_tick(sup, monkeypatch, drift=(victim == "restart_daemon"))
+    monkeypatch.setattr(
+        sup, victim,
+        lambda *a, **k: (_ for _ in ()).throw(RuntimeError(f"boom in {victim}")),
+    )
+
+    t = threading.Thread(target=sup.watch, args=(lambda: None,), daemon=True)
+    t.start()
+    time.sleep(0.6)
+    ticks = sup._tick_count
+    sup.shutting_down.set()
+    assert ticks >= 2, f"watcher stopped ticking after {ticks} ticks"
+    assert t.is_alive(), "watcher thread died on a raising tick"
+    t.join(timeout=3)
+    assert "watcher tick raised" in _log_text(sup)
+
+
+def test_watch_logs_its_own_exit(tmp_path, monkeypatch):
+    """A vanished watcher must leave a trace. In the incident it left none."""
+    sup = _sup(tmp_path)
+    monkeypatch.setattr(dapp, "WATCHER_TICK_SECS", 0.05)
+    _quiet_tick(sup, monkeypatch)
+    t = threading.Thread(target=sup.watch, args=(lambda: None,), daemon=True)
+    t.start()
+    time.sleep(0.2)
+    sup.shutting_down.set()
+    t.join(timeout=3)
+    assert not t.is_alive()
+    log = _log_text(sup)
+    assert "watcher: started" in log
+    assert "watcher: thread exiting" in log
+
+
+# ── property 2: never destroy a backend you cannot replace ───────────────────
+
+def test_restart_defers_instead_of_killing_a_healthy_daemon(tmp_path):
+    """The incident in one assertion.
+
+    Entrypoint is mid-rewrite, so restart_daemon must decline and leave the
+    running daemon alone. Before the fix it called stop() first and only
+    then discovered it could not spawn a replacement."""
+    sup = _sup(tmp_path, with_entrypoint=False)
+
+    class _LiveProc:
+        pid = 4242
+        terminated = False
+
+        def poll(self):
+            return None
+
+    live = _LiveProc()
+    sup.proc = live
+    stopped = {"called": False}
+    sup.stop = lambda: stopped.__setitem__("called", True)  # type: ignore[method-assign]
+
+    assert sup.restart_daemon() is False
+    assert stopped["called"] is False, "killed a healthy daemon it could not replace"
+    assert sup.proc is live, "dropped the live daemon handle"
+    assert "deferring restart" in _log_text(sup)
+
+
+def test_restart_failure_is_logged_on_the_drift_branch(tmp_path, monkeypatch):
+    """A failed restart used to be indistinguishable from a hang: both left
+    the log ending at the drift line."""
+    sup = _sup(tmp_path)
+    monkeypatch.setattr(sup, "_get_installed_version", lambda: "9.9.9")
+    monkeypatch.setattr(sup, "_get_running_daemon_version", lambda: "9.9.8")
+    monkeypatch.setattr(sup, "ensure_sync_daemon", lambda: None)
+    monkeypatch.setattr(sup, "restart_daemon", lambda: False)
+
+    sup._tick(lambda: None)  # tick 1: observe drift
+    sup._tick(lambda: None)  # tick 2: confirm and act
+    log = _log_text(sup)
+    assert "version drift:" in log
+    assert "restart after drift -> False" in log
+
+
+def test_status_never_gates_the_restart(tmp_path, monkeypatch):
+    """Recovery first, cosmetics second. on_status is a synchronous RPC into
+    a webview that can be wedged; it must not sit in front of the restart."""
+    sup = _sup(tmp_path)
+    order: list = []
+    monkeypatch.setattr(sup, "_get_installed_version", lambda: "9.9.9")
+    monkeypatch.setattr(sup, "_get_running_daemon_version", lambda: "9.9.8")
+    monkeypatch.setattr(sup, "ensure_sync_daemon", lambda: None)
+    monkeypatch.setattr(
+        sup, "restart_daemon", lambda: (order.append("restart"), False)[1],
+    )
+    sup.on_status = lambda msg: order.append("status")
+
+    sup._tick(lambda: None)
+    sup._tick(lambda: None)
+    assert order and order[0] == "restart", f"status ran before recovery: {order}"
+
+
+# ── property 3: only act on a settled install ────────────────────────────────
+
+def test_drift_is_debounced_across_two_ticks(tmp_path, monkeypatch):
+    """A single tick's reading can describe an install still in flight. One
+    transient disagreement must never trigger a restart."""
+    sup = _sup(tmp_path)
+    restarts = {"n": 0}
+    monkeypatch.setattr(sup, "ensure_sync_daemon", lambda: None)
+    monkeypatch.setattr(sup, "_should_upgrade", lambda: False)
+    monkeypatch.setattr(
+        sup, "restart_daemon",
+        lambda: (restarts.__setitem__("n", restarts["n"] + 1), True)[1],
+    )
+
+    seen = iter(["0.12.730", "0.12.729"])  # drift for exactly one tick
+    monkeypatch.setattr(sup, "_get_installed_version", lambda: next(seen))
+    monkeypatch.setattr(sup, "_get_running_daemon_version", lambda: "0.12.729")
+
+    sup._tick(lambda: None)
+    sup._tick(lambda: None)
+    assert restarts["n"] == 0, "restarted on a single-tick drift blip"
+    assert "version drift seen:" in _log_text(sup)
+
+
+def test_sustained_drift_still_restarts(tmp_path, monkeypatch):
+    """The debounce must not break the feature it guards -- 'Update now'
+    still has to land."""
+    sup = _sup(tmp_path)
+    restarts = {"n": 0}
+    reloaded = {"n": 0}
+    monkeypatch.setattr(sup, "ensure_sync_daemon", lambda: None)
+    monkeypatch.setattr(sup, "_should_upgrade", lambda: False)
+    monkeypatch.setattr(sup, "_get_installed_version", lambda: "0.12.730")
+    monkeypatch.setattr(sup, "_get_running_daemon_version", lambda: "0.12.729")
+    monkeypatch.setattr(
+        sup, "restart_daemon",
+        lambda: (restarts.__setitem__("n", restarts["n"] + 1), True)[1],
+    )
+
+    on_restart = lambda: reloaded.__setitem__("n", reloaded["n"] + 1)
+    sup._tick(on_restart)
+    assert restarts["n"] == 0
+    sup._tick(on_restart)
+    assert restarts["n"] == 1, "sustained drift never restarted"
+    assert reloaded["n"] == 1, "window was not reloaded onto the new daemon"
+
+
+def test_installed_version_ignores_an_install_without_RECORD(tmp_path):
+    """pip creates dist-info/ seconds before the package is launchable.
+    RECORD is pip's own completion marker; the directory name alone is a lie
+    for the length of the install."""
+    sup = _sup(tmp_path)
+    sp = sup.venv / "lib" / "python3.11" / "site-packages"
+    good = sp / "clawmetry-0.12.729.dist-info"
+    good.mkdir(parents=True)
+    (good / "RECORD").write_text("")
+    partial = sp / "clawmetry-0.12.730.dist-info"
+    partial.mkdir(parents=True)
+    (partial / "METADATA").write_text("Name: clawmetry\n")  # no RECORD yet
+
+    assert sup._get_installed_version() == "0.12.729"
+
+    (partial / "RECORD").write_text("")
+    assert sup._get_installed_version() == "0.12.730"
+
+
+# ── one venv, one updater ────────────────────────────────────────────────────
+
+def test_child_env_disarms_the_daemons_own_updater(tmp_path, monkeypatch):
+    """Two updaters shared one venv: the shell's, and the child's in-process
+    worker that pip-upgrades then calls os._exit(0) expecting a supervisor.
+    That second writer is what raced pip against the shell's restart."""
+    sup = _sup(tmp_path)
+    captured = {}
+
+    class _FakeProc:
+        pid = 1234
+
+        def poll(self):
+            return None
+
+    def _fake_popen(argv, **kwargs):
+        captured["env"] = kwargs.get("env", {})
+        return _FakeProc()
+
+    monkeypatch.setattr(dapp.subprocess, "Popen", _fake_popen)
+    monkeypatch.delenv("CLAWMETRY_AUTO_UPDATE", raising=False)
+
+    assert sup.start_daemon() is True
+    assert captured["env"].get("CLAWMETRY_AUTO_UPDATE") == "0"
+    # The shell's own updater must stay armed.
+    assert "CLAWMETRY_AUTO_UPDATE" not in os.environ
+
+
+# ── the user could not get out ───────────────────────────────────────────────
+
+def test_recovery_surface_exists_on_the_js_bridge(tmp_path):
+    """A stranded page's only working channel is the JS bridge -- the HTTP
+    origin is dead by definition. Without these the user's sole options were
+    Quit and Uninstall."""
+    sup = _sup(tmp_path)
+    api = dapp.DesktopAPI(sup)
+    for name in ("restart_backend", "reload_dashboard", "backend_state"):
+        assert callable(getattr(api, name, None)), f"DesktopAPI.{name} missing"
+
+    # Unwired is a clean refusal, never an exception.
+    assert api.restart_backend()["ok"] is False
+    assert api.reload_dashboard()["ok"] is False
+
+    calls = []
+    api._recover_backend = lambda: calls.append("recover")
+    api._reload_window = lambda: calls.append("reload")
+    assert api.restart_backend()["ok"] is True
+    assert api.reload_dashboard()["ok"] is True
+    time.sleep(0.3)
+    assert set(calls) == {"recover", "reload"}
+
+
+def test_backend_state_is_answerable_with_a_dead_backend(tmp_path):
+    """The overlay polls this to decide what to show. It must not raise when
+    there is no child at all -- that is precisely when it is called."""
+    sup = _sup(tmp_path)
+    sup.proc = None
+    state = dapp.DesktopAPI(sup).backend_state()
+    assert state["ok"] is True
+    assert state["daemon_running"] is False
+    assert state["port"] == sup.port
+
+
+def test_gui_calls_are_bounded():
+    """pywebview's Cocoa evaluate_js/load_url park the CALLING thread on an
+    unbounded Semaphore.acquire(). Nothing on the supervision path may wait
+    on the GUI forever."""
+    assert dapp.GUI_CALL_TIMEOUT_SECS > 0
+    assert dapp.GUI_CALL_TIMEOUT_SECS <= dapp.WATCHER_TICK_SECS


### PR DESCRIPTION
## What happened

A desktop window sat frozen across **every** tab for 6 hours 39 minutes: Activity showing `Failed to load: TypeError: Load failed` plus a `Connection lost. Reconnecting...` banner that never recovered, Cost panels stuck on `Loading...` with `--` tiles, Agents claiming "No agents yet, and that is fine." The app process was alive and responsive the whole time. It simply had no backend, no supervisor, and no way to tell the user either.

Reconstructed to the millisecond from the live machine (dist-info `st_birthtime`, `bootstrap.log`, runtime-dir mtime, a `sample(1)` of the wedged process, `launchctl print`):

| Time | Event |
|---|---|
| 16:51:41.518 | The daemon's **own** in-process updater pip-installs 0.12.730 into the runtime venv both processes share, unlinking `venv/bin/clawmetry` with the old dist |
| 16:51:44.345 | Watcher reads `0.12.730` off the dist-info **directory name** of a still-in-flight install, sees drift vs the running 0.12.729, decides to restart |
| 16:51:44.532 | `restart_daemon()` → `stop()` SIGTERMs a **healthy, serving** daemon and unlinks `app-instance.json` |
| 16:51:45.032 | `start_daemon()` → `Popen(venv/bin/clawmetry)` raises `FileNotFoundError` — the script does not exist yet |
| 16:51:45.580 | pip re-creates it. **548 ms too late** |

The `Popen` was unguarded, `watch()` had no `try/except`, and the thread was a bare daemon thread inside a PyInstaller windowed `.app` with no stderr sink. The exception vanished, the watcher thread died, and nothing was left to respawn the daemon or reload the window.

`bootstrap.log`'s last line is the drift message. `app-instance.json`'s absence is what pins the failure to that exact call: `_write_instance_file()` runs on the statement *after* `Popen`, so its absence proves line 689 never executed. A `sample(1)` of the live process confirms zero Python threads besides the Cocoa main loop — the watcher was gone, not parked.

Empirically reproduced: during one `pip install --upgrade`, a tight poller caught the console script absent on 29/265 samples, with 28 `subprocess.run` calls raising `FileNotFoundError: [Errno 2]`.

## The fix

**Shell supervision** (`desktop/app.py`) — six changes, each closing one link:
- `start_daemon()` probes the entrypoint, catches `OSError`, returns `bool`, logs. A spawn that cannot happen costs one 60 s tick.
- `restart_daemon()` probes **before** `stop()`, so a half-written venv can never cost a working backend. Retries 3× with backoff.
- `watch()` moves its body into `_tick()` behind `try/except BaseException` and records `_last_tick`.
- Version drift must hold across **two consecutive ticks**; pip settles in ~4 s, the tick is 60 s. Recovery now runs **before** `on_status`.
- `_get_installed_version()` requires `dist-info/RECORD`, pip's own completion marker.
- The child env sets `CLAWMETRY_AUTO_UPDATE=0` (on the copy, not `os.environ`) — one venv, one updater, instead of two racing writers.

**A way out for the user** — the original complaint was *"there is no refresh button when it gets into this kind of state"*, and that was literally true: pywebview's Cocoa backend swallows Cmd-R (`cocoa.py:512-543`) and strips the context menu (`cocoa.py:508-510`), so the only menu items were Quit and Uninstall.
- "Reload Dashboard" and "Restart Backend" in the app menu.
- `restart_backend` / `reload_dashboard` / `backend_state` on the JS bridge — the only channel that still works once the HTTP origin is dead.
- A watchdog thread that re-arms supervision when `_last_tick` goes stale, and `_gui_call()`, which bounds every pywebview call made off the main thread (`cocoa.py:916` is an **unbounded** `Semaphore.acquire()`; it did not fire this time but sits directly on the supervision path).

**Frontend** (`clawmetry/static/js/auth-bootstrap.js`) — stops the disappearance from being invisible. A global detector at the one chokepoint every `/api/` call passes through fires `cm:backend-unreachable` after 3 consecutive network-level failures (an HTTP 500 is explicitly *not* an outage), and a global overlay always carries an action.

## Why both layers

`desktop/` ships in the `.app` bundle, so the shell fix only reaches users who redownload the `.dmg`. The frontend fix ships in the wheel and lands on existing desktop installs at their next auto-update.

## Tests

- `tests/test_desktop_supervisor_resilience.py` — 20 tests. **All 20 fail against pre-fix `origin/main`; all 20 pass with the fix.**
- `tests/test_backend_outage_overlay.{js,py}` — 9 behavioural tests extracting the shipped IIFEs and running them against a DOM stub. Reverting the JS fails the suite.
- `ruff` clean. 213 passing in the surrounding desktop/onboarding/update sweep.

Pre-existing and unrelated, not touched here: `tests/test_hooks.py` (6 errors, `clawmetry.hooks` has no `HOOKS_DIR`) and `tests/test_moat_cloud_robustness.py::test_dlq_replay_drains_post_failures_after_outage` (fails in isolation on a clean tree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)