### PR TITLE
feat(nemoclaw): orchestration capture — sandboxed OpenClaw sub-agents get parent edges, prompt/reply, live status

### DIFF
--- a/clawmetry/adapters/nemo.py
+++ b/clawmetry/adapters/nemo.py
@@ -1005,12 +1005,146 @@ def _read_onboard_trace_timing() -> dict:
     return {}
 
 
+# Orchestration capture (nemoclaw leg) ---------------------------------------
+# A sandboxed OpenClaw child is "running" only while the registry row shows
+# no endedAt AND recent activity — a child killed with the sandbox never gets
+# a terminal write, so recency is the honest liveness signal (same window the
+# hermes/claude_code legs use).
+_NEMO_CHILD_RUNNING_WINDOW_S = 180.0
+
+
+def _nemoclaw_subagent_rows() -> list[dict]:
+    """``subagents`` rows for ``agent_type='nemoclaw'``. -> [].
+
+    Goes through ``query_subagents`` (daemon-proxy allowlisted, see
+    ``routes/local_query.py``) instead of raw ``_fetch`` SQL so the dashboard
+    process — where ``get_store()`` returns the ``_ProxyStore`` and ``_fetch``
+    is deliberately not proxyable — still sees the delegation rows."""
+    try:
+        from clawmetry import local_store as _ls
+        store = _ls.get_store(read_only=True)
+        rows = store.query_subagents(agent_type="nemoclaw", limit=500)
+        return rows if isinstance(rows, list) else []
+    except Exception as exc:
+        logger.debug("nemoclaw subagent rows read failed: %s", exc)
+        return []
+
+
+def _nemoclaw_child_texts(store, session_id: str) -> tuple[str, str]:
+    """(prompt, reply) for a sandboxed child from its OWN DuckDB events.
+
+    The sandbox jsonl is OpenClaw v3, so ``_parse_v3_event`` lands the
+    child's first user turn as ``prompt.submitted`` (``data.finalPromptText``
+    — for a spawn this IS the task text the parent handed over) and its final
+    answer as ``model.completed`` (``data.completionText``). Returns ('', '')
+    when the child has no such events (e.g. a spawn that failed before
+    writing a transcript) — never invented. Uses ``_fetch``, which is
+    unavailable through the daemon proxy; the enrichment then degrades to
+    the registry facts only, which is the honest floor."""
+    prompt = reply = ""
+
+    def _text(rows, key: str) -> str:
+        for r in rows or []:
+            raw = r[0]
+            try:
+                if isinstance(raw, (bytes, bytearray)):
+                    raw = bytes(raw).decode("utf-8", "replace")
+                obj = json.loads(raw) if isinstance(raw, str) else raw
+                if isinstance(obj, dict):
+                    val = obj.get(key) or (obj.get("data") or {}).get(key)
+                    if val:
+                        return str(val)[:400]
+            except Exception:
+                continue
+        return ""
+
+    try:
+        rows = store._fetch(
+            "SELECT data FROM events WHERE agent_type = ? AND session_id = ? "
+            "AND event_type = 'prompt.submitted' ORDER BY ts ASC LIMIT 1",
+            ["nemoclaw", str(session_id)],
+        )
+        prompt = _text(rows, "finalPromptText")
+        rows = store._fetch(
+            "SELECT data FROM events WHERE agent_type = ? AND session_id = ? "
+            "AND event_type = 'model.completed' ORDER BY ts DESC LIMIT 3",
+            ["nemoclaw", str(session_id)],
+        )
+        reply = _text(rows, "completionText")
+    except Exception as exc:
+        logger.debug("nemoclaw child text read failed: %s", exc)
+    return prompt, reply
+
+
+def _nemoclaw_apply_subagent_row(session: Session, row: dict, store) -> None:
+    """Enrich one child Session in place from its ``subagents`` row.
+
+    parent_id is set ONLY when the sandbox registry resolved a real spawner
+    (``spawnedBy`` -> parent transcript uuid) — advisor-dir sessions and
+    orphan children keep parent_id None rather than getting a guessed edge."""
+    data = row.get("data") if isinstance(row.get("data"), dict) else {}
+    parent = row.get("parent_session_id")
+    if parent:
+        session.parent_id = str(parent)
+    session.extra["kind"] = "subagent"
+    session.extra["isSubagent"] = True
+    session.extra["depth"] = int(data.get("depth") or 1)
+    # OpenClaw spawns carry no named persona — subagentRole ('leaf' /
+    # 'coordinator') is the closest on-disk fact; never invent one.
+    session.extra["agentType"] = data.get("subagentRole") or "subagent"
+    label = str(data.get("label") or "")
+    if label:
+        session.extra["label"] = label
+        if not session.title or session.title.startswith("NemoClaw session"):
+            session.title = label
+    if data.get("sandbox"):
+        session.extra["sandbox"] = data["sandbox"]
+    prompt, reply = _nemoclaw_child_texts(store, session.id)
+    # The registry task (parent-declared) wins as prompt; the child's first
+    # user turn is the same text when the transcript exists.
+    task = str(row.get("task") or "")
+    if task:
+        session.extra["prompt"] = task[:400]
+    elif prompt:
+        session.extra["prompt"] = prompt
+    if reply:
+        session.extra["reply"] = reply
+    status = str(row.get("status") or "").lower()
+    raw_status = str(data.get("rawStatus") or status).lower()
+    if any(b in raw_status for b in ("error", "fail", "kill", "cancel", "timeout")):
+        session.end_reason = "error"
+    ended_ms = int(data.get("endedAtMs") or 0)
+    updated_ms = int(data.get("updatedAtMs") or 0)
+    if not ended_ms and updated_ms:
+        if (time.time() - updated_ms / 1000.0) <= _NEMO_CHILD_RUNNING_WINDOW_S:
+            session.cost_status = "running"
+    if ended_ms and session.ended_at is None:
+        session.ended_at = ended_ms / 1000.0
+    started_ms = int(data.get("startedAtMs") or 0)
+    if started_ms and not session.started_at:
+        session.started_at = started_ms / 1000.0
+
+
 class NemoClawAdapter(AgentAdapter):
     """Read-side adapter for the NemoClaw Free runtime.
 
     Reads events tagged ``agent_type='nemoclaw'`` from DuckDB. Detection
     is "any nemoclaw-tagged events present" so an OSS install with no
     NemoClaw data does not clutter the chip bar.
+
+    Orchestration capture: a NemoClaw sandbox hosts a full OpenClaw
+    workspace, so a sandboxed agent can spawn sub-agents exactly like host
+    OpenClaw (``agent:main:subagent:<uuid>`` entries in the sandbox's own
+    ``sessions.json``). The sync daemon reads that index per sandbox
+    (``sync.py::sync_sandbox_sessions_openshell`` +
+    ``_parse_openclaw_subagent_index``) and upserts ``subagents`` rows with
+    ``agent_type='nemoclaw'``; ``list_sessions`` joins those rows back so a
+    child appears as a Session with ``parent_id`` + ``extra.kind='subagent'``
+    and its prompt/reply lifted from its OWN transcript events. Advisor-dir
+    sessions are sibling agents, not delegations — they never get a parent
+    edge. NOT recoverable: per-child token splits when the sandboxed
+    OpenClaw predates per-subagent usage stamping, and any child whose
+    sandbox was deleted before a sync tick ran.
     """
 
     name = "nemoclaw"
@@ -1094,6 +1228,50 @@ class NemoClawAdapter(AgentAdapter):
                 ))
         except Exception as exc:
             logger.debug("nemoclaw list_sessions read failed: %s", exc)
+
+        # Orchestration capture: join the sandbox registry's delegation rows
+        # back onto the event-derived sessions. Children whose transcript
+        # events already landed (session_id == subagent uuid, or the legacy
+        # pre-capture file uuid via data.sessionId) are enriched in place;
+        # a child the registry knows but that never wrote a transcript
+        # (observed live: a 55 ms 'failed' spawn) is synthesised from the
+        # registry row alone — with NO prompt/reply invented for it.
+        try:
+            sa_rows = _nemoclaw_subagent_rows()
+            if sa_rows:
+                from clawmetry import local_store as _ls
+                store = _ls.get_store(read_only=True)
+                by_id: dict[str, dict] = {}
+                for row in sa_rows:
+                    said = str(row.get("subagent_id") or "")
+                    if not said:
+                        continue
+                    by_id[said] = row
+                    d = row.get("data") if isinstance(row.get("data"), dict) else {}
+                    if d.get("sessionId"):
+                        by_id.setdefault(str(d["sessionId"]), row)
+                seen: set[str] = set()
+                for s in sessions:
+                    row = by_id.get(s.id)
+                    if row is not None:
+                        _nemoclaw_apply_subagent_row(s, row, store)
+                        seen.add(str(row.get("subagent_id") or ""))
+                for row in sa_rows:
+                    said = str(row.get("subagent_id") or "")
+                    if not said or said in seen:
+                        continue
+                    child = Session(
+                        agent=self.name,
+                        id=said,
+                        title=f"NemoClaw session {said[:8]}",
+                        message_count=0,
+                        total_tokens=int(row.get("token_count") or 0),
+                        cost_usd=float(row.get("cost_usd") or 0.0),
+                    )
+                    _nemoclaw_apply_subagent_row(child, row, store)
+                    sessions.append(child)
+        except Exception as exc:
+            logger.debug("nemoclaw subagent enrichment failed: %s", exc)
         return sessions
 
     def list_events(self, session_id: str, limit: int = 500) -> list[Event]:
@@ -1202,6 +1380,10 @@ class NemoClawAdapter(AgentAdapter):
             Capability.COST,
             Capability.SKILLS,
             Capability.LOGS,
+            # Genuinely emitted: list_sessions joins the sandbox registry's
+            # subagents rows and sets parent_id + extra.kind='subagent' on
+            # every persisted delegation (orchestration capture, nemoclaw leg).
+            Capability.SUBAGENTS,
         }
 
 

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -2758,6 +2758,141 @@ def sync_sessions(config: dict, state: dict, paths: dict) -> int:
     return total
 
 
+def _parse_openclaw_subagent_index(index) -> dict:
+    """Delegation records from an OpenClaw ``sessions.json`` index. -> {}.
+
+    Orchestration capture, nemoclaw leg. A NemoClaw sandbox hosts a full
+    OpenClaw workspace, so a sandboxed agent that spawns a sub-agent writes
+    the SAME ``agent:<agent>:subagent:<uuid>`` index entries the host runtime
+    does. Real entry shape (captured live from a 2026.8 OpenClaw
+    ``sessions.json`` on 2026-08-20 — a ``sessions_spawn`` run):
+
+        agent:main:subagent:d38a6bbd-… : {
+          "spawnDepth": 1, "subagentRole": "leaf",
+          "sessionId": "55d5d1e2-…",            # child transcript file uuid
+          "sessionFile": "…/sessions/55d5d1e2-….jsonl",
+          "spawnedBy": "agent:main:main",       # index key of the spawner
+          "label": "ping-test", "status": "failed",
+          "startedAt": 1787185058306, "endedAt": 1787185058372,   # epoch ms
+          "updatedAt": 1787185058560, "runtimeMs": 55, …
+        }
+
+    ``task`` / ``model`` / ``totalTokens`` are optional (the captured failed
+    spawn carried none). Returns ``{child_file_uuid: record}`` where record
+    holds the delegation facts; ``parent_session_id`` is resolved through the
+    index (``spawnedBy`` key -> that entry's own ``sessionId``) and left None
+    when the spawner entry is missing — an unresolvable parent is never
+    guessed. Pure function so tests can pin it without an openshell install.
+    """
+    out: dict = {}
+    if not isinstance(index, dict):
+        return out
+
+    def _file_uuid(meta: dict) -> str:
+        fid = str(meta.get("sessionId") or "")
+        if not fid:
+            sf = str(meta.get("sessionFile") or "")
+            if sf.endswith(".jsonl"):
+                fid = os.path.basename(sf).split(".jsonl", 1)[0]
+        return fid
+
+    for key, meta in index.items():
+        if not isinstance(meta, dict) or ":subagent:" not in str(key):
+            continue
+        child_uuid = str(key).rsplit(":", 1)[-1]
+        fid = _file_uuid(meta)
+        if not child_uuid:
+            continue
+        parent_uuid = None
+        spawned_by = str(meta.get("spawnedBy") or "")
+        pmeta = index.get(spawned_by)
+        if isinstance(pmeta, dict):
+            parent_uuid = _file_uuid(pmeta) or None
+        rec = {
+            "subagent_id": child_uuid,
+            "file_uuid": fid,
+            "parent_session_id": parent_uuid,
+            "spawned_by_key": spawned_by,
+            "label": str(meta.get("label") or ""),
+            "task": str(meta.get("task") or ""),
+            "status": str(meta.get("status") or ""),
+            "spawn_depth": meta.get("spawnDepth"),
+            "subagent_role": str(meta.get("subagentRole") or ""),
+            "model": str(meta.get("model") or ""),
+            "started_at_ms": meta.get("startedAt") or meta.get("sessionStartedAt") or 0,
+            "ended_at_ms": meta.get("endedAt") or 0,
+            "updated_at_ms": meta.get("updatedAt") or 0,
+            "total_tokens": meta.get("totalTokens") or 0,
+        }
+        # Key by the transcript file uuid so the jsonl scan can look up its
+        # subagent identity; a failed spawn may never write a transcript
+        # (observed live: 55 ms 'failed' child with no .jsonl on disk), so
+        # fall back to the subagent uuid to keep the record reachable for
+        # the rollup ingest below.
+        out[fid or child_uuid] = rec
+    return out
+
+
+def _ingest_sandbox_subagent_rows(sub_by_file: dict, sb_name: str, node_id: str) -> None:
+    """Upsert one ``subagents`` row per sandbox delegation record. Never raises.
+
+    Mirrors the family-adapter branch in ``sync_family_runtimes`` (the
+    ``ingest_subagent`` call around line 13466) so the /api/subagents shaper,
+    the Command River and ``query_subagents`` treat sandboxed OpenClaw
+    children exactly like host ones. ``agent_type='nemoclaw'`` keeps the
+    (agent_type, subagent_id) PK from colliding with host OpenClaw rows.
+    """
+    if not sub_by_file:
+        return
+    try:
+        from clawmetry import local_store as _ls
+        _store = _ls.get_store()
+        for _rec in sub_by_file.values():
+            _status = _rec["status"] or ""
+            _lowered = _status.lower()
+            if any(b in _lowered for b in ("error", "fail", "kill", "cancel")):
+                _norm = "failed"
+            elif _rec["ended_at_ms"]:
+                _norm = "completed"
+            else:
+                _norm = _status or "running"
+            _store.ingest_subagent({
+                "subagent_id": _rec["subagent_id"],
+                "agent_type": "nemoclaw",
+                # Bare parent file uuid — NemoClawAdapter session ids ARE the
+                # transcript file uuids (no runtime prefix), so this matches
+                # the parent Session row 1:1. None stays None (never guessed).
+                "parent_session_id": _rec["parent_session_id"],
+                "spawned_at": _epoch_to_iso((_rec["started_at_ms"] or 0) / 1000.0),
+                "ended_at": _epoch_to_iso((_rec["ended_at_ms"] or 0) / 1000.0),
+                "task": _rec["task"],
+                "status": _norm,
+                "token_count": int(_rec["total_tokens"] or 0),
+                # data-blob fields (whitelisted by the /api/subagents shaper +
+                # NemoClawAdapter enrichment).
+                "kind": "subagent",
+                "label": _rec["label"],
+                "displayName": _rec["label"] or _rec["subagent_id"][:12],
+                "model": _rec["model"],
+                "depth": int(_rec["spawn_depth"] or 1),
+                "subagentRole": _rec["subagent_role"],
+                "sessionId": _rec["file_uuid"],
+                "sandbox": sb_name,
+                "spawnedBy": _rec["spawned_by_key"],
+                "rawStatus": _status,
+                "updatedAtMs": int(_rec["updated_at_ms"] or 0),
+                "startedAtMs": int(_rec["started_at_ms"] or 0),
+                "endedAtMs": int(_rec["ended_at_ms"] or 0),
+                # prompt only when the registry actually persisted a task —
+                # the captured failed spawn carried none, and an empty/
+                # invented prompt violates the orchestration honesty contract.
+                **({"prompt": _rec["task"][:400]} if _rec["task"] else {}),
+            })
+        _store.flush()
+    except Exception as _sae:
+        log.debug("nemoclaw sandbox subagent ingest failed (non-fatal): %s", _sae)
+
+
 def sync_sandbox_sessions_openshell(config: dict, state: dict) -> int:
     """Ingest sessions from inside NemoClaw sandbox containers via openshell exec.
 
@@ -2819,6 +2954,29 @@ def sync_sandbox_sessions_openshell(config: dict, state: dict) -> int:
         sb_name = sb.get("name", "")
         if not sb_name:
             continue
+
+        # Orchestration capture (nemoclaw leg): read the sandbox's own
+        # sessions.json index so spawned sub-agents stop landing as unrelated
+        # peer sessions. One extra exec per sandbox per tick; the index is a
+        # small JSON file. Only agents/main spawns sub-agents — the advisor
+        # dir is a sibling agent, not a delegation, and gets NO parent edge.
+        sub_by_file: dict = {}
+        try:
+            idx_out = subprocess.run(
+                [openshell_bin, "sandbox", "exec", "--name", sb_name, "--",
+                 "cat", "/sandbox/.openclaw/agents/main/sessions/sessions.json"],
+                capture_output=True, text=True, timeout=10,
+            )
+            if idx_out.returncode == 0 and idx_out.stdout.strip():
+                sub_by_file = _parse_openclaw_subagent_index(
+                    json.loads(idx_out.stdout)
+                )
+        except Exception as _ie:
+            log.debug(
+                "sandbox-session sync: subagent index read failed for %s: %s",
+                sb_name, _ie,
+            )
+        _ingest_sandbox_subagent_rows(sub_by_file, sb_name, node_id)
 
         # Scan both main and advisor agent dirs (#3698).
         # NemoClaw's advisor/analysis session runner (createAgentSession) writes
@@ -2886,7 +3044,16 @@ def sync_sandbox_sessions_openshell(config: dict, state: dict) -> int:
                             for _ev in batch:
                                 if isinstance(_ev, dict):
                                     _ev["_nemo_rk"] = _rk
-                        _flush_session_batch(batch, fname, api_key, enc_key, node_id, None,
+                        # Child transcripts flush under their subagent uuid
+                        # (matches the host path: events.session_id ==
+                        # subagents.subagent_id, the query_subagents join
+                        # key). Non-delegation files keep the filename uuid.
+                        _sa_rec = (
+                            sub_by_file.get(fname.split(".jsonl", 1)[0])
+                            if _agent_dir == "main" else None
+                        )
+                        _flush_session_batch(batch, fname, api_key, enc_key, node_id,
+                                             _sa_rec["subagent_id"] if _sa_rec else None,
                                              agent_type="nemoclaw")
                         total += len(batch)
                     cursors[cursor_key] = len(all_lines)

--- a/tests/test_nemoclaw_orchestration.py
+++ b/tests/test_nemoclaw_orchestration.py
@@ -1,0 +1,356 @@
+"""Orchestration capture — NemoClaw leg.
+
+A NemoClaw sandbox hosts a full OpenClaw workspace, so a sandboxed agent
+that delegates writes the same ``agent:main:subagent:<uuid>`` entries into
+the sandbox's ``sessions.json`` that host OpenClaw writes. The sync daemon
+now reads that index per sandbox (``_parse_openclaw_subagent_index`` +
+``_ingest_sandbox_subagent_rows``) and ``NemoClawAdapter.list_sessions``
+joins the resulting ``subagents`` rows back into child Sessions.
+
+Index-entry shapes in these tests mirror a REAL entry captured live on
+2026-08-20 from a 2026.8 OpenClaw ``sessions.json`` (a ``sessions_spawn``
+run that failed after 55 ms): fields ``spawnDepth / subagentRole /
+sessionId / sessionFile / spawnedBy / label / status / startedAt / endedAt /
+updatedAt / runtimeMs`` — and NO ``task`` / ``model`` / ``totalTokens`` on
+that failed spawn. Transcript lines use the real v3 ``message`` envelope
+(role user = content string; role assistant = content parts list + usage),
+as captured from ``~/.openclaw/agents/main/sessions/*.jsonl``.
+"""
+from __future__ import annotations
+
+import importlib
+import json
+import time
+import uuid
+
+import pytest
+
+MAIN_UUID = "74bc4ddb-a09f-4a9d-93c2-904ea7708938"
+CHILD_SA_UUID = "d38a6bbd-c530-4119-ac84-ae1e3b91c775"
+CHILD_FILE_UUID = "55d5d1e2-fdb4-48de-9a67-c98254038e95"
+
+
+def _real_index(*, now_ms: int | None = None, child_status: str = "failed",
+                ended: bool = True, task: str = "") -> dict:
+    """sessions.json index with the REAL captured field set."""
+    now_ms = now_ms or int(time.time() * 1000)
+    child: dict = {
+        "spawnDepth": 1,
+        "subagentRole": "leaf",
+        "subagentControlScope": "none",
+        "thinkingLevel": "high",
+        "sessionId": CHILD_FILE_UUID,
+        "sessionFile": f"/sandbox/.openclaw/agents/main/sessions/{CHILD_FILE_UUID}.jsonl",
+        "spawnedBy": "agent:main:main",
+        "spawnedWorkspaceDir": "/sandbox/.openclaw/workspace",
+        "label": "ping-test",
+        "status": child_status,
+        "startedAt": now_ms - 60000,
+        "updatedAt": now_ms,
+        "lastInteractionAt": now_ms,
+        "sessionStartedAt": now_ms - 60000,
+        "runtimeMs": 55,
+    }
+    if ended:
+        child["endedAt"] = now_ms - 55000
+    if task:
+        child["task"] = task
+    return {
+        "agent:main:main": {
+            "sessionId": MAIN_UUID,
+            "sessionFile": f"/sandbox/.openclaw/agents/main/sessions/{MAIN_UUID}.jsonl",
+            "model": "anthropic/claude-opus-4-6",
+        },
+        f"agent:main:subagent:{CHILD_SA_UUID}": child,
+    }
+
+
+def _v3_user_line(text: str, ts_iso: str) -> dict:
+    """Real v3 user-message envelope (content is a plain string)."""
+    return {
+        "type": "message",
+        "id": str(uuid.uuid4()),
+        "timestamp": ts_iso,
+        "message": {"role": "user", "content": text,
+                    "timestamp": int(time.time() * 1000)},
+    }
+
+
+def _v3_assistant_line(text: str, ts_iso: str, *, total_tokens: int = 120) -> dict:
+    """Real v3 assistant envelope (content parts list + usage block)."""
+    return {
+        "type": "message",
+        "id": str(uuid.uuid4()),
+        "timestamp": ts_iso,
+        "message": {
+            "role": "assistant",
+            "content": [{"type": "text", "text": text}],
+            "model": "anthropic/claude-opus-4-6",
+            "provider": "anthropic",
+            "usage": {"input": 100, "output": 20, "totalTokens": total_tokens},
+        },
+    }
+
+
+@pytest.fixture
+def isolated_store(tmp_path, monkeypatch):
+    """Fresh LocalStore at a tmp path (same pattern as
+    test_nemoclaw_runtime_adapter.py) so tests never touch the dev DuckDB."""
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "1")
+    monkeypatch.setenv("HOME", str(tmp_path))  # daemon-detection shield
+    import clawmetry.local_store as _ls
+    importlib.reload(_ls)
+    s = _ls.LocalStore()
+    s.start()
+    monkeypatch.setattr(_ls, "get_store", lambda *a, **kw: s)
+    yield s
+    s.stop(flush=True)
+
+
+def _ingest_jsonl(store, batch: list[dict], fname: str, subagent_id: str | None):
+    """Same call the sandbox loop makes (minus the cloud POST)."""
+    from clawmetry import sync as _sync
+    _sync._local_ingest_session_batch(batch, fname, "test-node",
+                                      subagent_id, agent_type="nemoclaw")
+    store.flush()
+
+
+def _ingest_index(store, index: dict, sb_name: str = "sb-alpha"):
+    from clawmetry import sync as _sync
+    sub = _sync._parse_openclaw_subagent_index(index)
+    _sync._ingest_sandbox_subagent_rows(sub, sb_name, "test-node")
+    store.flush()
+    return sub
+
+
+# ── _parse_openclaw_subagent_index (pure) ────────────────────────────────────
+
+
+def test_parse_index_real_shape():
+    from clawmetry import sync as _sync
+    sub = _sync._parse_openclaw_subagent_index(_real_index())
+    assert CHILD_FILE_UUID in sub
+    rec = sub[CHILD_FILE_UUID]
+    assert rec["subagent_id"] == CHILD_SA_UUID
+    # spawnedBy 'agent:main:main' resolves to the main entry's OWN sessionId.
+    assert rec["parent_session_id"] == MAIN_UUID
+    assert rec["label"] == "ping-test"
+    assert rec["status"] == "failed"
+    assert rec["spawn_depth"] == 1
+    assert rec["subagent_role"] == "leaf"
+    # No task on the real failed capture -> empty, never invented.
+    assert rec["task"] == ""
+
+
+def test_parse_index_unresolvable_spawner_keeps_parent_none():
+    """A child whose spawner entry is missing gets parent None — not a guess."""
+    from clawmetry import sync as _sync
+    index = _real_index()
+    del index["agent:main:main"]
+    rec = _sync._parse_openclaw_subagent_index(index)[CHILD_FILE_UUID]
+    assert rec["parent_session_id"] is None
+
+
+def test_parse_index_ignores_non_subagent_keys():
+    from clawmetry import sync as _sync
+    assert _sync._parse_openclaw_subagent_index(
+        {"agent:main:main": {"sessionId": MAIN_UUID}}) == {}
+    assert _sync._parse_openclaw_subagent_index("not-a-dict") == {}
+
+
+# ── linkage + enrichment ─────────────────────────────────────────────────────
+
+
+def test_child_linkage_prompt_reply_and_tokens(isolated_store):
+    """Delegation with a transcript: parent edge, kind, prompt from the
+    child's own first user turn, reply from its last assistant turn, tokens
+    from the child's OWN persisted usage (never the parent's)."""
+    now = time.time()
+
+    def iso(off: float) -> str:
+        return time.strftime("%Y-%m-%dT%H:%M:%S+00:00", time.gmtime(now + off))
+
+    # Parent transcript under its own file uuid.
+    _ingest_jsonl(isolated_store, [
+        _v3_user_line("Use the subagents tool to spawn one subagent", iso(0)),
+        _v3_assistant_line("Spawned. Run ID: fc8920c6", iso(1), total_tokens=500),
+    ], f"{MAIN_UUID}.jsonl", None)
+    # Child transcript flushed under its SUBAGENT uuid (what the sandbox
+    # loop now passes as subagent_id — the query_subagents join key).
+    _ingest_jsonl(isolated_store, [
+        _v3_user_line("Reply with exactly the word pong and nothing else.", iso(2)),
+        _v3_assistant_line("pong", iso(3), total_tokens=120),
+    ], f"{CHILD_FILE_UUID}.jsonl", CHILD_SA_UUID)
+    _ingest_index(isolated_store,
+                  _real_index(child_status="completed", ended=True))
+
+    from clawmetry.adapters.nemo import NemoClawAdapter
+    sessions = {s.id: s for s in NemoClawAdapter().list_sessions()}
+    child = sessions[CHILD_SA_UUID]
+    assert child.parent_id == MAIN_UUID
+    assert child.extra["kind"] == "subagent"
+    assert child.extra["isSubagent"] is True
+    assert child.extra["depth"] == 1
+    assert child.extra["agentType"] == "leaf"
+    assert child.extra["label"] == "ping-test"
+    assert child.title == "ping-test"
+    assert child.extra["sandbox"] == "sb-alpha"
+    # Prompt = the child's first user turn (IS the handed task text).
+    assert child.extra["prompt"].startswith("Reply with exactly the word pong")
+    assert child.extra["reply"] == "pong"
+    # Tokens come from the child's own events, not the parent's 500.
+    assert child.total_tokens == 120
+    assert child.end_reason != "error"
+    # The parent stays a plain top-level session.
+    parent = sessions[MAIN_UUID]
+    assert parent.parent_id is None
+    assert "kind" not in parent.extra
+
+
+def test_registry_task_wins_as_prompt(isolated_store):
+    """When the registry persisted a task, it IS the handed context."""
+    _ingest_jsonl(isolated_store, [
+        _v3_user_line("Reply with pong.", "2026-08-20T00:17:38+00:00"),
+    ], f"{CHILD_FILE_UUID}.jsonl", CHILD_SA_UUID)
+    _ingest_index(isolated_store,
+                  _real_index(child_status="completed", ended=True,
+                              task="Reply with exactly the word pong"))
+    from clawmetry.adapters.nemo import NemoClawAdapter
+    child = {s.id: s for s in NemoClawAdapter().list_sessions()}[CHILD_SA_UUID]
+    assert child.extra["prompt"] == "Reply with exactly the word pong"
+    # No assistant turn on disk -> no reply invented.
+    assert "reply" not in child.extra
+
+
+# ── status mapping ───────────────────────────────────────────────────────────
+
+
+def test_failed_child_without_transcript(isolated_store):
+    """The REAL capture: a 55 ms 'failed' spawn that never wrote a
+    transcript. The child is synthesised from the registry row alone —
+    parent edge + error, but NO invented prompt/reply, zero messages."""
+    _ingest_index(isolated_store, _real_index(child_status="failed", ended=True))
+    from clawmetry.adapters.nemo import NemoClawAdapter
+    sessions = {s.id: s for s in NemoClawAdapter().list_sessions()}
+    child = sessions[CHILD_SA_UUID]
+    assert child.parent_id == MAIN_UUID
+    assert child.end_reason == "error"
+    assert child.message_count == 0
+    assert "prompt" not in child.extra
+    assert "reply" not in child.extra
+    assert child.cost_status != "running"
+    assert child.ended_at is not None
+
+
+def test_running_only_within_recency_window(isolated_store):
+    """No endedAt + fresh updatedAt -> running; stale -> not running."""
+    from clawmetry.adapters.nemo import NemoClawAdapter
+    _ingest_index(isolated_store,
+                  _real_index(child_status="", ended=False))
+    child = {s.id: s for s in NemoClawAdapter().list_sessions()}[CHILD_SA_UUID]
+    assert child.cost_status == "running"
+
+    stale_ms = int((time.time() - 3600) * 1000)
+    _ingest_index(isolated_store,
+                  _real_index(now_ms=stale_ms, child_status="", ended=False))
+    child = {s.id: s for s in NemoClawAdapter().list_sessions()}[CHILD_SA_UUID]
+    assert child.cost_status != "running"
+
+
+def test_compound_failure_reasons_map_to_error(isolated_store):
+    """Substring matching on compound reason strings (contract)."""
+    from clawmetry import sync as _sync
+    from clawmetry.adapters.nemo import NemoClawAdapter
+    index = _real_index(child_status="killed: sandbox torn down", ended=True)
+    sub = _sync._parse_openclaw_subagent_index(index)
+    _sync._ingest_sandbox_subagent_rows(sub, "sb-alpha", "test-node")
+    isolated_store.flush()
+    child = {s.id: s for s in NemoClawAdapter().list_sessions()}[CHILD_SA_UUID]
+    assert child.end_reason == "error"
+
+
+# ── honesty ──────────────────────────────────────────────────────────────────
+
+
+def test_advisor_sibling_gets_no_parent(isolated_store):
+    """Advisor-dir sessions are sibling agents, not delegations — no edge."""
+    advisor_uuid = str(uuid.uuid4())
+    _ingest_jsonl(isolated_store, [
+        _v3_user_line("analyse the last run", "2026-08-20T01:00:00+00:00"),
+        _v3_assistant_line("analysis done", "2026-08-20T01:00:05+00:00"),
+    ], f"{advisor_uuid}.jsonl", None)
+    _ingest_index(isolated_store, _real_index())
+    from clawmetry.adapters.nemo import NemoClawAdapter
+    adv = {s.id: s for s in NemoClawAdapter().list_sessions()}[advisor_uuid]
+    assert adv.parent_id is None
+    assert "kind" not in adv.extra
+    assert "prompt" not in adv.extra
+
+
+def test_unresolvable_spawner_child_has_no_parent(isolated_store):
+    """Registry row without a resolvable spawner: child still surfaces
+    (kind='subagent') but parent_id stays None — never guessed."""
+    index = _real_index(child_status="completed", ended=True)
+    del index["agent:main:main"]
+    _ingest_index(isolated_store, index)
+    from clawmetry.adapters.nemo import NemoClawAdapter
+    child = {s.id: s for s in NemoClawAdapter().list_sessions()}[CHILD_SA_UUID]
+    assert child.parent_id is None
+    assert child.extra["kind"] == "subagent"
+
+
+def test_sandbox_loop_passes_subagent_id_and_ingests_rows(isolated_store):
+    """End-to-end through the mocked openshell loop: the sandbox's
+    sessions.json is read once per sandbox, a delegation transcript flushes
+    under its SUBAGENT uuid (the query_subagents join key), a plain
+    transcript keeps the filename uuid, and one subagents row lands."""
+    from unittest.mock import MagicMock, patch
+    from clawmetry.sync import sync_sandbox_sessions_openshell
+
+    def _run(returncode=0, stdout=""):
+        r = MagicMock()
+        r.returncode = returncode
+        r.stdout = stdout
+        return r
+
+    index = _real_index(child_status="completed", ended=True,
+                        task="Reply with exactly the word pong")
+    line = json.dumps({"type": "message", "id": "e1",
+                       "timestamp": "2026-08-20T00:17:38+00:00",
+                       "message": {"role": "user", "content": "hi"}})
+    side_effects = [
+        _run(0, json.dumps([{"name": "sb-alpha", "status": "running"}])),
+        _run(0, json.dumps(index)),                          # cat sessions.json
+        _run(0, f"{MAIN_UUID}.jsonl\n{CHILD_FILE_UUID}.jsonl\n"),  # ls main
+        _run(0, line + "\n"),                                # cat parent jsonl
+        _run(0, line + "\n"),                                # cat child jsonl
+        _run(1, ""),                                         # ls advisor (absent)
+    ]
+
+    flush_calls = []
+    with patch("clawmetry.sync._find_openshell_bin",
+               return_value="/usr/bin/openshell"), \
+         patch("subprocess.run", side_effect=side_effects), \
+         patch("clawmetry.sync._flush_session_batch",
+               side_effect=lambda b, f, *a, **k: flush_calls.append((f, a))):
+        sync_sandbox_sessions_openshell(
+            {"api_key": "", "encryption_key": None, "node_id": "n1"}, {})
+
+    by_fname = {f: a for f, a in flush_calls}
+    # positional args after fname: api_key, enc_key, node_id, subagent_id
+    assert by_fname[f"{CHILD_FILE_UUID}.jsonl"][3] == CHILD_SA_UUID
+    assert by_fname[f"{MAIN_UUID}.jsonl"][3] is None
+    isolated_store.flush()
+    rows = isolated_store.query_subagents(agent_type="nemoclaw")
+    assert len(rows) == 1
+    assert rows[0]["subagent_id"] == CHILD_SA_UUID
+    assert rows[0]["parent_session_id"] == MAIN_UUID
+    assert rows[0]["task"] == "Reply with exactly the word pong"
+
+
+def test_capabilities_advertise_subagents():
+    from clawmetry.adapters.base import Capability
+    from clawmetry.adapters.nemo import NemoClawAdapter
+    assert Capability.SUBAGENTS in NemoClawAdapter().capabilities()

--- a/tests/test_obs_gap_nemoclaw_advisor_ingest_3698.py
+++ b/tests/test_obs_gap_nemoclaw_advisor_ingest_3698.py
@@ -35,6 +35,7 @@ def test_advisor_sessions_ingested_when_present():
 
     side_effects = [
         _run(0, sandbox_list),
+        _run(1, ""),  # cat main/sessions.json (subagent index absent)
         _run(1, ""),                   # ls agents/main/sessions (absent)
         _run(0, "adv-sess-1.jsonl\n"), # ls agents/advisor/sessions
         _run(0, advisor_line + "\n"),  # cat advisor/adv-sess-1.jsonl
@@ -60,6 +61,7 @@ def test_advisor_sessions_tagged_nemoclaw():
 
     side_effects = [
         _run(0, sandbox_list),
+        _run(1, ""),  # cat main/sessions.json (subagent index absent)
         _run(1, ""),
         _run(0, "adv-sess-2.jsonl\n"),
         _run(0, advisor_line + "\n"),
@@ -84,6 +86,7 @@ def test_advisor_cursor_namespaced_separately_from_main():
 
     side_effects = [
         _run(0, sandbox_list),
+        _run(1, ""),  # cat main/sessions.json (subagent index absent)
         _run(0, "sess.jsonl\n"),      # ls agents/main/sessions
         _run(0, main_line + "\n"),     # cat main/sess.jsonl
         _run(0, "sess.jsonl\n"),      # ls agents/advisor/sessions (same filename)
@@ -110,6 +113,7 @@ def test_main_events_not_stamped_with_agent_dir():
 
     side_effects = [
         _run(0, sandbox_list),
+        _run(1, ""),  # cat main/sessions.json (subagent index absent)
         _run(0, "main.jsonl\n"),
         _run(0, main_line + "\n"),
         _run(1, ""),

--- a/tests/test_sandbox_session_sync.py
+++ b/tests/test_sandbox_session_sync.py
@@ -34,6 +34,7 @@ def test_happy_path_flushes_events_and_advances_cursor():
 
     side_effects = [
         _run(0, sandbox_list),
+        _run(1, ""),  # cat main/sessions.json (subagent index absent)
         _run(0, ls_output),   # ls agents/main/sessions
         _run(0, cat_output),  # cat main/abc123.jsonl
         _run(1, ""),          # ls agents/advisor/sessions (absent — nonzero)
@@ -61,6 +62,7 @@ def test_sidecar_files_excluded():
     # Only abc.jsonl should be read (1 cat call); sidecars produce no cat call
     side_effects = [
         _run(0, sandbox_list),
+        _run(1, ""),  # cat main/sessions.json (subagent index absent)
         _run(0, ls_output),   # ls agents/main/sessions
         _run(0, cat_output),  # cat main/abc.jsonl (only non-sidecar)
         _run(1, ""),          # ls agents/advisor/sessions (absent)
@@ -86,6 +88,7 @@ def test_sandbox_sessions_tagged_as_nemoclaw():
 
     side_effects = [
         _run(0, sandbox_list),
+        _run(1, ""),  # cat main/sessions.json (subagent index absent)
         _run(0, ls_output),   # ls agents/main/sessions
         _run(0, cat_output),  # cat main/sess.jsonl
         _run(1, ""),          # ls agents/advisor/sessions (absent)
@@ -117,6 +120,7 @@ def test_cursor_skips_already_seen_lines_on_second_call():
     def make_effects():
         return [
             _run(0, sandbox_list),
+            _run(1, ""),  # cat main/sessions.json (subagent index absent)
             _run(0, ls_output),  # ls agents/main/sessions
             _run(0, cat_output), # cat main/sess.jsonl
             _run(1, ""),         # ls agents/advisor/sessions (absent)


### PR DESCRIPTION
nemoclaw leg of orchestration capture (implementation agent, coordinator-reviewed: new tests + lint delta independently rerun green).

**What:** IMPORTANT REPO DEVIATION: this leg lives in the OSS repo (github.com/vivekchand/clawmetry), NOT clawmetry-pro. The pro repo has no nemoclaw adapter at all (only routes/nemoclaw.py governance); NemoClawAdapter is OSS clawmetry/adapters/nemo.py and the sandbox ingest is OSS clawmetry/sync.py — the dossier itself pointed there, and the openclaw leg (#5008) also landed in OSS. Branch feat/orchestration-nemoclaw is pushed to the OSS origin off origin/main (ba42556c8, which already carries the orchestration plumbing).
What was captured: NemoClaw = OpenClaw inside an OpenShell sandbox; the sandbox writes its own sessions.json with agent:main:subagent:<uuid> entries. sync.py now (a) reads that index per sandbox via one extra `openshell sandbox exec -- cat` (pure parser _parse_openclaw_subagent_index, testable without openshell), (b) upserts subagents rows (agent_type='nemoclaw', parent resolved spawnedBy->spawner.sessionId, None when unresolvable — never guessed), (c) flushes delegation transcripts under their subagent uuid (the query_subagents join key). NemoClawAdapter.list_sessions joins those rows back: parent_id + extra{kind:'subagent', isSubagent, depth, agentType:subagentRole, label, sandbox}, prompt = registry task else the child's own first user turn, reply = its last assistant turn (<=400 chars each, omitted when not on disk); a registry-known child with no transcript is synthesised with NO invented prompt/reply. Status: end_reason='error' on substring match (fail/kill/canc

**Tests:** tests/test_nemoclaw_orchestration.py: 12 passed (index parsing incl. unresolvable spawner, linkage+prompt/reply+child-own-tokens, registry-task precedence, failed-child-without-transcript honesty, 180s running window, compound-reason error mapping, advisor sibling no parent, mocked end-to-end sandbox loop, capability). Adjacent existing: 83 passed across the six nemoclaw/nemo test files; broad sel

**Live verification:** No nemoclaw/openshell install on this machine (which -> not found; no ~/.nemoclaw; live DuckDB checked via file copy: 0 events and 0 subagents rows with agent_type='nemoclaw'), so a live sandbox turn was impossible. What WAS verified against real local data: (1) the exact sessions.json subagent-entry field set from a real host-OpenClaw sessions_spawn run on this machine (2026-08-20) — including the real 55ms 'failed' child with no transcript file; (2) real v3 transcript envelopes from ~/.openclaw/agents/main/sessions; the sandbox writes both formats identically (same OpenClaw build family, and

**Honest caveats:** (1) REPO: implemented in the OSS repo, not clawmetry-pro as the task template said — the pro repo has no nemoclaw surface to patch (verified: no adapter, no ingest, no falsely-advertised SUBAGENTS capability there). The instructed pro worktree was never created; the OSS worktree sits at the instructed path. If the coordinator's review tooling expects a pro branch it will not find one. (2) Sandbox-side layout is still INFERRED for the sandbox itself: dossier confidence was medium, and my evidence is the host registry format (same OpenClaw lineage), not a captured sandbox index. If a sandboxed OpenClaw build writes a divergent sessions.json, the parser degrades to no-op (best-effort try/except), never crashes ingest. (3) 'task' field on subagent entries is read defensively but was NOT presen

🤖 Generated with [Claude Code](https://claude.com/claude-code)