### PR TITLE
[RELEASE] Claude Code gate uses the shadow-proof launcher (carries #5038)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Unreleased
 
+- **Release: the Claude Code gate hook launches the same shadow-proof way. Carries #5038 to PyPI.**
+  - **Who this reaches:** anyone with a Claude Code approval rule whose project contains a folder named `clawmetry`. The gate was installed, but it could not run.
+  - **What was wrong:** the previous release fixed this launcher for Cursor and Copilot, where the consequence was severe enough to block the agent outright. Claude Code treats the same failure as a warning and carries on, so the tool call ran with nobody checking it. A rule that is shown as active and quietly does nothing is worse than one that is visibly off, which is why it is fixed here too.
+  - **What changed:** the hook and the approval mirror now both run through the installed `clawmetry` command, whose location determines what it imports. Entries written by earlier releases are recognised and replaced rather than left in place beside a new one.
+
 - **Release: the Cursor and Copilot gate hooks launch a way the working directory cannot break. Carries #5035 to PyPI.**
   - **Who this reaches:** anyone using the new pre-execution gates whose project happens to contain a folder named `clawmetry`. On GitHub Copilot that combination denied every tool call.
   - **What was wrong:** the runtimes start our hook with the agent's own working directory, and the previous launcher form let that directory take precedence when importing. A project with a folder of that name shadowed the installed package, the command was rejected, and the hook exited with an error. Copilot treats a hook that errors as a refusal, so the agent could not run anything.

--- a/dashboard.py
+++ b/dashboard.py
@@ -326,7 +326,7 @@ def _otlp_service_name_to_agent_type(service_name):
     return slug or "custom"
 
 
-__version__ = "0.12.745"
+__version__ = "0.12.747"
 
 # Extensions (Phase 2): import the plugin host now, but defer the actual
 # load_plugins() call until after the Flask app is created below so we can


### PR DESCRIPTION
Ships #5038, completing the launcher fix across all three gated runtimes.

0.12.746 fixed Cursor and Copilot, where a hook that errors is a **refusal** and the agent was blocked outright. Claude Code treats the same error as *non-blocking*, so there the tool call proceeded **ungated** — the rule is shown as active and quietly does nothing, which is the failure mode this module already logs to avoid.

Both the pre-tool gate and the PermissionRequest mirror now run through the installed `clawmetry` console script (import path fixed by install location, not by the agent's working directory), with form-agnostic markers so entries written by 0.12.744-0.12.746 are replaced rather than stacked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)