### PR TITLE
[RELEASE] Test fixtures no longer leak into the live DuckDB; DuckDB-backed alert rules render as real rules

### DIFF
--- a/clawmetry/local_server.py
+++ b/clawmetry/local_server.py
@@ -106,11 +106,63 @@ def _pick_free_port() -> int:
     return port
 
 
+def default_db_path() -> str:
+    """The DuckDB file a daemon owns when nothing overrides it."""
+    return os.path.expanduser("~/.clawmetry/clawmetry.duckdb")
+
+
+def process_db_path() -> str:
+    """The DuckDB file THIS process is pointed at (``CLAWMETRY_LOCAL_STORE_PATH``
+    wins; else the default)."""
+    return os.environ.get("CLAWMETRY_LOCAL_STORE_PATH") or default_db_path()
+
+
+def _norm_path(p) -> str:
+    try:
+        return os.path.normcase(os.path.realpath(os.path.expanduser(str(p))))
+    except Exception:
+        return str(p)
+
+
+def discovery_serves_this_db(disc, db_path=None) -> bool:
+    """True when the daemon described by discovery payload ``disc`` owns the
+    SAME DuckDB file this process is pointed at.
+
+    A registered daemon only ever owns *its* file. Every proxy decision
+    (``local_store.get_store()`` handing out a ``_ProxyStore``,
+    ``routes.local_query`` forwarding over HTTP) must first ask this — a
+    process pointed at a different file (``CLAWMETRY_LOCAL_STORE_PATH``:
+    pytest fixtures, a second install, a scratch DB) must open that file
+    directly, never talk to the daemon. Before this check existed, running
+    ``pytest tests/test_alert_rules_local_store.py`` on a dev box with the
+    daemon up forwarded every fixture write into the LIVE store: the
+    fixture's tmp DuckDB was never touched and thirteen ``rule 0`` /
+    ``owner-A`` / ``Via dispatch`` rows rendered in the operator's Alerts
+    tab as "unrecognized" (2026-08-19).
+
+    ``db_path`` overrides the env-derived process path (``local_store`` passes
+    its module-level ``DB_PATH`` so a monkeypatched path is honoured too).
+    Discovery files written before ``db_path`` was recorded are read as the
+    default path — the only file a legacy daemon could have owned by default.
+    """
+    daemon_db = (disc or {}).get("db_path") if isinstance(disc, dict) else None
+    mine = db_path if db_path is not None else process_db_path()
+    return _norm_path(daemon_db or default_db_path()) == _norm_path(mine)
+
+
 def _write_discovery_file(port: int, token: str) -> None:
     """Atomically write the port+token JSON. Mode 0600 so only the same
-    user can read it."""
+    user can read it. Records ``db_path`` so non-owner processes can tell
+    whether this daemon serves *their* DuckDB (see
+    :func:`discovery_serves_this_db`)."""
     DISCOVERY_PATH.parent.mkdir(parents=True, exist_ok=True)
-    payload = {"port": port, "token": token, "pid": os.getpid()}
+    try:
+        from clawmetry import local_store as _ls
+        db_path = str(_ls.DB_PATH)
+    except Exception:
+        db_path = process_db_path()
+    payload = {"port": port, "token": token, "pid": os.getpid(),
+               "db_path": db_path}
     tmp = DISCOVERY_PATH.with_suffix(DISCOVERY_PATH.suffix + ".tmp")
     tmp.write_text(json.dumps(payload))
     os.chmod(tmp, 0o600)

--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -1622,13 +1622,23 @@ def _daemon_registered() -> bool:
     right back to reclaim it. Stealing it there starves the daemon's ingest and
     blanks every snapshot read (Models/Embodied go empty). Only a true
     single-process boot (no file at all — tests / dev / first run) lets a
-    non-owner open the writer. Best-effort; any error -> False (allow)."""
+    non-owner open the writer. Best-effort; any error -> False (allow).
+
+    The daemon only owns ITS file. When this process is pointed at a
+    different DuckDB (``DB_PATH`` != the daemon's ``db_path``) it is not a
+    non-owner of that daemon's store — it is the sole user of another file
+    and must open it directly. Proxying here sent pytest fixture writes
+    into the live store (see ``local_server.discovery_serves_this_db``)."""
     try:
         import json as _j
 
         with open(os.path.expanduser("~/.clawmetry/local_query.json")) as _f:
-            pid = _j.load(_f).get("pid")
-        return bool(pid) and int(pid) != os.getpid()
+            disc = _j.load(_f)
+        pid = disc.get("pid")
+        if not pid or int(pid) == os.getpid():
+            return False
+        from clawmetry.local_server import discovery_serves_this_db
+        return discovery_serves_this_db(disc, db_path=DB_PATH)
     except Exception:
         return False
 

--- a/clawmetry/static/js/alerts.js
+++ b/clawmetry/static/js/alerts.js
@@ -181,6 +181,17 @@
         // Local rows speak the local schema (type/threshold/channels);
         // normalise onto the fields the renderer reads.
         serverRules = (serverRules || []).map(function (r) {
+          // DuckDB-backed rows (cloud-authored via the heartbeat relay, or
+          // evaluator-owned rules mirrored from the fleet DB) keep the rule
+          // body in ``condition_json`` — alert_type / threshold_value /
+          // channel_ids live one level down, exactly like the cloud blob.
+          // Flatten first (top-level id/name/enabled win); without this
+          // every such rule missed the alert_type match and rendered as an
+          // "unrecognized" orphan even though it was a perfectly good
+          // daily_spend / token_velocity rule.
+          if (r && r.condition_json && typeof r.condition_json === 'object') {
+            r = Object.assign({}, r.condition_json, r);
+          }
           return Object.assign({}, r, {
             alert_type: r.alert_type || r.type,
             name: r.name || r.type,

--- a/routes/alerts.py
+++ b/routes/alerts.py
@@ -107,7 +107,24 @@ def _try_local_store_alert_rules():
     # the handler fall through to the legacy fleet-DB path, which hangs
     # ~3 s on this user's box. Return [] tagged with the local_store
     # source instead — the dashboard JS handles an empty list cleanly.
-    return {"rules": rows or [], "_source": "local_store"}
+    #
+    # DuckDB keeps the rule body (alert_type / threshold_value / channel_ids
+    # / runtime) inside ``condition_json``; the top level is id / name /
+    # enabled / timestamps. Promote body keys the top level lacks so the
+    # evaluator-provenance stamp below, the mirror repair, and the Alerts
+    # tab all see ``alert_type`` where they read it. Without this every
+    # DuckDB-backed rule was an "unrecognized" orphan with no evaluator,
+    # even a valid daily_spend rule. ``condition_json`` stays intact.
+    flat = []
+    for r in rows or []:
+        if isinstance(r, dict):
+            body = r.get("condition_json")
+            if isinstance(body, dict) and body:
+                merged = dict(body)
+                merged.update(r)
+                r = merged
+        flat.append(r)
+    return {"rules": flat, "_source": "local_store"}
 
 
 def _mirror_rule_to_duckdb(rule_id, *, alert_type, threshold, runtime,

--- a/routes/local_query.py
+++ b/routes/local_query.py
@@ -136,6 +136,13 @@ def _read_discovery():
 
         if not _pid_alive(pid):
             return None
+        # The daemon only owns ITS DuckDB. A process pointed at a different
+        # file (CLAWMETRY_LOCAL_STORE_PATH — pytest fixtures, a scratch DB)
+        # must not forward reads OR writes to it: that is how test fixture
+        # rows ended up in an operator's live alert_rules table.
+        from clawmetry.local_server import discovery_serves_this_db
+        if not discovery_serves_this_db(data):
+            return None
         return {"port": port, "token": token}
     except (FileNotFoundError, ValueError, OSError):
         return None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,27 @@ import pytest
 import requests
 
 
+# Point the WHOLE test session at a scratch DuckDB unless the caller already
+# chose one. ``clawmetry.local_store`` resolves ``DB_PATH`` from this env var
+# at import time, so it has to be set here (conftest imports before any test
+# module is collected), not in a fixture.
+#
+# Why (2026-08-19): a test module that called ``get_store()`` without a path
+# override opened — or, with the sync daemon up, PROXIED INTO — the
+# developer's real ``~/.clawmetry/clawmetry.duckdb``. Thirteen alert-rule
+# fixtures (``rule 0``, ``owner-A``, ``Via dispatch`` …) landed in the live
+# store and rendered in the Alerts tab. The per-process ownership check in
+# ``local_server.discovery_serves_this_db`` stops the proxy hop; this default
+# stops the direct-open leak for every test that forgot to isolate itself.
+_CONFTEST_SET_STORE_PATH = "CLAWMETRY_LOCAL_STORE_PATH" not in os.environ
+if _CONFTEST_SET_STORE_PATH:
+    import tempfile as _tempfile
+
+    os.environ["CLAWMETRY_LOCAL_STORE_PATH"] = os.path.join(
+        _tempfile.mkdtemp(prefix="clawmetry-pytest-store-"), "clawmetry.duckdb"
+    )
+
+
 # On Windows, ntpath.expanduser resolves "~" from USERPROFILE (not HOME), so
 # monkeypatch.setenv("HOME", tmp_path) silently fails to sandbox the config
 # dir.  This shim restores POSIX parity for the test suite only.
@@ -179,6 +200,11 @@ def server(base_url, token):
     # setdefault) so a CI runner that happens to inherit CLAWMETRY_HARD_BLOCK=1
     # from a matrix step still gets the opt-out applied here.
     env["CLAWMETRY_HARD_BLOCK"] = "0"
+    # The spawned dashboard must see the SAME store the CI workflow's other
+    # processes use (default path) — the scratch path above is for in-process
+    # unit tests only, so hand back the caller's original environment here.
+    if _CONFTEST_SET_STORE_PATH:
+        env.pop("CLAWMETRY_LOCAL_STORE_PATH", None)
     # Derive port from base_url
     try:
         port = base_url.split(":")[-1].rstrip("/")

--- a/tests/test_alert_rules_local_store.py
+++ b/tests/test_alert_rules_local_store.py
@@ -181,6 +181,12 @@ def test_api_alerts_rules_fast_path_serves_local_store(fresh_store, monkeypatch)
     rule = body["rules"][0]
     assert rule["id"] == "r-fast"
     assert rule["condition_json"]["alert_type"] == "token_velocity"
+    # The body is promoted to the top level too: the Alerts tab and the
+    # evaluator-provenance stamp read ``alert_type`` there. Before the
+    # promote, every DuckDB-backed rule rendered as an "unrecognized" orphan.
+    assert rule["alert_type"] == "token_velocity"
+    assert rule["threshold_value"] == 9999
+    assert rule["name"] == "fast-path rule"
 
 
 def test_api_alerts_rules_flag_off_uses_legacy(fresh_store, monkeypatch):

--- a/tests/test_store_path_ownership.py
+++ b/tests/test_store_path_ownership.py
@@ -1,0 +1,164 @@
+"""A registered daemon only owns ITS DuckDB file — never proxy to it from a
+process pointed at a different file.
+
+Regression for 2026-08-19: ``pytest tests/test_alert_rules_local_store.py``
+run on a dev box with the sync daemon up forwarded every fixture write into
+the operator's LIVE ``~/.clawmetry/clawmetry.duckdb``. ``get_store()`` saw
+``~/.clawmetry/local_query.json`` and handed the test a ``_ProxyStore`` even
+though the fixture had pointed ``CLAWMETRY_LOCAL_STORE_PATH`` at a tmp file;
+thirteen ``rule 0`` / ``owner-A`` / ``Via dispatch`` rows then rendered in the
+Alerts tab as "unrecognized".
+
+Three guards, all exercised here:
+  * ``local_server.discovery_serves_this_db`` — the single predicate.
+  * ``local_store._daemon_registered`` — ``get_store()`` opens the file
+    directly when the daemon owns a different one.
+  * ``routes.local_query._read_discovery`` — the HTTP proxy refuses too.
+"""
+from __future__ import annotations
+
+import importlib
+import json
+import os
+import sys
+
+import pytest
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+
+@pytest.fixture
+def srv():
+    from clawmetry import local_server
+    return local_server
+
+
+# ── the predicate ─────────────────────────────────────────────────────────────
+
+
+def test_legacy_discovery_without_db_path_means_default_file(srv, tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("CLAWMETRY_LOCAL_STORE_PATH", raising=False)
+    legacy = {"port": 1, "token": "t", "pid": 4242}
+    # Process on the default file → the legacy daemon is ours.
+    assert srv.discovery_serves_this_db(legacy) is True
+    # Process on a scratch file → it is NOT ours.
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "scratch.duckdb"))
+    assert srv.discovery_serves_this_db(legacy) is False
+
+
+def test_discovery_db_path_must_match_process_path(srv, tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    mine = tmp_path / "mine.duckdb"
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(mine))
+    assert srv.discovery_serves_this_db({"pid": 1, "db_path": str(mine)}) is True
+    assert srv.discovery_serves_this_db({"pid": 1, "db_path": str(tmp_path / "other.duckdb")}) is False
+    assert srv.discovery_serves_this_db({"pid": 1, "db_path": srv.default_db_path()}) is False
+    # Explicit override beats the env-derived path.
+    assert srv.discovery_serves_this_db({"pid": 1, "db_path": str(mine)},
+                                        db_path=str(tmp_path / "x.duckdb")) is False
+    # Garbage never raises; a missing payload reads as the default file.
+    assert srv.discovery_serves_this_db(None) is False
+    monkeypatch.delenv("CLAWMETRY_LOCAL_STORE_PATH")
+    assert srv.discovery_serves_this_db(None) is True
+
+
+def test_discovery_file_records_db_path(srv, tmp_path, monkeypatch):
+    db = tmp_path / "events.duckdb"
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(db))
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    monkeypatch.setattr(srv, "DISCOVERY_PATH", tmp_path / "local_query.json", raising=False)
+    srv._write_discovery_file(12345, "tok")
+    disc = json.loads((tmp_path / "local_query.json").read_text())
+    assert disc["port"] == 12345 and disc["pid"] == os.getpid()
+    assert os.path.realpath(disc["db_path"]) == os.path.realpath(str(db))
+    assert srv.discovery_serves_this_db(disc) is True
+
+
+# ── get_store(): opens the fixture file, never the daemon's ───────────────────
+
+
+def _fake_daemon_discovery(home, *, db_path=None, pid=None):
+    d = home / ".clawmetry"
+    d.mkdir(parents=True, exist_ok=True)
+    payload = {"port": 1, "token": "x" * 32, "pid": pid or (os.getpid() + 100000)}
+    if db_path is not None:
+        payload["db_path"] = str(db_path)
+    (d / "local_query.json").write_text(json.dumps(payload))
+
+
+def test_get_store_ignores_daemon_that_owns_a_different_file(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    mine = tmp_path / "fixture.duckdb"
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(mine))
+    # A "live" daemon (different pid) on the DEFAULT file. Legacy discovery
+    # shape (no db_path) — the exact file the 2026-08-19 leak went through.
+    _fake_daemon_discovery(tmp_path)
+
+    sys.modules.pop("clawmetry.local_store", None)
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    ls._reset_singleton_for_tests()
+    try:
+        assert ls._daemon_registered() is False
+        store = ls.get_store()
+        assert isinstance(store, ls.LocalStore), type(store)
+        assert not isinstance(store, ls._ProxyStore)
+        store.ingest_alert_rule({
+            "id": "fixture-rule", "owner_hash": "owner-A",
+            "name": "must stay in tmp",
+            "condition_json": {"alert_type": "daily_spend"}, "enabled": True,
+        })
+        assert [r["id"] for r in store.query_alert_rules()] == ["fixture-rule"]
+        assert mine.exists()
+    finally:
+        ls._reset_singleton_for_tests()
+
+
+def test_get_store_still_proxies_when_daemon_owns_our_file(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    mine = tmp_path / "shared.duckdb"
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(mine))
+    _fake_daemon_discovery(tmp_path, db_path=mine)
+
+    sys.modules.pop("clawmetry.local_store", None)
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    ls._reset_singleton_for_tests()
+    try:
+        assert ls._daemon_registered() is True
+        assert isinstance(ls.get_store(), ls._ProxyStore)
+    finally:
+        ls._reset_singleton_for_tests()
+
+
+# ── routes.local_query: the HTTP proxy refuses too ────────────────────────────
+
+
+def test_read_discovery_refuses_daemon_on_other_file(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "fixture.duckdb"))
+    disc_path = tmp_path / "local_query.json"
+    # Own pid → passes the liveness probe; only the ownership check can veto.
+    disc_path.write_text(json.dumps({"port": 65001, "token": "y" * 32, "pid": os.getpid()}))
+    import routes.local_query as lq
+    importlib.reload(lq)
+    monkeypatch.setattr(lq, "_DISCOVERY_PATH", str(disc_path))
+    assert lq._read_discovery() is None
+
+    disc_path.write_text(json.dumps({"port": 65001, "token": "y" * 32, "pid": os.getpid(),
+                                     "db_path": str(tmp_path / "fixture.duckdb")}))
+    assert lq._read_discovery() == {"port": 65001, "token": "y" * 32}
+
+
+def test_conftest_isolates_the_session_store_path():
+    """Every in-process test runs against a scratch DuckDB unless it chose
+    its own path — the suite can no longer touch ``~/.clawmetry``."""
+    p = os.environ.get("CLAWMETRY_LOCAL_STORE_PATH", "")
+    assert p, "conftest must set CLAWMETRY_LOCAL_STORE_PATH for the session"
+    from clawmetry.local_server import default_db_path
+    assert os.path.realpath(p) != os.path.realpath(default_db_path())


### PR DESCRIPTION
## What the operator saw
Alerts tab listing 13 rows named **Cloud-authored / v2 / Old rule ×5 / fast-path rule / rule 0 / rule 1 / rule 2 / Via dispatch / Daily spend > \$10**, every one badged "unrecognized · not evaluated" (screenshots in the session, 2026-08-19, v0.12.737).

## Root cause
Every one of those rows is a pytest fixture from `tests/test_alert_rules_local_store.py` (ids `r1`, `r-a-on`, `cloud-rule-1`, `rule-0`, `via-dispatch`; owner hashes `owner-A`, `abc123`, `owner-X`).

`local_store.get_store()` checked `_daemon_registered()` (the daemon's `~/.clawmetry/local_query.json`) **before** honouring the fixture's `CLAWMETRY_LOCAL_STORE_PATH`. With the sync daemon running on a dev box, every `store.ingest_alert_rule(...)` in the suite was a `_ProxyStore` HTTP forward into the **live** daemon (0.12.737 allowlists `ingest_alert_rule` and maps positional args). The fixture's tmp DuckDB was never opened. ~20 other test files had each individually monkeypatched `_read_discovery` / `_daemon_registered` to dodge this; the alerts test had not.

Second, independent bug the screenshot exposed: DuckDB rows keep `alert_type` / `threshold_value` / `channel_ids` inside `condition_json`, and the Alerts tab's local-mode normaliser never flattened it (the cloud-blob path does). So **any** DuckDB-backed rule — including real cloud-authored ones via the heartbeat relay — rendered as an "unrecognized" orphan, even a valid `daily_spend` rule.

## Fix
- `clawmetry/local_server.py`: discovery file now records `db_path`; `discovery_serves_this_db(disc, db_path=None)` is the single predicate (legacy files without `db_path` = default path).
- `clawmetry/local_store.py::_daemon_registered` and `routes/local_query.py::_read_discovery`: refuse to proxy (reads **or** writes) when this process is pointed at a different DuckDB file. A daemon only owns *its* file.
- `tests/conftest.py`: the whole in-process session defaults to a scratch DuckDB path (spawned CI server gets the original env back). No test can touch `~/.clawmetry` by accident any more.
- `routes/alerts.py` fast path + `static/js/alerts.js` local mode: promote `condition_json` body keys to the top level (top-level id/name/enabled win), so DuckDB-backed rules match their canonical rows.
- `tests/test_store_path_ownership.py`: predicate, `get_store()` direct-open with a legacy discovery file present, proxy-still-works when paths match, `_read_discovery` veto, and the conftest isolation guarantee.

## Verification
- 154 tests across `test_alert*`, `test_local_query_api`, `test_local_store_rename`, `test_approvals_local_store`, `test_moat_tier1_daemon_proxy_sweep`, `test_query_contract_goldens`, `test_builtin_monitors` + the new file: all green **with the live daemon running** on the dev box, and the live `alert_rules` table gained zero rows from the run (checked via the daemon proxy).
- Live store: the 13 fixture rows were deleted via `delete_alert_rule`; `/api/alerts/rules` on the desktop dashboard now returns `rules=[]`, `_source=local_store`.
- `test_local_server_proxy.py` has 4 pre-existing failures (`_cleanup_discovery_file` removed in #1810) unrelated to this change.

## Risk
A custom install that sets `CLAWMETRY_LOCAL_STORE_PATH` for the daemon **only** would stop proxying from an un-overridden dashboard until both processes see the same path — the env var is a test/dev knob (one CHANGELOG mention, no installer sets it), so this is theoretical; noted for completeness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)