### PR TITLE
feat(cloud-parity): carry orchestration fields on the /api/subagents shaper so the snapshot ships them

### DIFF
--- a/routes/sessions.py
+++ b/routes/sessions.py
@@ -2251,6 +2251,29 @@ def _try_local_store_subagents(_rows=None):
             "tokensOut":        int(extra.get("tokensOut") or 0),
             "spawnAck":         extra.get("spawnAck") or "",
             "runId":            extra.get("runId") or "",
+            # Orchestration capture (#5008/#5014 + the per-runtime legs): the
+            # facts the Activity badges and the Sessions Orchestration panel
+            # render. They ride HERE because this shaper is also what the sync
+            # daemon reads back to build the cloud snapshot's ``subagents[]``
+            # slice — without them the hosted dashboard can only ever show the
+            # legacy flat list, and the feature is inert in cloud.
+            "kind":             extra.get("kind") or "subagent",
+            "workflowRunId":    extra.get("workflowRunId") or "",
+            "workflowName":     extra.get("workflowName") or "",
+            "phase":            extra.get("phase") or "",
+            "agentType":        extra.get("agentType") or "",
+            "label":            extra.get("label") or display,
+            "prompt":           extra.get("prompt") or "",
+            "reply":            extra.get("reply") or "",
+            "nowTool":          (extra.get("nowTool") or "") if status in ("active", "running") else "",
+            "lastTool":         extra.get("lastTool") or "",
+            "toolCalls":        int(extra.get("toolCalls") or 0),
+            "turns":            int(extra.get("turns") or 0),
+            "agentCount":       int(extra.get("agentCount") or 0),
+            "agentsRunning":    int(extra.get("agentsRunning") or 0),
+            "agentsDone":       int(extra.get("agentsDone") or 0),
+            "agentsFailed":     int(extra.get("agentsFailed") or 0),
+            "runtimeName":      extra.get("runtime") or r.get("agent_type") or "",
         })
 
     # "running" is the daemon's own word for "active"; without it the

--- a/tests/test_orchestration_capture.py
+++ b/tests/test_orchestration_capture.py
@@ -235,3 +235,40 @@ def test_orchestration_empty_session_is_honest(app):
     d = client.get("/api/session-orchestration/claude_code:no-such").get_json()
     assert d["workflows"] == [] and d["subagents"] == []
     assert d["summary"]["children"] == 0
+
+
+def test_subagents_shaper_carries_orchestration_fields_for_cloud(app):
+    """The /api/subagents shaper is ALSO what the sync daemon reads back to
+    build the cloud snapshot's ``subagents[]`` slice. If the orchestration
+    fields stop riding it, the hosted dashboard silently degrades to the
+    legacy flat list — the feature goes inert in cloud while local keeps
+    working (the classic silent-cloud-drift class). Lock the contract.
+    """
+    a, ls = app
+    _seed(ls)
+    import routes.sessions as sessions_mod
+    rows = ls.get_store().query_subagents(limit=500)
+    shaped = sessions_mod._try_local_store_subagents(_rows=rows)
+    assert shaped and shaped["subagents"]
+    by_id = {x["sessionId"]: x for x in shaped["subagents"]}
+
+    run = by_id[RUN]
+    assert run["kind"] == "workflow"
+    assert run["workflowRunId"] == "wf_test1234-abc"
+    assert run["workflowName"] == "orchestration-e2e"
+    assert run["agentCount"] == 2
+
+    agent = by_id[f"{RUN}::agent-adead1"]
+    assert agent["kind"] == "workflow_agent"
+    assert agent["phase"] == "Audit"
+    assert agent["prompt"].startswith("You are a research agent")
+    assert agent["reply"] == '{"found": 3}'
+
+    live = by_id[f"{RUN}::agent-abeef2"]
+    assert live["nowTool"] == "WebFetch"          # only while running
+
+    plain = by_id[f"{NS_PARENT}::agent-acafe3"]
+    assert plain["kind"] == "subagent"
+    assert plain["agentType"] == "Explore"
+    assert plain["reply"].startswith("It lives in")
+


### PR DESCRIPTION
Prep for making orchestration capture live in **cloud**.

The hosted dashboard serves `/api/subagents` client-side from the decrypted snapshot, and that snapshot slice is built by reading back through this shaper. It only emitted the legacy flat fields — so kind / workflowRunId / phase / agentType / prompt / reply / nowTool / per-run agent counts stopped at the local boundary and the feature would be **inert in cloud**.

- Shaper now carries them (`nowTool` only while genuinely running, mirroring local).
- New regression test locks the snapshot contract so a future edit can't silently degrade the hosted view while local keeps working.

Zero new lint errors; 6 orchestration tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)