### PR TITLE
Assert register and heartbeat agree on the plan, not that register says "free"

### DIFF
--- a/tests/e2e/cloud-contract.mjs
+++ b/tests/e2e/cloud-contract.mjs
@@ -217,10 +217,29 @@ async function testNormalUser() {
     // intentionally no `source` field
   });
   check('register: api_key shape', /^cm_[a-f0-9]{32}$/.test(reg.api_key));
-  check('register: plan=free', reg.plan === 'free');
 
   const hb = await heartbeat(reg, machineId);
   console.log(`  hb response: ${JSON.stringify(hb)}`);
+  // Registration must report the plan the account actually holds.
+  //
+  // This used to assert `plan === 'free'`, which pinned a hardcoded string
+  // in the response rather than a fact about the account: registration
+  // creates the row on a trial, and the heartbeat two lines down has always
+  // said so. A returning operator whose address already has a paid account
+  // got the same 'free', which is one of the ways a paid install renders as
+  // an unpaid one after a reinstall.
+  //
+  // Comparing the two answers is the contract worth holding: whatever the
+  // plan is, the two endpoints must not disagree about it. That catches the
+  // hardcoded lie in either direction without pinning today's default.
+  check(
+    'register: plan is a real value, not a placeholder',
+    typeof reg.plan === 'string' && reg.plan.length > 0
+  );
+  check(
+    `register + heartbeat agree on the plan (register=${reg.plan}, heartbeat=${hb.plan})`,
+    reg.plan === hb.plan
+  );
   check(
     'normal user heartbeat: sync_allowed is NOT false (deferred-sync gate must not catch standard users)',
     hb.sync_allowed !== false


### PR DESCRIPTION
The cloud-contract spec asserted `reg.plan === 'free'` on a fresh registration. That was never a fact about the account: registration creates the row on a **trial**, and the heartbeat printed two lines later in the same scenario has always answered `"plan":"trial"`. The check pinned a hardcoded string.

It held it hard enough to block a real fix. [clawmetry-cloud #2073](https://github.com/vivekchand/clawmetry-cloud/pull/2073) made `/api/register` report the plan the account actually holds — the hardcoded `'free'` also went out to a **returning** operator whose address already had a paid account, which is one of the ways a paid install renders as an unpaid one after a reinstall. The deploy gate then failed on `register: plan=free` and correctly left traffic on the previous revision.

## The change

Move the plan assertion below the heartbeat and compare the two answers:

```js
check('register: plan is a real value, not a placeholder',
      typeof reg.plan === 'string' && reg.plan.length > 0);
check(`register + heartbeat agree on the plan (register=${reg.plan}, heartbeat=${hb.plan})`,
      reg.plan === hb.plan);
```

Whatever the plan is, these two endpoints must not disagree about it. That catches a hardcoded response in either direction without pinning today's default — and it would have caught the original lie.

Nothing consumes the field: the only caller of the cloud `/api/register` is `clawmetry/cli.py:_instant_register`, which reads `api_key`, `dashboard_url`, `dashboard_id` and `node_id` and never touches `plan`.

Unblocks the cloud deploy of #2073, which is already merged to `clawmetry-cloud` main and waiting at the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vm2FrDJM7GUiiC4eeCeyz9
