### PR TITLE
Sell the plan in the modal, and let people switch accounts

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -48,6 +48,19 @@
     starter: ['Unlimited channels + cloud sync', 'Approval queue'],
     pro: ['Everything in Starter', 'Tool policy + evals + cost optimizer'],
   };
+  // Publish the table so the OTHER in-app upgrade surface — the self-host
+  // modal's expired-trial step (static/js/onboarding.js, loaded after this
+  // file) — sells the same plans at the same prices. Two hardcoded ladders
+  // is how a reprice ships half-done.
+  window.CM_PLANS = {
+    prices: PLAN_PRICES,
+    blurb: PLAN_BLURB,
+    features: PLAN_FEATURES,
+    // Annual-only perk. The cloud collects a shipping address on annual
+    // checkouts (_annual_device_checkout_extras) and ships on the first PAID
+    // invoice, so this is a real promise, not a made-up one.
+    deviceValue: 149,
+  };
   var _selTier = 'starter';
   var _selInterval = 'year';   // annual preselected: better retention + the device perk
   // Filled from /api/entitlement (allowlisted, so it answers while blocked).

--- a/clawmetry/static/js/gw-setup.js
+++ b/clawmetry/static/js/gw-setup.js
@@ -465,6 +465,18 @@ function _cmProfileRender(st) {
       + '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-4"/><polyline points="10 17 15 12 10 7"/><line x1="15" y1="12" x2="3" y2="12"/></svg>'
       + t('profile.sign_in', null, 'Sign in / Create account') + '</button>';
   }
+  if (st.signedIn) {
+    // Switch account. Distinct from the "Sign out" below it, which only ever
+    // clears THIS BROWSER's dashboard session token: this one forgets the
+    // ClawMetry account on the machine (licence + cm_ key + onboarding
+    // stamps) so the gate can be answered with a different email. Until it
+    // existed the only way off a wrong account was the CLI, which stranded
+    // anyone whose licence lives on another address (founder report
+    // 2026-08-18). Two clicks — the first arms, the second commits.
+    h += '<button class="cm-profile-item" onclick="cmAccountSignOut(this)">'
+      + '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M16 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="8.5" cy="7" r="4"/><polyline points="17 11 19 13 23 9"/></svg>'
+      + t('profile.switch_account', null, 'Switch account') + '</button>';
+  }
   // No "Gateway settings" item: the gw-setup overlay is a first-run wizard
   // for the OpenClaw gateway token, not an ongoing settings surface — it
   // auto-opens whenever the gateway is unconfigured, which is the only time
@@ -480,6 +492,33 @@ function _cmProfileRender(st) {
       + t('profile.sign_out', null, 'Sign out') + '</button>';
   }
   menu.innerHTML = h;
+}
+
+// Two-step so a stray click never signs anybody out. The first click swaps
+// the row's label (the menu stays open); the second calls the endpoint, which
+// clears the licence, the cm_ key and both onboarding stamps, then kicks the
+// sync daemon so it drops the old account's key from memory. Local DuckDB
+// data is untouched — this is an identity change, not a wipe.
+function cmAccountSignOut(btn) {
+  if (!btn) return;
+  if (btn.dataset.armed !== '1') {
+    btn.dataset.armed = '1';
+    btn.textContent = t('profile.switch_account_confirm', null,
+      'Confirm — sign out of this account');
+    btn.style.color = '#ef4444';
+    return;
+  }
+  btn.textContent = t('profile.signing_out', null, 'Signing out');
+  fetch('/api/account/signout', { method: 'POST' })
+    .then(function (r) { return r.json(); })
+    .then(function (d) {
+      if (d && d.ok) { location.reload(); return; }
+      btn.textContent = (d && d.error)
+        || t('profile.switch_account_failed', null, 'Could not sign out');
+    })
+    .catch(function () {
+      btn.textContent = t('profile.switch_account_failed', null, 'Could not sign out');
+    });
 }
 
 function cmProfileClose() {

--- a/clawmetry/static/js/onboarding.js
+++ b/clawmetry/static/js/onboarding.js
@@ -91,10 +91,28 @@
       var el = $('shm-step-' + s);
       if (el) el.style.display = s === name ? 'block' : 'none';
     });
+    // The sign-in tagline promises a free 7-day trial. On the expired-trial
+    // step that is the one thing this user cannot have, so it goes away
+    // rather than sitting two lines above "Your 7-day trial has ended".
+    var tag = $('shm-tagline');
+    if (tag) tag.style.display = (name === 'ended') ? 'none' : '';
+    if (name === 'ended') {
+      _shmRenderPlans();
+      // Signing in as an account that ALREADY pays lands here too: the
+      // self-host rail reports "trial expired" because the trial is spent,
+      // while the real licence for that account arrives on the daemon's next
+      // heartbeat (up to ~60s later). Poll from the moment this step opens so
+      // a paying customer is let in instead of being sold a plan they own.
+      _shmPollForLicense();
+    }
   }
 
   function _shmStopPoll() {
     if (_oauthTimer) { clearInterval(_oauthTimer); _oauthTimer = null; }
+    // The post-checkout licence poll reloads the page when it lands, so a
+    // closed modal must stop it too — otherwise closing the modal to look at
+    // the free runtimes still yanks the page out from under the user.
+    if (_shmPollTimer) { clearInterval(_shmPollTimer); _shmPollTimer = null; }
   }
 
   window.openSelfhostModal = function () {
@@ -123,6 +141,176 @@
     _err('shm-license-error', '');
     _shmStep('license');
     setTimeout(function () { var el = $('shm-license-input'); if (el) el.focus(); }, 60);
+  };
+
+  // ── Expired trial: pick a plan and pay, without leaving the modal ────
+  // The account is already known locally (the cm_ key written at sign-in),
+  // so /api/trial/checkout can mint a Stripe Checkout Session scoped to it
+  // and the user lands on a card form instead of a marketing page. Prices
+  // come from window.CM_PLANS (app.js) — one table for both upgrade
+  // surfaces, so a reprice can't leave this one quoting stale numbers.
+  var _PLAN_FALLBACK = {
+    prices: { starter: { month: 9, year: 90, was: 190 },
+              pro: { month: 19, year: 190, was: 390 } },
+    blurb: {
+      starter: 'Every agent, every session, and every dollar in one dashboard.',
+      pro: 'The governance layer: gate tools before they fire, score runs with evals, catch runaway waste.',
+    },
+    deviceValue: 149,
+  };
+  var _shmTier = 'starter';
+  var _shmInterval = 'year';   // annual first: it carries the device perk
+  var _shmPollTimer = null;
+
+  function _plans() { return window.CM_PLANS || _PLAN_FALLBACK; }
+
+  function _shmPriceHtml(tier) {
+    var p = (_plans().prices || {})[tier] || {};
+    var yearly = _shmInterval === 'year';
+    var amt = yearly ? p.year : p.month;
+    if (typeof amt !== 'number') return '';
+    var was = (yearly && p.was)
+      ? '<span class="shm-was">$' + p.was + '</span>' : '';
+    return was + '$' + amt + '<span class="shm-tier-per"> / node / '
+      + (yearly ? 'year' : 'month') + '</span>';
+  }
+
+  function _shmRenderPlans() {
+    ['starter', 'pro'].forEach(function (tier) {
+      var pe = $('shm-price-' + tier);
+      if (pe) pe.innerHTML = _shmPriceHtml(tier);
+      var be = $('shm-blurb-' + tier);
+      if (be && !be.textContent) be.textContent = (_plans().blurb || {})[tier] || '';
+      var card = document.querySelector('#shm-step-ended .shm-tier[data-tier="' + tier + '"]');
+      if (card) card.setAttribute('aria-pressed', String(tier === _shmTier));
+    });
+    Array.prototype.forEach.call(
+      document.querySelectorAll('#shm-step-ended .shm-seg button'), function (b) {
+        b.setAttribute('aria-pressed',
+          String(b.getAttribute('data-interval') === _shmInterval));
+      });
+    var dev = $('shm-device');
+    if (dev) dev.style.display = (_shmInterval === 'year') ? '' : 'none';
+  }
+
+  function _shmStatus(msg, isErr) {
+    var el = $('shm-ended-status');
+    if (!el) return;
+    el.textContent = msg || '';
+    el.style.color = isErr ? '#E5443A' : '#94a3b8';
+    el.style.display = msg ? 'block' : 'none';
+  }
+
+  window.shmShowPlans = function () {
+    _shmStopPoll();
+    _shmStatus('');
+    _shmStep('ended');
+  };
+
+  window.shmSetInterval = function (interval) {
+    _shmInterval = interval === 'year' ? 'year' : 'month';
+    _shmRenderPlans();
+  };
+
+  window.shmSetTier = function (tier) {
+    _shmTier = tier === 'pro' ? 'pro' : 'starter';
+    _shmRenderPlans();
+  };
+
+  // Checkout completes in a Stripe tab; the licence comes back to THIS
+  // machine on the daemon's next heartbeat (up to ~60s), so poll the gate's
+  // own state and reload the moment it stops requiring a choice. No key to
+  // copy, no second sign-in.
+  function _shmPollForLicense() {
+    if (_shmPollTimer) clearInterval(_shmPollTimer);
+    var tries = 0;
+    _shmPollTimer = setInterval(function () {
+      tries += 1;
+      if (tries > 120) { clearInterval(_shmPollTimer); _shmPollTimer = null; return; }
+      fetch('/api/trial/refresh-license', { method: 'POST' }).catch(function () {})
+        .then(function () { return fetch('/api/onboarding/state'); })
+        .then(function (r) { return r.json(); })
+        .then(function (d) {
+          if (d && d.required === false) {
+            clearInterval(_shmPollTimer); _shmPollTimer = null;
+            location.reload();
+          }
+        }).catch(function () {});
+    }, 5000);
+  }
+
+  window.shmCheckout = function () {
+    var btn = $('shm-checkout-btn');
+    // The tab MUST be opened synchronously inside the click handler —
+    // popup blockers kill a window.open() fired from a fetch callback.
+    var payTab = null;
+    try { payTab = window.open('about:blank', '_blank'); } catch (e) { payTab = null; }
+    function go(url) {
+      if (payTab) { try { payTab.location = url; return; } catch (e) { /* fall through */ } }
+      try { window.open(url, '_blank', 'noopener'); } catch (e) { window.location.href = url; }
+    }
+    if (btn) btn.disabled = true;
+    _shmStatus('Opening secure checkout…');
+    fetch('/api/trial/checkout', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        tier: _shmTier,
+        plan: _shmInterval === 'year' ? 'yearly' : 'monthly',
+      }),
+    }).then(function (r) { return r.json(); }).then(function (d) {
+      if (btn) btn.disabled = false;
+      if (!d || !d.url) {
+        if (payTab) { try { payTab.close(); } catch (e) { /* noop */ } }
+        _shmStatus('Could not open checkout. Try again, or paste a license key.', true);
+        return;
+      }
+      go(d.url);
+      _shmStatus('Waiting for payment. This dashboard unlocks by itself once checkout completes.');
+      _shmPollForLicense();
+    }).catch(function () {
+      if (btn) btn.disabled = false;
+      if (payTab) { try { payTab.close(); } catch (e) { /* noop */ } }
+      _shmStatus('Network error. Try again, or paste a license key.', true);
+    });
+  };
+
+  // ── Sign out / switch account ────────────────────────────────────────
+  // The account on disk may simply be the wrong one (the licence lives on
+  // another email). Clearing it was CLI-only until now, which meant the
+  // expired-trial modal was a dead end for exactly that user. Two clicks,
+  // so a stray click never signs anyone out.
+  var _shmSignoutArmed = false;
+
+  window.shmSignOut = function () {
+    var link = $('shm-signout-link');
+    if (!_shmSignoutArmed) {
+      _shmSignoutArmed = true;
+      if (link) { link.textContent = 'Confirm sign out'; link.style.color = '#E5443A'; }
+      _shmStatus('Signs this machine out of the current account. Your local data stays.');
+      setTimeout(function () {
+        if (!_shmSignoutArmed) return;
+        _shmSignoutArmed = false;
+        if (link) { link.textContent = 'Use a different account'; link.style.color = '#94a3b8'; }
+      }, 8000);
+      return;
+    }
+    _shmSignoutArmed = false;
+    if (link) link.textContent = 'Signing out';
+    _shmStatus('Signing out…');
+    fetch('/api/account/signout', { method: 'POST' })
+      .then(function (r) { return r.json(); })
+      .then(function (d) {
+        if (!d || !d.ok) {
+          _shmStatus((d && d.error) || 'Could not sign out. Run `clawmetry disconnect` instead.', true);
+          if (link) link.textContent = 'Use a different account';
+          return;
+        }
+        location.reload();
+      }).catch(function () {
+        _shmStatus('Network error. Try again.', true);
+        if (link) link.textContent = 'Use a different account';
+      });
   };
 
   // Google/GitHub → mode=selfhost bridge: identity + trial, egress stays off.
@@ -197,6 +385,8 @@
       var em = $('shm-otp-email');
       if (em) em.textContent = _email;
       _err('shm-otp-error', '');
+      var plansEl = $('shm-otp-plans');
+      if (plansEl) plansEl.style.display = 'none';
       _shmStep('otp');
       setTimeout(function () { var el = $('shm-otp-input'); if (el) { el.value = ''; el.focus(); } }, 60);
     }).catch(function () {
@@ -236,6 +426,11 @@
     }).then(function (r) { return r.json(); }).then(function (d) {
       if (!d || !d.ok) {
         _err('shm-otp-error', (d && d.error) || 'Activation failed. Try again.');
+        // Most activation failures at this point are "this account already
+        // had its trial" — the one failure a retry cannot fix. Surface the
+        // paid path rather than leaving the user re-typing codes.
+        var plansEl = $('shm-otp-plans');
+        if (plansEl) plansEl.style.display = 'block';
         if (btn) { btn.textContent = 'Activate trial'; btn.disabled = false; }
         return;
       }

--- a/clawmetry/templates/partials/selfhost-modal.html
+++ b/clawmetry/templates/partials/selfhost-modal.html
@@ -42,7 +42,7 @@
       <img src="/static/img/logo.svg" width="28" height="28" style="border-radius:6px;">
       <span style="font-size:18px;font-weight:700;color:#fff;" data-i18n="selfhost.title">Self-Host</span>
     </div>
-    <p style="
+    <p id="shm-tagline" style="
       color:#94a3b8;
       font-size:14px;
       margin:0 0 24px;
@@ -150,6 +150,12 @@
           " data-i18n="selfhost.activate_trial">Activate trial</button>
       </div>
       <p id="shm-otp-error" style="color:#E5443A;font-size:12px;margin:6px 0 0;display:none;"></p>
+      <!-- An account whose trial is already spent fails activation with the
+           cloud's message and nothing to do about it. Offer the plans step
+           right there instead of sending them back to the email box. -->
+      <p id="shm-otp-plans" style="margin:8px 0 0;text-align:center;display:none;">
+        <span style="color:#E5443A;font-size:12px;font-weight:600;cursor:pointer;" onclick="shmShowPlans()" data-i18n="selfhost.see_plans">See plans</span>
+      </p>
       <p style="color:#64748b;font-size:12px;margin:10px 0 0;text-align:center;">
         <span style="cursor:pointer;" onclick="shmResendOtp()" data-i18n="selfhost.resend_code">Resend code</span>
         <span style="color:#334155;margin:0 8px;">·</span>
@@ -191,11 +197,62 @@
       <p id="shm-license-error" style="color:#E5443A;font-size:12px;margin:6px 0 0;display:none;"></p>
       <p style="color:#64748b;font-size:12px;margin:10px 0 0;text-align:center;cursor:pointer;" onclick="shmBackHome()" data-i18n="selfhost.back">Back</p>
     </div>
-    <div id="shm-step-ended" style="display:none;text-align:center;padding:8px 0;">
-      <p style="color:#cbd5e1;font-size:14px;font-weight:600;margin:0 0 6px;" data-i18n="selfhost.trial_ended_title">Your 7-day trial has ended</p>
-      <p style="color:#94a3b8;font-size:13px;margin:0 0 16px;" data-i18n="selfhost.trial_ended_body">You're signed in. Keep every runtime with a license.</p>
-      <a href="https://clawmetry.com/pricing?deploy=self" target="_blank" rel="noopener" style="display:block;padding:10px 14px;background:#E5443A;color:#fff;border-radius:8px;font-size:14px;font-weight:600;text-decoration:none;" data-i18n="selfhost.see_pricing">See pricing</a>
-      <p style="color:#64748b;font-size:12px;margin:12px 0 0;cursor:pointer;" onclick="shmShowLicense()" data-i18n="selfhost.have_license">I have a license key</p>
+    <!-- Expired trial → in-modal plan picker. This step used to be a single
+         "See pricing" link out to clawmetry.com, which dropped a user who
+         had already signed in onto a public marketing page and made them
+         start a checkout from scratch. Everything needed to charge them is
+         already on this machine (the account's cm_ key), so the picker sells
+         here: interval × tier, then POST /api/trial/checkout mints a Stripe
+         Checkout Session scoped to that account. Prices/blurbs come from
+         window.CM_PLANS (app.js) so the hard-block overlay and this modal can
+         never quote different numbers. -->
+    <div id="shm-step-ended" style="display:none;padding:4px 0;">
+      <style>
+        #shm-step-ended .shm-seg{display:flex;gap:6px;background:#1a2235;border-radius:10px;padding:4px;margin:0 0 14px;}
+        #shm-step-ended .shm-seg button{flex:1;padding:8px 6px;border:none;border-radius:7px;background:transparent;color:#94a3b8;font-size:13px;font-weight:600;cursor:pointer;font-family:inherit;}
+        #shm-step-ended .shm-seg button[aria-pressed="true"]{background:#2a3550;color:#fff;}
+        #shm-step-ended .shm-save{display:block;font-size:10px;font-weight:600;color:#4ade80;letter-spacing:0.2px;}
+        #shm-step-ended .shm-tier{display:flex;align-items:flex-start;gap:10px;width:100%;text-align:left;padding:12px;margin-bottom:8px;border-radius:10px;border:1px solid rgba(255,255,255,0.1);background:#141c2c;color:#e2e8f0;cursor:pointer;font-family:inherit;}
+        #shm-step-ended .shm-tier[aria-pressed="true"]{border-color:#E5443A;background:rgba(229,68,58,0.08);}
+        #shm-step-ended .shm-radio{flex:0 0 16px;width:16px;height:16px;margin-top:2px;border-radius:50%;border:2px solid #475569;}
+        #shm-step-ended .shm-tier[aria-pressed="true"] .shm-radio{border-color:#E5443A;background:radial-gradient(#E5443A 45%,transparent 47%);}
+        #shm-step-ended .shm-tier-head{display:flex;justify-content:space-between;align-items:baseline;gap:8px;}
+        #shm-step-ended .shm-tier-name{font-size:14px;font-weight:700;color:#fff;}
+        #shm-step-ended .shm-tier-price{font-size:13px;font-weight:700;color:#fff;white-space:nowrap;}
+        #shm-step-ended .shm-tier-per{font-size:11px;font-weight:500;color:#94a3b8;}
+        #shm-step-ended .shm-was{color:#64748b;text-decoration:line-through;font-weight:500;margin-right:4px;}
+        #shm-step-ended .shm-tier-sub{display:block;margin-top:3px;font-size:12px;line-height:1.4;color:#94a3b8;}
+      </style>
+      <p style="color:#cbd5e1;font-size:14px;font-weight:600;margin:0 0 4px;" data-i18n="selfhost.trial_ended_title">Your 7-day trial has ended</p>
+      <p style="color:#94a3b8;font-size:13px;margin:0 0 14px;" data-i18n="selfhost.trial_ended_pick">Pick a plan to keep every runtime unlocked. Priced per node, cancel any time.</p>
+      <div class="shm-seg" role="group" aria-label="Billing interval">
+        <button type="button" data-interval="month" aria-pressed="false" onclick="shmSetInterval('month')" data-i18n="selfhost.monthly">Monthly</button>
+        <button type="button" data-interval="year" aria-pressed="true" onclick="shmSetInterval('year')"><span data-i18n="selfhost.annual">Annual</span><span class="shm-save" data-i18n="selfhost.two_months_free">2 months free</span></button>
+      </div>
+      <button type="button" class="shm-tier" data-tier="starter" aria-pressed="true" onclick="shmSetTier('starter')">
+        <span class="shm-radio"></span>
+        <span style="flex:1;">
+          <span class="shm-tier-head"><span class="shm-tier-name" data-i18n="selfhost.tier_starter">Starter</span><span class="shm-tier-price" id="shm-price-starter"></span></span>
+          <span class="shm-tier-sub" id="shm-blurb-starter"></span>
+        </span>
+      </button>
+      <button type="button" class="shm-tier" data-tier="pro" aria-pressed="false" onclick="shmSetTier('pro')">
+        <span class="shm-radio"></span>
+        <span style="flex:1;">
+          <span class="shm-tier-head"><span class="shm-tier-name" data-i18n="selfhost.tier_pro">Pro</span><span class="shm-tier-price" id="shm-price-pro"></span></span>
+          <span class="shm-tier-sub" id="shm-blurb-pro"></span>
+        </span>
+      </button>
+      <div id="shm-device" style="margin:2px 0 12px;padding:9px 11px;border-radius:8px;background:rgba(74,222,128,0.08);border:1px solid rgba(74,222,128,0.25);color:#bbf7d0;font-size:12px;line-height:1.45;">
+        <span data-i18n="selfhost.device_perk">Includes a free $149 desk device, shipped when your first annual invoice is paid.</span>
+      </div>
+      <button type="button" id="shm-checkout-btn" onclick="shmCheckout()" style="display:block;width:100%;padding:11px 14px;background:#E5443A;color:#fff;border:none;border-radius:8px;font-size:14px;font-weight:600;cursor:pointer;font-family:inherit;" data-i18n="selfhost.continue_checkout">Continue to secure checkout</button>
+      <p id="shm-ended-status" style="color:#94a3b8;font-size:12px;margin:8px 0 0;text-align:center;line-height:1.45;display:none;"></p>
+      <div style="margin-top:14px;padding-top:12px;border-top:1px solid rgba(255,255,255,0.06);text-align:center;">
+        <span style="color:#94a3b8;font-size:12px;cursor:pointer;" onclick="shmShowLicense()" data-i18n="selfhost.have_license">I have a license key</span>
+        <span style="color:#334155;font-size:12px;margin:0 8px;">·</span>
+        <span id="shm-signout-link" style="color:#94a3b8;font-size:12px;cursor:pointer;" onclick="shmSignOut()" data-i18n="selfhost.use_other_account">Use a different account</span>
+      </div>
     </div>
   </div>
 </div>

--- a/clawmetry/trial_enforcement.py
+++ b/clawmetry/trial_enforcement.py
@@ -103,6 +103,12 @@ _ALLOWED_PATH_PREFIXES = (
     "/api/heartbeat",           # cloud liveness probe
     "/api/extensions",          # "is clawmetry-pro loaded?" probe
     "/api/auth/",               # OSS auth-check + zero-click bootstrap
+    "/api/onboarding/",         # the gate is how a locked install gets a
+                                # licence: state + activate-license + the
+                                # post-checkout poll all run while blocked
+    "/api/cloud-cta/",          # sign-in plumbing (OTP / OAuth bridge) — a
+                                # user who signs OUT to switch accounts must
+                                # be able to sign back IN without unlocking
     "/auth",                    # legacy auth endpoint sibling of /api/auth
     "/static/",                 # overlay JS/CSS must load
     "/favicon",                 # tab icon
@@ -112,6 +118,9 @@ _ALLOWED_PATH_EXACT = frozenset({
     "/robots.txt",
     "/api/entitlement",         # exact, also matched by prefix — belt & braces
     "/api/health",              # k8s / docker / cURL liveness probe
+    "/api/account/signout",     # forget the wrong account. Strictly narrows
+                                # entitlement (it deletes the licence), so it
+                                # can never be a way around the block
 })
 
 # Default upgrade destination when the cloud hasn't handed us a signed

--- a/routes/onboarding.py
+++ b/routes/onboarding.py
@@ -400,3 +400,140 @@ def api_onboarding_activate_license():
     _ensure_daemon_for_choice(state)
     _ping_onboarded(state)
     return jsonify({"ok": True, "state": state, "message": msg})
+
+
+# ── Account sign-out (switch to a different ClawMetry account) ─────────────
+# Until this existed the ONLY way off a signed-in account was the CLI
+# (``clawmetry disconnect`` then ``clawmetry login``) — so a user whose Pro
+# licence sits on a different email hit the expired-trial modal with no way
+# forward: the gate blocks the dashboard, and every button on it re-uses the
+# identity already on disk (founder live-hit 2026-08-18).
+#
+# "Sign out" here means FORGET THE ACCOUNT ON THIS MACHINE, which is four
+# separate pieces of state — miss any one and the gate either refuses to
+# re-open or the daemon quietly re-installs the old account's licence on its
+# next heartbeat:
+#   1. ~/.clawmetry/license.key      the entitlement itself
+#   2. ~/.clawmetry/config.json      the cm_ cloud key (+ sync state file)
+#   3. ~/.clawmetry/onboarding.json  this gate's recorded choice
+#   4. the desktop shell's onboarding-completed.json stamp (_shell_stamp_choice
+#      keeps the gate closed on .app installs even with 1-3 gone)
+# Ingested data in DuckDB is deliberately left alone: signing out is an
+# identity operation, not a factory reset.
+
+def _signout_clear_cloud_identity() -> bool:
+    """Delete the cm_ key + sync state. True when something was removed."""
+    removed = False
+    try:
+        from clawmetry.sync import CONFIG_FILE, STATE_FILE
+
+        for path in (Path(str(CONFIG_FILE)), Path(str(STATE_FILE))):
+            try:
+                if path.exists():
+                    path.unlink()
+                    removed = True
+            except Exception as exc:
+                log.warning("signout: cannot remove %s: %s", path, exc)
+    except Exception as exc:
+        log.warning("signout: cloud identity clear failed: %s", exc)
+    # A stale sync-progress file makes the dashboard banner freeze on
+    # whatever phase the old account's daemon was in (same reason
+    # ``clawmetry disconnect`` drops it).
+    try:
+        prog = Path.home() / ".clawmetry" / "sync_progress.json"
+        if prog.exists():
+            prog.unlink()
+    except Exception:
+        pass
+    return removed
+
+
+def _signout_clear_choice() -> bool:
+    """Drop both onboarding stamps so the gate prompts again."""
+    removed = False
+    for path in (Path(_STATE_PATH),
+                 _desktop_shell_runtime_dir() / "onboarding-completed.json"):
+        try:
+            if path.exists():
+                path.unlink()
+                removed = True
+        except Exception as exc:
+            log.warning("signout: cannot remove %s: %s", path, exc)
+    return removed
+
+
+def _signout_restart_daemon() -> None:
+    """Kick the sync daemon so it drops the old account's key.
+
+    ``run_daemon`` reads ``config.json`` ONCE at startup and keeps the key in
+    memory for the whole process, so deleting the file is not enough — a
+    running daemon would keep heartbeating as the signed-out account and
+    ``_maybe_install_license_from_heartbeat`` would write its licence straight
+    back. Restarting drops it into local-only mode (ingestion continues,
+    nothing leaves the machine). Off-thread + best-effort: launchctl/systemctl
+    are real latency the browser should not wait on, and a failed restart just
+    means the change lands on the daemon's next natural restart.
+    """
+    def _run() -> None:
+        try:
+            import dashboard as _d
+
+            _d._restart_sync_daemon()
+        except Exception as exc:
+            log.warning("signout: daemon restart failed: %s", exc)
+
+    try:
+        threading.Thread(target=_run, daemon=True).start()
+    except Exception:
+        _run()
+
+
+@bp_onboarding.route("/api/account/signout", methods=["POST"])
+def api_account_signout():
+    """Forget the ClawMetry account this machine is signed in with.
+
+    Idempotent — signing out twice is a no-op, not an error. Always returns
+    HTTP 200 with what was actually cleared so the caller can reload into the
+    gate regardless; the one hard failure is the hosted dashboard, where
+    account state lives in the cloud session rather than on disk.
+    """
+    if os.environ.get("CLAWMETRY_CLOUD", "").strip():
+        return jsonify({
+            "ok": False,
+            "error": "Sign out from your account menu on app.clawmetry.com.",
+        }), 400
+
+    cleared = {"license": False, "cloud": False, "choice": False}
+    try:
+        from clawmetry import license as _lic
+
+        ok, removed = _lic.deactivate(actor="dashboard-signout")
+        cleared["license"] = bool(ok and removed)
+    except Exception as exc:
+        log.warning("signout: license deactivate failed: %s", exc)
+
+    cleared["cloud"] = _signout_clear_cloud_identity()
+    cleared["choice"] = _signout_clear_choice()
+
+    # No egress while nobody is signed in. Symmetric with sign-in: the
+    # managed branch clears this marker via ``config.enable_cloud()`` and the
+    # self-host branch re-writes it, so neither path is blocked by it.
+    try:
+        from clawmetry import config as _cfg
+
+        marker = Path(str(_cfg.NOCLOUD_MARKER_PATH))
+        marker.parent.mkdir(parents=True, exist_ok=True)
+        marker.touch(exist_ok=True)
+    except Exception as exc:
+        log.warning("signout: nocloud marker failed: %s", exc)
+
+    try:
+        from clawmetry import entitlements as _ent
+
+        _ent.invalidate()
+    except Exception:
+        pass
+
+    _signout_restart_daemon()
+    log.info("signout: cleared %s", cleared)
+    return jsonify({"ok": True, "cleared": cleared, "state": _resolve_state()})

--- a/tests/test_upgrade_dialog_and_account_signout.py
+++ b/tests/test_upgrade_dialog_and_account_signout.py
@@ -1,0 +1,274 @@
+"""Expired-trial upgrade dialog + account sign-out.
+
+Two founder reports, 2026-08-18, both about the same dead end: an install
+whose 7-day trial has ended shows the self-host modal with a single "See
+pricing" link to the public site, and no way to reach an account whose Pro
+licence lives on a different email.
+
+  1. The modal now sells in place — interval x tier picker, the annual
+     device perk, and a POST to /api/trial/checkout that mints a Stripe
+     session scoped to the account already on disk.
+  2. POST /api/account/signout forgets that account (licence, cm_ key, both
+     onboarding stamps) so the gate can be answered with a different one.
+
+Route logic runs against a minimal Flask app with every filesystem path
+redirected into tmp_path; the UI checks read the shipped static/template
+files (no build step, so the files ARE the app).
+"""
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+
+import pytest
+from flask import Flask
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def _read(*parts: str) -> str:
+    with open(os.path.join(_ROOT, *parts), encoding="utf-8") as fh:
+        return fh.read()
+
+
+# ── POST /api/account/signout ──────────────────────────────────────────────
+
+class _SyncThread:
+    """Run the "background" work inline so the test can assert on it."""
+
+    def __init__(self, target=None, daemon=True):
+        self._target = target
+        self.daemon = daemon
+
+    def start(self):
+        if self._target:
+            self._target()
+
+
+@pytest.fixture
+def signout(monkeypatch, tmp_path):
+    """A signed-in machine: licence + cm_ key + both onboarding stamps."""
+    import routes.onboarding as mod
+    importlib.reload(mod)
+
+    home = tmp_path / "clawmetry-home"
+    home.mkdir()
+    state_path = home / "onboarding.json"
+    state_path.write_text('{"choice": "selfhost_trial"}')
+    config_file = home / "config.json"
+    config_file.write_text('{"api_key": "cm_old_account"}')
+    sync_state = home / "state.json"
+    sync_state.write_text("{}")
+    shell_dir = tmp_path / "desktop-shell-runtime"
+    shell_dir.mkdir()
+    (shell_dir / "onboarding-completed.json").write_text(
+        '{"completed": true, "signed_in": true, "mode": "selfhost"}')
+    marker = home / "nocloud"
+
+    monkeypatch.setattr(mod, "_STATE_PATH", str(state_path))
+    monkeypatch.setattr(mod, "_desktop_shell_runtime_dir", lambda: shell_dir)
+    # The handler resolves the stale sync-progress file off Path.home(), so
+    # the fake HOME has to carry a real ~/.clawmetry to find it in.
+    monkeypatch.setattr(mod.Path, "home", staticmethod(lambda: tmp_path))
+    (tmp_path / ".clawmetry").mkdir()
+    progress = tmp_path / ".clawmetry" / "sync_progress.json"
+    progress.write_text("{}")
+    monkeypatch.setattr(mod, "_license_state", lambda: "")
+    monkeypatch.setattr(mod, "_cloud_connected", lambda: False)
+    monkeypatch.setattr(mod.threading, "Thread", _SyncThread)
+    monkeypatch.delenv("CLAWMETRY_CLOUD", raising=False)
+
+    import clawmetry.sync as _sync
+    monkeypatch.setattr(_sync, "CONFIG_FILE", config_file, raising=False)
+    monkeypatch.setattr(_sync, "STATE_FILE", sync_state, raising=False)
+
+    import clawmetry.config as _cfg
+    monkeypatch.setattr(_cfg, "NOCLOUD_MARKER_PATH", str(marker))
+
+    import clawmetry.license as _lic
+    licence = home / "license.key"
+    licence.write_text("header.payload.signature")
+    removed = {"called": False}
+
+    def _fake_deactivate(actor=""):
+        removed["called"] = True
+        licence.unlink()
+        return True, True
+    monkeypatch.setattr(_lic, "deactivate", _fake_deactivate)
+
+    restarts = []
+    import dashboard as _d
+    monkeypatch.setattr(_d, "_restart_sync_daemon", lambda: restarts.append(1))
+
+    app = Flask(__name__)
+    app.register_blueprint(mod.bp_onboarding)
+    return {
+        "mod": mod,
+        "client": app.test_client(),
+        "licence": licence,
+        "config": config_file,
+        "sync_state": sync_state,
+        "progress": progress,
+        "choice": state_path,
+        "shell_stamp": shell_dir / "onboarding-completed.json",
+        "marker": marker,
+        "restarts": restarts,
+        "deactivated": removed,
+    }
+
+
+def test_signout_clears_every_piece_of_identity(signout):
+    """Miss ANY one of the four and the user is still stuck: a surviving
+    licence keeps the old entitlement, a surviving cm_ key lets the daemon
+    re-install it from the next heartbeat, and either onboarding stamp keeps
+    the gate closed so there is nowhere to sign in again."""
+    d = signout["client"].post("/api/account/signout").get_json()
+    assert d["ok"] is True
+    assert d["cleared"] == {"license": True, "cloud": True, "choice": True}
+    assert signout["deactivated"]["called"] is True
+    assert not signout["licence"].exists()
+    assert not signout["config"].exists()
+    assert not signout["sync_state"].exists()
+    assert not signout["progress"].exists()
+    assert not signout["choice"].exists()
+    assert not signout["shell_stamp"].exists()
+
+
+def test_signout_reopens_the_gate(signout):
+    d = signout["client"].post("/api/account/signout").get_json()
+    assert d["state"]["required"] is True
+
+
+def test_signout_restarts_the_daemon(signout):
+    """run_daemon() reads config.json ONCE at startup and holds the api_key in
+    memory for the life of the process, so deleting the file is not enough --
+    a still-running daemon keeps heart-beating as the signed-out account and
+    _maybe_install_license_from_heartbeat writes its licence straight back."""
+    signout["client"].post("/api/account/signout")
+    assert signout["restarts"] == [1]
+
+
+def test_signout_stops_egress(signout):
+    """Nobody is signed in, so nothing may leave the machine until somebody
+    chooses again. Sign-in re-clears (managed) or re-writes (self-host) the
+    marker, so this never blocks the next account."""
+    signout["client"].post("/api/account/signout")
+    assert signout["marker"].exists()
+
+
+def test_signout_is_idempotent(signout):
+    signout["client"].post("/api/account/signout")
+    d = signout["client"].post("/api/account/signout").get_json()
+    assert d["ok"] is True
+    assert d["cleared"]["cloud"] is False and d["cleared"]["choice"] is False
+
+
+def test_signout_refuses_on_hosted_cloud(signout, monkeypatch):
+    """Hosted accounts have no on-disk identity to clear; deleting files there
+    would be someone else's container, not the caller's machine."""
+    monkeypatch.setenv("CLAWMETRY_CLOUD", "1")
+    r = signout["client"].post("/api/account/signout")
+    assert r.status_code == 400
+    assert r.get_json()["ok"] is False
+    assert signout["config"].exists(), "must not touch disk in cloud mode"
+
+
+def test_signout_survives_a_broken_license_layer(signout, monkeypatch):
+    """A licence file we cannot parse or delete must not strand the user on
+    the account -- the rest of the sign-out still has to land."""
+    import clawmetry.license as _lic
+
+    def boom(actor=""):
+        raise RuntimeError("corrupt key")
+    monkeypatch.setattr(_lic, "deactivate", boom)
+    d = signout["client"].post("/api/account/signout").get_json()
+    assert d["ok"] is True and d["cleared"]["license"] is False
+    assert not signout["config"].exists() and not signout["choice"].exists()
+
+
+# ── Trial-enforcement allowlist ────────────────────────────────────────────
+
+def test_signout_and_gate_reachable_while_hard_blocked():
+    """The hard block exists to force a payment decision. Both ways OUT of it
+    -- pay, or sign in as the account that already paid -- have to answer
+    while it is up, or the block is a trap rather than a paywall."""
+    from clawmetry import trial_enforcement as _te
+
+    for path in ("/api/account/signout", "/api/onboarding/state",
+                 "/api/onboarding/activate-license", "/api/cloud-cta/send-otp",
+                 "/api/cloud-cta/oauth-status", "/api/trial/checkout"):
+        assert _te.allowlisted_path(path), "%s must survive the hard block" % path
+    assert not _te.allowlisted_path("/api/usage"), "allowlist must stay tiny"
+
+
+# ── The upgrade dialog (static files ARE the app: no build step) ───────────
+
+def test_expired_trial_step_sells_in_place():
+    modal = _read("clawmetry", "templates", "partials", "selfhost-modal.html")
+    assert "clawmetry.com/pricing" not in modal, \
+        "expired trial must not bounce the user to the public pricing page"
+    for probe in ("shmSetInterval('month')", "shmSetInterval('year')",
+                  "shmSetTier('starter')", "shmSetTier('pro')",
+                  "shmCheckout()", 'id="shm-price-starter"',
+                  'id="shm-price-pro"', 'id="shm-device"'):
+        assert probe in modal, "upgrade dialog missing %s" % probe
+
+
+def test_annual_device_perk_is_offered():
+    """Annual bundles the $149 desk device (the cloud collects a shipping
+    address on annual checkouts and ships on the first PAID invoice)."""
+    modal = _read("clawmetry", "templates", "partials", "selfhost-modal.html")
+    assert "$149" in modal
+    js = _read("clawmetry", "static", "js", "onboarding.js")
+    assert "_shmInterval === 'year'" in js, "device perk must be annual-only"
+
+
+def test_checkout_posts_tier_and_interval():
+    js = _read("clawmetry", "static", "js", "onboarding.js")
+    assert "'/api/trial/checkout'" in js
+    assert "tier: _shmTier" in js
+    assert "plan: _shmInterval === 'year' ? 'yearly' : 'monthly'" in js
+
+
+def test_prices_come_from_one_table():
+    """Two hardcoded price ladders is how a reprice ships half-done: the
+    hard-block overlay publishes window.CM_PLANS and this modal reads it."""
+    app_js = _read("clawmetry", "static", "js", "app.js")
+    assert "window.CM_PLANS" in app_js
+    ob_js = _read("clawmetry", "static", "js", "onboarding.js")
+    assert "window.CM_PLANS" in ob_js
+
+
+def test_expired_step_polls_so_a_paying_account_is_let_in():
+    """Signing in as an account that already pays lands on this step too --
+    the self-host rail reports "trial expired" because the trial is spent,
+    while the real licence arrives on the daemon's next heartbeat. Without a
+    poll the customer is sold a plan they already own."""
+    js = _read("clawmetry", "static", "js", "onboarding.js")
+    body = js[js.index("function _shmStep("):js.index("function _shmStopPoll(")]
+    assert "_shmPollForLicense()" in body, \
+        "the expired-trial step must poll for a licence, not only after checkout"
+    assert "'/api/onboarding/state'" in js
+
+
+def test_trial_promise_is_hidden_once_the_trial_is_gone():
+    """The modal's tagline promises a free 7-day trial. Two lines above "Your
+    7-day trial has ended" that is a contradiction, not an offer."""
+    modal = _read("clawmetry", "templates", "partials", "selfhost-modal.html")
+    assert 'id="shm-tagline"' in modal
+    js = _read("clawmetry", "static", "js", "onboarding.js")
+    assert "$('shm-tagline')" in js
+
+
+def test_switch_account_is_offered_in_both_places():
+    """At the gate (where a blocked user is) and in the profile menu (where a
+    signed-in user is)."""
+    modal = _read("clawmetry", "templates", "partials", "selfhost-modal.html")
+    assert "shmSignOut()" in modal
+    ob_js = _read("clawmetry", "static", "js", "onboarding.js")
+    assert "'/api/account/signout'" in ob_js
+    gw = _read("clawmetry", "static", "js", "gw-setup.js")
+    assert "cmAccountSignOut" in gw and "'/api/account/signout'" in gw


### PR DESCRIPTION
Two dead ends on the expired-trial screen, both founder-reported 2026-08-18.

## 1. The upgrade dialog replaces "See pricing"

Before: an already-signed-in user whose trial ended got one link to clawmetry.com/pricing and had to start a checkout from scratch on a marketing page.

After: the modal sells in place.

- Monthly / Annual toggle (annual preselected, "2 months free")
- Starter / Pro cards with live per-node prices and the prior-ladder anchor struck through
- The free **$149 desk device** on annual, hidden on monthly (the cloud already collects a shipping address on annual checkouts and ships on the first paid invoice, so this is a real promise)
- One button → `POST /api/trial/checkout {tier, plan}` → Stripe Checkout Session scoped to the account already on this machine

Prices come from `window.CM_PLANS`, published by the hard-block overlay in `app.js`. Two hardcoded ladders is how a reprice ships half-done.

The step also polls for a licence now: signing in as an account that **already pays** lands here too (the self-host rail reports "trial expired" because the trial is spent), so a paying customer is let in on the next heartbeat instead of being sold a plan they own.

## 2. Sign out / switch account

If the Pro licence lives on a different email there was no way to get to it: the gate blocks the dashboard, every button on it reuses the identity on disk, and the only escape was `clawmetry disconnect` in a terminal.

`POST /api/account/signout` forgets the account — licence, cm_ key + sync state, this gate's stamp, and the desktop shell's stamp. Miss any one and the user is still stuck; and because `run_daemon()` reads `config.json` once at startup and holds the key in memory, a still-running daemon would re-install the old account's licence from its next heartbeat, so the endpoint kicks the daemon too. Local DuckDB data is untouched: identity change, not a wipe.

Offered where each user actually is — "Use a different account" in the modal, "Switch account" in the profile menu. Two clicks in both, so a stray click never signs anyone out.

## Allowlist

`/api/onboarding/`, `/api/cloud-cta/` and `/api/account/signout` now answer while the trial hard block is up. Both ways OUT of the block (pay, or sign in as the account that already paid) have to work, or the block is a trap rather than a paywall. Sign-out strictly narrows entitlement, so it can never be a bypass.

## Verification

Ran a dashboard from this branch on :8901 against a fake HOME and drove it in Chrome:

- expired step renders, Monthly/Annual and Starter/Pro switch prices live (`$90/$190 per node/year` ↔ `$9/$19 per node/month`), device line hides on monthly
- checkout button opens the tab synchronously and reports "Waiting for payment…" (`/api/trial/checkout` returned a URL)
- sign-out arms on the first click, and the live endpoint returned `{ok: true}`, reopened the gate, wrote the nocloud marker and restarted the daemon local-only
- profile menu renders "Switch account" for a signed-in account

13 new tests + the existing onboarding/hard-block suites pass; `make lint-js`, `lint-daemon-allowlist`, `lint-runtime-count` clean; ruff clean on every file touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)