### PR TITLE
feat(orchestration): workflows + sub-agents fully captured per session — context, replies, live status

### DIFF
--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -8004,6 +8004,72 @@ class LocalStore:
             })
         return out
 
+    def query_subagents_lite(
+        self,
+        *,
+        parent_session_ids: list[str] | None = None,
+        parent_like: list[str] | None = None,
+        since_ms: int | None = None,
+        limit: int = 2000,
+    ) -> list[dict[str, Any]]:
+        """Subagent rows straight off the ``subagents`` table — NO events join.
+
+        The orchestration surfaces (per-session fan-out tree, the Activity
+        tab's per-run "N workflows · M agents · running X" header) poll
+        often and only need the rollup columns + the ``data`` blob the
+        family adapters stamp (kind / workflowRunId / prompt / reply /
+        nowTool …). ``query_subagents`` derives cost from the events table
+        through a CTE that scans every sub-agent event; that is right for
+        the Agents tab but far too heavy for a 5-second Activity refresh.
+        Family-runtime rows carry cache-aware cost/tokens from the adapter
+        directly on the row, so this is exact for them; OpenClaw rows may
+        read low on cost here (use ``query_subagents`` when cost matters).
+
+        ``parent_session_ids`` matches the stored ``parent_session_id``
+        verbatim — callers pass every form they hold (bare uuid, runtime-
+        prefixed); ``parent_like`` adds SQL LIKE patterns (``%:<uuid>`` for
+        "any runtime prefix", ``%:<uuid>::%`` for "any grandchild", i.e. a
+        workflow run's agents). The two are OR-ed. Read-only -> [].
+        """
+        clauses: list[str] = []
+        params: list[Any] = []
+        parent_terms: list[str] = []
+        if parent_session_ids:
+            ids = [str(x) for x in parent_session_ids if x][:500]
+            if ids:
+                parent_terms.append(
+                    "parent_session_id IN (" + ",".join("?" * len(ids)) + ")")
+                params.extend(ids)
+        if parent_like:
+            pats = [str(x) for x in parent_like if x][:20]
+            for pat in pats:
+                parent_terms.append("parent_session_id LIKE ?")
+                params.append(pat)
+        if (parent_session_ids or parent_like) and not parent_terms:
+            return []
+        if parent_terms:
+            clauses.append("(" + " OR ".join(parent_terms) + ")")
+        if since_ms is not None:
+            clauses.append("updated_at >= ?")
+            params.append(int(since_ms))
+        where = ("WHERE " + " AND ".join(clauses)) if clauses else ""
+        sql = f"""
+            SELECT agent_type, subagent_id, parent_session_id, spawned_at,
+                   ended_at, task, status, cost_usd, token_count, data, updated_at
+            FROM subagents
+            {where}
+            ORDER BY spawned_at DESC
+            LIMIT ?
+        """
+        params.append(int(limit))
+        cols = ["agent_type", "subagent_id", "parent_session_id", "spawned_at",
+                "ended_at", "task", "status", "cost_usd", "token_count",
+                "data", "updated_at"]
+        try:
+            return _decode_data_blob_rows(self._fetch(sql, params), cols)
+        except Exception:
+            return []
+
     def query_subagents(
         self,
         *,

--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -7075,10 +7075,16 @@ var _brainTypeIcons = {
 
 // Issue #53 — apply the same filter pills that drive the list view to the
 // graph view, so toggling a source/type/channel hides matching neurons.
+// Canonical per-event source key. The JSONL slow path stamps ev.source; the
+// local-store fast path only carries sessionId/src — without this fallback the
+// session filter chips matched nothing on the fast path (the common install).
+function _brainEvSource(ev) {
+  return (ev && (ev.source || ev.sessionId || ev.src)) || 'main';
+}
 function _brainApplyFilters(events) {
   var out = Array.isArray(events) ? events : [];
   if (_brainFilter && _brainFilter !== 'all') {
-    out = out.filter(function(ev) { return ev && ev.source === _brainFilter; });
+    out = out.filter(function(ev) { return ev && _brainEvSource(ev) === _brainFilter; });
   }
   if (_brainTypeFilter && _brainTypeFilter !== 'all') {
     out = out.filter(function(ev) { return ev && ev.type === _brainTypeFilter; });
@@ -7452,7 +7458,7 @@ function _isPlumbingEvent(ev) {
 function renderBrainStream(events) {
   var el = document.getElementById('brain-stream');
   if (!el) return;
-  var filtered = _brainFilter === 'all' ? events : events.filter(function(ev) { return ev.source === _brainFilter; });
+  var filtered = _brainFilter === 'all' ? events : events.filter(function(ev) { return _brainEvSource(ev) === _brainFilter; });
   if (_brainTypeFilter !== 'all') {
     filtered = filtered.filter(function(ev) { return ev.type === _brainTypeFilter; });
   }
@@ -7843,12 +7849,81 @@ function _brainSeqLabel(ev) {
   var sid = (ev && (ev.sessionId || ev.src)) || '';
   var rt = 'openclaw', native = sid;
   var i = sid.indexOf(':');
-  if (i > 0) {
+  if (i > 0 && sid.charAt(i + 1) !== ':') {
     var pfx = sid.slice(0, i).toLowerCase();
     if (_CM_RT_PREFIXES && _CM_RT_PREFIXES[pfx]) { rt = pfx; native = sid.slice(i + 1); }
   }
   var label = (_CM_RT_LABEL && _CM_RT_LABEL[rt]) || rt;
+  // Orchestration children are namespaced "<parent>::wf_<run>::agent-<id>"
+  // (workflow agents) or "<parent>::agent-<id>" (plain subagents). Label
+  // them as what they are instead of repeating the parent uuid.
+  var parts = (native || '').split('::');
+  if (parts.length >= 2) {
+    var tail = parts[parts.length - 1];
+    var kindLbl = tail.indexOf('agent-') === 0
+      ? (parts.length >= 3 || parts[1].indexOf('wf_') === 0
+          ? t('brain.wf_agent', null, 'wf agent') : t('brain.subagent', null, 'subagent'))
+      : (tail.indexOf('wf_') === 0 ? t('brain.workflow', null, 'workflow') : 'child');
+    return label + ' \u00b7 ' + parts[0].slice(0, 8) + ' \u21b3 ' + kindLbl + ' ' +
+      tail.replace(/^agent-/, '').replace(/^wf_/, '').slice(0, 8);
+  }
   return label + ' \u00b7 ' + (native || '?').slice(0, 8);
+}
+
+// ── Orchestration badges: workflows + agents each session spawned ──────────
+// Filled by _brainLoadOrchSummaries (polls /api/orchestration-summary for the
+// TOP-LEVEL sessions in view); _brainOrchBadgeHtml renders inline in each
+// session block's header: "\u26a1 1 workflow \u00b7 9/10 agents \u00b7 \u25b6 Bash".
+var _brainOrchSummaries = {};
+var _brainOrchLastFetch = 0;
+function _brainOrchBadgeHtml(sid) {
+  if (!sid || sid.indexOf('::') >= 0) return '';
+  var sum = _brainOrchSummaries[sid];
+  if (!sum) return '';
+  var wf = sum.workflows || {}, ag = sum.agents || {}, sa = sum.subagents || {};
+  var bits = [];
+  if (wf.total) {
+    bits.push('\u26a1 ' + wf.total + ' ' + t(wf.total === 1 ? 'brain.workflow' : 'brain.workflows', null, wf.total === 1 ? 'workflow' : 'workflows')
+      + (wf.running ? ' (' + wf.running + ' ' + t('brain.running', null, 'running') + ')' : ''));
+  }
+  if (ag.total) {
+    bits.push('\ud83e\udd16 ' + ((ag.completed || 0) + (ag.failed || 0)) + '/' + ag.total + ' ' + t('brain.agents_done', null, 'agents done')
+      + (ag.failed ? ' \u00b7 \u26a0 ' + ag.failed : ''));
+  }
+  if (sa.total) bits.push('\ud83e\udd16 ' + sa.total + ' ' + t(sa.total === 1 ? 'brain.subagent' : 'brain.subagents', null, sa.total === 1 ? 'subagent' : 'subagents'));
+  var now = (sum.running_now || [])[0];
+  if (now && now.nowTool) bits.push('\u25b6 ' + escHtml(now.nowTool));
+  if (!bits.length) return '';
+  var running = (wf.running || 0) + (ag.running || 0) + (sa.running || 0);
+  var col = running ? '#f59e0b' : 'var(--text-muted)';
+  var title = t('brain.orch_badge_tooltip', null, 'Workflows and sub-agents this session spawned (from the local store). Open the session in the Sessions tab for the full fan-out with per-agent context and replies.');
+  return '<span class="brain-seq-orch" title="' + escHtml(title) + '" style="font-size:10px;color:' + col + ';white-space:nowrap;flex-shrink:0;border:1px solid ' + (running ? 'rgba(245,158,11,0.4)' : 'var(--border,#444)') + ';border-radius:10px;padding:1px 7px;">'
+    + bits.join(' \u00b7 ') + '</span>';
+}
+function _brainLoadOrchSummaries(events) {
+  var nowMs = Date.now();
+  if (nowMs - _brainOrchLastFetch < 10000) return;  // poll at most every 10s
+  var seen = {}, ids = [];
+  (events || []).forEach(function(ev) {
+    var sid = ev.sessionId || ev.src || '';
+    if (!sid || sid.indexOf('::') >= 0 || seen[sid]) return;
+    seen[sid] = 1;
+    ids.push(sid);
+  });
+  ids = ids.slice(0, 40);
+  if (!ids.length) return;
+  _brainOrchLastFetch = nowMs;
+  fetch('/api/orchestration-summary?session_ids=' + encodeURIComponent(ids.join(',')))
+    .then(function(r) { return r.json(); })
+    .then(function(d) {
+      var sums = (d && d.sessions) || {};
+      var changed = JSON.stringify(sums) !== JSON.stringify(_brainOrchSummaries);
+      _brainOrchSummaries = sums;
+      if (changed && _brainAllEvents && _brainAllEvents.length) {
+        renderBrainStream(_brainAllEvents);
+      }
+    })
+    .catch(function() {});
 }
 
 function _brainGroupSequences(rows) {
@@ -7900,11 +7975,13 @@ function _brainGroupSequences(rows) {
     var errBadge = errs
       ? '<span class="brain-seq-errs" title="' + errs + ' failed tool call' + (errs === 1 ? '' : 's') + ' in this run">\u26a0 ' + errs + '</span>'
       : '';
-    out += '<div class="brain-seq" id="' + _brainSeqDomId(key) + '">'
+    var seqSid = ((g[0].ev || {}).sessionId || (g[0].ev || {}).src || '');
+    out += '<div class="brain-seq" id="' + _brainSeqDomId(key) + '" data-sess="' + escHtml(seqSid) + '">'
         +  '<div class="brain-seq-head" onclick="toggleBrainSequence(this)">'
         +  '<span class="brain-seq-chevron">\u203a</span>'
         +  '<span class="brain-seq-label">' + escHtml(_brainSeqLabel(g[0].ev)) + '</span>'
         +  errBadge
+        +  _brainOrchBadgeHtml(seqSid)
         +  '<span class="brain-seq-meta">' + escHtml(meta) + '</span>'
         +  '</div>'
         +  '<div class="brain-seq-body">'
@@ -8423,7 +8500,7 @@ function renderBrainChart(events) {
   // chart full of bars from other runtimes' events. Apply the same four
   // filters here.
   if (_brainFilter !== 'all') {
-    events = events.filter(function(ev) { return ev.source === _brainFilter; });
+    events = events.filter(function(ev) { return _brainEvSource(ev) === _brainFilter; });
   }
   if (_brainTypeFilter !== 'all') {
     events = events.filter(function(ev) { return ev.type === _brainTypeFilter; });
@@ -9163,13 +9240,26 @@ function _stopBrainSSE() {
 }
 
 function _buildSourcesList(events) {
+  // Client-side session chips: one chip per session in view, labelled the
+  // same way the sequence blocks are ("Claude Code · 097c609a"), newest
+  // first. This is the ONLY source list on the local-store fast path (the
+  // API's `sources` ride the JSONL slow path), so it powers the
+  // sessions/all-sessions filter for the standard install.
   var seen = {};
   var sources = [];
-  events.forEach(function(ev) {
-    if (!seen[ev.source]) {
-      seen[ev.source] = true;
-      sources.push({id: ev.source, label: ev.sourceLabel || ev.source, color: ev.color || '#888'});
+  (events || []).forEach(function(ev) {
+    var id = _brainEvSource(ev);
+    var ts = ev.time ? new Date(ev.time).getTime() : 0;
+    if (!seen[id]) {
+      var label = ev.sourceLabel || (typeof _brainSeqLabel === 'function' ? _brainSeqLabel(ev) : id);
+      var cat = 'other';
+      if (String(id).indexOf('::') >= 0 || String(id).indexOf('subagent') >= 0) cat = 'subagent';
+      seen[id] = {id: id, label: label, color: ev.color || brainSourceColor(id),
+                  category: cat, last_ts: ts, count: 0};
+      sources.push(seen[id]);
     }
+    seen[id].count++;
+    if (ts > seen[id].last_ts) seen[id].last_ts = ts;
   });
   return sources;
 }
@@ -9564,7 +9654,8 @@ async function loadBrainPage(silent) {
       return tb - ta;
     });
     _brainAllEvents = events;
-    renderBrainFilterChips(data.sources || []);
+    renderBrainFilterChips((data.sources && data.sources.length) ? data.sources : _buildSourcesList(events));
+    _brainLoadOrchSummaries(events);
     renderBrainTypeChips(events);
     // Channel filter chips
     window._brainChannelCounts = data.channels || {};
@@ -19209,6 +19300,7 @@ async function viewTranscript(sessionId) {
       + '</div>';
     document.getElementById('transcript-meta').innerHTML = metaHtml;
     _loadAuthorityPanel(sessionId);
+    _loadOrchestrationPanel(sessionId);
     _loadReplayTree(sessionId);   // wire-up per #4814 — no-op until adapters land (#4815, #4816)
     // Build replay events array - include compaction markers as special events
     var events = [];
@@ -19252,6 +19344,102 @@ async function viewTranscript(sessionId) {
   } catch(e) {
     document.getElementById('transcript-messages').innerHTML = '<div style="color:#e74c3c;padding:16px;">' + t("app.failed_to_load_transcript", null, "Failed to load transcript") + '</div>';
   }
+}
+
+// Orchestration panel — the session's full fan-out: every Workflow run it
+// launched (with each run's agents, phases, status, tokens/cost, the context
+// each agent was handed and what it replied) plus plain sub-agents. Fed by
+// /api/session-orchestration/<id> (DuckDB subagents table; local-store only).
+async function _loadOrchestrationPanel(sessionId) {
+  var panel = document.getElementById('orchestration-panel');
+  var body = document.getElementById('orchestration-panel-body');
+  var sumEl = document.getElementById('orchestration-panel-summary');
+  if (!panel || !body) return;
+  panel.style.display = 'none';
+  body.innerHTML = '';
+  try {
+    var d = await fetch('/api/session-orchestration/' + encodeURIComponent(sessionId)).then(function(r) { return r.json(); });
+    if (!d || d.error) return;
+    var wfs = d.workflows || [];
+    var subs = d.subagents || [];
+    if (!wfs.length && !subs.length) return;
+    var sum = d.summary || {};
+    var bits = [];
+    if ((sum.workflows || {}).total) bits.push((sum.workflows.total) + ' ' + t(sum.workflows.total === 1 ? 'brain.workflow' : 'brain.workflows', null, sum.workflows.total === 1 ? 'workflow' : 'workflows'));
+    if ((sum.agents || {}).total) bits.push(sum.agents.total + ' ' + t('transcripts.orch_agents', null, 'agents'));
+    if (subs.length) bits.push(subs.length + ' ' + t(subs.length === 1 ? 'brain.subagent' : 'brain.subagents', null, subs.length === 1 ? 'sub-agent' : 'sub-agents'));
+    var runningTotal = ((sum.workflows || {}).running || 0) + ((sum.agents || {}).running || 0) + ((sum.subagents || {}).running || 0);
+    if (runningTotal) bits.push('<span style="color:#f59e0b;">' + runningTotal + ' ' + t('brain.running', null, 'running') + '</span>');
+    if (sum.cost_usd) bits.push('$' + Number(sum.cost_usd).toFixed(2));
+    if (sumEl) sumEl.innerHTML = bits.join(' · ');
+
+    function statusPill(st) {
+      var m = {running: ['#f59e0b', t('brain.running', null, 'running')],
+               failed: ['#ef4444', t('transcripts.orch_failed', null, 'failed')],
+               completed: ['#10b981', t('transcripts.orch_done', null, 'done')]};
+      var c = m[st] || ['#888', st];
+      return '<span style="font-size:9px;font-weight:700;color:' + c[0] + ';border:1px solid ' + c[0] + ';border-radius:8px;padding:0 6px;">' + escHtml(c[1]) + '</span>';
+    }
+    function textBlock(label, txt) {
+      if (!txt) return '';
+      return '<div style="margin-top:4px;font-size:10px;"><span style="font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:0.5px;">' + escHtml(label) + '</span>'
+        + '<div style="margin-top:2px;padding:5px 8px;background:var(--bg-primary);border-radius:5px;color:var(--text-secondary);font-family:ui-monospace,SFMono-Regular,Menlo,monospace;white-space:pre-wrap;word-break:break-word;max-height:120px;overflow-y:auto;">' + escHtml(txt) + '</div></div>';
+    }
+    function agentRow(a) {
+      var meta = [];
+      if (a.phase) meta.push(escHtml(a.phase));
+      if (a.model) meta.push(escHtml(String(a.model).replace(/^claude-/, '')));
+      if (a.tokens) meta.push(Number(a.tokens).toLocaleString() + ' tok');
+      if (a.costUsd) meta.push('$' + Number(a.costUsd).toFixed(2));
+      if (a.status === 'running' && a.nowTool) meta.push('<span style="color:#f59e0b;">▶ ' + escHtml(a.nowTool) + '</span>');
+      else if (a.lastTool) meta.push('🔧 ' + escHtml(a.lastTool));
+      var det = textBlock(t('transcripts.orch_context', null, 'Context given'), a.prompt)
+              + textBlock(t('transcripts.orch_reply', null, 'Replied'), a.reply)
+              + (a.error ? textBlock(t('transcripts.orch_error', null, 'Error'), a.error) : '');
+      var hasDet = !!det;
+      return '<div style="border-top:1px solid var(--border-secondary);padding:5px 0 5px 14px;">'
+        + '<div style="display:flex;align-items:center;gap:7px;flex-wrap:wrap;' + (hasDet ? 'cursor:pointer;' : '') + '"'
+        + (hasDet ? ' onclick="var n=this.nextElementSibling;n.style.display=n.style.display===\'none\'?\'\':\'none\'"' : '') + '>'
+        + statusPill(a.status)
+        + '<span style="font-size:11px;color:var(--text-primary);">' + escHtml((a.label || a.id).slice(0, 90)) + '</span>'
+        + '<span style="font-size:10px;color:var(--text-muted);">' + meta.join(' · ') + '</span>'
+        + (hasDet ? '<span style="font-size:9px;color:var(--text-muted);">▾</span>' : '')
+        + '</div>'
+        + (hasDet ? '<div style="display:none;">' + det + '</div>' : '')
+        + '</div>';
+    }
+    var html = '';
+    wfs.forEach(function(w) {
+      var phases = (w.phases || []).map(function(ph) { return escHtml(ph.title); }).join(' → ');
+      var head = [];
+      head.push((w.agentsDone + w.agentsFailed) + '/' + (w.agentCount || (w.agents || []).length) + ' ' + t('transcripts.orch_agents', null, 'agents'));
+      if (w.agentsRunning) head.push('<span style="color:#f59e0b;">' + w.agentsRunning + ' ' + t('brain.running', null, 'running') + '</span>');
+      if (w.agentsFailed) head.push('<span style="color:#ef4444;">⚠ ' + w.agentsFailed + '</span>');
+      if (w.rollupTokens) head.push(Number(w.rollupTokens).toLocaleString() + ' tok');
+      if (w.rollupCostUsd) head.push('$' + Number(w.rollupCostUsd).toFixed(2));
+      html += '<div style="margin-top:10px;">'
+        + '<div style="display:flex;align-items:center;gap:8px;flex-wrap:wrap;">'
+        + '<span style="font-size:12px;">⚡</span>'
+        + '<span style="font-size:12px;font-weight:700;color:var(--text-primary);">' + escHtml(w.name || w.runId) + '</span>'
+        + statusPill(w.status)
+        + '<span style="font-size:10px;color:var(--text-muted);">' + head.join(' · ') + '</span>'
+        + '</div>'
+        + (w.description ? '<div style="font-size:10px;color:var(--text-muted);margin:2px 0 0 22px;">' + escHtml(w.description) + '</div>' : '')
+        + (phases ? '<div style="font-size:10px;color:var(--text-muted);margin:2px 0 4px 22px;">' + phases + '</div>' : '')
+        + '<div style="margin-left:8px;">' + (w.agents || []).map(agentRow).join('') + '</div>'
+        + (w.reply ? '<div style="margin-left:22px;">' + textBlock(t('transcripts.orch_result', null, 'Result'), w.reply) + '</div>' : '')
+        + '</div>';
+    });
+    if (subs.length) {
+      html += '<div style="margin-top:10px;">'
+        + '<div style="font-size:11px;font-weight:700;color:var(--text-primary);">🤖 ' + t('transcripts.orch_subagents', null, 'Sub-agents') + '</div>'
+        + subs.map(agentRow).join('') + '</div>';
+    }
+    body.innerHTML = html;
+    panel.style.display = '';
+    // Auto-expand while anything is still running — that is when you look.
+    if (runningTotal) body.style.display = '';
+  } catch (e) { /* panel stays hidden */ }
 }
 
 // Authority footprint panel (#880) — fetches /api/authority for the current

--- a/clawmetry/static/locales/en.json
+++ b/clawmetry/static/locales/en.json
@@ -1176,5 +1176,22 @@
   "approvals.min_risk_medium": "Medium or above",
   "approvals.min_risk_high": "High or above",
   "approvals.min_risk_critical": "Critical only",
-  "approvals.min_risk_hint": "ClawMetry scores every tool call (recursive deletes, sudo, credential access...). Set this to gate by risk with or without keywords."
+  "approvals.min_risk_hint": "ClawMetry scores every tool call (recursive deletes, sudo, credential access...). Set this to gate by risk with or without keywords.",
+  "brain.workflow": "workflow",
+  "brain.workflows": "workflows",
+  "brain.subagent": "sub-agent",
+  "brain.subagents": "sub-agents",
+  "brain.wf_agent": "wf agent",
+  "brain.running": "running",
+  "brain.agents_done": "agents done",
+  "brain.orch_badge_tooltip": "Workflows and sub-agents this session spawned (from the local store). Open the session in the Sessions tab for the full fan-out with per-agent context and replies.",
+  "transcripts.orchestration": "Orchestration",
+  "transcripts.orch_agents": "agents",
+  "transcripts.orch_subagents": "Sub-agents",
+  "transcripts.orch_done": "done",
+  "transcripts.orch_failed": "failed",
+  "transcripts.orch_context": "Context given",
+  "transcripts.orch_reply": "Replied",
+  "transcripts.orch_error": "Error",
+  "transcripts.orch_result": "Result"
 }

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -13207,6 +13207,21 @@ def _ingest_keepalive_heartbeat(config: dict) -> bool:
         return True
 
 
+# Session.extra keys a family adapter may stamp on a CHILD session (subagent /
+# workflow run / workflow agent) that ride into the ``subagents`` row's data
+# blob verbatim. Everything the orchestration surfaces read lives here; the
+# adapters clip the free-text ones (prompt / reply / lastToolSummary) to a few
+# hundred chars before we ever see them.
+_SUBAGENT_EXTRA_PASSTHROUGH = (
+    "kind", "workflowRunId", "workflowName", "phase", "phaseIndex", "phases",
+    "agentType", "agentFile", "toolUseId", "spawnDepth", "attempt",
+    "prompt", "reply", "lastTool", "lastToolSummary", "nowTool", "turns",
+    "toolCalls", "durationMs", "tokens", "manifestTokens", "taskId",
+    "agentCount", "agentsRunning", "agentsDone", "agentsFailed", "agentsListed",
+    "rollupCostUsd", "rollupTokens", "description",
+)
+
+
 def sync_family_runtimes(config: dict, state: dict, paths: dict) -> int:
     """Ingest PicoClaw + NanoClaw sessions into DuckDB (and the cloud) so they
     appear in the sessions list + transcripts the same way OpenClaw does.
@@ -13323,8 +13338,16 @@ def sync_family_runtimes(config: dict, state: dict, paths: dict) -> int:
                 _hw_raw = str(_evt_hw.get(ns_id) or "")
                 _hw_ts, _, _hw_rev = _hw_raw.partition("@@")
                 _activity = ended or started
+                # A still-running child (open stream: ended_at=None, so its
+                # activity mark never advances) must be re-read every pass —
+                # its row carries "what it is doing right now" (nowTool /
+                # reply so far / agents running), which is the whole point
+                # of surfacing it live. Finished children fall back to the
+                # normal skip.
+                _child_running = bool(getattr(s, "parent_id", None)) and (
+                    (getattr(s, "cost_status", "") or "") == "running")
                 if (_hw_ts and _activity and _activity <= _hw_ts
-                        and _hw_rev == _ingest_rev):
+                        and _hw_rev == _ingest_rev and not _child_running):
                     continue
                 metadata = {
                     "runtime": runtime,
@@ -13461,9 +13484,18 @@ def sync_family_runtimes(config: dict, state: dict, paths: dict) -> int:
                             "label": _ftitle,
                             "displayName": _ftitle,
                             "depth": int(_sa_extra.get("depth") or 1),
-                            "error": (_sa_extra.get("description")
+                            "error": (_sa_extra.get("error")
+                                      or _sa_extra.get("description")
                                       if s.end_reason == "error" else ""),
                             "runtime": runtime,
+                            # Orchestration capture: the adapter's view of
+                            # WHAT this child is (plain subagent / workflow
+                            # run / workflow agent), the context it was
+                            # handed, what it replied, and what it is doing
+                            # right now. Whitelisted so a future adapter key
+                            # can't silently bloat the row.
+                            **{k: _sa_extra[k] for k in _SUBAGENT_EXTRA_PASSTHROUGH
+                               if _sa_extra.get(k) not in (None, "", [], {})},
                         })
                         _subagent_ingested = True
                     except Exception as _sae:
@@ -13498,22 +13530,26 @@ def sync_family_runtimes(config: dict, state: dict, paths: dict) -> int:
                             "family spawn-span ingest failed (%s): %s",
                             ns_id, _spe,
                         )
-                # Sub-agent children stop here: they ride the snapshot
-                # ``subagents[]`` slice (river lanes), not the top-level
-                # Sessions list (local: excluded in ``query_sessions_table``;
-                # cloud: not pushed below). Their tokens/cost are carried on the
-                # subagent row itself (cache-aware, from the adapter), so we skip
-                # the per-event re-ingest + cloud session push entirely — a big
-                # CPU saving for a session that fanned out to hundreds of agents.
-                # Mark the watermark ONLY when the subagent row actually landed,
-                # so a failed write is retried next pass (self-healing) instead of
-                # being stranded behind an advanced high-water mark.
-                if getattr(s, "parent_id", None):
-                    if _activity and _subagent_ingested:
-                        _evt_hw[ns_id] = _activity
-                    continue
-                # Carry the same row to cloud so the cloud Sessions list shows it.
-                cloud_session_rows.append({
+                # Sub-agent children skip the CLOUD session push (they ride
+                # the snapshot ``subagents[]`` slice, not the Sessions list)
+                # but their EVENTS now flow through the rows loop below like
+                # any session (orchestration capture): without event rows the
+                # child's transcript 404s, it never appears in the Activity
+                # feed, and query_subagents' events-derived cost reads 0. The
+                # high-water mark below keeps re-passes cheap; a failed
+                # subagent-row write is retried next pass (self-healing)
+                # because the mark only advances on a clean event ingest.
+                _is_child = bool(getattr(s, "parent_id", None))
+                if _is_child and not _subagent_ingested and _activity:
+                    # Don't let the events loop advance the mark past a child
+                    # whose subagent row failed to land — clamp by clearing
+                    # activity so the mark stays behind and we retry.
+                    _activity = ""
+                # Carry the same row to cloud so the cloud Sessions list
+                # shows it (top-level sessions only; children ride the
+                # snapshot subagents[] slice instead).
+                if not _is_child:
+                    cloud_session_rows.append({
                     "agent_type": "openclaw",
                     "session_id": ns_id,
                     "node_id": node_id,

--- a/clawmetry/templates/tabs/transcripts.html
+++ b/clawmetry/templates/tabs/transcripts.html
@@ -29,6 +29,16 @@
       </div>
       <div id="authority-panel-body" style="padding:0 12px 10px 12px;display:none;"></div>
     </div>
+    <!-- Orchestration panel — workflows + sub-agents this session spawned,
+         with the context each child was handed and what it replied.
+         Populated async by _loadOrchestrationPanel(). -->
+    <div id="orchestration-panel" style="display:none;margin-bottom:10px;background:var(--bg-secondary);border:1px solid var(--border);border-radius:8px;overflow:hidden;">
+      <div onclick="var b=document.getElementById('orchestration-panel-body');b.style.display=b.style.display==='none'?'':'none'" style="display:flex;align-items:center;justify-content:space-between;padding:8px 12px;cursor:pointer;user-select:none;">
+        <span style="font-size:12px;font-weight:700;color:var(--text-primary);">🧬 <span data-i18n="transcripts.orchestration">Orchestration</span></span>
+        <span id="orchestration-panel-summary" style="font-size:11px;color:var(--text-muted);"></span>
+      </div>
+      <div id="orchestration-panel-body" style="padding:0 12px 10px 12px;display:none;"></div>
+    </div>
     <!-- Session Replay Controls -->
     <div id="replay-controls" style="
       display:none;

--- a/routes/local_query.py
+++ b/routes/local_query.py
@@ -629,6 +629,10 @@ _DAEMON_METHODS = frozenset({
     # ``routes/crons.py:_cron_runs_from_duckdb`` via the daemon proxy.
     "query_cron_runs",
     "query_subagents",
+    # Orchestration capture: events-join-free subagent rows (kind / workflow
+    # run / prompt / reply / nowTool live in the data blob). Read by
+    # /api/session-orchestration and the Brain feed's per-run header.
+    "query_subagents_lite",
     # Context graph: decision-lineage tree (recursive subagent fan-out) for a session.
     "query_session_lineage",
     # Context graph: per-parent sub-agent cost rollup (true-cost-of-an-ask chip).

--- a/routes/sessions.py
+++ b/routes/sessions.py
@@ -2654,6 +2654,275 @@ def api_orchestration():
     })
 
 
+# ── Orchestration capture: per-session fan-out (workflows + subagents) ──────
+#
+# The family adapters emit every spawned child as a Session with parent_id set
+# and extra.kind in {subagent, workflow, workflow_agent}; the daemon lands them
+# on the ``subagents`` table with those facts (plus the context each child was
+# handed, what it replied, and what tool it is on right now) in the data blob.
+# These two routes read that table straight (no events join) and shape it into
+# the tree the Sessions tab + the Activity per-run header render.
+
+_ORCH_TERMINAL_OK = ("completed", "done", "succeeded", "success", "idle", "stale")
+_ORCH_RUNNING = ("running", "active")
+
+
+def _orch_bare_id(sid):
+    """Strip a runtime prefix ('claude_code:<uuid>' -> '<uuid>'). A child id
+    ('<uuid>::wf_x') keeps its tail; only the FIRST ':' that is not part of a
+    '::' separator is treated as the prefix delimiter."""
+    sid = (sid or "").strip()
+    if not sid:
+        return ""
+    head = sid.split("::", 1)[0]
+    if ":" in head:
+        pfx, _, rest = sid.partition(":")
+        if rest and not rest.startswith(":"):
+            return rest
+    return sid
+
+
+def _orch_status(raw):
+    st = (raw or "").strip().lower()
+    if st in _ORCH_RUNNING:
+        return "running"
+    if st in ("failed", "error", "errored"):
+        return "failed"
+    return "completed"
+
+
+def _orch_ts_ms(ts):
+    if not ts:
+        return 0
+    if isinstance(ts, (int, float)):
+        return int(ts if ts > 1e12 else ts * 1000)
+    try:
+        return int(datetime.fromisoformat(
+            str(ts).replace("Z", "+00:00")).timestamp() * 1000)
+    except Exception:
+        return 0
+
+
+def _orch_child(row, *, include_text=True):
+    """One subagents row -> the flat child dict every orchestration surface
+    reads. ``include_text`` drops prompt/reply (the bulk summary endpoint
+    polls every few seconds and only needs counts + the live tool)."""
+    extra = row.get("data") if isinstance(row.get("data"), dict) else {}
+    status = _orch_status(row.get("status"))
+    started = _orch_ts_ms(row.get("spawned_at"))
+    ended = _orch_ts_ms(row.get("ended_at")) if status != "running" else 0
+    label = (extra.get("label") or extra.get("displayName")
+             or (row.get("task") or "") or (row.get("subagent_id") or ""))
+    out = {
+        "id":          row.get("subagent_id") or "",
+        "parent":      row.get("parent_session_id") or "",
+        "kind":        (extra.get("kind") or "subagent"),
+        "label":       str(label)[:160],
+        "status":      status,
+        "model":       extra.get("model") or "",
+        "agentType":   extra.get("agentType") or "",
+        "phase":       extra.get("phase") or "",
+        "startedAt":   started,
+        "endedAt":     ended,
+        "durationMs":  int(extra.get("durationMs") or 0) or (
+            max(0, ended - started) if (started and ended) else 0),
+        "tokens":      int(row.get("token_count") or 0),
+        "costUsd":     round(float(row.get("cost_usd") or 0.0), 6),
+        "toolCalls":   int(extra.get("toolCalls") or 0),
+        "turns":       int(extra.get("turns") or 0),
+        "nowTool":     (extra.get("nowTool") or "") if status == "running" else "",
+        "lastTool":    extra.get("lastTool") or "",
+        "error":       extra.get("error") or "",
+        "runtime":     extra.get("runtime") or row.get("agent_type") or "",
+    }
+    if extra.get("kind") == "workflow":
+        out.update({
+            "runId":         extra.get("workflowRunId") or "",
+            "name":          extra.get("workflowName") or out["label"],
+            "description":   extra.get("description") or "",
+            "agentCount":    int(extra.get("agentCount") or 0),
+            "agentsRunning": int(extra.get("agentsRunning") or 0),
+            "agentsDone":    int(extra.get("agentsDone") or 0),
+            "agentsFailed":  int(extra.get("agentsFailed") or 0),
+            "phases":        extra.get("phases") if isinstance(extra.get("phases"), list) else [],
+            "rollupCostUsd": round(float(extra.get("rollupCostUsd") or 0.0), 6),
+            "rollupTokens":  int(extra.get("rollupTokens") or extra.get("manifestTokens") or 0),
+            "agents":        [],
+        })
+    elif extra.get("kind") == "workflow_agent":
+        out["runId"] = extra.get("workflowRunId") or ""
+        out["workflowName"] = extra.get("workflowName") or ""
+    if include_text:
+        out["prompt"] = extra.get("prompt") or ""
+        out["reply"] = extra.get("reply") or ""
+        out["lastToolSummary"] = extra.get("lastToolSummary") or ""
+        out["description"] = out.get("description") or extra.get("description") or ""
+        out["toolUseId"] = extra.get("toolUseId") or ""
+    return out
+
+
+def _orch_rows_for(session_ids):
+    """Direct children + grandchildren (workflow agents) for the given parent
+    ids, in every id form the store may hold (bare / runtime-prefixed)."""
+    exact, like = [], []
+    for sid in session_ids:
+        sid = (sid or "").strip()
+        if not sid:
+            continue
+        bare = _orch_bare_id(sid)
+        exact.extend([sid, bare])
+        # Only bare uuids / simple ids go into LIKE (no wildcard chars).
+        if bare and "%" not in bare and "_" not in bare:
+            like.append("%:" + bare)
+            like.append("%:" + bare + "::%")
+            like.append(bare + "::%")
+    if not exact:
+        return []
+    rows = _ls_call("query_subagents_lite",
+                    parent_session_ids=sorted(set(exact)),
+                    parent_like=sorted(set(like)), limit=4000)
+    return rows if isinstance(rows, list) else []
+
+
+def _orch_tree(session_id, rows, *, include_text=True):
+    """Shape rows into {workflows:[{..., agents:[]}], subagents:[], summary}."""
+    sid = (session_id or "").strip()
+    bare = _orch_bare_id(sid)
+
+    def _is_direct_parent(pid):
+        pid = pid or ""
+        return pid == sid or pid == bare or (
+            pid.endswith(":" + bare) and "::" not in pid)
+
+    workflows = {}
+    subagents = []
+    orphans_by_parent = collections.defaultdict(list)
+    for r in rows:
+        child = _orch_child(r, include_text=include_text)
+        pid = child["parent"]
+        if child["kind"] == "workflow" and _is_direct_parent(pid):
+            workflows[child["id"]] = child
+            workflows.setdefault(_orch_bare_id(child["id"]), child)
+        elif child["kind"] == "workflow_agent":
+            orphans_by_parent[pid].append(child)
+            orphans_by_parent[_orch_bare_id(pid)].append(child)
+        elif _is_direct_parent(pid):
+            subagents.append(child)
+    seen = set()
+    for wid, wf in list(workflows.items()):
+        if id(wf) in seen:
+            continue
+        seen.add(id(wf))
+        agents = []
+        ag_seen = set()
+        for key in (wf["id"], _orch_bare_id(wf["id"])):
+            for a in orphans_by_parent.get(key, []):
+                if a["id"] in ag_seen:
+                    continue
+                ag_seen.add(a["id"])
+                agents.append(a)
+        agents.sort(key=lambda a: (a["startedAt"] or 0))
+        wf["agents"] = agents
+        # Live counts from the rows beat the manifest-time counts when the
+        # run is still going (the adapter refreshes running children each
+        # daemon pass; the manifest only lands at the end).
+        if agents:
+            wf["agentsRunning"] = sum(1 for a in agents if a["status"] == "running")
+            wf["agentsFailed"] = sum(1 for a in agents if a["status"] == "failed")
+            wf["agentsDone"] = sum(1 for a in agents if a["status"] == "completed")
+            if not wf.get("agentCount"):
+                wf["agentCount"] = len(agents)
+            wf["rollupCostUsd"] = round(sum(a["costUsd"] for a in agents), 6)
+            wf["rollupTokens"] = sum(a["tokens"] for a in agents)
+        if wf["agentsRunning"] and wf["status"] != "running":
+            # A run whose agents are still warm is still going, whatever the
+            # (possibly stale) run row says.
+            wf["status"] = "running"
+    wf_list = []
+    wf_ids = set()
+    for wf in workflows.values():
+        if wf["id"] in wf_ids:
+            continue
+        wf_ids.add(wf["id"])
+        wf_list.append(wf)
+    wf_list.sort(key=lambda w: -(w["startedAt"] or 0))
+    subagents.sort(key=lambda a: -(a["startedAt"] or 0))
+
+    def _bucket(items):
+        return {
+            "total":     len(items),
+            "running":   sum(1 for x in items if x["status"] == "running"),
+            "completed": sum(1 for x in items if x["status"] == "completed"),
+            "failed":    sum(1 for x in items if x["status"] == "failed"),
+        }
+    all_agents = [a for w in wf_list for a in w["agents"]]
+    running_now = []
+    for x in all_agents + subagents:
+        if x["status"] == "running":
+            running_now.append({
+                "id": x["id"], "label": x["label"], "kind": x["kind"],
+                "nowTool": x.get("nowTool") or "", "phase": x.get("phase") or "",
+            })
+    running_now = running_now[:8]
+    cost = round(sum(a["costUsd"] for a in all_agents) + sum(s["costUsd"] for s in subagents), 6)
+    tokens = sum(a["tokens"] for a in all_agents) + sum(s["tokens"] for s in subagents)
+    return {
+        "session_id": sid,
+        "summary": {
+            "workflows":   _bucket(wf_list),
+            "agents":      _bucket(all_agents),
+            "subagents":   _bucket(subagents),
+            "children":    len(all_agents) + len(subagents),
+            "cost_usd":    cost,
+            "tokens":      tokens,
+            "running_now": running_now,
+        },
+        "workflows": wf_list,
+        "subagents": subagents,
+    }
+
+
+@bp_sessions.route("/api/session-orchestration/<path:session_id>")
+def api_session_orchestration(session_id):
+    """The full fan-out of ONE session: every Workflow run it launched (with
+    each run's agents, their phase/model/state, the context each was handed
+    and what it replied) plus every plain sub-agent — straight from the
+    ``subagents`` table. Local-store only; honest empty tree otherwise."""
+    sid = (session_id or "").strip()
+    if not sid:
+        return jsonify({"error": "session_id required"}), 400
+    rows = _orch_rows_for([sid])
+    tree = _orch_tree(sid, rows, include_text=True)
+    tree["_source"] = "local_store" if rows else "none"
+    return jsonify(tree)
+
+
+@bp_sessions.route("/api/orchestration-summary")
+def api_orchestration_summary():
+    """Bulk per-session fan-out counts for the Activity feed's run headers.
+
+    ``?session_ids=a,b,c`` (max 60). Returns ``{sessions: {sid: summary}}``
+    where summary is the same shape as ``/api/session-orchestration``'s
+    ``summary`` (workflows/agents/subagents buckets + what is running now).
+    No prompt/reply text — this is polled."""
+    raw = request.args.get("session_ids") or request.args.get("ids") or ""
+    ids = [x.strip() for x in raw.split(",") if x.strip()][:60]
+    if not ids:
+        return jsonify({"sessions": {}})
+    rows = _orch_rows_for(ids)
+    out = {}
+    for sid in ids:
+        bare = _orch_bare_id(sid)
+        mine = [r for r in rows
+                if _orch_bare_id((r.get("parent_session_id") or "").split("::", 1)[0]) == bare]
+        if not mine:
+            continue
+        tree = _orch_tree(sid, mine, include_text=False)
+        if tree["summary"]["children"]:
+            out[sid] = tree["summary"]
+    return jsonify({"sessions": out})
+
+
 @bp_sessions.route("/api/subagents/integrity")
 def api_subagents_integrity():
     """Validate subagent state-machine: orphans, cycles, duplicate completions.

--- a/tests/test_orchestration_capture.py
+++ b/tests/test_orchestration_capture.py
@@ -1,0 +1,237 @@
+"""Orchestration capture (workflows + sub-agents) — the /api/session-orchestration
+and /api/orchestration-summary routes plus LocalStore.query_subagents_lite.
+
+The family adapters emit every spawned child as a Session with parent_id set
+and extra.kind in {subagent, workflow, workflow_agent}; the daemon lands them
+on the ``subagents`` table with the orchestration facts (context handed to the
+child, its reply, the tool it is on right now) in the data blob (see
+``_SUBAGENT_EXTRA_PASSTHROUGH`` in clawmetry/sync.py). These tests seed that
+table directly and assert the two routes shape it into the tree the Sessions
+tab + Activity feed render:
+
+1. query_subagents_lite: exact-id + LIKE parent matching, no events join.
+2. /api/session-orchestration/<sid>: workflow run + its agents nested under
+   it, plain sub-agents separate, live counts derived from the rows.
+3. A running workflow agent surfaces in summary.running_now with nowTool.
+4. /api/orchestration-summary bulk shape + sessions with no children omitted.
+5. Bare-uuid and runtime-prefixed parent ids resolve to the same tree.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+
+import pytest
+from flask import Flask
+
+
+PARENT = "097c0000-1111-2222-3333-444455556666"
+NS_PARENT = f"claude_code:{PARENT}"
+RUN = f"claude_code:{PARENT}::wf_test1234-abc"
+
+
+@pytest.fixture
+def app(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_READ", "1")
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    import routes.local_query as lq
+    importlib.reload(lq)
+    import routes.sessions as sessions_mod
+    importlib.reload(sessions_mod)
+
+    # Isolate from a locally running daemon (issue #1538 pattern) — otherwise
+    # _ls_call proxies into the contributor's production DuckDB, and
+    # get_store() hands back a _ProxyStore instead of the tmp_path writer.
+    monkeypatch.setattr(lq, "_read_discovery", lambda: None)
+    monkeypatch.setattr(ls, "_daemon_registered", lambda: False)
+
+    a = Flask(__name__)
+    a.register_blueprint(sessions_mod.bp_sessions)
+    yield a, ls
+    try:
+        ls.get_store().stop(flush=True)
+    except Exception:
+        pass
+
+
+def _seed(ls):
+    store = ls.get_store()
+    # The workflow RUN (child of the parent session).
+    store.ingest_subagent({
+        "subagent_id": RUN,
+        "agent_type": "openclaw",
+        "parent_session_id": NS_PARENT,
+        "spawned_at": "2026-08-19T10:00:00+00:00",
+        "ended_at": None,
+        "task": "orchestration-e2e",
+        "status": "running",
+        "cost_usd": 0.0,
+        "token_count": 0,
+        "kind": "workflow",
+        "workflowRunId": "wf_test1234-abc",
+        "workflowName": "orchestration-e2e",
+        "agentCount": 2,
+        "agentsRunning": 1,
+        "agentsDone": 1,
+        "agentsFailed": 0,
+        "phases": [{"title": "Audit", "detail": "look"}],
+        "runtime": "claude_code",
+    })
+    # A finished workflow agent (child of the run — depth 2).
+    store.ingest_subagent({
+        "subagent_id": f"{RUN}::agent-adead1",
+        "agent_type": "openclaw",
+        "parent_session_id": RUN,
+        "spawned_at": "2026-08-19T10:00:05+00:00",
+        "ended_at": "2026-08-19T10:05:00+00:00",
+        "task": "audit:disk",
+        "status": "completed",
+        "cost_usd": 1.25,
+        "token_count": 5000,
+        "kind": "workflow_agent",
+        "workflowRunId": "wf_test1234-abc",
+        "label": "audit:disk",
+        "phase": "Audit",
+        "prompt": "You are a research agent. Inventory X.",
+        "reply": '{"found": 3}',
+        "lastTool": "Bash",
+        "runtime": "claude_code",
+    })
+    # A still-running workflow agent with a live tool.
+    store.ingest_subagent({
+        "subagent_id": f"{RUN}::agent-abeef2",
+        "agent_type": "openclaw",
+        "parent_session_id": RUN,
+        "spawned_at": "2026-08-19T10:00:06+00:00",
+        "ended_at": None,
+        "task": "audit:web",
+        "status": "running",
+        "cost_usd": 0.5,
+        "token_count": 2000,
+        "kind": "workflow_agent",
+        "workflowRunId": "wf_test1234-abc",
+        "label": "audit:web",
+        "phase": "Audit",
+        "prompt": "Search upstream docs.",
+        "nowTool": "WebFetch",
+        "lastTool": "WebFetch",
+        "runtime": "claude_code",
+    })
+    # A plain (non-workflow) sub-agent, direct child of the parent.
+    store.ingest_subagent({
+        "subagent_id": f"{NS_PARENT}::agent-acafe3",
+        "agent_type": "openclaw",
+        "parent_session_id": NS_PARENT,
+        "spawned_at": "2026-08-19T09:00:00+00:00",
+        "ended_at": "2026-08-19T09:02:00+00:00",
+        "task": "explore the repo",
+        "status": "completed",
+        "cost_usd": 0.10,
+        "token_count": 800,
+        "kind": "subagent",
+        "agentType": "Explore",
+        "prompt": "Find the config loader.",
+        "reply": "It lives in clawmetry/config.py.",
+        "runtime": "claude_code",
+    })
+    # Noise: a child of an UNRELATED session must never leak into the tree.
+    store.ingest_subagent({
+        "subagent_id": "claude_code:ffff0000-aaaa-bbbb-cccc-dddd11112222::agent-a9",
+        "agent_type": "openclaw",
+        "parent_session_id": "claude_code:ffff0000-aaaa-bbbb-cccc-dddd11112222",
+        "spawned_at": "2026-08-19T10:00:00+00:00",
+        "task": "other",
+        "status": "completed",
+        "kind": "subagent",
+    })
+
+
+def test_query_subagents_lite_matches_exact_and_like(app):
+    _, ls = app
+    _seed(ls)
+    store = ls.get_store()
+    rows = store.query_subagents_lite(parent_session_ids=[NS_PARENT])
+    assert {r["subagent_id"] for r in rows} == {RUN, f"{NS_PARENT}::agent-acafe3"}
+    # LIKE patterns pull the run's agents (grandchildren) too.
+    rows = store.query_subagents_lite(
+        parent_session_ids=[NS_PARENT],
+        parent_like=[f"%:{PARENT}::%"],
+    )
+    ids = {r["subagent_id"] for r in rows}
+    assert f"{RUN}::agent-adead1" in ids and f"{RUN}::agent-abeef2" in ids
+    # data blob round-trips the orchestration fields.
+    agent = next(r for r in rows if r["subagent_id"].endswith("agent-abeef2"))
+    assert agent["data"]["nowTool"] == "WebFetch"
+    assert agent["data"]["kind"] == "workflow_agent"
+
+
+def test_session_orchestration_tree(app):
+    a, ls = app
+    _seed(ls)
+    client = a.test_client()
+    d = client.get(f"/api/session-orchestration/{NS_PARENT}").get_json()
+    assert d["_source"] == "local_store"
+    assert len(d["workflows"]) == 1
+    wf = d["workflows"][0]
+    assert wf["name"] == "orchestration-e2e"
+    assert wf["status"] == "running"
+    assert len(wf["agents"]) == 2
+    # Live counts derived from the agent rows.
+    assert wf["agentsRunning"] == 1 and wf["agentsDone"] == 1
+    done = next(x for x in wf["agents"] if x["status"] == "completed")
+    assert done["prompt"].startswith("You are a research agent")
+    assert done["reply"] == '{"found": 3}'
+    running = next(x for x in wf["agents"] if x["status"] == "running")
+    assert running["nowTool"] == "WebFetch"
+    # Plain sub-agent rides separately with its context + reply.
+    assert len(d["subagents"]) == 1
+    assert d["subagents"][0]["reply"].startswith("It lives in")
+    # The unrelated session's child never leaks in.
+    all_ids = [x["id"] for x in wf["agents"]] + [x["id"] for x in d["subagents"]]
+    assert not any("ffff0000" in x for x in all_ids)
+    # Summary counts + running_now carry the live tool.
+    s = d["summary"]
+    assert s["workflows"]["running"] == 1
+    assert s["agents"]["total"] == 2
+    assert any(r["nowTool"] == "WebFetch" for r in s["running_now"])
+
+
+def test_session_orchestration_accepts_bare_uuid(app):
+    a, ls = app
+    _seed(ls)
+    client = a.test_client()
+    d = client.get(f"/api/session-orchestration/{PARENT}").get_json()
+    assert len(d["workflows"]) == 1
+    assert len(d["workflows"][0]["agents"]) == 2
+
+
+def test_orchestration_summary_bulk(app):
+    a, ls = app
+    _seed(ls)
+    client = a.test_client()
+    quiet = "claude_code:00000000-0000-0000-0000-000000000000"
+    d = client.get(
+        "/api/orchestration-summary",
+        query_string={"session_ids": f"{NS_PARENT},{quiet}"},
+    ).get_json()
+    assert NS_PARENT in d["sessions"]
+    assert quiet not in d["sessions"]  # honest omission, no zero-noise
+    s = d["sessions"][NS_PARENT]
+    assert s["workflows"]["total"] == 1
+    assert s["agents"]["total"] == 2
+    assert s["subagents"]["total"] == 1
+    # Bulk shape is the polled one: no prompt/reply text anywhere.
+    assert "prompt" not in json.dumps(d)
+
+
+def test_orchestration_empty_session_is_honest(app):
+    a, _ = app
+    client = a.test_client()
+    d = client.get("/api/session-orchestration/claude_code:no-such").get_json()
+    assert d["workflows"] == [] and d["subagents"] == []
+    assert d["summary"]["children"] == 0


### PR DESCRIPTION
## What

Answers "what is this session doing right now, what did it spawn, what did each child get and reply" — end to end.

**Capture (daemon/store):**
- Family-adapter children (sub-agents, Workflow runs, workflow agents) land on the `subagents` table with the orchestration facts in the data blob: `kind`, `workflowRunId/Name`, `phase`, `prompt` (context given), `reply`, `nowTool` (live tool), agent counts + rollups (`_SUBAGENT_EXTRA_PASSTHROUGH` whitelist).
- Still-running children re-read every pass so live status never goes stale.
- **Child events now ingest** — child transcripts used to 404 and never appeared in the Activity feed.
- `query_subagents_lite`: poll-safe subagents read (no events join), exact + LIKE parent matching (runtime prefixes, grandchildren).

**API:** `/api/session-orchestration/<sid>` (full tree with per-agent prompt/reply) + `/api/orchestration-summary?session_ids=…` (bulk counts, no text).

**UI:**
- Activity tab: session filter chips now work on the local-store fast path (the common install — they previously only rode the JSONL slow path); `↳ sub-agent / wf agent` labels on child run blocks; orchestration badge per session block: `⚡ 1 workflow · 🤖 10/10 agents done · ▶ Bash`.
- Sessions tab: **Orchestration** panel in the transcript viewer — per run: phases, per-agent status/model/tokens/cost, expandable **Context given** / **Replied**, run result. Auto-expands while anything is running.

Pairs with clawmetry-pro `feat/orchestration-capture` (Claude Code adapter emits workflow runs/agents; other runtimes follow per the 22-runtime audit).

## Verify
- `tests/test_orchestration_capture.py` (5 tests: lite query, tree shaping, bare-uuid ids, bulk summary, honest empty).
- Live on a fake-HOME staging instance (:8902) against this machine's real `~/.claude`: 18 workflow runs / 231 workflow agents / 57 sub-agents, including one run captured **mid-flight** (running badge + live tool, converged to manifest labels on completion). Screenshots in comments.
- Lint delta vs main: 0 new errors on every touched file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)