### PR TITLE
Claude Code gate uses the same shadow-proof launcher (consistency)

### DIFF
--- a/clawmetry/claude_code_gate.py
+++ b/clawmetry/claude_code_gate.py
@@ -62,12 +62,15 @@ _SERVER_INFO_PATH = os.path.expanduser("~/.clawmetry/server.json")
 _MARKER_PATH = os.path.expanduser("~/.clawmetry/hooks_installed.json")
 
 # Any hook command containing this is OURS (the local-first gate).
-HOOK_CMD_MARKER = "-m clawmetry hook claude-code"
+# Form-agnostic: matches BOTH the legacy "<py> -m clawmetry hook claude-code"
+# written by older releases and the console-script form written now, so an
+# existing entry is replaced rather than stacked beside a second gate.
+HOOK_CMD_MARKER = "clawmetry hook claude-code"
 # …and this one is the MIRROR hook (PermissionRequest). Distinct marker so
 # each installer only ever removes its own entry. NOTE the ordering trap:
 # this string CONTAINS HOOK_CMD_MARKER, so any "is it ours?" test for the
 # PreToolUse gate must exclude mirror commands explicitly (_entry_is_ours).
-MIRROR_CMD_MARKER = "-m clawmetry hook claude-code-permission"
+MIRROR_CMD_MARKER = "clawmetry hook claude-code-permission"
 # Commands containing any of these belong to the CLOUD-path manual install
 # (hooks_claude_code.py). Their presence means claude_code is already
 # pre-tool gated — we must not stack a second gate.
@@ -285,9 +288,56 @@ def _windowless_python(py: str, is_windows: bool, exists=os.path.exists) -> str:
     return py
 
 
+def _console_script() -> "str | None":
+    """Absolute path of the installed ``clawmetry`` console script, if any.
+
+    Preferred over ``python -m clawmetry`` because Claude Code spawns the
+    hook with the AGENT'S working directory, which ``-m`` puts first on
+    ``sys.path``: any project containing a ``clawmetry/`` folder shadows the
+    installed package, the subcommand is rejected, and the hook errors. Claude
+    Code treats that as a non-blocking error, so the call proceeds ungated —
+    the gate silently does nothing, which is exactly the failure mode this
+    module's logging rule exists to prevent. A console script sets
+    ``sys.path[0]`` to its own bin directory, so the working directory can
+    never shadow the package. (The same defect DENIED calls on Copilot, where
+    a hook error is a refusal; see clawmetry/runtime_gates.py.)
+
+    None when no script sits next to the running interpreter (pipx / unusual
+    layouts), in which case the caller falls back to ``-m``.
+    """
+    exe = sys.executable or ""
+    if not exe:
+        return None
+    name = "clawmetry.exe" if os.name == "nt" else "clawmetry"
+    cand = os.path.join(os.path.dirname(exe), name)
+    try:
+        if os.path.isfile(cand) and (os.name == "nt" or os.access(cand, os.X_OK)):
+            return cand
+    except Exception:  # noqa: BLE001
+        return None
+    return None
+
+
+def _launcher_prefix() -> str:
+    """Quoted launcher + any ``-m`` suffix, shared by both hook commands.
+
+    The path is quoted because ``sys.executable`` routinely contains a space
+    (``/Users/First Last/venv/bin/python``) and Claude Code shell-splits the
+    command."""
+    script = _console_script()
+    launcher = script or _windowless_python(
+        sys.executable or "python3", os.name == "nt")
+    if os.name == "nt":
+        import subprocess as _sp
+        quoted = _sp.list2cmdline([launcher])
+    else:
+        import shlex as _shlex
+        quoted = _shlex.quote(launcher)
+    return quoted if script else f"{quoted} -m clawmetry"
+
+
 def _hook_command(base: str) -> str:
-    py = _windowless_python(sys.executable or "python3", os.name == "nt")
-    return f"{py} -m clawmetry hook claude-code --base {base}"
+    return f"{_launcher_prefix()} hook claude-code --base {base}"
 
 
 def _ensure_marker() -> bool:
@@ -372,8 +422,7 @@ def _mirror_wanted() -> bool:
 
 
 def _mirror_command(base: str) -> str:
-    py = _windowless_python(sys.executable or "python3", os.name == "nt")
-    return f"{py} -m clawmetry hook claude-code-permission --base {base}"
+    return f"{_launcher_prefix()} hook claude-code-permission --base {base}"
 
 
 def mirror_timeout_s() -> int:

--- a/tests/test_runtime_gates_and_hooks.py
+++ b/tests/test_runtime_gates_and_hooks.py
@@ -1002,3 +1002,43 @@ def test_legacy_dash_m_entry_is_replaced_not_duplicated(rt_gates):
     entries = json.loads(path.read_text())["hooks"]["beforeShellExecution"]
     ours = [e for e in entries if rg._cursor_entry_is_ours(e)]
     assert len(ours) == 1, "legacy entry must be replaced, not stacked"
+
+
+def test_cc_gate_prefers_console_script_and_quotes_it(tmp_path, monkeypatch):
+    """Same cwd-shadowing defect as the Cursor/Copilot gates: Claude Code
+    spawns the hook with the agent's cwd, so `-m` lets a project containing a
+    `clawmetry/` folder shadow the package. There the hook errors non-blocking
+    rather than denying, so the gate silently does nothing."""
+    import shlex
+    import clawmetry.claude_code_gate as ccg
+    bindir = tmp_path / "My Env" / "bin"
+    bindir.mkdir(parents=True)
+    script = bindir / "clawmetry"
+    script.write_text("#!/bin/sh\n")
+    script.chmod(0o755)
+    monkeypatch.setattr(ccg.sys, "executable", str(bindir / "python3"))
+    cmd = ccg._hook_command("http://127.0.0.1:8900")
+    assert str(script) in cmd
+    assert " -m clawmetry" not in cmd
+    # the space in the path must survive shell-splitting
+    assert shlex.split(cmd)[0] == str(script)
+    mirror = ccg._mirror_command("http://127.0.0.1:8900")
+    assert shlex.split(mirror)[0] == str(script)
+    assert mirror.endswith("hook claude-code-permission --base http://127.0.0.1:8900")
+
+
+def test_cc_gate_markers_match_both_forms_and_stay_distinct(tmp_path):
+    """The mirror marker CONTAINS the gate marker, so the ordering trap must
+    still hold with form-agnostic markers."""
+    import clawmetry.claude_code_gate as ccg
+    legacy_gate = {"hooks": [{"command": "/usr/bin/python3 -m clawmetry hook claude-code --base x"}]}
+    modern_gate = {"hooks": [{"command": "/venv/bin/clawmetry hook claude-code --base x"}]}
+    legacy_mirror = {"hooks": [{"command": "/usr/bin/python3 -m clawmetry hook claude-code-permission --base x"}]}
+    modern_mirror = {"hooks": [{"command": "/venv/bin/clawmetry hook claude-code-permission --base x"}]}
+    assert ccg._entry_is_ours(legacy_gate) is True
+    assert ccg._entry_is_ours(modern_gate) is True
+    # a mirror entry must NEVER read as the pre-tool gate
+    assert ccg._entry_is_ours(legacy_mirror) is False
+    assert ccg._entry_is_ours(modern_mirror) is False
+    assert ccg._entry_is_mirror(legacy_mirror) is True
+    assert ccg._entry_is_mirror(modern_mirror) is True


### PR DESCRIPTION
Closes the gap #5035 deliberately left, which drift-bot then flagged on the release PR.

#5035 fixed the launcher for Cursor and Copilot because a hook that errors on Copilot is a **refusal** (it denied every tool call). Claude Code treats a hook error as *non-blocking*, so it was lower priority. But the defect is still real there: spawned with the agent's working directory, `python -m clawmetry` lets any project containing a `clawmetry/` folder shadow the installed package, the subcommand is rejected, and the hook errors. The call then proceeds **ungated** — a governance gate that silently does nothing, which is exactly the failure mode this module already logs to avoid.

- Both the pre-tool gate and the PermissionRequest mirror now share one launcher helper: the installed `clawmetry` console script when present (its `sys.path[0]` is its own bin directory, so cwd cannot shadow it), `-m` otherwise, with the path quoted so a space in `sys.executable` survives shell-splitting.
- Markers become form-agnostic so entries written by earlier releases are replaced rather than stacked.
- The documented ordering trap still holds: `MIRROR_CMD_MARKER` contains `HOOK_CMD_MARKER`, and `_entry_is_ours` skips mirror commands first. Tested in both directions for both launcher forms.

51 tests green in the gates/hooks suite (89 across gates + mirror + claude-code hooks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)