### PR TITLE
Installer: detect an existing account and ask before re-onboarding

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -195,6 +195,246 @@ for _cm_dir in "${_cm_path_dirs[@]}"; do
   done
 done
 
+# >>> CM_EXISTING_SETUP_BLOCK_START (tests source everything between these
+# sentinels; keep them around the helpers) >>>
+# ── Existing setup: account probe + "re-onboard?" gate ──────────────────────
+# Re-running `curl … | bash` on a machine that is ALREADY set up used to replay
+# the whole first-run wizard (plans, [1]/[2], runtime grid) as if ClawMetry had
+# never been installed — even though the account, the cloud-vs-local choice and
+# the license were all sitting on disk. Now the installer reads that state back
+# first, prints it, and only re-runs `clawmetry onboard` when the user asks for
+# it. A machine with NO account linked keeps the original behaviour: straight
+# into the wizard.
+#
+# ``_cm_probe_account`` sets: CM_CONNECTED (0/1), CM_EMAIL, CM_PLAN,
+# CM_SYNC (cloud|local-only), CM_NODE, CM_VER.
+CM_CONNECTED=0
+CM_EMAIL=""
+CM_PLAN=""
+CM_SYNC=""
+CM_NODE=""
+CM_VER=""
+CM_E2E=0
+CM_DASH=""
+# Set once the "↻ Change it anytime: clawmetry onboard" line has been printed,
+# so the closing hint at the bottom of the installer doesn't repeat it.
+CM_HINTED=0
+
+# Reads `clawmetry status --json` (authoritative: it resolves the live account
+# email/plan and honours every local-only signal) and falls back to the config
+# files on disk when the CLI is too old, offline or broken — the probe must
+# never be the reason an install fails, so every branch degrades to "not
+# connected" and the caller just runs the wizard as before.
+_CM_PROBE_PY=$(cat <<'PYEOF'
+import json, os, shlex, sys
+
+HOME = os.path.expanduser("~")
+
+
+def _read_json(path):
+    try:
+        with open(path) as fh:
+            return json.load(fh) or {}
+    except Exception:
+        return {}
+
+
+try:
+    _raw = sys.stdin.read()
+except Exception:
+    _raw = ""
+try:
+    snap = json.loads(_raw) if _raw.strip() else {}
+except Exception:
+    snap = {}
+if not isinstance(snap, dict):
+    snap = {}
+
+cloud = snap.get("cloud_sync") or {}
+acct = cloud.get("account") or {}
+cfg = _read_json(os.path.join(HOME, ".clawmetry", "config.json"))
+
+api_key = str(cfg.get("api_key") or "") or os.environ.get("CLAWMETRY_API_KEY", "")
+connected = bool(api_key) or bool(cloud.get("api_key_masked"))
+
+# A placeholder account (…@clawmetry.auto / …@clawmetry.linked) is the daemon's
+# zero-friction auto-registration, not the user's login — it is invisible from
+# their dashboard, so treat it as "not connected" and let the wizard run.
+email = str(acct.get("email") or cfg.get("account_email") or "").strip()
+if bool(acct.get("placeholder")) or email.lower().endswith(("@clawmetry.auto", "@clawmetry.linked")):
+    connected = False
+    email = ""
+
+plan = str(acct.get("plan") or "").strip()
+if not plan:
+    plan = str(_read_json(os.path.join(HOME, ".clawmetry", "cloud_plan.json")).get("plan") or "").strip()
+plan_label = ""
+if plan:
+    try:
+        from clawmetry.entitlements import tier_label as _tl
+        plan_label = _tl(plan)
+    except Exception:
+        plan_label = plan.replace("cloud_", "").replace("_", " ").title()
+
+# Never promise a dashboard URL that nothing answers on, and never guess the
+# port: the daemon records the live one in server.json (8961 on a box where
+# 8900 was taken). Any HTTP answer -- including 401/302 -- counts as "up".
+def _dashboard_url():
+    import urllib.error
+    import urllib.request
+
+    ports, seen = [], set()
+    try:
+        _p = int(_read_json(os.path.join(HOME, ".clawmetry", "server.json")).get("port") or 0)
+    except Exception:
+        _p = 0
+    for cand in (_p, 8900):
+        if cand and cand not in seen:
+            seen.add(cand)
+            ports.append(cand)
+    for port in ports:
+        url = "http://127.0.0.1:%d/" % port
+        try:
+            urllib.request.urlopen(url, timeout=0.8).close()
+            return "http://localhost:%d" % port
+        except urllib.error.HTTPError:
+            return "http://localhost:%d" % port
+        except Exception:
+            continue
+    return ""
+
+
+local_only = cloud.get("local_only")
+if local_only is None:
+    local_only = (
+        bool(cfg.get("local_only"))
+        or os.path.isfile(os.path.join(HOME, ".clawmetry", "nocloud"))
+        or os.environ.get("CLAWMETRY_NO_CLOUD", "").strip().lower() in ("1", "true", "yes", "on")
+    )
+
+out = {
+    "CM_CONNECTED": "1" if connected else "0",
+    "CM_EMAIL": email,
+    "CM_PLAN": plan_label,
+    "CM_SYNC": "local-only" if local_only else "cloud",
+    "CM_NODE": str(cloud.get("node_id") or cfg.get("node_id") or ""),
+    "CM_VER": str(snap.get("version") or ""),
+    "CM_E2E": "1" if ((cloud.get("encryption") or {}).get("enabled") or cfg.get("encryption_key")) else "0",
+    "CM_DASH": _dashboard_url(),
+}
+for _k, _v in out.items():
+    print("%s=%s" % (_k, shlex.quote(str(_v))))
+PYEOF
+)
+
+_cm_probe_account() {
+  CM_CONNECTED=0
+  CM_EMAIL=""
+  CM_PLAN=""
+  CM_SYNC=""
+  CM_NODE=""
+  CM_VER=""
+  CM_E2E=0
+  CM_DASH=""
+  _p_bin="${1:-$INSTALL_DIR/bin/clawmetry}"
+  _p_py="$INSTALL_DIR/bin/python3"
+  if [ ! -x "$_p_py" ]; then
+    _p_py="$(command -v python3 2>/dev/null || true)"
+  fi
+  if [ -z "$_p_py" ]; then
+    return 0
+  fi
+  _p_snap=""
+  if [ -x "$_p_bin" ]; then
+    _p_snap=$("$_p_bin" status --json 2>/dev/null || true)
+  fi
+  _p_vals=$(printf '%s' "$_p_snap" | "$_p_py" -c "$_CM_PROBE_PY" 2>/dev/null || true)
+  if [ -n "$_p_vals" ]; then
+    eval "$_p_vals"
+  fi
+  # `status --json` is the version source; the console script is the fallback
+  # for the file-only path (CLI too old for --json, or the snapshot failed).
+  if [ -z "$CM_VER" ] && [ -x "$_p_bin" ]; then
+    CM_VER=$("$_p_bin" --version 2>/dev/null | awk '{print $NF}')
+  fi
+  return 0
+}
+
+# Show the setup that is already on this machine, so the user can tell at a
+# glance which account/plan this node reports to before deciding to change it.
+_cm_print_existing() {
+  echo ""
+  echo -e "  ${GREEN}${BOLD}✓ You're already connected to ClawMetry${NC}"
+  echo ""
+  if [ -n "$CM_EMAIL" ]; then
+    if [ -n "$CM_PLAN" ]; then
+      echo -e "    ${DIM}Account:${NC}     ${BOLD}${CM_EMAIL}${NC}  ${DIM}(${CM_PLAN} plan)${NC}"
+    else
+      echo -e "    ${DIM}Account:${NC}     ${BOLD}${CM_EMAIL}${NC}"
+    fi
+  fi
+  if [ "$CM_SYNC" = "local-only" ]; then
+    echo -e "    ${DIM}Cloud sync:${NC}  Local-only ${DIM}(data stays on this machine)${NC}"
+  elif [ "$CM_E2E" = "1" ]; then
+    echo -e "    ${DIM}Cloud sync:${NC}  On ${DIM}(E2E-encrypted snapshots to app.clawmetry.com)${NC}"
+  else
+    echo -e "    ${DIM}Cloud sync:${NC}  On ${DIM}(app.clawmetry.com)${NC}"
+  fi
+  if [ -n "$CM_VER" ]; then
+    echo -e "    ${DIM}Version:${NC}     ${CM_VER}"
+  fi
+  if [ -n "$CM_NODE" ]; then
+    echo -e "    ${DIM}Node:${NC}        ${CM_NODE}"
+  fi
+  if [ -n "$CM_DASH" ]; then
+    echo -e "    ${DIM}Dashboard:${NC}   ${CM_DASH}"
+  else
+    echo -e "    ${DIM}Dashboard:${NC}   not running ${DIM}(start it:${NC} ${GREEN}clawmetry${NC}${DIM})${NC}"
+  fi
+  echo ""
+}
+
+_cm_run_onboard() {
+  _o_bin="${1:-$CLAWMETRY_BIN}"
+  if (exec </dev/tty) 2>/dev/null; then
+    "$_o_bin" onboard </dev/tty || true
+  else
+    "$_o_bin" onboard || true
+  fi
+}
+
+# 0 => caller should re-run the wizard, 1 => keep the current setup untouched.
+# Never re-onboards without an explicit yes: a non-interactive re-install (CI,
+# provisioning script, `| bash` with no tty) keeps whatever is already set up.
+_cm_reonboard_gate() {
+  case "${CLAWMETRY_REONBOARD:-}" in
+    1|true|yes|on|TRUE|YES|ON) return 0 ;;
+    0|false|no|off|FALSE|NO|OFF) return 1 ;;
+  esac
+  if ! (exec </dev/tty) 2>/dev/null; then
+    echo -e "  ${DIM}Non-interactive install: keeping your current setup.${NC}"
+    echo -e "  ${DIM}↻ Change it anytime:${NC} ${GREEN}clawmetry onboard${NC}"
+    CM_HINTED=1
+    return 1
+  fi
+  _g_ans=""
+  printf "  Re-run setup (account, cloud vs local-only, license)? [y/N]: "
+  read -r _g_ans </dev/tty || _g_ans=""
+  case "$(printf '%s' "$_g_ans" | tr -d '\r' | tr '[:upper:]' '[:lower:]')" in
+    y|yes)
+      echo ""
+      return 0
+      ;;
+  esac
+  echo ""
+  echo -e "  ${DIM}Keeping your current setup.${NC}"
+  echo -e "  ${DIM}↻ Change it anytime:${NC} ${GREEN}clawmetry onboard${NC}"
+  CM_HINTED=1
+  return 1
+}
+
+# <<< CM_EXISTING_SETUP_BLOCK_END <<<
+
 # ── Early exit: already up to date ──────────────────────────────────────────
 if [ -x "$INSTALL_DIR/bin/clawmetry" ]; then
   _CURRENT=$("$INSTALL_DIR/bin/clawmetry" --version 2>/dev/null | awk '{print $NF}')
@@ -205,6 +445,18 @@ print(json.loads(r.read())['info']['version'])
 " 2>/dev/null)
   if [ -n "$_CURRENT" ] && [ "$_CURRENT" = "$_LATEST" ] && [ -n "$_existing_pids" ]; then
     echo -e "  ${GREEN}${BOLD}✓ ClawMetry $_CURRENT already up to date${NC}"
+    # Nothing to install — but if this node is already linked to an account,
+    # say so (email, plan, cloud-vs-local) and offer the wizard instead of
+    # dead-ending on a one-line hint.
+    _cm_probe_account "$INSTALL_DIR/bin/clawmetry"
+    if [ "$CM_CONNECTED" = "1" ]; then
+      _cm_print_existing
+      if _cm_reonboard_gate; then
+        _cm_run_onboard "$INSTALL_DIR/bin/clawmetry"
+      fi
+      echo ""
+      exit 0
+    fi
     echo ""
     echo -e "  ${DIM}↻ Change your setup (local-only ↔ cloud, license key)? Run:${NC} ${GREEN}clawmetry onboard${NC}"
     exit 0
@@ -850,10 +1102,19 @@ esac
 
 if [ "${CLAWMETRY_SKIP_ONBOARD:-}" = "1" ] || [ "$NEMOCLAW_DETECTED" = "1" ]; then
   [ "$NEMOCLAW_DETECTED" = "1" ] || echo -e "  ${DIM}Skipping onboard (CLAWMETRY_SKIP_ONBOARD=1) — set up later with:${NC} ${GREEN}clawmetry onboard${NC}"
-elif (exec </dev/tty) 2>/dev/null; then
-  "$CLAWMETRY_BIN" onboard </dev/tty || true
 else
-  "$CLAWMETRY_BIN" onboard || true
+  # Already linked to an account? The upgrade is done; show the setup that is
+  # on this box and ask before replaying the wizard over it. No account (fresh
+  # install, or a local-only node that never linked one) keeps the old path.
+  _cm_probe_account "$CLAWMETRY_BIN"
+  if [ "$CM_CONNECTED" = "1" ]; then
+    _cm_print_existing
+    if _cm_reonboard_gate; then
+      _cm_run_onboard "$CLAWMETRY_BIN"
+    fi
+  else
+    _cm_run_onboard "$CLAWMETRY_BIN"
+  fi
 fi
 
 # ── PATH reminder if needed ──────────────────────────────────────────────────
@@ -873,6 +1134,8 @@ fi
 # ── Closing hint ─────────────────────────────────────────────────────────────
 # `clawmetry onboard` is the setup wizard (local-only / cloud / license key)
 # and is always safe to re-run — advertise it on the way out.
-echo ""
-echo -e "  ${DIM}↻ Change your setup anytime (local-only ↔ cloud, license key):${NC} ${GREEN}clawmetry onboard${NC}"
-echo ""
+if [ "${CM_HINTED:-0}" != "1" ]; then
+  echo ""
+  echo -e "  ${DIM}↻ Change your setup anytime (local-only ↔ cloud, license key):${NC} ${GREEN}clawmetry onboard${NC}"
+  echo ""
+fi

--- a/tests/test_install_script_existing_account_gate.py
+++ b/tests/test_install_script_existing_account_gate.py
@@ -1,0 +1,388 @@
+"""Regression tests for install.sh's "you're already connected" gate (2026-08-18).
+
+Re-running ``curl -fsSL https://clawmetry.com/install.sh | bash`` on a machine
+that was already installed AND linked to an account used to upgrade the wheel
+and then replay the whole first-run wizard (plans, ``[1]``/``[2]``, runtime
+grid) as if ClawMetry had never been set up. Everything it asked about --
+account, cloud-vs-local, license -- was already on disk.
+
+install.sh now probes that state after the upgrade, prints it back (account
+email + plan, cloud sync mode, version, node) and only re-runs ``clawmetry
+onboard`` when the user says yes. A machine with NO account linked keeps the
+original behaviour: straight into the wizard, no prompt.
+
+The tests source the helper block out of install.sh (between the
+``CM_EXISTING_SETUP_BLOCK_START`` / ``END`` sentinels) and drive it against
+fake ``$HOME``s and a stub ``clawmetry`` binary, so they exercise the real
+shell + Python the installer runs -- not a paraphrase of it.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+INSTALL_SH = REPO_ROOT / "install.sh"
+
+posix_only = pytest.mark.skipif(
+    os.name != "posix", reason="install.sh is the macOS/Linux installer"
+)
+
+
+def _read_install_sh() -> str:
+    assert INSTALL_SH.exists(), f"install.sh missing at {INSTALL_SH}"
+    return INSTALL_SH.read_text()
+
+
+def _helper_block() -> str:
+    """The probe/print/gate helpers, extracted between the test sentinels."""
+    body = _read_install_sh()
+    start = body.index("# >>> CM_EXISTING_SETUP_BLOCK_START")
+    end = body.index("# <<< CM_EXISTING_SETUP_BLOCK_END")
+    return body[start:end]
+
+
+def _write_stub_cli(home: Path, snapshot: dict | None) -> Path:
+    """A fake ``clawmetry`` that answers --version / status --json and records
+    an ``onboard`` invocation by touching a marker file."""
+    bin_dir = home / ".clawmetry" / "bin"
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    stub = bin_dir / "clawmetry"
+    stub.write_text(
+        "#!/bin/bash\n"
+        "case \"$1\" in\n"
+        "  --version) echo 'clawmetry 0.12.999' ;;\n"
+        f"  status) cat <<'JSON'\n{json.dumps(snapshot or {})}\nJSON\n  ;;\n"
+        '  onboard) touch "$HOME/.clawmetry/onboard.ran" ;;\n'
+        "esac\n"
+    )
+    stub.chmod(0o755)
+    return stub
+
+
+def _probe(home: Path, cli: Path | None = None) -> dict:
+    """Run ``_cm_probe_account`` against ``home`` and return the shell vars."""
+    script = (
+        "set -e\n"
+        "GREEN=''; BOLD=''; DIM=''; NC=''\n"
+        f'INSTALL_DIR="{home}/.clawmetry"\n'
+        + _helper_block()
+        + f'\n_cm_probe_account "{cli or (home / "no-such-bin")}"\n'
+        'echo "connected=$CM_CONNECTED|email=$CM_EMAIL|plan=$CM_PLAN'
+        '|sync=$CM_SYNC|node=$CM_NODE|ver=$CM_VER|dash=$CM_DASH"\n'
+    )
+    env = dict(os.environ, HOME=str(home))
+    env.pop("CLAWMETRY_API_KEY", None)
+    env.pop("CLAWMETRY_NO_CLOUD", None)
+    out = subprocess.run(
+        ["bash", "-c", script], capture_output=True, text=True, env=env, timeout=60
+    )
+    assert out.returncode == 0, f"probe failed: {out.stderr}"
+    line = [ln for ln in out.stdout.splitlines() if ln.startswith("connected=")][-1]
+    return dict(kv.split("=", 1) for kv in line.split("|"))
+
+
+# ── Static guards ───────────────────────────────────────────────────────────
+
+
+@posix_only
+def test_install_sh_syntax_is_valid() -> None:
+    bash = shutil.which("bash")
+    assert bash, "bash not found on PATH -- required to syntax-check install.sh"
+    result = subprocess.run([bash, "-n", str(INSTALL_SH)], capture_output=True, text=True)
+    assert result.returncode == 0, f"bash -n failed: {result.stderr}"
+
+
+def test_sentinels_and_helpers_present() -> None:
+    body = _read_install_sh()
+    for needle in (
+        "# >>> CM_EXISTING_SETUP_BLOCK_START",
+        "# <<< CM_EXISTING_SETUP_BLOCK_END",
+        "_cm_probe_account()",
+        "_cm_print_existing()",
+        "_cm_reonboard_gate()",
+        "_cm_run_onboard()",
+    ):
+        assert needle in body, f"install.sh lost {needle!r}"
+
+
+def test_both_onboard_paths_go_through_the_gate() -> None:
+    """The early-exit (already up to date) path and the post-install path must
+    both probe first -- a connected node should never be re-wizarded from
+    either entry point."""
+    body = _read_install_sh()
+    assert body.count("_cm_probe_account \"") >= 2, (
+        "both the early-exit block and the onboarding block must probe for an "
+        "existing account before running the wizard"
+    )
+    onboarding = body[body.index("# ── Onboarding ──") :]
+    assert "_cm_probe_account" in onboarding and "_cm_reonboard_gate" in onboarding
+    # No-account installs keep the original unconditional wizard.
+    assert "else\n    _cm_run_onboard \"$CLAWMETRY_BIN\"\n  fi" in onboarding
+
+
+# ── Probe behaviour ─────────────────────────────────────────────────────────
+
+
+@posix_only
+def test_probe_fresh_machine_reports_not_connected(tmp_path: Path) -> None:
+    home = tmp_path / "fresh"
+    (home / ".clawmetry").mkdir(parents=True)
+    assert _probe(home)["connected"] == "0"
+
+
+@posix_only
+def test_probe_local_only_without_account_is_not_connected(tmp_path: Path) -> None:
+    """Local-only with no account is 'installed', not 'connected' -- it must
+    still get the wizard (that user has never linked an account)."""
+    home = tmp_path / "localnoacct"
+    (home / ".clawmetry").mkdir(parents=True)
+    (home / ".clawmetry" / "config.json").write_text(
+        json.dumps({"api_key": "", "node_id": "box-1", "local_only": True})
+    )
+    (home / ".clawmetry" / "nocloud").touch()
+    vals = _probe(home)
+    assert vals["connected"] == "0"
+    assert vals["sync"] == "local-only"
+
+
+@posix_only
+def test_probe_placeholder_account_is_not_connected(tmp_path: Path) -> None:
+    """A ``…@clawmetry.auto`` placeholder is the daemon's auto-registration,
+    invisible from the user's dashboard -- do not claim they're connected."""
+    home = tmp_path / "placeholder"
+    (home / ".clawmetry").mkdir(parents=True)
+    (home / ".clawmetry" / "config.json").write_text(
+        json.dumps(
+            {
+                "api_key": "cm_abc123456789",
+                "node_id": "box-2",
+                "account_email": "node-77@clawmetry.auto",
+            }
+        )
+    )
+    vals = _probe(home)
+    assert vals["connected"] == "0"
+    assert vals["email"] == ""
+
+
+@posix_only
+def test_probe_reads_config_files_when_cli_snapshot_unavailable(tmp_path: Path) -> None:
+    """No usable CLI (too old for ``status --json``, offline, crashed): the
+    probe still recovers account + plan + sync mode from disk."""
+    home = tmp_path / "cloudacct"
+    (home / ".clawmetry").mkdir(parents=True)
+    (home / ".clawmetry" / "config.json").write_text(
+        json.dumps(
+            {"api_key": "cm_abc123456789", "node_id": "box-3", "account_email": "a@b.com"}
+        )
+    )
+    (home / ".clawmetry" / "cloud_plan.json").write_text(json.dumps({"plan": "cloud_starter"}))
+    vals = _probe(home)
+    assert vals["connected"] == "1"
+    assert vals["email"] == "a@b.com"
+    assert vals["plan"] == "Starter"
+    assert vals["sync"] == "cloud"
+
+
+@posix_only
+def test_probe_prefers_cli_snapshot(tmp_path: Path) -> None:
+    """``status --json`` is authoritative (live email/plan + local-only)."""
+    home = tmp_path / "snap"
+    (home / ".clawmetry").mkdir(parents=True)
+    (home / ".clawmetry" / "config.json").write_text(
+        json.dumps({"api_key": "cm_abc123456789", "node_id": "stale", "account_email": "old@b.com"})
+    )
+    cli = _write_stub_cli(
+        home,
+        {
+            "version": "0.12.999",
+            "cloud_sync": {
+                "api_key_masked": "cm_abc…6789",
+                "account": {"email": "founder@example.com", "plan": "cloud_pro", "placeholder": False},
+                "node_id": "test-box",
+                "local_only": True,
+            },
+        },
+    )
+    vals = _probe(home, cli)
+    assert vals["connected"] == "1"
+    assert vals["email"] == "founder@example.com"
+    assert vals["plan"] == "Pro"
+    assert vals["sync"] == "local-only"
+    assert vals["node"] == "test-box"
+    assert vals["ver"] == "0.12.999"
+
+
+@posix_only
+def test_probe_survives_corrupt_config(tmp_path: Path) -> None:
+    """Never crash on bad input: a corrupt config degrades to 'not connected'
+    (the wizard runs) instead of aborting the install."""
+    home = tmp_path / "corrupt"
+    (home / ".clawmetry").mkdir(parents=True)
+    (home / ".clawmetry" / "config.json").write_text("not json at all")
+    assert _probe(home)["connected"] == "0"
+
+
+# ── Gate behaviour (the actual onboarding decision block) ───────────────────
+
+
+def _run_decision_block(home: Path, answer: bytes | None, env_extra: dict | None = None) -> str:
+    """Drive install.sh's onboarding block on a pty and report whether the
+    wizard ran. Returns the terminal transcript."""
+    import pty
+    import select
+    import time
+
+    body = _read_install_sh()
+    onboarding = body[body.index('if [ "${CLAWMETRY_SKIP_ONBOARD:-}" = "1" ]') :]
+    onboarding = onboarding[: onboarding.index("\nfi\n") + 4]
+    script = home / "decision.sh"
+    script.write_text(
+        textwrap.dedent(
+            f"""\
+            set -e
+            GREEN=''; BOLD=''; DIM=''; NC=''
+            INSTALL_DIR="{home}/.clawmetry"
+            CLAWMETRY_BIN="$INSTALL_DIR/bin/clawmetry"
+            NEMOCLAW_DETECTED=0
+            """
+        )
+        + _helper_block()
+        + "\n"
+        + onboarding
+        + '\necho "MARKER-DONE"\n'
+    )
+
+    env = dict(os.environ, HOME=str(home))
+    env.pop("CLAWMETRY_REONBOARD", None)
+    env.pop("CLAWMETRY_SKIP_ONBOARD", None)
+    env.update(env_extra or {})
+    pid, fd = pty.fork()
+    if pid == 0:  # child
+        os.execvpe("bash", ["bash", str(script)], env)
+    out, sent, deadline = b"", answer is None, time.time() + 60
+    while time.time() < deadline:
+        ready, _, _ = select.select([fd], [], [], 0.3)
+        if ready:
+            try:
+                chunk = os.read(fd, 4096)
+            except OSError:
+                break
+            if not chunk:
+                break
+            out += chunk
+        if not sent and b"[y/N]" in out:
+            time.sleep(0.2)
+            os.write(fd, answer)
+            sent = True
+        if b"MARKER-DONE" in out:
+            break
+    os.close(fd)
+    try:
+        os.waitpid(pid, 0)
+    except Exception:
+        pass
+    return out.decode(errors="replace")
+
+
+CONNECTED_SNAPSHOT = {
+    "version": "0.12.999",
+    "cloud_sync": {
+        "api_key_masked": "cm_abc…6789",
+        "account": {"email": "founder@example.com", "plan": "cloud_pro", "placeholder": False},
+        "node_id": "test-box",
+        "local_only": True,
+    },
+}
+
+
+def _connected_home(tmp_path: Path) -> Path:
+    home = tmp_path / "connected"
+    (home / ".clawmetry").mkdir(parents=True)
+    (home / ".clawmetry" / "config.json").write_text(
+        json.dumps(
+            {
+                "api_key": "cm_abc123456789",
+                "node_id": "test-box",
+                "account_email": "founder@example.com",
+            }
+        )
+    )
+    (home / ".clawmetry" / "nocloud").touch()
+    _write_stub_cli(home, CONNECTED_SNAPSHOT)
+    return home
+
+
+@posix_only
+def test_connected_node_shows_summary_and_keeps_setup_on_no(tmp_path: Path) -> None:
+    home = _connected_home(tmp_path)
+    transcript = _run_decision_block(home, b"n\n")
+    assert "already connected" in transcript.lower()
+    assert "founder@example.com" in transcript
+    assert "Pro plan" in transcript
+    assert "Local-only" in transcript
+    assert "0.12.999" in transcript
+    assert not (home / ".clawmetry" / "onboard.ran").exists(), (
+        "answering 'n' must NOT re-run the wizard over an existing setup"
+    )
+
+
+@posix_only
+def test_connected_node_reonboards_on_yes(tmp_path: Path) -> None:
+    home = _connected_home(tmp_path)
+    _run_decision_block(home, b"y\n")
+    assert (home / ".clawmetry" / "onboard.ran").exists(), "'y' must run clawmetry onboard"
+
+
+@posix_only
+def test_bare_enter_keeps_current_setup(tmp_path: Path) -> None:
+    home = _connected_home(tmp_path)
+    _run_decision_block(home, b"\n")
+    assert not (home / ".clawmetry" / "onboard.ran").exists()
+
+
+@posix_only
+def test_env_override_forces_reonboard(tmp_path: Path) -> None:
+    home = _connected_home(tmp_path)
+    _run_decision_block(home, None, {"CLAWMETRY_REONBOARD": "1"})
+    assert (home / ".clawmetry" / "onboard.ran").exists()
+
+
+@posix_only
+def test_unconnected_node_runs_wizard_without_prompting(tmp_path: Path) -> None:
+    """No account linked: unchanged behaviour -- onboard runs, no question."""
+    home = tmp_path / "noacct"
+    (home / ".clawmetry").mkdir(parents=True)
+    _write_stub_cli(home, {"version": "0.12.999", "cloud_sync": None})
+    transcript = _run_decision_block(home, None)
+    assert "[y/N]" not in transcript, "a fresh install must not be asked to re-onboard"
+    assert (home / ".clawmetry" / "onboard.ran").exists()
+
+
+@posix_only
+def test_summary_never_promises_a_dead_dashboard(tmp_path: Path) -> None:
+    """The dashboard URL is read from server.json and verified before it is
+    printed -- a hard-coded localhost:8900 is a lie on a box whose daemon
+    picked another port (or where nothing is listening at all)."""
+    home = tmp_path / "deaddash"
+    (home / ".clawmetry").mkdir(parents=True)
+    (home / ".clawmetry" / "config.json").write_text(
+        json.dumps({"api_key": "cm_abc123456789", "account_email": "a@b.com"})
+    )
+    # A port nothing can be listening on (0 is never bound).
+    (home / ".clawmetry" / "server.json").write_text(json.dumps({"port": 1}))
+    assert _probe(home)["dash"] in ("", "http://localhost:8900"), (
+        "the probe may only report a dashboard URL that actually answered"
+    )
+    body = _read_install_sh()
+    assert "not running" in body, (
+        "when no dashboard answers, say so instead of printing a dead link"
+    )


### PR DESCRIPTION
## Problem

Re-running `curl -fsSL https://clawmetry.com/install.sh | bash` on a machine that is **already installed and linked to an account** upgrades the wheel and then replays the entire first-run wizard (plans, `[1]`/`[2]`, runtime grid) as if ClawMetry had never been set up. Everything it asks about (account, cloud vs local-only, license) is already on disk.

## What this does

After the upgrade, the installer probes the existing setup, prints it back, and only re-runs `clawmetry onboard` on an explicit yes:

```
  ✓ You're already connected to ClawMetry

    Account:     founder@example.com  (Pro plan)
    Cloud sync:  Local-only (data stays on this machine)
    Version:     0.12.736
    Node:        Macbook-Pro-4.local
    Dashboard:   http://localhost:8961

  Re-run setup (account, cloud vs local-only, license)? [y/N]:
```

- **No account linked** (fresh install, or a local-only node that never linked one): unchanged behaviour, straight into `clawmetry onboard`, no question.
- **Default is "keep my setup"**: bare Enter, `n`, and any non-interactive install (CI, provisioning, no tty) leave the current setup untouched. `CLAWMETRY_REONBOARD=1` forces the wizard, `=0` forces skip.
- Both entry points go through the gate: the "already up to date" early exit and the post-install onboarding block.

## Honesty details

- The probe prefers `clawmetry status --json` (live account email/plan, and it honours every local-only signal), falling back to `~/.clawmetry/config.json` + `cloud_plan.json` + the `nocloud` marker when the CLI is too old, offline or broken. Every failure branch degrades to "not connected", so the probe can never be the reason an install fails.
- A placeholder account (`…@clawmetry.auto` / `…@clawmetry.linked`) counts as NOT connected: it is the daemon's auto-registration, invisible from the user's dashboard, so that node still deserves the wizard.
- The dashboard URL comes from `server.json` and is verified before printing (hard-coding 8900 is a lie on a box whose daemon picked 8961); when nothing answers it says "not running" instead of a dead link.

## Tests

`tests/test_install_script_existing_account_gate.py` sources the real shell helpers out of `install.sh` (between the `CM_EXISTING_SETUP_BLOCK_*` sentinels) and drives them against fake `$HOME`s and a stub CLI over a pty:

- probe: fresh / local-only-without-account / placeholder / corrupt config / config-files-only / `status --json` snapshot
- gate: `y`, `n`, bare Enter, `CLAWMETRY_REONBOARD=1`, and the no-account path (asserts no prompt is shown and the wizard still runs)
- dashboard URL is never promised when nothing answers

15 tests, plus the existing installer suite (`test_install_script_*`, `test_installer_stale_sweep`) still green. `bash -n` and `shellcheck -S warning` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)