### PR TITLE
fix(tls): ship certifi so every install has a usable trust store

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,10 +108,14 @@ The daemon owns the DuckDB writer lock and runs a localhost query server so the 
 - `/api/alerts/*` — Custom alert rules
 
 ## Dependencies
-Minimal by design:
+Minimal by design, and this list had drifted — `setup.py` is the source of truth:
 - **flask** (>=2.0,<4) — HTTP server framework
 - **waitress** (>=2.0) — WSGI application server
 - **cryptography** (>=3.0) — AES-256-GCM for cloud sync
+- **duckdb** (>=0.10) — the local store at `~/.clawmetry/clawmetry.duckdb`
+- **websocket-client** (>=1.6) — cloud cold-data relay tunnel
+- **truststore** (>=0.8, 3.10+ only) — OS trust store, so corporate TLS-interception root CAs work
+- **certifi** (>=2024.2.2) — CA bundle; the trust-store fallback on 3.8/3.9 and on any interpreter whose OpenSSL has no CA store. Without one, every outbound HTTPS call fails `CERTIFICATE_VERIFY_FAILED`, and for the fire-and-forget pings that failure is silent
 - **Optional**: `opentelemetry-proto` for OTLP support (`pip install clawmetry[otel]`)
 
 ## Running locally

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 flask>=3.1.3,<4
 duckdb>=1.5.5  # local event store (epic #964 phase 1)
 truststore>=0.10.4; python_version >= "3.10"  # OS trust store for corporate TLS-interception CAs
+certifi>=2024.2.2  # CA bundle: the trust-store fallback for 3.8/3.9 and for any interpreter with no CA store
 
 # Testing dependencies
 pytest>=9.1.1

--- a/setup.py
+++ b/setup.py
@@ -82,8 +82,20 @@ setup(
         # OS trust store for TLS (Windows CryptoAPI / macOS Security /
         # Linux CA dir) -- makes corporate TLS-interception root CAs
         # (Zscaler/Netskope/Palo Alto) "just work" without certifi hacks.
-        # Needs 3.10+; on 3.8/3.9 clawmetry.net falls back to stock trust.
+        # Needs 3.10+; 3.8/3.9 fall through to certifi below.
         'truststore>=0.8; python_version >= "3.10"',
+        # The second rung of that same ladder, and the only one available
+        # on 3.8/3.9 where truststore cannot install. Without a usable
+        # trust store, every outbound HTTPS call (cloud sync, licence
+        # checks, the install and desktop-open pings) fails with
+        # CERTIFICATE_VERIFY_FAILED on any interpreter whose OpenSSL has
+        # no CA bundle -- a python.org install whose certificate step was
+        # never run is the common case. The pings swallow their own
+        # errors so that a network problem cannot break a launch, which
+        # means that failure is SILENT: no traceback, no report, just an
+        # endpoint that never hears from those machines. ~160 KB, pure
+        # data, no transitive deps. See docs/TELEMETRY.md.
+        "certifi>=2024.2.2",
     ],
     extras_require={
         "otel": ["opentelemetry-proto>=1.20.0", "protobuf>=4.21.0"],

--- a/tests/test_desktop_open_telemetry.py
+++ b/tests/test_desktop_open_telemetry.py
@@ -388,3 +388,69 @@ def test_trust_ladder_never_raises(tele, monkeypatch):
     monkeypatch.setattr(builtins, "__import__", _no_tls_libs)
     monkeypatch.setattr(tele, "_SSL_CTX", None)
     assert isinstance(tele._ssl_context(), ssl.SSLContext)
+
+
+# ── The trust store must exist on every install ─────────────────────────────
+#
+# The ladder is only as good as what is installed alongside it. truststore
+# cannot install below 3.10, so on 3.8/3.9 certifi is the ONLY rung that
+# works, and without it the ladder falls through to a default context that
+# has no CA bundle at all on interpreters whose certificate step was never
+# run. That is a silent failure by construction: the pings swallow their
+# errors, so it surfaces as an endpoint that never hears from those
+# machines rather than as anything anybody could report.
+
+
+def _install_requires():
+    """Read setup.py's install_requires without importing it (importing
+    runs setup())."""
+    import ast
+
+    tree = ast.parse(Path(REPO_ROOT / "setup.py").read_text())
+    for node in ast.walk(tree):
+        if isinstance(node, ast.keyword) and node.arg == "install_requires":
+            return [ast.literal_eval(e) for e in node.value.elts]
+    raise AssertionError("install_requires not found in setup.py")
+
+
+def test_certifi_is_an_unconditional_dependency():
+    """Ungated on purpose: 3.8/3.9 cannot have truststore, and those are
+    exactly the interpreters most likely to lack a CA bundle."""
+    reqs = _install_requires()
+    certifi_reqs = [r for r in reqs if r.split(">=")[0].split(";")[0].strip() == "certifi"]
+    assert certifi_reqs, f"certifi must be in install_requires; got {reqs}"
+    assert ";" not in certifi_reqs[0], (
+        f"certifi must NOT carry a version marker ({certifi_reqs[0]}) -- gating it "
+        "would leave 3.8/3.9 with no usable trust store at all"
+    )
+
+
+def test_truststore_stays_gated_at_310():
+    """It cannot install below 3.10, so the marker has to stay or the
+    whole package becomes uninstallable on 3.9."""
+    reqs = _install_requires()
+    ts = [r for r in reqs if r.startswith("truststore")]
+    assert ts and 'python_version >= "3.10"' in ts[0], ts
+
+
+def test_ladder_finds_real_cas_when_truststore_is_unavailable(tele, monkeypatch):
+    """The 3.8/3.9 path, exercised on whatever Python runs the suite: with
+    truststore blocked, the context must still carry actual CA
+    certificates. An empty store is what CERTIFICATE_VERIFY_FAILED looks
+    like before it happens."""
+    import builtins
+
+    real_import = builtins.__import__
+
+    def _no_truststore(name, *a, **kw):
+        if name == "truststore":
+            raise ImportError("simulating a 3.9 interpreter")
+        return real_import(name, *a, **kw)
+
+    monkeypatch.setattr(builtins, "__import__", _no_truststore)
+    monkeypatch.setattr(tele, "_SSL_CTX", None)
+    ctx = tele._ssl_context()
+    assert len(ctx.get_ca_certs()) > 0, (
+        "no CA certificates loaded -- every HTTPS call from this install "
+        "would fail with CERTIFICATE_VERIFY_FAILED, silently"
+    )


### PR DESCRIPTION
Follow-up to #5025, which gave both pings a trust ladder. This makes the ladder's rungs actually present on every install.

## What was still broken

`truststore` was already in `install_requires`, so **3.10+ was fine**: a clean install of 0.12.741 carries truststore 0.10.4 and the ladder returns a real OS-backed context. I got this wrong in an earlier note and it is worth stating plainly.

The gap is **3.8/3.9**, where truststore cannot install at all. There the ladder had nothing to fall back to but a default context, which is empty on any interpreter whose OpenSSL has no CA bundle. A python.org install whose certificate step was never run is the common case. On such a machine every outbound HTTPS call fails `CERTIFICATE_VERIFY_FAILED`: cloud sync, licence checks, and both pings.

For the pings, that failure is silent by design (they swallow errors so a network problem cannot break a launch), so it surfaces as an endpoint that never hears from those machines. The anonymous install ping has had this shape since it was written, which means install counts may have been quietly low on that population all along.

## The change

`certifi>=2024.2.2` in `install_requires`, **ungated**: the interpreters that cannot have truststore are precisely the ones most likely to lack a CA bundle. About 160 KB of pure data, no transitive dependencies. Also mirrored into `requirements.txt`.

## Verified

On Apple's `/usr/bin/python3` (3.9.6), where truststore is absent, a fresh install of this branch produces a context carrying **121 CA certificates** from certifi, instead of depending on whatever OpenSSL happens to find.

Guards: certifi must be declared and must NOT carry a version marker (gating it would recreate the hole), truststore must stay gated at 3.10+ or the package becomes uninstallable on 3.9, and the ladder must load real CA certificates when truststore is blocked. The first fails on the parent commit, confirmed by restoring its `setup.py` and re-running.

Also corrects the dependency list in `CLAUDE.md`, which still claimed three packages and had missed duckdb, websocket-client and truststore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)