### PR TITLE
feat(openclaw): surface gatewayLogLevel from openclaw.json (#5060)

### DIFF
--- a/clawmetry/adapters/openclaw.py
+++ b/clawmetry/adapters/openclaw.py
@@ -517,6 +517,35 @@ def _read_logging_file_config() -> str:
         return ""
 
 
+def _read_logging_level_config() -> str:
+    """Read ``logging.level`` from openclaw.json and return the level string.
+
+    openclaw.json can set a minimum severity for the file transport via
+    ``{"logging": {"level": "warn"}}``.  Returns the level string (lower-cased)
+    when present, empty string otherwise.  Never raises (#5060).
+    """
+    try:
+        home = os.environ.get("OPENCLAW_HOME") or os.path.expanduser("~/.openclaw")
+        cfg_path = os.path.join(home, "openclaw.json")
+        if not os.path.isfile(cfg_path):
+            alt = os.path.expanduser("~/.clawdbot/openclaw.json")
+            if os.path.isfile(alt):
+                cfg_path = alt
+            else:
+                return ""
+        with open(cfg_path) as _fh:
+            cfg = json.load(_fh)
+        if not isinstance(cfg, dict):
+            return ""
+        logging_cfg = cfg.get("logging")
+        if not isinstance(logging_cfg, dict):
+            return ""
+        level = logging_cfg.get("level")
+        return str(level).lower() if level else ""
+    except Exception:
+        return ""
+
+
 def _gateway_log_files() -> list:
     """Return the newest-5 rotating gateway log files across known candidate dirs.
 
@@ -586,6 +615,9 @@ def _gateway_log_meta() -> dict:
             )
         except OSError:
             pass
+        level = _read_logging_level_config()
+        if level:
+            result["gatewayLogLevel"] = level
         return result
     except Exception:
         return {}

--- a/tests/test_obs_gap_logging_level_5060.py
+++ b/tests/test_obs_gap_logging_level_5060.py
@@ -1,0 +1,85 @@
+"""Tests for #5060: _gateway_log_meta() surfaces logging.level from openclaw.json.
+
+Covers:
+- _read_logging_level_config() returns lower-cased level string when present.
+- _read_logging_level_config() returns empty string when key is absent.
+- _read_logging_level_config() returns empty string on missing / malformed config.
+- _gateway_log_meta() propagates gatewayLogLevel when level is configured.
+- _gateway_log_meta() omits gatewayLogLevel when level is not configured.
+"""
+import glob as _glob
+import json
+import os
+
+import pytest
+
+from clawmetry.adapters.openclaw import (
+    _gateway_log_meta,
+    _read_logging_level_config,
+)
+
+
+def _write_config(tmp_path, cfg: dict):
+    cfg_path = tmp_path / "openclaw.json"
+    cfg_path.write_text(json.dumps(cfg))
+    return cfg_path
+
+
+class TestReadLoggingLevelConfig:
+    def test_returns_level_lower_cased(self, tmp_path, monkeypatch):
+        _write_config(tmp_path, {"logging": {"level": "WARN"}})
+        monkeypatch.setenv("OPENCLAW_HOME", str(tmp_path))
+        assert _read_logging_level_config() == "warn"
+
+    def test_returns_empty_when_level_absent(self, tmp_path, monkeypatch):
+        _write_config(tmp_path, {"logging": {"file": "/tmp/openclaw.log"}})
+        monkeypatch.setenv("OPENCLAW_HOME", str(tmp_path))
+        assert _read_logging_level_config() == ""
+
+    def test_returns_empty_when_logging_key_absent(self, tmp_path, monkeypatch):
+        _write_config(tmp_path, {"other": "key"})
+        monkeypatch.setenv("OPENCLAW_HOME", str(tmp_path))
+        assert _read_logging_level_config() == ""
+
+    def test_returns_empty_when_config_missing(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("OPENCLAW_HOME", str(tmp_path))
+        assert _read_logging_level_config() == ""
+
+    def test_returns_empty_on_malformed_json(self, tmp_path, monkeypatch):
+        (tmp_path / "openclaw.json").write_text("{not valid json")
+        monkeypatch.setenv("OPENCLAW_HOME", str(tmp_path))
+        assert _read_logging_level_config() == ""
+
+    def test_info_level(self, tmp_path, monkeypatch):
+        _write_config(tmp_path, {"logging": {"level": "info"}})
+        monkeypatch.setenv("OPENCLAW_HOME", str(tmp_path))
+        assert _read_logging_level_config() == "info"
+
+
+class TestGatewayLogMetaLevel:
+    def _make_log_file(self, tmp_path):
+        log_dir = tmp_path / "logs"
+        log_dir.mkdir()
+        log_file = log_dir / "openclaw-2026-08-22.log"
+        log_file.write_text('{"level":"info","msg":"hello"}\n')
+        return log_dir
+
+    def test_gateway_log_meta_includes_level_when_configured(
+        self, tmp_path, monkeypatch
+    ):
+        self._make_log_file(tmp_path)
+        _write_config(tmp_path, {"logging": {"level": "warn"}})
+        monkeypatch.setenv("OPENCLAW_HOME", str(tmp_path))
+        monkeypatch.setenv("CLAWMETRY_OPENCLAW_DIR", str(tmp_path))
+        result = _gateway_log_meta()
+        assert result.get("gatewayLogLevel") == "warn"
+
+    def test_gateway_log_meta_omits_level_when_not_configured(
+        self, tmp_path, monkeypatch
+    ):
+        self._make_log_file(tmp_path)
+        _write_config(tmp_path, {"logging": {"file": str(tmp_path / "openclaw.log")}})
+        monkeypatch.setenv("OPENCLAW_HOME", str(tmp_path))
+        monkeypatch.setenv("CLAWMETRY_OPENCLAW_DIR", str(tmp_path))
+        result = _gateway_log_meta()
+        assert "gatewayLogLevel" not in result


### PR DESCRIPTION
## Summary

Operators couldn't tell from the ClawMetry dashboard why lower-severity events were absent from the tailed gateway log. The `_gateway_log_meta()` function already surfaced log dir, archive count, and current file size — but silently omitted the configured minimum file-log level from `openclaw.json`.

This adds `gatewayLogLevel` to the metadata dict when `logging.level` is set in `openclaw.json`.

## Changes

- **`clawmetry/adapters/openclaw.py`**: Add `_read_logging_level_config()` helper (mirrors the existing `_read_logging_file_config()` pattern — same OPENCLAW_HOME fallback, `~/.clawdbot` alt path, graceful empty-string return, never raises). Call it in `_gateway_log_meta()` and propagate the result as `gatewayLogLevel` when non-empty.
- **`tests/test_obs_gap_logging_level_5060.py`**: 8 tests covering `_read_logging_level_config()` (present/absent/malformed config, case normalisation) and `_gateway_log_meta()` level propagation (included when configured, omitted when not).

## Test plan

- [ ] `python3 -m pytest tests/test_obs_gap_logging_level_5060.py -q` — all 8 pass (verified locally)
- [ ] `python3 -c 'import ast; ast.parse(open("clawmetry/adapters/openclaw.py").read())'` — syntax OK (verified)
- [ ] Smoke: set `{"logging": {"level": "warn"}}` in `openclaw.json`, restart ClawMetry, confirm `gatewayLogLevel: "warn"` appears in the detect/health JSON response

## Bot meta

<!-- bot-autofix -->
Draft PR opened autonomously based on the plan in #5060. Marked draft for human review — mark Ready for Review once happy.

Closes #5060

---
_Generated by [Claude Code](https://claude.ai/code/session_01EPrBovMxVp7HuSd1Xw1Qtr)_