### PR TITLE
feat(ui): an always-visible refresh button that can actually recover

### DIFF
--- a/clawmetry/static/css/dashboard.css
+++ b/clawmetry/static/css/dashboard.css
@@ -67,6 +67,12 @@
   .version-badge { font-size: 11px; color: var(--text-secondary); background: var(--bg-secondary); border: 1px solid var(--border-primary); border-radius: 6px; padding: 2px 8px; white-space: nowrap; cursor: default; transition: all 0.2s; user-select: none; }
   .version-badge.update-available { color: #22c55e; border-color: rgba(34,197,94,0.4); cursor: pointer; }
   .version-badge.update-available:hover { background: rgba(34,197,94,0.1); }
+  /* Refresh / reconnect control. Amber once the backend is known
+     unreachable, so the way out is visible before the user hunts for it. */
+  #cm-reconnect-btn.cm-attention { color: #f59e0b; border-color: rgba(245,158,11,0.5); background: rgba(245,158,11,0.08); }
+  #cm-reconnect-btn.cm-spinning { cursor: wait; opacity: 0.75; }
+  #cm-reconnect-btn.cm-spinning svg { animation: cm-spin 0.9s linear infinite; }
+  @keyframes cm-spin { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
   .version-badge.updating { color: #f59e0b; border-color: rgba(245,158,11,0.4); cursor: wait; }
   .theme-toggle { background: var(--button-bg); border: none; border-radius: 8px; padding: 8px 12px; color: var(--text-tertiary); cursor: pointer; font-size: 16px; margin-left: 12px; transition: all 0.15s; box-shadow: var(--card-shadow); }
   .theme-toggle:hover { background: var(--button-hover); color: var(--text-secondary); }

--- a/clawmetry/static/js/auth-bootstrap.js
+++ b/clawmetry/static/js/auth-bootstrap.js
@@ -363,16 +363,23 @@ function clawmetryLocalSignin(){
       throw e;
     });
   };
+  // The probe in the recovery block uses this so a health check that
+  // fails cannot itself inflate the outage counter.
+  window.__cmOrigFetch=_origFetch;
   window.cmBackendFailures=function(){return _netFail;};
 })();
 
-// ── Global "backend unreachable" overlay ──
-// The recovery surface of last resort. Rendered on top of every tab, so it
-// cannot be missed the way a per-panel spinner can, and it always offers an
-// action. Inside the desktop shell the pywebview JS bridge still works when
-// the HTTP origin does not, so prefer it; in a browser tab, reload.
+// ── Backend recovery: the refresh button, the outage overlay, and Cmd-R ──
+// One implementation behind three entry points, because a naive "reload the
+// page" button is a trap in the desktop shell. A pywebview window has no
+// browser chrome, so if the backend is dead, location.reload() replaces a
+// frozen-but-readable dashboard with a blank WebKit error page that has no
+// buttons on it at all -- strictly worse than the freeze. So: probe first,
+// heal the backend if it is down, and only then reload.
 (function(){
   var BAR_ID='cm-backend-outage';
+  var BTN_ID='cm-reconnect-btn';
+  var busy=false;
 
   function _bridge(){
     try{
@@ -380,13 +387,71 @@ function clawmetryLocalSignin(){
     }catch(e){ return null; }
   }
 
+  // Probe with the UNWRAPPED fetch: a health probe that fails must not count
+  // toward the outage threshold that raised this overlay in the first place.
+  function _probe(timeoutMs){
+    return new Promise(function(resolve){
+      var done=false;
+      var t=setTimeout(function(){ if(!done){ done=true; resolve(false); } }, timeoutMs||4000);
+      function settle(v){ if(!done){ done=true; clearTimeout(t); resolve(v); } }
+      try{
+        (window.__cmOrigFetch||window.fetch).call(window,'/api/health',{cache:'no-store'})
+          .then(function(){ settle(true); }, function(){ settle(false); });
+      }catch(e){ settle(false); }
+    });
+  }
+
+  function _waitForBackend(budgetMs){
+    var deadline=Date.now()+(budgetMs||45000);
+    return new Promise(function(resolve){
+      (function attempt(){
+        _probe(2500).then(function(alive){
+          if(alive) return resolve(true);
+          if(Date.now()>=deadline) return resolve(false);
+          setTimeout(attempt,1500);
+        });
+      })();
+    });
+  }
+
+  function _btn(){ return document.getElementById(BTN_ID); }
+
+  function _setBusy(on,label){
+    busy=on;
+    var b=_btn();
+    if(b){
+      b.classList.toggle('cm-spinning',!!on);
+      b.setAttribute('aria-busy',on?'true':'false');
+      b.title=on?(label||'Reconnecting…'):'Refresh (Cmd/Ctrl + R)';
+    }
+    var bar=document.getElementById(BAR_ID);
+    if(bar && bar.__btn){
+      bar.__btn.disabled=!!on;
+      if(on) bar.__btn.textContent=label||'Restarting…';
+      else   bar.__btn.textContent=bar.__label;
+    }
+  }
+
+  // Mark the header button when the backend is known-unreachable, so the
+  // affordance is discoverable BEFORE the user goes hunting for it.
+  function _markDown(down){
+    var b=_btn();
+    if(b) b.classList.toggle('cm-attention',!!down);
+  }
+
   function _dismiss(){
     var el=document.getElementById(BAR_ID);
     if(el && el.parentNode) el.parentNode.removeChild(el);
+    _markDown(false);
   }
 
-  function _show(){
-    if(document.getElementById(BAR_ID)) return;
+  function _show(note){
+    _markDown(true);
+    var existing=document.getElementById(BAR_ID);
+    if(existing){
+      if(note && existing.__note) existing.__note.textContent=note;
+      return;
+    }
     var api=_bridge();
     var el=document.createElement('div');
     el.id=BAR_ID;
@@ -416,42 +481,70 @@ function clawmetryLocalSignin(){
       'border-radius:8px','border:1px solid #ef4444','background:#ef4444',
       'color:#fff','font-weight:600','font-size:13px'
     ].join(';');
-    btn.textContent=(api&&api.restart_backend)?'Restart backend':'Reload';
-    btn.onclick=function(){
-      btn.disabled=true;
-      btn.textContent='Restarting…';
-      if(api&&api.restart_backend){
-        try{
-          api.restart_backend();
-          // The shell reloads the window itself once the daemon answers.
-          // If it cannot, re-enable so the user can try again.
-          setTimeout(function(){
-            btn.disabled=false;
-            btn.textContent='Restart backend';
-          },20000);
-          return;
-        }catch(e){}
-      }
-      location.reload();
-    };
+    el.__label=(api&&api.restart_backend)?'Restart backend':'Reload';
+    btn.textContent=el.__label;
+    btn.onclick=function(){ window.cmReconnect(); };
+    el.__btn=btn;
     el.appendChild(btn);
 
-    // Honest fallback for the case the shell cannot fix itself.
-    if(!(api&&api.restart_backend)){
-      var hint=document.createElement('div');
-      hint.style.cssText='flex-basis:100%;font-size:12px;color:#e7a3a3';
-      hint.textContent='If reloading does not help, quit ClawMetry and open '
-        +'it again.';
-      el.appendChild(hint);
-    }
+    var hint=document.createElement('div');
+    hint.style.cssText='flex-basis:100%;font-size:12px;color:#e7a3a3';
+    hint.textContent=note||((api&&api.restart_backend)
+      ? 'This restarts the local backend and reloads the page.'
+      : 'If reloading does not help, quit ClawMetry and open it again.');
+    el.__note=hint;
+    el.appendChild(hint);
+
     (document.body||document.documentElement).appendChild(el);
   }
 
-  window.addEventListener('cm:backend-unreachable',_show);
+  // The single recovery path. Safe to call whether the backend is healthy
+  // (plain refresh) or dead (heal, then refresh).
+  function cmReconnect(){
+    if(busy) return Promise.resolve(false);
+    _setBusy(true,'Checking…');
+    return _probe(4000).then(function(alive){
+      if(alive){ location.reload(); return true; }
+      var api=_bridge();
+      if(api && api.restart_backend){
+        _setBusy(true,'Restarting…');
+        try{ api.restart_backend(); }
+        catch(e){ _setBusy(false); _show('Could not reach the app shell. Quit ClawMetry and open it again.'); return false; }
+        // Budget is overridable so the test suite can exercise the
+        // did-not-come-back branch without waiting three quarters of a minute.
+        return _waitForBackend(window.__cmRestartBudgetMs||45000).then(function(ok){
+          if(ok){ location.reload(); return true; }
+          _setBusy(false);
+          _show('The backend did not come back. Quit ClawMetry and open it again.');
+          return false;
+        });
+      }
+      // No bridge and no backend. Reloading here would swap the page for a
+      // blank error page with no way back, so refuse and say what helps.
+      _setBusy(false);
+      _show('The backend is not answering, so reloading would leave a blank page. Quit ClawMetry and open it again.');
+      return false;
+    });
+  }
+
+  window.addEventListener('cm:backend-unreachable',function(){ _show(); });
   window.addEventListener('cm:backend-reachable',_dismiss);
-  // Exposed for tests and for panels that want to raise it directly.
+
+  // Cmd/Ctrl+R. pywebview's Cocoa backend swallows the native shortcut, so
+  // inside the shell we implement it ourselves; in a real browser the native
+  // reload is already correct, so leave it alone.
+  document.addEventListener('keydown',function(e){
+    if(!(e.metaKey||e.ctrlKey) || e.altKey) return;
+    if(e.key!=='r' && e.key!=='R') return;
+    if(!_bridge()) return;
+    e.preventDefault();
+    cmReconnect();
+  },true);
+
+  window.cmReconnect=cmReconnect;
   window.cmShowBackendOutage=_show;
   window.cmHideBackendOutage=_dismiss;
+  window.cmBackendProbe=_probe;
 })();
 
 // ── Version badge + one-click update ──

--- a/clawmetry/static/locales/en.json
+++ b/clawmetry/static/locales/en.json
@@ -1077,6 +1077,7 @@
   "skills.title": "Skills",
   "topbar.active_alerts": "Active alerts",
   "topbar.logout": "Logout",
+  "topbar.refresh": "Refresh (Cmd/Ctrl + R)",
   "topbar.switch_profile": "Switch profile (this machine). Local OpenClaw profiles only. For fleet view across multiple machines, upgrade to Pro.",
   "topbar.version": "ClawMetry version",
   "topbar.zoom_in": "Zoom in (Ctrl/Cmd + +)",

--- a/dashboard.py
+++ b/dashboard.py
@@ -12801,6 +12801,16 @@ DASHBOARD_HTML = r"""
     <span style="font-size:11px;color:var(--text-muted);font-weight:600;">Runtime</span>
     <select id="cm-global-runtime" onchange="_cmOnGlobalRuntimeChange(this)" title="Scope session views to a single agent runtime" style="font-size:12px;font-weight:600;padding:7px 10px;border:1px solid var(--border-color,rgba(255,255,255,0.22));border-radius:8px;background:var(--button-bg,transparent);color:var(--text-tertiary,#cbd5e1);cursor:pointer;"></select>
   </div>
+  <!-- Refresh / reconnect. Always visible, because the desktop shell has no
+       browser chrome: no address bar, no reload button, and pywebview's Cocoa
+       backend swallows Cmd-R. Without this the only way out of a wedged page
+       was to quit the app. cmReconnect() probes the backend first and only
+       reloads when something is there to reload into -- reloading against a
+       dead port would replace the page with a blank error page. Turns amber
+       (.cm-attention) once the backend is known unreachable. -->
+  <div class="theme-toggle" id="cm-reconnect-btn" onclick="window.cmReconnect && window.cmReconnect()" role="button" tabindex="0" data-i18n-title="topbar.refresh" title="Refresh (Cmd/Ctrl + R)" style="cursor:pointer;">
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="23 4 23 10 17 10"/><polyline points="1 20 1 14 7 14"/><path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15"/></svg>
+  </div>
   <div class="theme-toggle" id="alerts-bell-btn" onclick="switchTab('alerts')" data-i18n-title="topbar.active_alerts" title="Active alerts" style="cursor:pointer;position:relative;"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"/><path d="M13.73 21a2 2 0 0 1-3.46 0"/></svg><span id="alerts-bell-badge" style="display:none;position:absolute;top:-4px;right:-4px;background:#ef4444;color:#fff;border-radius:10px;padding:0 4px;font-size:9px;font-weight:700;min-width:14px;line-height:14px;text-align:center;">0</span></div>
 
   <!-- Cloud sync toggle chip. Included in every ClawMetry plan (Self-Hosted

--- a/tests/test_backend_outage_overlay.js
+++ b/tests/test_backend_outage_overlay.js
@@ -1,6 +1,6 @@
 /**
- * Behavioural tests for the global "backend unreachable" detector + overlay
- * in clawmetry/static/js/auth-bootstrap.js.
+ * Behavioural tests for backend-outage detection and recovery in
+ * clawmetry/static/js/auth-bootstrap.js.
  *
  * Why this exists: on 2026-08-17 a desktop user's backend died and every tab
  * froze -- Activity showed "Failed to load: TypeError: Load failed", Cost sat
@@ -9,9 +9,16 @@
  * offered a way back. The user's words: there is no refresh button when it
  * gets into this state.
  *
- * The two IIFEs under test are extracted from the shipped source and run
- * against a minimal DOM/window stub -- no jsdom dependency, and it fails if
- * the shipped file stops containing them.
+ * The sharp edge these tests pin down: a pywebview window has no browser
+ * chrome, so a naive refresh that calls location.reload() against a DEAD port
+ * replaces a frozen-but-readable dashboard with a blank WebKit error page
+ * carrying no buttons at all. Recovery must therefore probe first, heal the
+ * backend when it is down, and only then reload -- and must refuse to reload
+ * when it cannot heal.
+ *
+ * The IIFEs are extracted from the shipped source and run against a minimal
+ * DOM/window stub -- no jsdom dependency, and it fails if the shipped file
+ * stops containing them.
  */
 'use strict';
 
@@ -33,17 +40,9 @@ function check(name, fn) {
     }
   };
   let out;
-  try {
-    out = fn();
-  } catch (e) {
-    record(e);
-    return;
-  }
-  if (out && typeof out.then === 'function') {
-    pending.push(out.then(function () { record(null); }, record));
-  } else {
-    record(null);
-  }
+  try { out = fn(); } catch (e) { record(e); return; }
+  if (out && typeof out.then === 'function') pending.push(out.then(function () { record(null); }, record));
+  else record(null);
 }
 function assert(cond, msg) { if (!cond) throw new Error(msg || 'assertion failed'); }
 function eq(a, b, msg) {
@@ -57,7 +56,6 @@ function sliceBlock(startMarker, label) {
   const at = source.indexOf(startMarker);
   assert(at !== -1, 'shipped auth-bootstrap.js no longer contains ' + label +
     ' (looked for: ' + startMarker + ')');
-  // Walk forward to the IIFE that follows, then brace-match it.
   const open = source.indexOf('(function(){', at);
   assert(open !== -1, 'no IIFE after ' + label);
   let depth = 0, i = open;
@@ -66,9 +64,9 @@ function sliceBlock(startMarker, label) {
     if (c === '{') depth++;
     else if (c === '}') { depth--; if (depth === 0) break; }
   }
-  // i is the IIFE body's closing brace. Take through the invoking "()" --
-  // stopping at the first ")" yields a function expression that is never
-  // called, and every assertion then silently sees an undefined global.
+  // Take through the invoking "()" -- stopping at the first ")" yields a
+  // function expression that is never called, and every assertion then
+  // silently sees an undefined global.
   const call = source.indexOf('()', i);
   assert(call !== -1 && call - i <= 3,
     'expected "})();" to close ' + label + ', got: ' + JSON.stringify(source.slice(i, i + 8)));
@@ -76,15 +74,16 @@ function sliceBlock(startMarker, label) {
 }
 
 const fetchBlock = sliceBlock('// Inject auth header into all fetch calls', 'the fetch wrapper');
-const overlayBlock = sliceBlock('// ── Global "backend unreachable" overlay ──', 'the outage overlay');
+const recoveryBlock = sliceBlock('// ── Backend recovery:', 'the recovery block');
 
 // ── a small DOM/window stub ──────────────────────────────────────────────────
 function makeElement(tag) {
-  return {
+  const el = {
     tagName: tag, id: '', style: { cssText: '' }, textContent: '', innerHTML: '',
     type: '', disabled: false, onclick: null, children: [], parentNode: null,
-    _attrs: {},
+    _attrs: {}, _classes: new Set(),
     setAttribute(k, v) { this._attrs[k] = v; },
+    getAttribute(k) { return this._attrs[k]; },
     appendChild(c) { c.parentNode = this; this.children.push(c); return c; },
     removeChild(c) {
       const i = this.children.indexOf(c);
@@ -92,14 +91,20 @@ function makeElement(tag) {
       c.parentNode = null;
     },
   };
+  el.classList = {
+    toggle(n, on) { if (on) el._classes.add(n); else el._classes.delete(n); },
+    contains(n) { return el._classes.has(n); },
+    add(n) { el._classes.add(n); },
+    remove(n) { el._classes.delete(n); },
+  };
+  return el;
 }
 
 function makeEnv(opts) {
   opts = opts || {};
   const body = makeElement('body');
-  const byId = {};
   const listeners = {};
-  const timers = [];
+  const docListeners = {};
 
   function collect(el, out) {
     out.push(el);
@@ -113,48 +118,58 @@ function makeEnv(opts) {
     CustomEvent: function (type, init) { this.type = type; this.detail = init && init.detail; },
     addEventListener(type, fn) { (listeners[type] = listeners[type] || []).push(fn); },
     dispatchEvent(ev) { (listeners[ev.type] || []).forEach(function (f) { f(ev); }); return true; },
-    setTimeout(fn, ms) { timers.push({ fn: fn, ms: ms }); return timers.length; },
+    // Real timers: the recovery path genuinely schedules retries.
+    setTimeout: setTimeout, clearTimeout: clearTimeout,
+    Promise: Promise, Date: Date,
     location: { reload() { win.__reloaded = (win.__reloaded || 0) + 1; } },
     document: {
       body: body,
       documentElement: body,
       getElementById(id) {
-        const all = collect(body, []);
-        for (const el of all) if (el.id === id) return el;
-        return byId[id] || null;
+        for (const el of collect(body, [])) if (el.id === id) return el;
+        return null;
       },
       createElement: makeElement,
+      addEventListener(type, fn) { (docListeners[type] = docListeners[type] || []).push(fn); },
+      __fire(type, ev) { (docListeners[type] || []).forEach(function (f) { f(ev); }); },
     },
-    __timers: timers,
     __body: body,
   };
   if (opts.pywebview) win.pywebview = opts.pywebview;
   win.window = win;
+  // The header refresh button lives in the topbar; the recovery code styles
+  // it by id, so the stub page carries one.
+  if (opts.withButton !== false) {
+    const b = makeElement('div');
+    b.id = 'cm-reconnect-btn';
+    body.appendChild(b);
+  }
   return win;
 }
 
-function run(env, blocks) {
+function run(env) {
   const ctx = vm.createContext(env);
-  // The blocks reference bare `window`, `document`, `localStorage`.
   ctx.document = env.document;
   ctx.localStorage = env.localStorage;
-  blocks.forEach(function (b) { vm.runInContext(b, ctx); });
+  vm.runInContext(fetchBlock, ctx);
+  vm.runInContext(recoveryBlock, ctx);
   return ctx;
 }
 
-function netError() {
-  const e = new TypeError('Load failed');
-  return e;
+function netError() { return new TypeError('Load failed'); }
+function overlay(env) { return env.document.getElementById('cm-backend-outage'); }
+function reconnectBtn(env) { return env.document.getElementById('cm-reconnect-btn'); }
+function overlayButton(env) {
+  const el = overlay(env);
+  return el && el.children.filter(function (c) { return c.tagName === 'button'; })[0];
 }
 
-function overlay(env) { return env.document.getElementById('cm-backend-outage'); }
-
-// ── tests ────────────────────────────────────────────────────────────────────
-console.log('backend outage overlay');
+// ── detection ────────────────────────────────────────────────────────────────
+console.log('backend outage detection + recovery');
 
 check('a single network failure does NOT raise the overlay', function () {
   const env = makeEnv({ fetch: function () { return Promise.reject(netError()); } });
-  run(env, [fetchBlock, overlayBlock]);
+  run(env);
   return env.fetch('/api/overview').catch(function () {}).then(function () {
     eq(overlay(env), null, 'overlay appeared on the first failure');
   });
@@ -162,115 +177,180 @@ check('a single network failure does NOT raise the overlay', function () {
 
 check('three consecutive network failures raise the overlay', function () {
   const env = makeEnv({ fetch: function () { return Promise.reject(netError()); } });
-  run(env, [fetchBlock, overlayBlock]);
+  run(env);
   let p = Promise.resolve();
-  for (let i = 0; i < 3; i++) {
-    p = p.then(function () { return env.fetch('/api/overview').catch(function () {}); });
-  }
+  for (let i = 0; i < 3; i++) p = p.then(function () { return env.fetch('/api/overview').catch(function () {}); });
   return p.then(function () {
     assert(overlay(env), 'overlay never appeared after 3 network failures');
-    const text = JSON.stringify(overlay(env).children.map(function (c) {
-      return c.innerHTML || c.textContent;
-    }));
-    assert(/Cannot reach the ClawMetry backend/.test(text),
-      'overlay does not name the problem: ' + text);
+    const text = JSON.stringify(overlay(env).children.map(function (c) { return c.innerHTML || c.textContent; }));
+    assert(/Cannot reach the ClawMetry backend/.test(text), 'overlay does not name the problem: ' + text);
   });
 });
 
 check('an HTTP error status is NOT an outage (the server answered)', function () {
-  const env = makeEnv({
-    fetch: function () { return Promise.resolve({ status: 500, ok: false }); },
-  });
-  run(env, [fetchBlock, overlayBlock]);
+  const env = makeEnv({ fetch: function () { return Promise.resolve({ status: 500, ok: false }); } });
+  run(env);
   let p = Promise.resolve();
   for (let i = 0; i < 5; i++) p = p.then(function () { return env.fetch('/api/overview'); });
-  return p.then(function () {
-    eq(overlay(env), null, '500s were mistaken for an outage');
-  });
+  return p.then(function () { eq(overlay(env), null, '500s were mistaken for an outage'); });
 });
 
 check('recovery dismisses the overlay', function () {
   let dead = true;
   const env = makeEnv({
-    fetch: function () {
-      return dead ? Promise.reject(netError()) : Promise.resolve({ status: 200, ok: true });
-    },
+    fetch: function () { return dead ? Promise.reject(netError()) : Promise.resolve({ status: 200, ok: true }); },
   });
-  run(env, [fetchBlock, overlayBlock]);
+  run(env);
   let p = Promise.resolve();
-  for (let i = 0; i < 3; i++) {
-    p = p.then(function () { return env.fetch('/api/overview').catch(function () {}); });
-  }
+  for (let i = 0; i < 3; i++) p = p.then(function () { return env.fetch('/api/overview').catch(function () {}); });
   return p.then(function () {
     assert(overlay(env), 'overlay never appeared');
     dead = false;
     return env.fetch('/api/overview');
-  }).then(function () {
-    eq(overlay(env), null, 'overlay survived the backend coming back');
-  });
-});
-
-check('the overlay always carries an actionable button', function () {
-  const env = makeEnv({ fetch: function () { return Promise.reject(netError()); } });
-  run(env, [fetchBlock, overlayBlock]);
-  env.window.cmShowBackendOutage();
-  const el = overlay(env);
-  assert(el, 'overlay missing');
-  const btn = el.children.filter(function (c) { return c.tagName === 'button'; })[0];
-  assert(btn, 'no button in the outage overlay -- this is the whole point');
-  assert(typeof btn.onclick === 'function', 'button has no click handler');
-  eq(btn.textContent, 'Reload', 'browser fallback should offer Reload');
-});
-
-check('in a browser the button reloads the page', function () {
-  const env = makeEnv({ fetch: function () { return Promise.reject(netError()); } });
-  run(env, [fetchBlock, overlayBlock]);
-  env.window.cmShowBackendOutage();
-  const btn = overlay(env).children.filter(function (c) { return c.tagName === 'button'; })[0];
-  btn.onclick();
-  eq(env.__reloaded, 1, 'Reload did not reload');
-});
-
-check('in the desktop shell the button restarts the backend via the bridge', function () {
-  let restarted = 0;
-  const env = makeEnv({
-    fetch: function () { return Promise.reject(netError()); },
-    pywebview: { api: { restart_backend: function () { restarted++; return { ok: true }; } } },
-  });
-  run(env, [fetchBlock, overlayBlock]);
-  env.window.cmShowBackendOutage();
-  const el = overlay(env);
-  const btn = el.children.filter(function (c) { return c.tagName === 'button'; })[0];
-  eq(btn.textContent, 'Restart backend', 'desktop should offer a real restart');
-  btn.onclick();
-  eq(restarted, 1, 'bridge restart_backend was not called');
-  eq(env.__reloaded, undefined, 'should not fall back to reload when the bridge works');
-});
-
-check('a browser outage tells the user what else to try', function () {
-  const env = makeEnv({ fetch: function () { return Promise.reject(netError()); } });
-  run(env, [fetchBlock, overlayBlock]);
-  env.window.cmShowBackendOutage();
-  const text = overlay(env).children.map(function (c) {
-    return c.textContent || c.innerHTML;
-  }).join(' ');
-  assert(/quit ClawMetry and open it again/i.test(text),
-    'no fallback guidance when the shell cannot self-heal: ' + text);
+  }).then(function () { eq(overlay(env), null, 'overlay survived the backend coming back'); });
 });
 
 check('non-/api/ requests are not counted toward an outage', function () {
   const env = makeEnv({ fetch: function () { return Promise.reject(netError()); } });
-  run(env, [fetchBlock, overlayBlock]);
+  run(env);
   let p = Promise.resolve();
-  for (let i = 0; i < 5; i++) {
-    p = p.then(function () { return env.fetch('/static/js/app.js').catch(function () {}); });
-  }
-  return p.then(function () {
-    eq(overlay(env), null, 'a static-asset failure raised a backend outage');
+  for (let i = 0; i < 5; i++) p = p.then(function () { return env.fetch('/static/js/app.js').catch(function () {}); });
+  return p.then(function () { eq(overlay(env), null, 'a static-asset failure raised a backend outage'); });
+});
+
+// ── the refresh button ───────────────────────────────────────────────────────
+
+check('cmReconnect is exposed for the header button to call', function () {
+  const env = makeEnv({ fetch: function () { return Promise.resolve({ ok: true }); } });
+  run(env);
+  eq(typeof env.window.cmReconnect, 'function', 'window.cmReconnect missing');
+});
+
+check('a healthy backend means the button is a plain refresh', function () {
+  const env = makeEnv({ fetch: function () { return Promise.resolve({ status: 200, ok: true }); } });
+  run(env);
+  return env.window.cmReconnect().then(function () {
+    eq(env.__reloaded, 1, 'a healthy backend should just reload');
+    eq(overlay(env), null, 'no outage overlay should appear when the backend is fine');
   });
 });
 
-// Several checks are async; drain them before reporting.
+check('a dead backend WITHOUT a bridge must NOT reload into a blank page', function () {
+  const env = makeEnv({ fetch: function () { return Promise.reject(netError()); } });
+  run(env);
+  return env.window.cmReconnect().then(function () {
+    eq(env.__reloaded, undefined, 'reloaded against a dead origin -- this blanks the window');
+    assert(overlay(env), 'refused to reload but told the user nothing');
+    const text = overlay(env).children.map(function (c) { return c.textContent || c.innerHTML; }).join(' ');
+    assert(/quit ClawMetry and open it again/i.test(text), 'no actionable guidance: ' + text);
+  });
+});
+
+check('a dead backend WITH a bridge restarts it, then reloads', function () {
+  let alive = false, restarted = 0;
+  const env = makeEnv({
+    fetch: function () { return alive ? Promise.resolve({ ok: true }) : Promise.reject(netError()); },
+    pywebview: { api: { restart_backend: function () { restarted++; alive = true; return { ok: true }; } } },
+  });
+  run(env);
+  return env.window.cmReconnect().then(function () {
+    eq(restarted, 1, 'did not ask the shell to restart the backend');
+    eq(env.__reloaded, 1, 'did not reload after the backend came back');
+  });
+});
+
+check('a backend that never comes back does not reload, and says so', function () {
+  const env = makeEnv({
+    fetch: function () { return Promise.reject(netError()); },
+    pywebview: { api: { restart_backend: function () { return { ok: true }; } } },
+  });
+  env.__cmRestartBudgetMs = 60;
+  run(env);
+  return env.window.cmReconnect().then(function () {
+    eq(env.__reloaded, undefined, 'reloaded even though the backend never answered');
+    const text = overlay(env).children.map(function (c) { return c.textContent || c.innerHTML; }).join(' ');
+    assert(/did not come back/i.test(text), 'did not report the failed restart: ' + text);
+  });
+});
+
+check('the health probe does not inflate the outage counter', function () {
+  const env = makeEnv({ fetch: function () { return Promise.reject(netError()); } });
+  run(env);
+  // Three probes would trip the threshold if they went through the wrapper.
+  return env.window.cmBackendProbe(20)
+    .then(function () { return env.window.cmBackendProbe(20); })
+    .then(function () { return env.window.cmBackendProbe(20); })
+    .then(function () { eq(env.window.cmBackendFailures(), 0, 'probes counted as app traffic'); });
+});
+
+check('the header button shows a busy state while working', function () {
+  let resolveFetch;
+  const env = makeEnv({ fetch: function () { return new Promise(function (r) { resolveFetch = r; }); } });
+  run(env);
+  const p = env.window.cmReconnect();
+  assert(reconnectBtn(env).classList.contains('cm-spinning'), 'button never entered a busy state');
+  resolveFetch({ ok: true });
+  return p;
+});
+
+check('the header button goes amber when the backend is known down', function () {
+  const env = makeEnv({ fetch: function () { return Promise.reject(netError()); } });
+  run(env);
+  eq(reconnectBtn(env).classList.contains('cm-attention'), false, 'button started in the alarm state');
+  env.window.cmShowBackendOutage();
+  eq(reconnectBtn(env).classList.contains('cm-attention'), true, 'button did not flag the outage');
+  env.window.cmHideBackendOutage();
+  eq(reconnectBtn(env).classList.contains('cm-attention'), false, 'button stayed amber after recovery');
+});
+
+check('the overlay button routes through the same recovery path', function () {
+  const env = makeEnv({ fetch: function () { return Promise.resolve({ ok: true }); } });
+  run(env);
+  env.window.cmShowBackendOutage();
+  const btn = overlayButton(env);
+  assert(btn && typeof btn.onclick === 'function', 'overlay has no actionable button');
+  btn.onclick();
+  return new Promise(function (r) { setTimeout(r, 30); }).then(function () {
+    eq(env.__reloaded, 1, 'overlay button did not recover');
+  });
+});
+
+// ── Cmd/Ctrl+R ───────────────────────────────────────────────────────────────
+
+check('Cmd-R is handled in the shell, where the native shortcut is swallowed', function () {
+  let alive = true;
+  const env = makeEnv({
+    fetch: function () { return alive ? Promise.resolve({ ok: true }) : Promise.reject(netError()); },
+    pywebview: { api: { restart_backend: function () { return { ok: true }; } } },
+  });
+  run(env);
+  let prevented = 0;
+  env.document.__fire('keydown', { metaKey: true, key: 'r', preventDefault: function () { prevented++; } });
+  eq(prevented, 1, 'Cmd-R was not intercepted inside the desktop shell');
+  return new Promise(function (r) { setTimeout(r, 30); }).then(function () {
+    eq(env.__reloaded, 1, 'Cmd-R did not refresh');
+  });
+});
+
+check('Cmd-R is left alone in a browser, where it already works', function () {
+  const env = makeEnv({ fetch: function () { return Promise.resolve({ ok: true }); } });
+  run(env);
+  let prevented = 0;
+  env.document.__fire('keydown', { metaKey: true, key: 'r', preventDefault: function () { prevented++; } });
+  eq(prevented, 0, 'hijacked the browser native reload');
+});
+
+check('an unrelated keypress is ignored', function () {
+  const env = makeEnv({
+    fetch: function () { return Promise.resolve({ ok: true }); },
+    pywebview: { api: { restart_backend: function () { return { ok: true }; } } },
+  });
+  run(env);
+  let prevented = 0;
+  env.document.__fire('keydown', { metaKey: true, key: 'k', preventDefault: function () { prevented++; } });
+  eq(prevented, 0, 'swallowed Cmd-K');
+});
+
 Promise.all(pending).then(function () {
   if (failures) {
     console.log('\nFAIL: ' + failures + ' check(s) failed');

--- a/tests/test_topbar_refresh_button.py
+++ b/tests/test_topbar_refresh_button.py
@@ -1,0 +1,92 @@
+"""The topbar carries an always-visible refresh/reconnect control.
+
+The desktop shell has no browser chrome: no address bar, no reload button,
+and pywebview's Cocoa backend swallows Cmd-R and strips the context menu. On
+2026-08-17 that left a user staring at a frozen dashboard for 6h39m whose
+only escape was quitting the app. The control has to be in the page itself.
+
+Two things are easy to get wrong and are pinned here:
+
+1. `dashboard.py` defines DASHBOARD_HTML TWICE and the SECOND one wins (see
+   CLAUDE.md). Markup added to the first block renders for nobody. This test
+   asserts the button lands in the live block.
+2. The button must not be a bare `location.reload()`. Against a dead port a
+   reload swaps the frozen-but-readable dashboard for a blank WebKit error
+   page with no buttons on it -- strictly worse. It routes through
+   `cmReconnect()`, which probes first and heals before reloading.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DASHBOARD = REPO_ROOT / "dashboard.py"
+STATIC = REPO_ROOT / "clawmetry" / "static"
+
+BTN_ID = 'id="cm-reconnect-btn"'
+
+
+def _live_dashboard_html() -> str:
+    """The SECOND DASHBOARD_HTML block -- the one actually served."""
+    src = DASHBOARD.read_text()
+    starts = [m.start() for m in re.finditer(r'^DASHBOARD_HTML = r"""', src, re.M)]
+    assert len(starts) == 2, (
+        f"expected exactly 2 DASHBOARD_HTML definitions, found {len(starts)}. "
+        "If this changed, re-check which block is live before trusting this test."
+    )
+    return src[starts[1]:]
+
+
+def test_refresh_button_is_in_the_live_html_block():
+    assert BTN_ID in _live_dashboard_html(), (
+        "the refresh button is missing from the live (second) DASHBOARD_HTML "
+        "block -- if it was added to the first block it renders for nobody"
+    )
+
+
+def test_refresh_button_appears_exactly_once():
+    assert DASHBOARD.read_text().count(BTN_ID) == 1
+
+
+def test_refresh_button_routes_through_cmReconnect_not_a_bare_reload():
+    live = _live_dashboard_html()
+    at = live.index(BTN_ID)
+    tag = live[at - 400:at + 400]
+    assert "cmReconnect" in tag, "refresh button does not call cmReconnect()"
+    assert "location.reload" not in tag, (
+        "refresh button reloads directly; against a dead backend that leaves "
+        "the user on a blank error page with no way back"
+    )
+
+
+def test_recovery_helpers_are_exported_from_auth_bootstrap():
+    js = (STATIC / "js" / "auth-bootstrap.js").read_text()
+    for needle in (
+        "window.cmReconnect=",
+        "window.cmShowBackendOutage=",
+        "window.cmHideBackendOutage=",
+        "window.cmBackendProbe=",
+        "window.__cmOrigFetch=",
+    ):
+        assert needle in js, f"auth-bootstrap.js missing: {needle}"
+
+
+def test_probe_uses_the_unwrapped_fetch():
+    """A health probe that fails must not count toward the outage threshold
+    that raised the overlay in the first place."""
+    js = (STATIC / "js" / "auth-bootstrap.js").read_text()
+    assert "window.__cmOrigFetch||window.fetch" in js
+
+
+def test_button_has_a_busy_and_an_attention_style():
+    css = (STATIC / "css" / "dashboard.css").read_text()
+    assert "#cm-reconnect-btn.cm-attention" in css
+    assert "#cm-reconnect-btn.cm-spinning" in css
+
+
+def test_tooltip_key_is_translatable():
+    import json
+    en = json.loads((STATIC / "locales" / "en.json").read_text())
+    assert "topbar.refresh" in en, "topbar.refresh missing from the en locale"


### PR DESCRIPTION
Follow-up to #4976 (the 6h39m desktop freeze). That PR made a dead backend **visible**. This one makes getting back to a working one **a single click**, with no quit-and-reopen.

## The trap in the obvious version

A pywebview window has no browser chrome. If the backend is dead, `location.reload()` throws away the frozen-but-readable dashboard and replaces it with a **blank WebKit error page carrying no buttons at all** — strictly worse than the freeze, and with no way back except quitting.

So a refresh button here cannot just reload. It has to check first, and heal before reloading.

## One recovery path, three entry points

`cmReconnect()`:

1. Probe `/api/health` with the **unwrapped** fetch — a probe that fails must not count toward the outage threshold that raised the overlay.
2. Backend answers → plain `location.reload()`.
3. Backend dead **+ desktop shell** → `restart_backend()` over the JS bridge, poll until it binds, then reload.
4. Backend dead **+ no bridge** → refuse to reload, and say what does help.

Reached from:

- **A topbar refresh control**, always visible, left of the alerts bell. Spins while working; turns amber once the backend is known unreachable, so the way out is visible *before* the user goes hunting.
- **Cmd/Ctrl+R**, implemented in JS because pywebview's Cocoa backend swallows the native shortcut (`cocoa.py:512-543`). In a real browser the native reload is already correct, so the handler does not `preventDefault` there.
- **The outage overlay's button**, now routed through the same function instead of carrying a second copy of the logic.

## Two placement traps, both pinned by tests

- `dashboard.py` defines `DASHBOARD_HTML` **twice and the second wins** (CLAUDE.md). Markup added to the first block renders for nobody.
- The live CSS is `clawmetry/static/css/dashboard.css`, not the inline `<style>` in `dashboard.py`.

## Tests

- `tests/test_backend_outage_overlay.js` — **17** behavioural tests (up from 9), covering every branch above. The one that matters most: *a dead backend with no bridge must NOT reload*.
- `tests/test_topbar_refresh_button.py` — 7 guards on live-block placement, `cmReconnect` wiring (and the absence of a bare `location.reload`), exported helpers, probe isolation, CSS states, and the locale key.
- Reverting `auth-bootstrap.js` fails the JS suite. No new ruff errors (`dashboard.py` sits at its pre-existing 113 both before and after).

## Verified by looking

Booted a real instance on :8902 and drove it in Chrome: the button renders in the topbar, `cmShowBackendOutage()` turns it amber and raises the overlay, and the overlay offers the action with honest fallback copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)