### PR TITLE
fix: surface model-router endpoint pool health

### DIFF
--- a/clawmetry/adapters/openclaw.py
+++ b/clawmetry/adapters/openclaw.py
@@ -1212,19 +1212,32 @@ def _discover_model_router_port() -> Optional[int]:
     return None
 
 
-def _model_router_health_ok(port: int) -> bool:
-    """True if the model-router ``/health`` endpoint answers 2xx on localhost.
+def _model_router_health_ok(port: int) -> tuple[bool, dict]:
+    """Return ``(running, health)`` for the model-router ``/health`` endpoint.
 
-    Falls back to a raw TCP connect (port accepting connections) when the HTTP
-    probe errors, so a wedged-but-listening router still reads as up. Short
-    timeouts keep detect() fast. Never raises.
+    ``running`` is based on the HTTP status or TCP fallback. ``health`` contains
+    optional healthy and unhealthy endpoint metadata when the JSON response
+    provides it. Never raises.
     """
     try:
         import urllib.request as _u
         req = _u.Request(f"http://127.0.0.1:{port}/health", method="GET")
         with _u.urlopen(req, timeout=0.3) as resp:  # nosec B310 - localhost only
             status = getattr(resp, "status", None) or resp.getcode()
-            return 200 <= int(status) < 300
+            running = 200 <= int(status) < 300
+            health: dict = {}
+            try:
+                body = json.loads(resp.read())
+                if isinstance(body, dict):
+                    healthy = body.get("healthy_endpoints")
+                    unhealthy = body.get("unhealthy_endpoints")
+                    if isinstance(healthy, list):
+                        health["modelRouterHealthyEndpoints"] = healthy
+                    if isinstance(unhealthy, list):
+                        health["modelRouterUnhealthyEndpoints"] = unhealthy
+            except (json.JSONDecodeError, TypeError, ValueError):
+                pass
+            return running, health
     except Exception:
         pass
     try:
@@ -1233,9 +1246,9 @@ def _model_router_health_ok(port: int) -> bool:
         s.settimeout(0.2)
         rc = s.connect_ex(("127.0.0.1", port))
         s.close()
-        return rc == 0
+        return rc == 0, {}
     except Exception:
-        return False
+        return False, {}
 
 
 def _model_router_launch_log(tail_lines: int = 50) -> Optional[str]:
@@ -1300,8 +1313,9 @@ def _model_router_live() -> dict:
         if log is not None:
             result["modelRouterLaunchLog"] = log
         return result
-    running = _model_router_health_ok(port)
+    running, health = _model_router_health_ok(port)
     result = {"modelRouterPort": port, "modelRouterRunning": running}
+    result.update(health)
     if not running:
         log = _model_router_launch_log()
         if log is not None:

--- a/tests/test_obs_gap_talk_sandbox.py
+++ b/tests/test_obs_gap_talk_sandbox.py
@@ -165,7 +165,11 @@ def test_model_router_port_supports_equals_form(monkeypatch):
 def test_model_router_live_running_when_health_ok(monkeypatch):
     import clawmetry.adapters.openclaw as oc
     monkeypatch.setattr(oc, "_discover_model_router_port", lambda: 49000)
-    monkeypatch.setattr(oc, "_model_router_health_ok", lambda port: True)
+    monkeypatch.setattr(
+        oc,
+        "_model_router_health_ok",
+        lambda port: (True, {}),
+    )
     out = oc._model_router_live()
     assert out == {"modelRouterPort": 49000, "modelRouterRunning": True}
 
@@ -175,7 +179,11 @@ def test_model_router_live_crashed_router_is_distinguishable(monkeypatch):
     # crashed/wedged router reads as NOT running, the whole point of #2795.
     import clawmetry.adapters.openclaw as oc
     monkeypatch.setattr(oc, "_discover_model_router_port", lambda: 49001)
-    monkeypatch.setattr(oc, "_model_router_health_ok", lambda port: False)
+    monkeypatch.setattr(
+        oc,
+        "_model_router_health_ok",
+        lambda port: (False, {}),
+    )
     out = oc._model_router_live()
     assert out == {"modelRouterPort": 49001, "modelRouterRunning": False}
 
@@ -233,7 +241,11 @@ def test_model_router_live_running_omits_launch_log(tmp_path, monkeypatch):
     monkeypatch.setenv("NEMOCLAW_MODEL_ROUTER_LOG", str(log_file))
     import clawmetry.adapters.openclaw as oc
     monkeypatch.setattr(oc, "_discover_model_router_port", lambda: 49000)
-    monkeypatch.setattr(oc, "_model_router_health_ok", lambda port: True)
+    monkeypatch.setattr(
+        oc,
+        "_model_router_health_ok",
+        lambda port: (True, {}),
+    )
     out = oc._model_router_live()
     assert out == {"modelRouterPort": 49000, "modelRouterRunning": True}
     assert "modelRouterLaunchLog" not in out
@@ -260,7 +272,9 @@ def test_model_router_health_ok_probes_real_localhost_server():
     t = threading.Thread(target=srv.serve_forever, daemon=True)
     t.start()
     try:
-        assert _model_router_health_ok(port) is True
+        running, health = _model_router_health_ok(port)
+        assert running is True
+        assert health == {}
     finally:
         srv.shutdown()
 
@@ -268,7 +282,9 @@ def test_model_router_health_ok_probes_real_localhost_server():
 def test_model_router_health_ok_false_when_nothing_listening():
     from clawmetry.adapters.openclaw import _model_router_health_ok
     # Port 0 is never a live listener; probe must fail closed, not raise.
-    assert _model_router_health_ok(0) is False
+    running, health = _model_router_health_ok(0)
+    assert running is False
+    assert health == {}
 
 
 # -- #2960 model-router proxy-config model_list -----------------------------


### PR DESCRIPTION
## What This PR Does

Fixes `clawmetry#5048`.

### Changes

- Updated `clawmetry/adapters/openclaw.py`:
  - `_model_router_health_ok()` now parses the model-router `/health` JSON body.
  - Extracts `healthy_endpoints` and `unhealthy_endpoints`.
  - Preserves the existing liveness and TCP fallback behavior.
  - `_model_router_live()` merges the parsed endpoint health into detection metadata.

- Updated `tests/test_obs_gap_talk_sandbox.py`:
  - Adjusted existing model-router mocks and assertions for the new `(running, health)` return value.

## Testing

- [x] Focused model-router tests:
  `.venv/bin/pytest -q tests/test_obs_gap_talk_sandbox.py -k model_router`
  - Result: `16 passed, 27 deselected`
- [x] Python syntax validation:
  `python3 -m py_compile clawmetry/adapters/openclaw.py`
- [x] `git diff --check`
- [ ] Tested auto-detection with a real OpenClaw installation
- [ ] Tested console entry point
- [ ] Tested UI tabs
- [ ] Tested with real OpenClaw logs

The full test file has one unrelated existing failure in
`test_parse_proxy_config_model_list_litellm_format`, which concers the
proxy-config YAML parser and is outside this PR's scope.
## Screenshots

Not applicable: this PR changes backend detection metadata and tests only.