### PR TITLE
Gate hooks launch via the console script, not `python -m` (fail-closed DoS)

### DIFF
--- a/clawmetry/runtime_gates.py
+++ b/clawmetry/runtime_gates.py
@@ -78,13 +78,46 @@ def _hook_command(runtime_slug: str, base: str) -> str:
     space into a "command not found", and a Copilot ``preToolUse`` command
     hook that exits non-zero is fail-CLOSED — every gated tool call would be
     denied. Found in review before this ever shipped."""
-    py = _windowless_python(sys.executable or "python3", os.name == "nt")
+    launcher = _console_script() or _windowless_python(
+        sys.executable or "python3", os.name == "nt")
     if os.name == "nt":
         import subprocess as _sp
-        quoted = _sp.list2cmdline([py])
+        quoted = _sp.list2cmdline([launcher])
     else:
-        quoted = shlex.quote(py)
-    return f"{quoted} -m clawmetry hook {runtime_slug} --base {base}"
+        quoted = shlex.quote(launcher)
+    suffix = "" if _console_script() else " -m clawmetry"
+    return f"{quoted}{suffix} hook {runtime_slug} --base {base}"
+
+
+def _console_script() -> "str | None":
+    """Absolute path of the installed ``clawmetry`` console script, if any.
+
+    Preferred over ``python -m clawmetry`` because the runtimes spawn the
+    hook with the AGENT'S working directory. For ``-m``, Python puts that
+    directory first on ``sys.path``, so any project containing a
+    ``clawmetry/`` folder shadows the installed package: the import resolves
+    to the user's own directory, argparse rejects the ``hook`` subcommand,
+    and the process exits non-zero. On Copilot a non-zero command hook is
+    fail-CLOSED, so that would deny EVERY tool call for anyone whose repo has
+    a directory of that name (this repo included). A console script sets
+    ``sys.path[0]`` to its own bin directory instead, so the working
+    directory can never shadow the package.
+
+    Returns None when no script sits next to the running interpreter (pipx /
+    unusual layouts), in which case the caller falls back to ``-m``.
+    """
+    exe = sys.executable or ""
+    if not exe:
+        return None
+    bindir = os.path.dirname(exe)
+    name = "clawmetry.exe" if os.name == "nt" else "clawmetry"
+    cand = os.path.join(bindir, name)
+    try:
+        if os.path.isfile(cand) and (os.name == "nt" or os.access(cand, os.X_OK)):
+            return cand
+    except Exception:  # noqa: BLE001
+        return None
+    return None
 
 
 def _timeout_from_policies(policies) -> int:
@@ -189,7 +222,11 @@ def _remove_marker_if_ours(runtime: str) -> None:
 # ═══════════════════════════════════════════════════════════════════════════
 
 _CURSOR_STATE_PATH = os.path.expanduser("~/.clawmetry/cursor_gate.json")
-CURSOR_CMD_MARKER = "-m clawmetry hook cursor"
+# Deliberately form-agnostic: matches BOTH "<py> -m clawmetry hook cursor"
+# (how we used to write it, still present in older installs) and
+# "<prefix>/bin/clawmetry hook cursor" (what we write now). An entry is ours
+# if it carries this substring, whichever launcher form it uses.
+CURSOR_CMD_MARKER = "clawmetry hook cursor"
 
 # Blocking Cursor hook events we install on. beforeShellExecution +
 # beforeMCPExecution are always gated (exec is what policies overwhelmingly
@@ -327,7 +364,7 @@ def _cursor_uninstall() -> None:
 # ═══════════════════════════════════════════════════════════════════════════
 
 _COPILOT_STATE_PATH = os.path.expanduser("~/.clawmetry/copilot_gate.json")
-COPILOT_CMD_MARKER = "-m clawmetry hook copilot"
+COPILOT_CMD_MARKER = "clawmetry hook copilot"  # form-agnostic, see CURSOR_CMD_MARKER
 _COPILOT_GATE_BASENAME = "clawmetry.json"
 
 

--- a/tests/test_runtime_gates_and_hooks.py
+++ b/tests/test_runtime_gates_and_hooks.py
@@ -944,3 +944,61 @@ def test_copilot_uninstall_leaves_a_foreign_file_alone(rt_gates):
         {"type": "command", "command": "/usr/local/bin/someone-else"}]}}))
     rg.copilot_gate_handler(False, [])
     assert path.exists(), "a foreign file must never be deleted"
+
+
+def test_hook_command_prefers_console_script(rt_gates, monkeypatch, tmp_path):
+    """The runtimes spawn the hook with the AGENT'S cwd. With `-m`, that
+    directory is first on sys.path, so a project containing a `clawmetry/`
+    folder shadows the installed package: argparse rejects `hook`, the
+    process exits non-zero, and on Copilot that DENIES every tool call."""
+    rg, _ = rt_gates
+    bindir = tmp_path / "venv" / "bin"
+    bindir.mkdir(parents=True)
+    script = bindir / "clawmetry"
+    script.write_text("#!/bin/sh\n")
+    script.chmod(0o755)
+    monkeypatch.setattr(rg.sys, "executable", str(bindir / "python3"))
+    cmd = rg._hook_command("copilot", "http://127.0.0.1:8900")
+    assert str(script) in cmd
+    assert " -m clawmetry" not in cmd
+    assert cmd.endswith("hook copilot --base http://127.0.0.1:8900")
+
+
+def test_hook_command_falls_back_to_dash_m_without_a_script(rt_gates,
+                                                            monkeypatch,
+                                                            tmp_path):
+    rg, _ = rt_gates
+    bindir = tmp_path / "nolauncher" / "bin"
+    bindir.mkdir(parents=True)
+    monkeypatch.setattr(rg.sys, "executable", str(bindir / "python3"))
+    cmd = rg._hook_command("cursor", "http://127.0.0.1:8900")
+    assert " -m clawmetry hook cursor " in cmd
+
+
+def test_markers_match_both_launcher_forms(rt_gates):
+    """Older installs wrote the `-m` form; uninstall must still recognise
+    them as ours."""
+    rg, _ = rt_gates
+    legacy = {"type": "command",
+              "command": "/usr/bin/python3 -m clawmetry hook cursor --base x"}
+    modern = {"type": "command",
+              "command": "/venv/bin/clawmetry hook cursor --base x"}
+    foreign = {"type": "command", "command": "/usr/local/bin/other-hook"}
+    assert rg._cursor_entry_is_ours(legacy) is True
+    assert rg._cursor_entry_is_ours(modern) is True
+    assert rg._cursor_entry_is_ours(foreign) is False
+
+
+def test_legacy_dash_m_entry_is_replaced_not_duplicated(rt_gates):
+    rg, tmp = rt_gates
+    path = tmp / "cursor" / "hooks.json"
+    path.parent.mkdir(parents=True)
+    path.write_text(json.dumps({"version": 1, "hooks": {
+        "beforeShellExecution": [
+            {"type": "command",
+             "command": "/old/python3 -m clawmetry hook cursor --base y",
+             "timeout": 60}]}}))
+    rg.cursor_gate_handler(True, _POL)
+    entries = json.loads(path.read_text())["hooks"]["beforeShellExecution"]
+    ours = [e for e in entries if rg._cursor_entry_is_ours(e)]
+    assert len(ours) == 1, "legacy entry must be replaced, not stacked"


### PR DESCRIPTION
Follow-up hardening on #5009, found while verifying the published 0.12.744 wheel.

## The bug

The runtimes spawn our pre-tool hook with **the agent's working directory**. With `python -m clawmetry`, Python puts that directory first on `sys.path`, so any project containing a `clawmetry/` folder shadows the installed package: the import resolves to the user's own directory, argparse rejects the `hook` subcommand, and the process **exits 1**.

On Copilot a non-zero command hook is **fail-closed** — so in such a project, *every* tool call gets denied.

Reproduced against the published wheel, from a directory containing `clawmetry/`:

```
dash-m exit code: 1        (non-zero = Copilot DENIES the tool)
console-script exit code: 0  (0 = no opinion, agent proceeds)
```

Anyone whose repo has a directory of that name is affected — including anyone working on ClawMetry itself. That is how it surfaced: it bit my verification run twice before I recognised it as the product's bug rather than my harness's.

## The fix

Prefer the installed `clawmetry` console script next to the running interpreter. A console script sets `sys.path[0]` to its own bin directory, so the working directory can never shadow the package. Falls back to `-m` when no script exists (pipx / unusual layouts).

The command markers become form-agnostic (`clawmetry hook cursor` rather than `-m clawmetry hook cursor`) so entries written by 0.12.744 are still recognised as ours and get **replaced rather than stacked** — covered by a test.

4 new tests: console-script preference, the no-script fallback, both marker forms recognised, and the legacy-entry migration.

`claude_code_gate.py` writes the same `-m` form. Claude Code treats a hook error as non-blocking, so it degrades to "no opinion" there rather than denying, which is why this PR is scoped to the fail-closed runtime. Worth a follow-up for consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)