### PR TITLE
fix(desktop): verify certificates on both open pings

### DIFF
--- a/clawmetry/telemetry.py
+++ b/clawmetry/telemetry.py
@@ -172,6 +172,41 @@ def _build_payload(version: str, event: str = "install", extra: dict | None = No
     return payload
 
 
+_SSL_CTX = None
+
+
+def _ssl_context():
+    """An SSLContext that can verify public certs wherever we run.
+
+    The stdlib default trusts whatever OpenSSL finds on the box, which is
+    nothing at all inside a frozen bundle and nothing on a python.org
+    interpreter whose certificate installer was never run. Both cases
+    fail closed with CERTIFICATE_VERIFY_FAILED, and because this module
+    swallows every error by design, they fail SILENTLY: the ping simply
+    never arrives. Same ladder the desktop shell uses (OS trust store,
+    then certifi's bundle, then the default), cached because building it
+    parses a PEM. Never raises; the last rung is the old behaviour.
+    """
+    global _SSL_CTX
+    if _SSL_CTX is not None:
+        return _SSL_CTX
+    import ssl
+    try:
+        import truststore  # type: ignore
+        _SSL_CTX = truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+        return _SSL_CTX
+    except Exception:
+        pass
+    try:
+        import certifi  # type: ignore
+        _SSL_CTX = ssl.create_default_context(cafile=certifi.where())
+        return _SSL_CTX
+    except Exception:
+        pass
+    _SSL_CTX = ssl.create_default_context()
+    return _SSL_CTX
+
+
 def _post(payload: dict, url: str, api_key: str = "") -> None:
     """Fire-and-forget POST. Swallows every exception by design — any
     failure here must NEVER surface to the user.
@@ -193,7 +228,8 @@ def _post(payload: dict, url: str, api_key: str = "") -> None:
             method="POST",
             headers=headers,
         )
-        with urllib.request.urlopen(req, timeout=TELEMETRY_TIMEOUT_SEC) as r:
+        ctx = _ssl_context() if url.lower().startswith("https://") else None
+        with urllib.request.urlopen(req, timeout=TELEMETRY_TIMEOUT_SEC, context=ctx) as r:
             r.read()  # drain so the connection releases cleanly
     except Exception as e:
         log.debug("telemetry: post failed: %s", e)

--- a/desktop/app.py
+++ b/desktop/app.py
@@ -513,7 +513,17 @@ def _post_open_ping(payload: dict, base: str, api_key: str) -> None:
             method="POST",
             headers=headers,
         )
-        with urllib.request.urlopen(req, timeout=OPEN_PING_TIMEOUT_SECS) as r:
+        # A frozen bundle cannot verify public certs with the default
+        # context: OpenSSL looks for a trust store at build-machine paths
+        # that do not exist inside the .app/.exe, so every HTTPS call
+        # dies with CERTIFICATE_VERIFY_FAILED. That is what broke the
+        # onboarding "Send code" button on 2026-08-12, and the ladder
+        # built for it (OS trust store, then bundled certifi, then the
+        # default) is reused here rather than rediscovered. Without it
+        # the shell-stage ping fails silently in exactly the builds it
+        # exists to report on.
+        ctx = onboarding._ssl_context() if base.lower().startswith("https://") else None
+        with urllib.request.urlopen(req, timeout=OPEN_PING_TIMEOUT_SECS, context=ctx) as r:
             r.read()
     except Exception:
         pass

--- a/tests/test_desktop_open_telemetry.py
+++ b/tests/test_desktop_open_telemetry.py
@@ -153,7 +153,7 @@ def test_key_is_sent_as_a_header_only_when_paired(shell, monkeypatch):
         def __enter__(self): return self
         def __exit__(self, *a): return False
 
-    def _urlopen(req, timeout=None):
+    def _urlopen(req, timeout=None, context=None):
         seen["headers"] = dict(req.headers)
         seen["url"] = req.full_url
         return _Resp()
@@ -308,3 +308,83 @@ def test_runtime_detection_failure_is_not_fatal(tele, monkeypatch):
 
     monkeypatch.setattr(sync, "_detect_runtimes_lite", _boom)
     assert tele._monitored_runtimes() == []
+
+
+# ── TLS trust (the 2026-08-12 class) ────────────────────────────────────────
+#
+# A frozen bundle has no OpenSSL trust store at the paths the default
+# context looks in, so every HTTPS call from inside the .app/.exe fails
+# with CERTIFICATE_VERIFY_FAILED. That took out the onboarding "Send
+# code" button once already. Both pings swallow errors by design, so the
+# same mistake here does not surface as a bug report: it surfaces as an
+# endpoint that quietly receives nothing, from precisely the installs it
+# exists to hear about. These guards fail if either ping ever goes back
+# to an unverified default context.
+
+
+def _capture_urlopen(monkeypatch, mod):
+    seen = {}
+
+    class _Resp:
+        def read(self): return b""
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
+
+    def _urlopen(req, timeout=None, context=None, **kw):
+        seen["context"] = context
+        seen["url"] = getattr(req, "full_url", req)
+        return _Resp()
+
+    monkeypatch.setattr(mod.urllib.request, "urlopen", _urlopen)
+    return seen
+
+
+def test_shell_ping_verifies_certificates(shell, monkeypatch):
+    import ssl
+
+    seen = _capture_urlopen(monkeypatch, shell)
+    shell._post_open_ping({"desktop_version": "1"}, "https://app.clawmetry.com", "")
+    assert isinstance(seen["context"], ssl.SSLContext), (
+        "the shell ping must pass a verifying SSL context; the frozen bundle "
+        "cannot verify public certs with the default one"
+    )
+
+
+def test_shell_ping_skips_the_context_for_plain_http(shell, monkeypatch):
+    """A local sink over http has no certificates to verify, and handing
+    a context to a plain-http request is meaningless."""
+    seen = _capture_urlopen(monkeypatch, shell)
+    shell._post_open_ping({"desktop_version": "1"}, "http://127.0.0.1:8977", "")
+    assert seen["context"] is None
+
+
+def test_daemon_ping_verifies_certificates(tele, monkeypatch):
+    import ssl
+
+    seen = _capture_urlopen(monkeypatch, tele)
+    tele._post({"version": "1"}, "https://app.clawmetry.com/api/desktop/open")
+    assert isinstance(seen["context"], ssl.SSLContext)
+
+
+def test_daemon_ping_skips_the_context_for_plain_http(tele, monkeypatch):
+    seen = _capture_urlopen(monkeypatch, tele)
+    tele._post({"version": "1"}, "http://127.0.0.1:8977/api/desktop/open")
+    assert seen["context"] is None
+
+
+def test_trust_ladder_never_raises(tele, monkeypatch):
+    """Every rung is best-effort: a missing truststore/certifi must
+    degrade to the default context, not take the ping down with it."""
+    import builtins
+    import ssl
+
+    real_import = builtins.__import__
+
+    def _no_tls_libs(name, *a, **kw):
+        if name in ("truststore", "certifi"):
+            raise ImportError(name)
+        return real_import(name, *a, **kw)
+
+    monkeypatch.setattr(builtins, "__import__", _no_tls_libs)
+    monkeypatch.setattr(tele, "_SSL_CTX", None)
+    assert isinstance(tele._ssl_context(), ssl.SSLContext)


### PR DESCRIPTION
Follow-up to #5020, found while verifying that release against production rather than assuming it worked.

## The bug

`_post_open_ping` in the desktop shell called `urlopen` with no SSL context. Inside a frozen bundle that fails with `CERTIFICATE_VERIFY_FAILED`, because OpenSSL looks for a trust store at build-machine paths that do not exist in the `.app`/`.exe`.

This is not a new discovery. It is the same failure that broke the onboarding "Send code" button on 2026-08-12, and it is why `desktop/onboarding.py` already carries a trust ladder. The ping should have reused that ladder. Every other `urlopen` in `desktop/app.py` is localhost http, so this was the only offender, but it was the one that mattered.

**Why it would never have been reported:** both pings swallow errors by design, so there is no traceback and no user-visible symptom. The only symptom is an endpoint that receives nothing, from exactly the population the shell stage exists to observe: installs whose bootstrap never completes.

## Reproduced, then fixed

Fired the published 0.12.740 wheel's daemon ping at production from an interpreter with no trust store. It reported success and nothing arrived; debug logging showed `CERTIFICATE_VERIFY_FAILED`. With the fix, the same interpreter lands the row, with live runtime detection. Verification rows were deleted afterwards, so the live rollup reads zero.

## The fix

The shell reuses `onboarding._ssl_context()` for https. `clawmetry/telemetry.py` grows the same ladder (OS trust store via truststore, then certifi's bundle, then the default), which also covers the install ping, which has always had this shape. Plain-http sinks still pass no context. No new dependency: every rung is a best-effort import that degrades to the previous behaviour.

## Guards

5 tests across both pings: a verifying context on https, no context on http, and the ladder degrading rather than raising when neither library is importable. Three fail on the parent commit, confirmed by restoring `origin/main`'s two files and re-running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)