### PR TITLE
[RELEASE] Gate hooks launch via the console script (carries #5035)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Unreleased
 
+- **Release: the Cursor and Copilot gate hooks launch a way the working directory cannot break. Carries #5035 to PyPI.**
+  - **Who this reaches:** anyone using the new pre-execution gates whose project happens to contain a folder named `clawmetry`. On GitHub Copilot that combination denied every tool call.
+  - **What was wrong:** the runtimes start our hook with the agent's own working directory, and the previous launcher form let that directory take precedence when importing. A project with a folder of that name shadowed the installed package, the command was rejected, and the hook exited with an error. Copilot treats a hook that errors as a refusal, so the agent could not run anything.
+  - **How it was found:** while verifying the published wheel from a checkout of this repo, which is itself such a project. It looked like a problem with the verification setup twice before it was recognised as the product's own bug.
+  - **What changed:** the hook now runs through the installed `clawmetry` command, whose import path is fixed by where it is installed rather than by where the agent happens to be working. Installs that predate this release are recognised and replaced rather than left behind.
+
 - **Release: stop and pause reach six more runtimes, and Cursor and GitHub Copilot get real pre-execution gates. Carries #5009 to PyPI.**
   - **Who this reaches:** anyone whose Stop button covered fewer runtimes than the product claimed, and anyone who wanted a tool call paused for approval on Cursor or Copilot rather than reported after the fact.
   - **The claim that was not true.** Stop and Pause were advertised for Codex, OpenCode, Aider and Goose, but the shipped path could not work. The relay that carries a stop request never included the session's working directory, the resolver needs it to find the process, and no session row had ever stored one. Every such stop ended in `no_cwd`. The daemon now looks the directory up from the session record before resolving, and family-runtime sessions persist it at ingest.

--- a/dashboard.py
+++ b/dashboard.py
@@ -326,7 +326,7 @@ def _otlp_service_name_to_agent_type(service_name):
     return slug or "custom"
 
 
-__version__ = "0.12.743"
+__version__ = "0.12.745"
 
 # Extensions (Phase 2): import the plugin host now, but defer the actual
 # load_plugins() call until after the Flask app is created below so we can


### PR DESCRIPTION
Ships #5035. **0.12.744 is affected**, so this should follow it promptly.

0.12.744 introduced the Cursor and Copilot pre-execution gates with a hook command of the form `python -m clawmetry hook <runtime>`. The runtimes start that hook with **the agent's working directory**, which `-m` puts first on the import path. In any project containing a `clawmetry/` folder the import resolves there, the subcommand is rejected, and the process exits 1 — and on Copilot a hook that exits non-zero is a **refusal**, so every tool call in that project is denied.

Measured against the published 0.12.744 wheel from such a directory:

```
dash-m exit code: 1          (Copilot denies the tool)
console-script exit code: 0  (no opinion, agent proceeds)
```

#5035 switches to the installed `clawmetry` console script, whose import path is fixed by its install location rather than the agent's cwd, and makes the command markers form-agnostic so entries written by 0.12.744 are recognised and replaced rather than stacked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)