### PR TITLE
Add osai-verify ownership token to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,3 +112,5 @@ More, per runtime: [docs/RUNTIME_SCREENSHOTS.md](docs/RUNTIME_SCREENSHOTS.md).
 ## License
 
 MIT · Built by [@vivekchand](https://github.com/vivekchand) · [clawmetry.com](https://clawmetry.com)
+
+<!-- osai-verify: f3ac716d40002c1ad6dd -->


### PR DESCRIPTION
Adds the OSAI directory verification token to the README so the repo listing can be claimed.

```
osai-verify: f3ac716d40002c1ad6dd
```

Placed at the bottom as an HTML comment, so it is present in the raw file (which is what the verifier fetches) but invisible in the rendered README. Safe to remove in a follow-up once verification completes.

One line, README only. No code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)