### PR TITLE
feat(desktop): report every app open, not just the download

### DIFF
--- a/.github/workflows/desktop-artifacts.yml
+++ b/.github/workflows/desktop-artifacts.yml
@@ -48,6 +48,20 @@ jobs:
       # version check on Tahoe / macOS 26 and refuses to build; the
       # setup_py2app.py spec is kept in-tree for the day py2app
       # catches up but is not on the shipping path.
+      # Stamp the bundle version into desktop/assets/version.txt so the
+      # shipped shell can report WHICH build the user opened (the open
+      # ping in desktop/app.py reads it). Tag-first, same resolution the
+      # packaging steps below use.
+      - name: Stamp bundle version
+        run: |
+          if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
+            VERSION="${GITHUB_REF_NAME#v}"
+          else
+            VERSION=$(python3 -c "import re; print(re.search(r'__version__ = \"(.+?)\"', open('dashboard.py').read()).group(1))")
+          fi
+          echo "$VERSION" > desktop/assets/version.txt
+          echo "stamped $VERSION"
+
       - name: Build .app
         run: pyinstaller --clean --noconfirm desktop/build_mac.spec
 
@@ -212,6 +226,21 @@ jobs:
         run: |
           python -m pip install --upgrade pip wheel
           pip install -r desktop/requirements-dev.txt
+
+      # Stamp the bundle version into desktop/assets/version.txt — see
+      # the macOS job for why. -NoNewline so the shell reads a clean
+      # value, and ASCII so no BOM lands in the file.
+      - name: Stamp bundle version
+        shell: pwsh
+        run: |
+          $refName = "${{ github.ref_name }}"
+          if ("${{ github.ref_type }}" -eq "tag") {
+            $version = $refName.Substring(1)
+          } else {
+            $version = (Select-String -Path dashboard.py -Pattern '__version__ = "(.+?)"').Matches.Groups[1].Value
+          }
+          [IO.File]::WriteAllText("desktop/assets/version.txt", $version, [Text.Encoding]::ASCII)
+          Write-Host "stamped $version"
 
       - name: Build tray .exe
         run: pyinstaller --clean --noconfirm desktop/build_windows.spec
@@ -390,6 +419,20 @@ jobs:
           # actually needs (see requirements-dev.txt), and re-introduce
           # the "cannot import _gi" crash the pin exists to avoid.
           pip install --ignore-installed -r desktop/requirements-dev.txt
+
+      # Stamp the bundle version into desktop/assets/version.txt so the
+      # shipped shell can report WHICH build the user opened (the open
+      # ping in desktop/app.py reads it). Tag-first, same resolution the
+      # packaging steps below use.
+      - name: Stamp bundle version
+        run: |
+          if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
+            VERSION="${GITHUB_REF_NAME#v}"
+          else
+            VERSION=$(python3 -c "import re; print(re.search(r'__version__ = \"(.+?)\"', open('dashboard.py').read()).group(1))")
+          fi
+          echo "$VERSION" > desktop/assets/version.txt
+          echo "stamped $VERSION"
 
       - name: Build tray binary
         run: pyinstaller --clean --noconfirm desktop/build_linux.spec

--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ desktop/installer/version_info.txt
 *.p12
 build/
 dist/
+
+# Stamped by CI at desktop-build time (see desktop-artifacts.yml)
+desktop/assets/version.txt

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ the same machine. Docker instructions: [docs/DOCKER.md](docs/DOCKER.md).
 | [NemoClaw / OpenShell](docs/NEMOCLAW.md) | Sandboxed NVIDIA NemoClaw setups |
 | [Docker](docs/DOCKER.md) | Image, compose, volume mounts |
 | [Architecture](ARCHITECTURE.md) · [Development](docs/DEVELOPMENT.md) | How it works inside; running from source |
-| [Telemetry](docs/TELEMETRY.md) | The anonymous install ping, and how to turn it off |
+| [Telemetry](docs/TELEMETRY.md) | The anonymous install and desktop-open pings, and how to turn them off |
 
 ## Screenshots
 

--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -6983,6 +6983,10 @@ def main() -> None:
         except Exception:
             _ver = "unknown"
         _telemetry.maybe_ping(_ver)
+        # Desktop shell launched us? Report the open (which runtimes this
+        # machine has, cloud vs local) once things settle. No-ops for a
+        # plain `pip install clawmetry && clawmetry`.
+        _telemetry.maybe_desktop_ping(_ver)
     except Exception:
         # Never let telemetry plumbing break startup.
         pass

--- a/clawmetry/telemetry.py
+++ b/clawmetry/telemetry.py
@@ -172,19 +172,26 @@ def _build_payload(version: str, event: str = "install", extra: dict | None = No
     return payload
 
 
-def _post(payload: dict, url: str) -> None:
+def _post(payload: dict, url: str, api_key: str = "") -> None:
     """Fire-and-forget POST. Swallows every exception by design — any
-    failure here must NEVER surface to the user."""
+    failure here must NEVER surface to the user.
+
+    ``api_key`` is only ever set by the desktop ping below, and only so
+    the machine can be listed under "Desktop apps" in its own owner's
+    account. The anonymous install ping never sends it."""
     try:
         body = json.dumps(payload).encode("utf-8")
+        headers = {
+            "Content-Type": "application/json",
+            "User-Agent":   f"clawmetry/{payload.get('version','?')} install-telemetry",
+        }
+        if api_key.startswith("cm_"):
+            headers["Authorization"] = f"Bearer {api_key}"
         req = urllib.request.Request(
             url,
             data=body,
             method="POST",
-            headers={
-                "Content-Type": "application/json",
-                "User-Agent":   f"clawmetry/{payload.get('version','?')} install-telemetry",
-            },
+            headers=headers,
         )
         with urllib.request.urlopen(req, timeout=TELEMETRY_TIMEOUT_SEC) as r:
             r.read()  # drain so the connection releases cleanly
@@ -367,6 +374,160 @@ def ping_event(event: str, version: str = "unknown",
         args=(event, version, extra),
         daemon=True,
         name="clawmetry-telemetry-event",
+    )
+    t.start()
+    return t
+
+
+# ── Desktop app: per-open telemetry (daemon stage) ───────────────────────────
+# The .app/.exe shell pings ``/api/desktop/open`` the moment its window
+# appears (see desktop/app.py) — that stage fires even when the Python
+# bootstrap never completes. This is the second stage: once the daemon is
+# actually running we report what the shell could not know — which agent
+# runtimes this machine has data for, whether the install syncs to cloud or
+# stays local, and which node it is. Correlated with the shell ping by
+# ``session_id``, so "opened but never reached a working daemon" is a
+# subtraction rather than a guess.
+#
+# Fires ONLY when launched by the desktop shell (CLAWMETRY_LAUNCHER=desktop);
+# a plain ``pip install clawmetry && clawmetry`` never sends this.
+#
+# Same privacy contract as the install ping above: no hostname, username,
+# IP (the server derives a country and drops the IP), workspace path, or
+# transcript content. The one addition is the cm_ key, sent as a bearer
+# header purely so the machine shows up under "Desktop apps" in its own
+# owner's account; without a paired key the ping stays anonymous.
+DESKTOP_PING_PATH = "/api/desktop/open"
+# Runtime detection walks the home dir (~3s) and a freshly-claimed account
+# key can land seconds after boot — both settle inside this delay.
+DESKTOP_PING_DELAY_SEC = 10.0
+CONFIG_JSON = CONFIG_DIR / "config.json"
+NOCLOUD_MARKER = CONFIG_DIR / "nocloud"
+
+
+def _read_config() -> dict:
+    try:
+        data = json.loads(CONFIG_JSON.read_text(encoding="utf-8"))
+        return data if isinstance(data, dict) else {}
+    except Exception:
+        return {}
+
+
+def _sync_mode(cfg: dict) -> str:
+    """cloud | local | selfhosted | unknown — how this install is wired.
+
+    ``local`` is the ``clawmetry disconnect`` state: the daemon runs and
+    keeps everything on the machine. ``selfhosted`` means an enterprise
+    endpoint is configured (and, per the contract above, we never get
+    here — those installs don't ping the managed cloud at all)."""
+    try:
+        from clawmetry.endpoints import is_custom_endpoint
+        if is_custom_endpoint():
+            return "selfhosted"
+    except Exception:
+        pass
+    try:
+        if NOCLOUD_MARKER.exists():
+            return "local"
+    except Exception:
+        pass
+    if cfg.get("local_only"):
+        return "local"
+    if str(cfg.get("api_key") or "").startswith("cm_"):
+        return "cloud"
+    return "unknown"
+
+
+def _monitored_runtimes() -> list:
+    """Runtime ids with data on this machine, e.g.
+    ``["openclaw", "claude_code", "cursor"]``. Ids only — no paths, no
+    session contents, no counts."""
+    out = []
+    for name, p in _AGENT_DIRS:
+        try:
+            if p.exists():
+                out.append(name)
+        except Exception:
+            pass
+    try:
+        from clawmetry.sync import _detect_runtimes_lite
+        for r in (_detect_runtimes_lite() or []):
+            rid = str((r or {}).get("id") or "").strip()
+            if rid and rid not in out:
+                out.append(rid)
+    except Exception:
+        pass
+    return out[:40]
+
+
+def _build_desktop_payload(version: str) -> dict:
+    cfg = _read_config()
+    try:
+        open_count = int(os.environ.get("CLAWMETRY_DESKTOP_OPEN_COUNT", "") or 0)
+    except ValueError:
+        open_count = 0
+    runtimes = _monitored_runtimes()
+    return {
+        "install_id":      _ensure_install_id() or "",
+        "event":           "desktop_ready",
+        "stage":           "daemon",
+        "session_id":      os.environ.get("CLAWMETRY_DESKTOP_SESSION", "")[:64],
+        "open_count":      open_count,
+        "first_open":      open_count == 1,
+        "desktop_version": os.environ.get("CLAWMETRY_DESKTOP_VERSION", "")[:32],
+        "version":         version,
+        "os":              platform.system() or "unknown",
+        "os_version":      platform.release() or "",
+        "arch":            platform.machine() or "",
+        "python":          platform.python_version(),
+        "mode":            _sync_mode(cfg),
+        "runtimes":        runtimes,
+        "runtime_count":   len(runtimes),
+        "node_id":         str(cfg.get("node_id") or "")[:64],
+    }
+
+
+def _send_desktop_ping(version: str) -> None:
+    """Worker body. Sleeps out the settle delay, then posts once.
+    Swallows everything — telemetry never surfaces to the user."""
+    try:
+        time.sleep(DESKTOP_PING_DELAY_SEC)
+        if _is_optout():
+            return
+        payload = _build_desktop_payload(version)
+        if not payload.get("install_id"):
+            return
+        url = os.environ.get("CLAWMETRY_DESKTOP_PING_URL", "").strip()
+        if not url:
+            try:
+                from clawmetry.endpoints import is_custom_endpoint, app_url
+                if is_custom_endpoint():
+                    # Enterprise deployment — its data stays inside it.
+                    return
+                base = app_url()
+            except Exception:
+                base = "https://app.clawmetry.com"
+            url = base.rstrip("/") + DESKTOP_PING_PATH
+        api_key = str(_read_config().get("api_key") or "")
+        _post(payload, url, api_key=api_key)
+    except Exception as e:
+        log.debug("telemetry: desktop ping failed: %s", e)
+
+
+def maybe_desktop_ping(version: str = "unknown") -> threading.Thread | None:
+    """Public entry point, called once on CLI startup alongside
+    :func:`maybe_ping`. No-ops unless the desktop shell launched us.
+
+    Returns the thread for tests; ``None`` when it does not apply."""
+    if os.environ.get("CLAWMETRY_LAUNCHER", "").strip().lower() != "desktop":
+        return None
+    if _is_optout():
+        return None
+    t = threading.Thread(
+        target=_send_desktop_ping,
+        args=(version,),
+        daemon=True,
+        name="clawmetry-desktop-ping",
     )
     t.start()
     return t

--- a/desktop/app.py
+++ b/desktop/app.py
@@ -344,6 +344,224 @@ def _win_subprocess_kwargs() -> dict:
     return {}
 
 
+# ── Open telemetry (shell stage) ──────────────────────────────────────────
+# The .app/.exe phones home once per launch so we can tell a download
+# apart from an actual open, and a first open apart from the nth. This
+# is the ONLY stage that fires when the Python bootstrap fails (no
+# system Python, PyPI unreachable, venv wedged) — exactly the installs
+# we would otherwise never hear about.
+#
+# The daemon fires a second, richer ping (`desktop_ready`) once the
+# dashboard is live; see clawmetry/telemetry.py. The two are correlated
+# by `session_id`, so "opened but never got a working daemon" is a
+# subtraction, not a guess.
+#
+# What we send: install_id (random uuid4, same file the CLI telemetry
+# uses), a per-launch session_id, the open counter, app/OS versions.
+# What we DO NOT send: hostname, username, IP (the server derives a
+# country and drops the IP), workspace paths, transcript content.
+#
+# Opt-out (any one disables it): CLAWMETRY_NO_TELEMETRY=1, DO_NOT_TRACK=1,
+# ~/.clawmetry/notelemetry, or an enterprise endpoint (a self-hosted
+# deployment must never phone the managed cloud).
+CONFIG_DIR = Path.home() / ".clawmetry"
+INSTALL_ID_FILE = CONFIG_DIR / "install_id"
+OPTOUT_MARKER = CONFIG_DIR / "notelemetry"
+NOCLOUD_MARKER = CONFIG_DIR / "nocloud"
+CONFIG_JSON = CONFIG_DIR / "config.json"
+OPEN_STATE_FILE = CONFIG_DIR / "desktop-opens.json"
+OPEN_PING_TIMEOUT_SECS = 4.0
+DEFAULT_APP_BASE = "https://app.clawmetry.com"
+
+
+def _desktop_version() -> str:
+    """Version stamped into the bundle at build time (assets/version.txt,
+    written by .github/workflows/desktop-artifacts.yml). Dev runs from a
+    checkout have no stamp — report "dev" rather than lying."""
+    try:
+        v = (_assets_dir() / "version.txt").read_text(encoding="utf-8").strip()
+        return v[:32] if v else "dev"
+    except OSError:
+        return "dev"
+
+
+def _truthy_env(name: str) -> bool:
+    return os.environ.get(name, "").strip() not in ("", "0", "false", "False")
+
+
+def _telemetry_optout() -> bool:
+    if _truthy_env("CLAWMETRY_NO_TELEMETRY") or _truthy_env("DO_NOT_TRACK"):
+        return True
+    try:
+        return OPTOUT_MARKER.exists()
+    except OSError:
+        return False
+
+
+def _read_config() -> dict:
+    try:
+        data = json.loads(CONFIG_JSON.read_text(encoding="utf-8"))
+        return data if isinstance(data, dict) else {}
+    except Exception:
+        return {}
+
+
+def _app_base(cfg: dict) -> Optional[str]:
+    """Where the open ping goes, or None when it must not be sent.
+
+    An enterprise/self-hosted endpoint (CLAWMETRY_ENDPOINT or the
+    `endpoint` key in config.json) means the deployment's data stays
+    inside the deployment — we skip the ping entirely rather than
+    redirect it at someone's private server."""
+    override = os.environ.get("CLAWMETRY_DESKTOP_PING_URL", "").strip()
+    if override:
+        return override.rstrip("/")
+    custom = (
+        os.environ.get("CLAWMETRY_ENDPOINT", "").strip()
+        or os.environ.get("CLAWMETRY_INGEST_URL", "").strip()
+        or str(cfg.get("endpoint") or "").strip()
+    )
+    if custom:
+        return None
+    return DEFAULT_APP_BASE
+
+
+def _install_id() -> str:
+    """Read (or create) ~/.clawmetry/install_id — the same identity the
+    pip CLI's first-run ping uses, so a desktop open and a CLI install
+    are the same install, not two."""
+    try:
+        if INSTALL_ID_FILE.exists():
+            txt = INSTALL_ID_FILE.read_text(encoding="utf-8").strip()
+            if 16 < len(txt) <= 64 and all(c in "0123456789abcdef-" for c in txt):
+                return txt
+        CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+        import uuid
+
+        new = str(uuid.uuid4())
+        INSTALL_ID_FILE.write_text(new + "\n", encoding="utf-8")
+        return new
+    except Exception:
+        return ""
+
+
+def _bump_open_state(session_id: str) -> dict:
+    """Increment the local open counter and return the new state.
+
+    Kept on disk (not derived server-side) so opens that happen offline
+    still show up in the count on the next successful ping."""
+    state = {}
+    try:
+        state = json.loads(OPEN_STATE_FILE.read_text(encoding="utf-8"))
+        if not isinstance(state, dict):
+            state = {}
+    except Exception:
+        state = {}
+    now = time.time()
+    count = int(state.get("open_count") or 0) + 1
+    state = {
+        "open_count": count,
+        "first_open_ts": float(state.get("first_open_ts") or now),
+        "last_open_ts": now,
+        "session_id": session_id,
+    }
+    try:
+        CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+        OPEN_STATE_FILE.write_text(json.dumps(state), encoding="utf-8")
+    except OSError:
+        pass
+    return state
+
+
+def _sync_mode(cfg: dict) -> str:
+    """cloud | local | selfhosted | unknown — how this install is wired.
+
+    `local` is the `clawmetry disconnect` / nocloud state: the daemon
+    runs and stores everything on the machine, nothing leaves it."""
+    if (
+        os.environ.get("CLAWMETRY_ENDPOINT", "").strip()
+        or str(cfg.get("endpoint") or "").strip()
+    ):
+        return "selfhosted"
+    try:
+        if NOCLOUD_MARKER.exists():
+            return "local"
+    except OSError:
+        pass
+    if cfg.get("local_only"):
+        return "local"
+    if str(cfg.get("api_key") or "").startswith("cm_"):
+        return "cloud"
+    return "unknown"
+
+
+def _post_open_ping(payload: dict, base: str, api_key: str) -> None:
+    """Fire-and-forget POST. Every failure is swallowed — a launch must
+    never be slowed, blocked, or made to look broken by telemetry."""
+    try:
+        headers = {
+            "Content-Type": "application/json",
+            "User-Agent": f"clawmetry-desktop/{payload.get('desktop_version', '?')}",
+        }
+        if api_key.startswith("cm_"):
+            # Attribution only: lets the account page show this machine
+            # under "Desktop apps". Anonymous when the app isn't paired.
+            headers["Authorization"] = f"Bearer {api_key}"
+        req = urllib.request.Request(
+            base + "/api/desktop/open",
+            data=json.dumps(payload).encode("utf-8"),
+            method="POST",
+            headers=headers,
+        )
+        with urllib.request.urlopen(req, timeout=OPEN_PING_TIMEOUT_SECS) as r:
+            r.read()
+    except Exception:
+        pass
+
+
+def open_ping_state(session_id: str, attached: bool = False) -> dict:
+    """Bump the counter, ping in the background, hand the state back to
+    the caller so the daemon child can inherit the same session/count.
+
+    `attached` marks a window that joined a daemon another instance
+    already owns; those launches never spawn a daemon, so the server
+    must not score them as a failed startup."""
+    state = _bump_open_state(session_id)
+    if _telemetry_optout():
+        return state
+    cfg = _read_config()
+    base = _app_base(cfg)
+    if not base:
+        return state
+    install_id = _install_id()
+    if not install_id:
+        return state
+    payload = {
+        "install_id": install_id,
+        "event": "desktop_open",
+        "stage": "shell",
+        "session_id": session_id,
+        "open_count": state["open_count"],
+        "first_open": state["open_count"] == 1,
+        "days_since_first_open": round(
+            max(0.0, state["last_open_ts"] - state["first_open_ts"]) / 86400.0, 2
+        ),
+        "desktop_version": _desktop_version(),
+        "os": platform.system() or "unknown",
+        "os_version": platform.release() or "",
+        "arch": platform.machine() or "",
+        "mode": _sync_mode(cfg),
+        "attached": bool(attached),
+    }
+    threading.Thread(
+        target=_post_open_ping,
+        args=(payload, base, str(cfg.get("api_key") or "")),
+        daemon=True,
+        name="clawmetry-desktop-open-ping",
+    ).start()
+    return state
+
+
 def _bootstrap_python(cache_file: Optional[Path] = None) -> Optional[str]:
     """A real Python interpreter the shell can use to create a venv.
     PyInstaller's bundled interpreter can't (its `sys.executable` is
@@ -1485,6 +1703,25 @@ def main() -> int:
 
     runtime = _runtime_dir()
     existing = _check_existing_instance(runtime)
+
+    # Count and report this launch before anything can fail. Every path
+    # below (attach, orphan-kill, cold boot) is a user opening the app,
+    # so the ping fires first and carries whether this window attached to
+    # an already-running daemon — otherwise a second window would look
+    # like an open whose daemon never came up.
+    import uuid as _uuid
+
+    _session_id = str(_uuid.uuid4())
+    _open_state = open_ping_state(
+        _session_id, attached=bool(existing and existing[0] == "attach")
+    )
+    # Inherited by the daemon child (start_daemon copies os.environ), which
+    # fires the enriched `desktop_ready` ping under the same session_id.
+    os.environ["CLAWMETRY_LAUNCHER"] = "desktop"
+    os.environ["CLAWMETRY_DESKTOP_VERSION"] = _desktop_version()
+    os.environ["CLAWMETRY_DESKTOP_SESSION"] = _session_id
+    os.environ["CLAWMETRY_DESKTOP_OPEN_COUNT"] = str(_open_state.get("open_count", 0))
+
     if existing and existing[0] == "attach":
         # Another instance owns the daemon — open a window onto it and
         # get out of the way. No supervisor, no watcher, and closing

--- a/desktop/build_linux.spec
+++ b/desktop/build_linux.spec
@@ -90,6 +90,14 @@ brand_datas = [
      'desktop/assets'),
 ]
 
+# Written by the CI "Stamp bundle version" step; absent in a dev checkout
+# (app.py then reports "dev"). Appended conditionally so a local
+# `pyinstaller` run doesn't fail on a missing data file.
+_version_txt = os.path.join(ASSETS_SRC, 'version.txt')
+if os.path.exists(_version_txt):
+    brand_datas.append((_version_txt, 'desktop/assets'))
+
+
 extra_hidden = [
     'PIL',
     'webview',

--- a/desktop/build_mac.spec
+++ b/desktop/build_mac.spec
@@ -51,6 +51,14 @@ brand_datas = [
      'desktop/assets'),
 ]
 
+# Written by the CI "Stamp bundle version" step; absent in a dev checkout
+# (app.py then reports "dev"). Appended conditionally so a local
+# `pyinstaller` run doesn't fail on a missing data file.
+_version_txt = os.path.join(ASSETS_SRC, 'version.txt')
+if os.path.exists(_version_txt):
+    brand_datas.append((_version_txt, 'desktop/assets'))
+
+
 extra_hidden = [
     'PIL',
     'webview',

--- a/desktop/build_windows.spec
+++ b/desktop/build_windows.spec
@@ -93,6 +93,14 @@ brand_datas = [
      'desktop/assets'),
 ]
 
+# Written by the CI "Stamp bundle version" step; absent in a dev checkout
+# (app.py then reports "dev"). Appended conditionally so a local
+# `pyinstaller` run doesn't fail on a missing data file.
+_version_txt = os.path.join(ASSETS_SRC, 'version.txt')
+if os.path.exists(_version_txt):
+    brand_datas.append((_version_txt, 'desktop/assets'))
+
+
 extra_hidden = [
     'PIL',
     'webview',

--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -27,6 +27,37 @@ path, file contents, your api_key, your email, anything PII or
 workspace-specific. The wire payload is auditable in
 [`clawmetry/telemetry.py`](clawmetry/telemetry.py).
 
+## The desktop app's open ping
+
+The macOS/Windows/Linux desktop app additionally posts to
+`https://app.clawmetry.com/api/desktop/open` **once per launch**, so we
+can tell a download apart from an actual open, and a first open apart
+from the fiftieth. It goes out in two stages: the shell pings the moment
+the window appears (this one fires even when the app fails to bootstrap
+its Python runtime — otherwise we would never hear about the launches
+that break), and the daemon pings once the dashboard is actually live.
+
+| Field | Example | Why |
+|---|---|---|
+| `install_id` | the same UUID as above | one machine is one install, not two |
+| `session_id` | random UUID per launch | pairs the two stages of one launch |
+| `open_count` / `first_open` | `7` / `false` | first open vs nth; opens counted locally, so offline launches still count |
+| `stage` | `shell` / `daemon` | opened vs opened-and-working |
+| `desktop_version` / `version` | `0.12.900` / `0.12.900` | which bundle, and which pip release it pulled |
+| `os` / `os_version` / `arch` | `Windows` / `11` / `AMD64` | platform support priorities |
+| `mode` | `cloud` / `local` / `unknown` | how many installs sync to Cloud vs stay entirely local |
+| `runtimes` | `["openclaw", "claude_code"]` | which agent runtimes this machine has data for — **ids only**, no paths, no session contents, no counts |
+
+If the app is paired with a Cloud account, the ping carries your API key
+as a bearer header — never in the stored body — purely so the machine
+shows up under **Desktop apps** on your own account page. Unpaired
+installs stay anonymous.
+
+Everything above is subject to the same opt-outs, and an enterprise
+endpoint (`CLAWMETRY_ENDPOINT`, or `endpoint` in
+`~/.clawmetry/config.json`) disables both pings entirely — a self-hosted
+deployment's data stays inside the deployment.
+
 **Opt out** (any one of these disables it permanently):
 
 ```bash

--- a/tests/test_desktop_open_telemetry.py
+++ b/tests/test_desktop_open_telemetry.py
@@ -1,0 +1,310 @@
+"""Desktop open telemetry — the download → open → working-daemon funnel.
+
+A .dmg download told us nothing about whether anyone ever opened the app.
+Two pings close that gap, and each stage exists because the other cannot
+cover it:
+
+  shell  (desktop/app.py)        fires when the window appears, so it
+                                 reports opens whose Python bootstrap
+                                 never completes — the failure mode we
+                                 were structurally blind to.
+  daemon (clawmetry/telemetry.py) fires once the dashboard is live, and
+                                 is the only stage that can say which
+                                 runtimes the machine has data for and
+                                 whether it syncs to cloud or stays local.
+
+Both are opt-out, both are silent on enterprise endpoints, and neither may
+ever slow, block, or visibly break a launch. The tests below hold those
+properties: nothing here touches the network or the real ~/.clawmetry.
+"""
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+import desktop.app as dapp  # noqa: E402
+
+
+# ── Shell stage ─────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def shell(monkeypatch, tmp_path):
+    """desktop.app with its ~/.clawmetry paths redirected at a tmp dir."""
+    cfg_dir = tmp_path / ".clawmetry"
+    monkeypatch.setattr(dapp, "CONFIG_DIR", cfg_dir)
+    monkeypatch.setattr(dapp, "INSTALL_ID_FILE", cfg_dir / "install_id")
+    monkeypatch.setattr(dapp, "OPTOUT_MARKER", cfg_dir / "notelemetry")
+    monkeypatch.setattr(dapp, "NOCLOUD_MARKER", cfg_dir / "nocloud")
+    monkeypatch.setattr(dapp, "CONFIG_JSON", cfg_dir / "config.json")
+    monkeypatch.setattr(dapp, "OPEN_STATE_FILE", cfg_dir / "desktop-opens.json")
+    for k in ("CLAWMETRY_NO_TELEMETRY", "DO_NOT_TRACK", "CLAWMETRY_ENDPOINT",
+              "CLAWMETRY_INGEST_URL", "CLAWMETRY_DESKTOP_PING_URL"):
+        monkeypatch.delenv(k, raising=False)
+    return dapp
+
+
+def _write_cfg(shell_mod, **keys):
+    shell_mod.CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+    shell_mod.CONFIG_JSON.write_text(json.dumps(keys), encoding="utf-8")
+
+
+def test_open_counter_survives_relaunch(shell):
+    """The nth-open number comes off disk, not the server, so opens that
+    happen offline still show up in the count on the next ping."""
+    first = shell._bump_open_state("s1")
+    second = shell._bump_open_state("s2")
+    third = shell._bump_open_state("s3")
+    assert [first["open_count"], second["open_count"], third["open_count"]] == [1, 2, 3]
+    # first_open_ts is pinned at the first launch — it dates the install.
+    assert third["first_open_ts"] == pytest.approx(first["first_open_ts"])
+    on_disk = json.loads(shell.OPEN_STATE_FILE.read_text())
+    assert on_disk["open_count"] == 3
+
+
+def test_first_open_flagged_then_not(shell, monkeypatch):
+    sent = []
+    monkeypatch.setattr(shell, "_post_open_ping",
+                        lambda payload, base, key: sent.append((payload, base, key)))
+    monkeypatch.setattr(shell.threading, "Thread",
+                        lambda target, args, daemon, name: type(
+                            "T", (), {"start": lambda _self: target(*args)})())
+    shell.open_ping_state("s1")
+    shell.open_ping_state("s2")
+    assert [p["first_open"] for p, _, _ in sent] == [True, False]
+    assert [p["open_count"] for p, _, _ in sent] == [1, 2]
+    assert sent[0][0]["event"] == "desktop_open"
+    assert sent[0][0]["stage"] == "shell"
+
+
+def test_optout_still_counts_locally_but_never_posts(shell, monkeypatch):
+    """Opting out silences the network, not the local counter — the user's
+    own 'nth open' bookkeeping stays correct if they later opt back in."""
+    posted = []
+    monkeypatch.setattr(shell, "_post_open_ping",
+                        lambda *a, **k: posted.append(a))
+    monkeypatch.setenv("CLAWMETRY_NO_TELEMETRY", "1")
+    state = shell.open_ping_state("s1")
+    assert state["open_count"] == 1
+    assert posted == []
+
+
+def test_optout_marker_file_also_silences(shell, monkeypatch):
+    posted = []
+    monkeypatch.setattr(shell, "_post_open_ping", lambda *a, **k: posted.append(a))
+    shell.CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+    shell.OPTOUT_MARKER.write_text("")
+    shell.open_ping_state("s1")
+    assert posted == []
+
+
+def test_enterprise_endpoint_never_phones_the_managed_cloud(shell, monkeypatch):
+    """A self-hosted deployment's data stays inside the deployment: we skip
+    the ping rather than redirect it at someone's private server."""
+    monkeypatch.setenv("CLAWMETRY_ENDPOINT", "https://clawmetry.internal.acme")
+    assert shell._app_base({}) is None
+    assert shell._app_base({"endpoint": "https://x.internal"}) is None
+    monkeypatch.delenv("CLAWMETRY_ENDPOINT")
+    assert shell._app_base({}) == shell.DEFAULT_APP_BASE
+
+
+def test_shell_sync_mode(shell):
+    assert shell._sync_mode({}) == "unknown"
+    assert shell._sync_mode({"api_key": "cm_live_x"}) == "cloud"
+    assert shell._sync_mode({"api_key": "cm_live_x", "local_only": True}) == "local"
+    shell.CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+    shell.NOCLOUD_MARKER.write_text("")
+    assert shell._sync_mode({"api_key": "cm_live_x"}) == "local"
+
+
+def test_attached_window_is_marked(shell, monkeypatch):
+    """A second window joins the first instance's daemon and never spawns
+    one. Unmarked, it would read as an open whose daemon never came up."""
+    sent = []
+    monkeypatch.setattr(shell, "_post_open_ping",
+                        lambda payload, base, key: sent.append(payload))
+    monkeypatch.setattr(shell.threading, "Thread",
+                        lambda target, args, daemon, name: type(
+                            "T", (), {"start": lambda _self: target(*args)})())
+    shell.open_ping_state("s1", attached=True)
+    assert sent[0]["attached"] is True
+
+
+def test_install_id_is_shared_with_the_cli(shell):
+    """One machine is one install — the shell reuses the CLI's id file
+    rather than minting a second identity for the same person."""
+    first = shell._install_id()
+    assert first and shell.INSTALL_ID_FILE.exists()
+    assert shell._install_id() == first
+
+
+def test_key_is_sent_as_a_header_only_when_paired(shell, monkeypatch):
+    seen = {}
+
+    class _Resp:
+        def read(self): return b""
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
+
+    def _urlopen(req, timeout=None):
+        seen["headers"] = dict(req.headers)
+        seen["url"] = req.full_url
+        return _Resp()
+
+    monkeypatch.setattr(shell.urllib.request, "urlopen", _urlopen)
+    shell._post_open_ping({"desktop_version": "1"}, "https://app.example", "")
+    assert "Authorization" not in seen["headers"]
+    assert seen["url"].endswith("/api/desktop/open")
+    shell._post_open_ping({"desktop_version": "1"}, "https://app.example", "cm_live_k")
+    assert seen["headers"]["Authorization"] == "Bearer cm_live_k"
+
+
+def test_network_failure_is_invisible(shell, monkeypatch):
+    def _boom(*a, **k):
+        raise OSError("network down")
+
+    monkeypatch.setattr(shell.urllib.request, "urlopen", _boom)
+    shell._post_open_ping({}, "https://app.example", "")  # must not raise
+
+
+def test_version_is_dev_without_a_build_stamp(shell, monkeypatch, tmp_path):
+    monkeypatch.setattr(shell, "_assets_dir", lambda: tmp_path / "nope")
+    assert shell._desktop_version() == "dev"
+    assets = tmp_path / "assets"
+    assets.mkdir()
+    (assets / "version.txt").write_text("0.12.999\n")
+    monkeypatch.setattr(shell, "_assets_dir", lambda: assets)
+    assert shell._desktop_version() == "0.12.999"
+
+
+# ── Daemon stage ────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def tele(monkeypatch, tmp_path):
+    from clawmetry import telemetry as t
+    importlib.reload(t)
+    cfg_dir = tmp_path / ".clawmetry"
+    monkeypatch.setattr(t, "CONFIG_DIR", cfg_dir)
+    monkeypatch.setattr(t, "INSTALL_ID_FILE", cfg_dir / "install_id")
+    monkeypatch.setattr(t, "OPTOUT_MARKER", cfg_dir / "notelemetry")
+    monkeypatch.setattr(t, "STATE_FILE", cfg_dir / "telemetry_state.json")
+    monkeypatch.setattr(t, "CONFIG_JSON", cfg_dir / "config.json")
+    monkeypatch.setattr(t, "NOCLOUD_MARKER", cfg_dir / "nocloud")
+    monkeypatch.setattr(t, "DESKTOP_PING_DELAY_SEC", 0.0)
+    for k in ("CLAWMETRY_NO_TELEMETRY", "DO_NOT_TRACK", "CLAWMETRY_LAUNCHER",
+              "CLAWMETRY_ENDPOINT", "CLAWMETRY_INGEST_URL",
+              "CLAWMETRY_DESKTOP_PING_URL", "CLAWMETRY_DESKTOP_SESSION",
+              "CLAWMETRY_DESKTOP_VERSION", "CLAWMETRY_DESKTOP_OPEN_COUNT"):
+        monkeypatch.delenv(k, raising=False)
+    return t
+
+
+def test_pip_installs_never_send_the_desktop_ping(tele):
+    """The daemon stage is desktop-only. A plain `clawmetry` run must not
+    start a thread, let alone post."""
+    assert tele.maybe_desktop_ping("0.0.0") is None
+
+
+def test_desktop_launcher_fires(tele, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_LAUNCHER", "desktop")
+    posted = []
+    monkeypatch.setattr(tele, "_post",
+                        lambda payload, url, api_key="": posted.append((payload, url, api_key)))
+    monkeypatch.setattr(tele, "_monitored_runtimes", lambda: ["openclaw", "claude_code"])
+    t = tele.maybe_desktop_ping("0.12.900")
+    assert t is not None
+    t.join(timeout=5)
+    payload, url, api_key = posted[0]
+    assert payload["event"] == "desktop_ready"
+    assert payload["stage"] == "daemon"
+    assert payload["runtimes"] == ["openclaw", "claude_code"]
+    assert payload["runtime_count"] == 2
+    assert payload["version"] == "0.12.900"
+    assert url.endswith("/api/desktop/open")
+    assert api_key == ""
+
+
+def test_daemon_ping_carries_the_shell_session_and_count(tele, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_LAUNCHER", "desktop")
+    monkeypatch.setenv("CLAWMETRY_DESKTOP_SESSION", "sess-42")
+    monkeypatch.setenv("CLAWMETRY_DESKTOP_OPEN_COUNT", "7")
+    monkeypatch.setenv("CLAWMETRY_DESKTOP_VERSION", "0.12.901")
+    monkeypatch.setattr(tele, "_monitored_runtimes", lambda: [])
+    payload = tele._build_desktop_payload("0.12.900")
+    assert payload["session_id"] == "sess-42"
+    assert payload["open_count"] == 7
+    assert payload["first_open"] is False
+    assert payload["desktop_version"] == "0.12.901"
+
+
+def test_garbage_open_count_does_not_raise(tele, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_DESKTOP_OPEN_COUNT", "not-a-number")
+    monkeypatch.setattr(tele, "_monitored_runtimes", lambda: [])
+    assert tele._build_desktop_payload("0.0.0")["open_count"] == 0
+
+
+def test_daemon_optout_beats_the_launcher(tele, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_LAUNCHER", "desktop")
+    monkeypatch.setenv("DO_NOT_TRACK", "1")
+    assert tele.maybe_desktop_ping("0.0.0") is None
+
+
+def test_daemon_skips_enterprise_endpoints(tele, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_LAUNCHER", "desktop")
+    monkeypatch.setenv("CLAWMETRY_ENDPOINT", "https://clawmetry.internal.acme")
+    posted = []
+    monkeypatch.setattr(tele, "_post", lambda *a, **k: posted.append(a))
+    monkeypatch.setattr(tele, "_monitored_runtimes", lambda: [])
+    tele._send_desktop_ping("0.0.0")
+    assert posted == []
+
+
+def test_paired_install_attributes_to_its_account(tele, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_LAUNCHER", "desktop")
+    tele.CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+    tele.CONFIG_JSON.write_text(json.dumps({"api_key": "cm_live_abc", "node_id": "n1"}))
+    posted = []
+    monkeypatch.setattr(tele, "_post",
+                        lambda payload, url, api_key="": posted.append((payload, api_key)))
+    monkeypatch.setattr(tele, "_monitored_runtimes", lambda: [])
+    tele._send_desktop_ping("0.0.0")
+    payload, api_key = posted[0]
+    assert api_key == "cm_live_abc"
+    assert payload["mode"] == "cloud"
+    assert payload["node_id"] == "n1"
+    # The key is a header, never part of the stored body.
+    assert "api_key" not in payload
+
+
+def test_daemon_sync_mode_local(tele):
+    tele.CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+    tele.NOCLOUD_MARKER.write_text("")
+    assert tele._sync_mode({"api_key": "cm_live_abc"}) == "local"
+
+
+def test_monitored_runtimes_are_ids_only(tele, monkeypatch):
+    monkeypatch.setattr(tele, "_AGENT_DIRS", ())
+    import clawmetry.sync as sync
+    monkeypatch.setattr(sync, "_detect_runtimes_lite",
+                        lambda: [{"id": "claude_code", "label": "Claude Code", "sessions": 91},
+                                 {"id": "cursor", "label": "Cursor", "sessions": 0}])
+    assert tele._monitored_runtimes() == ["claude_code", "cursor"]
+
+
+def test_runtime_detection_failure_is_not_fatal(tele, monkeypatch):
+    monkeypatch.setattr(tele, "_AGENT_DIRS", ())
+    import clawmetry.sync as sync
+
+    def _boom():
+        raise RuntimeError("detection exploded")
+
+    monkeypatch.setattr(sync, "_detect_runtimes_lite", _boom)
+    assert tele._monitored_runtimes() == []


### PR DESCRIPTION
## Why

We get an email every time someone downloads the desktop app, and then silence. We could not tell a download from an open, a first open from the fiftieth, or an open from an open that actually produced a working dashboard.

## What

The desktop shell pings `POST /api/desktop/open` once per launch, in two stages:

| stage | fires when | carries |
|---|---|---|
| `shell` | the window appears | open counter (first vs nth), app build, OS/arch, whether this window attached to another instance's daemon |
| `daemon` | the dashboard is actually live | which runtimes this machine has data for, cloud-sync vs local, node id, pip version |

The shell stage is the one that matters most: it fires even when the Python bootstrap never completes (no system Python, PyPI unreachable, wedged venv). That failure mode was structurally invisible before — the user sees a splash screen forever and we hear nothing.

Both stages of one launch share a `session_id`, so **opened but never reached a working daemon** is a subtraction, not a guess.

- Open counter lives on disk (`~/.clawmetry/desktop-opens.json`), so launches made offline still count on the next ping.
- `install_id` is the same file the CLI's first-run ping uses — one machine is one install, not two.
- Paired installs send the `cm_` key as a bearer header (never in the body) purely so the machine can be listed under "Desktop apps" on its own owner's account. Unpaired installs stay anonymous.
- CI now stamps the bundle version into `desktop/assets/version.txt`, so the ping can say *which build* was launched (absent in a dev checkout → reports `dev`).

## Privacy

Unchanged contract, extended in `docs/TELEMETRY.md`. No hostname, username, IP (the server derives a country and drops the IP), workspace path, or transcript content. `runtimes` is a list of runtime **ids**. Every existing opt-out still kills both pings — `CLAWMETRY_NO_TELEMETRY=1`, `DO_NOT_TRACK=1`, `~/.clawmetry/notelemetry` — and an enterprise endpoint disables them entirely: a self-hosted deployment's data stays inside the deployment.

## Tests

`tests/test_desktop_open_telemetry.py` — 21 tests over both stages: counter persistence, first vs nth, opt-out (still counts locally, never posts), enterprise-endpoint silence, attached windows, header-vs-body key handling, network failure invisibility, runtime-detection failure tolerance.

Server side: vivekchand/clawmetry-cloud PR (linked below).

🤖 Generated with [Claude Code](https://claude.com/claude-code)