### PR TITLE
Add Cursor and Copilot CLI posture providers, with a grading rule for closed-source runtimes

### DIFF
--- a/clawmetry/security_posture.py
+++ b/clawmetry/security_posture.py
@@ -1159,8 +1159,470 @@ def codex_posture() -> dict:
     return _score_envelope(checks, runtime="codex", config_path=config_path)
 
 
+# ═══════════════════════════════════════════════════════════════════════════
+# Cursor provider.
+#
+# GRADING DISCIPLINE (read before adding a check here): Cursor is CLOSED
+# SOURCE. We cannot read the code that consumes any of its settings, so a
+# setting's presence never proves the behaviour is enforced. Checks split
+# into two grades:
+#
+#   FAIL-grade  — a filesystem FACT, where "is it honored?" does not arise:
+#                 a file exists or not, a mode bit, a literal byte in a file.
+#   WARN-grade  — documented or observed-on-disk only. Never fail these.
+#
+# A posture check that fails on a clean install is worse than no check at
+# all: it teaches the operator to ignore the grade. (Near miss, 2026-08-18:
+# a proposed Cline check keyed on ``executeAllCommands``, a field the code
+# never reads, which would have failed every clean install.)
+# ═══════════════════════════════════════════════════════════════════════════
+
+# Unicode tag block + zero-width/bidi characters. Tag chars (U+E0000-U+E007F)
+# are invisible in every editor and are the standard carrier for instructions
+# smuggled into an agent rules file.
+_INVISIBLE_RANGES = (
+    (0xE0000, 0xE007F),  # Unicode tag characters
+    (0x200B, 0x200F),    # zero-width space/non-joiner/joiner, LRM/RLM
+    (0x202A, 0x202E),    # bidi embedding/override
+    (0x2060, 0x2064),    # word joiner, invisible operators
+)
+
+_SECRET_KEY_HINT = re.compile(
+    r"(token|api[_-]?key|secret|password|passwd|credential|authorization|bearer)",
+    re.I,
+)
+
+
+def _cursor_home() -> str:
+    return os.environ.get("CURSOR_HOME") or os.path.expanduser("~/.cursor")
+
+
+def _read_json(path: str):
+    try:
+        with open(path, encoding="utf-8") as fh:
+            text = fh.read()
+    except OSError:
+        return None
+    # Cursor writes JSONC (the CLI's own config.json ships with // comments).
+    lines = [ln for ln in text.splitlines() if not ln.lstrip().startswith("//")]
+    try:
+        return json.loads("\n".join(lines))
+    except (ValueError, TypeError):
+        return None
+
+
+def _invisible_hits(text: str) -> int:
+    n = 0
+    for ch in text:
+        cp = ord(ch)
+        for lo, hi in _INVISIBLE_RANGES:
+            if lo <= cp <= hi:
+                n += 1
+                break
+    return n
+
+
+def _looks_like_literal_secret(value) -> bool:
+    """True when a config value carries a secret inline rather than by
+    reference. ``$FOO``/``${FOO}``/``env:FOO`` are references, not secrets."""
+    if not isinstance(value, str) or len(value.strip()) < 8:
+        return False
+    v = value.strip()
+    if v.startswith("$") or v.startswith("env:") or v.startswith("${"):
+        return False
+    return True
+
+
+def cursor_posture() -> dict:
+    """Security posture for Cursor.
+
+    Leans on filesystem facts (hook wiring, secrets written literally into
+    MCP config, invisible Unicode in rules files) because those hold true
+    whatever the closed-source client does with its settings.
+    """
+    home = _cursor_home()
+    cli_cfg = _read_json(os.path.join(home, "cli-config.json"))
+    hooks = _read_json(os.path.join(home, "hooks.json"))
+    mcp = _read_json(os.path.join(home, "mcp.json"))
+    sandbox = _read_json(os.path.join(home, "sandbox.json"))
+
+    found = [
+        name for name, data in (
+            ("cli-config.json", cli_cfg), ("hooks.json", hooks),
+            ("mcp.json", mcp), ("sandbox.json", sandbox),
+        ) if data is not None
+    ]
+    if not os.path.isdir(home):
+        return _not_available("cursor")
+
+    checks: list[dict] = []
+    checks.append(_check(
+        "config_found", "Configuration",
+        "pass" if found else "warn",
+        "Read {} from {}".format(", ".join(found), home) if found
+        else "Cursor directory exists at {} but no readable config files.".format(home),
+        None if found else "Run Cursor once so it writes its configuration.",
+        "low", 20,
+    ))
+
+    # (a) Hook wiring. FAIL-grade: the file either declares a pre-execution
+    # hook or it does not. Nothing about enforcement is assumed.
+    hook_map = (hooks or {}).get("hooks") if isinstance(hooks, dict) else None
+    hook_names = sorted(hook_map) if isinstance(hook_map, dict) else []
+    pre_exec = [h for h in hook_names if h in ("beforeShellExecution", "beforeMCPExecution")]
+    if pre_exec:
+        checks.append(_check(
+            "pre_exec_hooks", "Pre-execution hooks", "pass",
+            "Hooks inspect actions before they run: {}.".format(", ".join(pre_exec)),
+            None, "medium", 15,
+        ))
+    else:
+        checks.append(_check(
+            "pre_exec_hooks", "Pre-execution hooks", "warn",
+            "No beforeShellExecution or beforeMCPExecution hook, so nothing "
+            "inspects a shell command or MCP call before it runs."
+            + ("" if hooks is None else " (hooks.json is present but declares none.)"),
+            "Add a beforeShellExecution hook, or run `clawmetry secure enable` "
+            "to install monitor-only agent-EDR hooks.",
+            "medium", 15,
+        ))
+
+    # (b) Secrets written literally into MCP server config. FAIL-grade: the
+    # bytes are either in the file or they are not.
+    literal_secrets = []
+    servers = (mcp or {}).get("mcpServers") if isinstance(mcp, dict) else None
+    if isinstance(servers, dict):
+        for sname, sconf in servers.items():
+            if not isinstance(sconf, dict):
+                continue
+            for block in ("env", "headers"):
+                blk = sconf.get(block)
+                if not isinstance(blk, dict):
+                    continue
+                for k, v in blk.items():
+                    if _SECRET_KEY_HINT.search(str(k)) and _looks_like_literal_secret(v):
+                        literal_secrets.append("{}.{}.{}".format(sname, block, k))
+    if literal_secrets:
+        checks.append(_check(
+            "mcp_secrets_inline", "Secrets in MCP config", "fail",
+            "Credential values are written directly into mcp.json: {}.".format(
+                ", ".join(literal_secrets[:5])),
+            "Replace the literal values with environment references such as "
+            "\"$MY_TOKEN\" so the secret is not stored in a config file.",
+            "critical", 20,
+        ))
+    else:
+        checks.append(_check(
+            "mcp_secrets_inline", "Secrets in MCP config", "pass",
+            "No credential values written directly into mcp.json."
+            if servers else "No MCP servers configured.",
+            None, "critical", 20,
+        ))
+
+    # (c) Invisible Unicode in rules files. FAIL-grade byte-level fact. One
+    # occurrence is enough: these characters have no legitimate use in a
+    # human-authored rules file.
+    rule_files = []
+    rules_dir = os.path.join(home, "rules")
+    if os.path.isdir(rules_dir):
+        try:
+            rule_files += [
+                os.path.join(rules_dir, f) for f in sorted(os.listdir(rules_dir))
+                if f.endswith((".mdc", ".md"))
+            ]
+        except OSError:
+            pass
+    legacy = os.path.expanduser("~/.cursorrules")
+    if os.path.isfile(legacy):
+        rule_files.append(legacy)
+    tainted = []
+    for rf in rule_files[:200]:
+        try:
+            with open(rf, encoding="utf-8", errors="replace") as fh:
+                hits = _invisible_hits(fh.read())
+        except OSError:
+            continue
+        if hits:
+            tainted.append("{} ({} char{})".format(
+                os.path.basename(rf), hits, "" if hits == 1 else "s"))
+    if tainted:
+        checks.append(_check(
+            "rules_invisible_unicode", "Hidden text in rules", "fail",
+            "Invisible characters found in {}. Text you cannot see in an "
+            "editor is instructing the agent.".format(", ".join(tainted[:5])),
+            "Open the file, strip the invisible characters, and confirm the "
+            "visible text is all the agent is being told.",
+            "critical", 20,
+        ))
+    else:
+        checks.append(_check(
+            "rules_invisible_unicode", "Hidden text in rules", "pass",
+            "No invisible characters in {} rules file(s).".format(len(rule_files))
+            if rule_files else "No rules files found.",
+            None, "critical", 20,
+        ))
+
+    # (d) CLI permission grants.
+    perms = (cli_cfg or {}).get("permissions") if isinstance(cli_cfg, dict) else None
+    allow = [str(r) for r in (perms or {}).get("allow", []) if isinstance(perms, dict)]
+    deny = [str(r) for r in (perms or {}).get("deny", []) if isinstance(perms, dict)]
+    wild = sorted({r for r in allow if r.strip().lower() in _CC_DANGEROUS_ALLOW
+                   or r.strip() in ("Shell(*)", "*")})
+    if wild:
+        checks.append(_check(
+            "cli_wildcard_allow", "Blanket command grants", "warn",
+            "Unrestricted grant(s) in cli-config.json: {}.".format(", ".join(wild)),
+            "Replace blanket grants with scoped rules, e.g. \"Shell(git status)\".",
+            "high", 15,
+        ))
+    elif not deny:
+        checks.append(_check(
+            "cli_wildcard_allow", "Blanket command grants", "warn",
+            "{} allow rule(s) and no deny rules in cli-config.json.".format(len(allow)),
+            "Add deny rules for sensitive paths and destructive commands.",
+            "high", 15,
+        ))
+    else:
+        checks.append(_check(
+            "cli_wildcard_allow", "Blanket command grants", "pass",
+            "{} allow rule(s), {} deny rule(s), no blanket grants.".format(
+                len(allow), len(deny)),
+            None, "high", 15,
+        ))
+
+    # (e) Sandbox. WARN-grade: documented, but we cannot confirm the closed
+    # client applies it, so this never fails.
+    stype = (sandbox or {}).get("type") if isinstance(sandbox, dict) else None
+    if stype == "insecure_none":
+        checks.append(_check(
+            "sandbox_mode", "Sandbox", "warn",
+            "sandbox.json sets type \"insecure_none\", which the documentation "
+            "describes as no sandbox at all.",
+            "Choose a sandbox type other than \"insecure_none\".",
+            "high", 10,
+        ))
+    elif stype:
+        checks.append(_check(
+            "sandbox_mode", "Sandbox", "pass",
+            "sandbox.json sets type \"{}\".".format(stype), None, "high", 10,
+        ))
+    else:
+        checks.append(_check(
+            "sandbox_mode", "Sandbox", "warn",
+            "No sandbox.json, so the sandbox is whatever Cursor defaults to. "
+            "An unset value is unmeasured, not proven safe.",
+            "Write a sandbox.json with an explicit type so the setting is "
+            "pinned rather than inherited.",
+            "high", 10,
+        ))
+
+    # (f) Honest unknown, weight 0. Cursor's auto-run / Run Mode level has no
+    # documented on-disk key: a dump of state.vscdb turned up telemetry flags
+    # only. Saying so beats inventing a key, and weight 0 keeps an unmeasured
+    # thing out of the grade entirely.
+    checks.append(_check(
+        "auto_run_level", "Auto-run level", "pass",
+        "Cursor does not record its auto-run (Run Mode) level anywhere "
+        "ClawMetry can read, so this cannot be verified from disk. Check it "
+        "in Cursor's own settings.",
+        None, "low", 0,
+    ))
+
+    return _score_envelope(checks, runtime="cursor", config_path=home)
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# GitHub Copilot CLI provider.
+#
+# Same grading discipline as the Cursor provider above: the CLI ships as a
+# closed bundled package, so a grant's presence in the file is a fact but its
+# enforcement is not observable. Blanket grants therefore WARN; only the
+# indefensible cases (trusting "/" or the whole home directory, an
+# allow-everything switch wired into a shell profile) FAIL.
+# ═══════════════════════════════════════════════════════════════════════════
+
+_COPILOT_ALLOW_ALL_RE = re.compile(
+    r"(COPILOT_ALLOW_ALL\s*=\s*[\"']?(1|true|yes)|copilot\b[^\n|;]*--(yolo|allow-all))",
+    re.I,
+)
+
+
+def _copilot_home() -> str:
+    return os.environ.get("COPILOT_HOME") or os.path.expanduser("~/.copilot")
+
+
+def copilot_posture() -> dict:
+    """Security posture for GitHub Copilot CLI."""
+    home = _copilot_home()
+    if not os.path.isdir(home):
+        return _not_available("copilot")
+
+    perms = _read_json(os.path.join(home, "permissions-config.json"))
+    cfg = _read_json(os.path.join(home, "config.json"))
+    settings = _read_json(os.path.join(home, "settings.json"))
+    found = [n for n, d in (("permissions-config.json", perms),
+                            ("config.json", cfg),
+                            ("settings.json", settings)) if d is not None]
+
+    checks: list[dict] = []
+    checks.append(_check(
+        "config_found", "Configuration",
+        "pass" if found else "warn",
+        "Read {} from {}".format(", ".join(found), home) if found
+        else "Copilot directory exists at {} but no readable config.".format(home),
+        None if found else "Run Copilot CLI once so it writes its configuration.",
+        "low", 20,
+    ))
+
+    home_dir = os.path.expanduser("~")
+    locations = (perms or {}).get("locations") if isinstance(perms, dict) else None
+    blanket_write = []
+    indefensible = []
+    relative_grants = []
+    if isinstance(locations, dict):
+        for loc, conf in locations.items():
+            approvals = (conf or {}).get("tool_approvals") if isinstance(conf, dict) else None
+            if not isinstance(approvals, list):
+                continue
+            for ap in approvals:
+                if not isinstance(ap, dict):
+                    continue
+                if ap.get("kind") == "write" and not ap.get("paths"):
+                    # A write grant with no path restriction: every file under
+                    # this location, for every future session.
+                    if str(loc).rstrip("/") in ("", home_dir):
+                        indefensible.append(str(loc))
+                    else:
+                        blanket_write.append(str(loc))
+                for pth in (ap.get("paths") or []):
+                    if isinstance(pth, str) and not pth.startswith("/"):
+                        relative_grants.append("{} -> {}".format(loc, pth))
+
+    if indefensible:
+        checks.append(_check(
+            "blanket_write_grant", "Standing write access", "fail",
+            "An unrestricted write grant covers {}, which is the whole home "
+            "directory or the filesystem root.".format(", ".join(indefensible[:3])),
+            "Revoke the grant and re-approve writes for a specific project "
+            "directory instead.",
+            "critical", 25,
+        ))
+    elif blanket_write:
+        checks.append(_check(
+            "blanket_write_grant", "Standing write access", "warn",
+            "A standing write grant with no path restriction covers {}. Every "
+            "future session can write anywhere under it without asking.".format(
+                ", ".join(blanket_write[:3])),
+            "Remove the {\"kind\": \"write\"} entry so writes are approved per "
+            "file, or scope it with an explicit paths list.",
+            "high", 25,
+        ))
+    else:
+        checks.append(_check(
+            "blanket_write_grant", "Standing write access", "pass",
+            "No unrestricted standing write grants."
+            if locations else "No stored tool approvals.",
+            None, "high", 25,
+        ))
+
+    # Documented footgun: a relative path matches by trailing components, so
+    # a grant for ".env" matches a file named .env in ANY directory.
+    if relative_grants:
+        checks.append(_check(
+            "relative_path_grants", "Relative path grants", "warn",
+            "Grant(s) use a relative path: {}. A relative path matches by "
+            "trailing components, so it applies to a file of that name in any "
+            "directory.".format(", ".join(relative_grants[:3])),
+            "Re-approve using absolute paths.",
+            "medium", 10,
+        ))
+    else:
+        checks.append(_check(
+            "relative_path_grants", "Relative path grants", "pass",
+            "No relative-path grants.", None, "medium", 10,
+        ))
+
+    trusted = (cfg or {}).get("trustedFolders") if isinstance(cfg, dict) else None
+    trusted = [str(t) for t in trusted] if isinstance(trusted, list) else []
+    broad = [t for t in trusted if t.rstrip("/") in ("", home_dir)]
+    if broad:
+        checks.append(_check(
+            "trusted_folders", "Trusted folders", "fail",
+            "Trusted folders include {}, which trusts everything below it.".format(
+                ", ".join(broad)),
+            "Trust individual project directories instead of the home "
+            "directory or the filesystem root.",
+            "critical", 20,
+        ))
+    elif trusted:
+        checks.append(_check(
+            "trusted_folders", "Trusted folders", "pass",
+            "{} project folder(s) trusted, none of them broad.".format(len(trusted)),
+            None, "high", 20,
+        ))
+    else:
+        checks.append(_check(
+            "trusted_folders", "Trusted folders", "pass",
+            "No folders trusted yet.", None, "high", 20,
+        ))
+
+    # Sandbox. WARN-grade: documented as shipping disabled, enforcement not
+    # observable. Copilot's own help text: shell commands run directly on your
+    # machine with the same access your user account has.
+    sbox = (settings or {}).get("sandbox") if isinstance(settings, dict) else None
+    enabled = (sbox or {}).get("enabled") if isinstance(sbox, dict) else None
+    if enabled is True:
+        checks.append(_check(
+            "sandbox_enabled", "Sandbox", "pass",
+            "Sandbox is enabled in settings.json.", None, "high", 15,
+        ))
+    else:
+        checks.append(_check(
+            "sandbox_enabled", "Sandbox", "warn",
+            "Sandbox is not enabled, so shell commands run directly on this "
+            "machine with your user account's access.",
+            "Set sandbox.enabled to true in Copilot's settings.json.",
+            "high", 15,
+        ))
+
+    # Allow-everything switch wired into a shell profile. FAIL-grade: this is
+    # text in a file, not a behaviour we have to trust the client about.
+    rc_hits = []
+    for rc in ("~/.zshrc", "~/.bashrc", "~/.bash_profile", "~/.zprofile", "~/.profile"):
+        path = os.path.expanduser(rc)
+        try:
+            with open(path, encoding="utf-8", errors="replace") as fh:
+                for line in fh:
+                    if line.lstrip().startswith("#"):
+                        continue
+                    if _COPILOT_ALLOW_ALL_RE.search(line):
+                        rc_hits.append(rc)
+                        break
+        except OSError:
+            continue
+    if rc_hits:
+        checks.append(_check(
+            "allow_all_switch", "Approval bypass in shell profile", "fail",
+            "An allow-everything switch is set in {}, so approvals are "
+            "bypassed for every session started from that shell.".format(
+                ", ".join(rc_hits)),
+            "Remove the setting and approve actions per session instead.",
+            "critical", 10,
+        ))
+    else:
+        checks.append(_check(
+            "allow_all_switch", "Approval bypass in shell profile", "pass",
+            "No allow-everything switch in your shell profiles.",
+            None, "critical", 10,
+        ))
+
+    return _score_envelope(checks, runtime="copilot", config_path=home)
+
+
 # ── built-in provider registration ─────────────────────────────────────────
 
 register_posture_provider("openclaw", openclaw_posture)
 register_posture_provider("claude_code", claude_code_posture)
 register_posture_provider("codex", codex_posture)
+register_posture_provider("cursor", cursor_posture)
+register_posture_provider("copilot", copilot_posture)

--- a/tests/test_security_posture_registry.py
+++ b/tests/test_security_posture_registry.py
@@ -333,3 +333,164 @@ def test_route_default_runtime_is_openclaw(client, fake_home, monkeypatch):
     assert r.status_code == 200
     d = r.get_json()
     assert d["runtime"] == "openclaw"
+
+
+# ── cursor + copilot providers ─────────────────────────────────────────────
+# Both runtimes are CLOSED SOURCE, so no check here may FAIL on the strength
+# of a documented setting alone: only filesystem facts earn a fail. The
+# governing near-miss (2026-08-18): a proposed Cline check keyed on
+# `executeAllCommands`, a field that runtime's code never reads, would have
+# failed every clean install. A check that fails on a healthy machine teaches
+# the operator to ignore the grade, which is worse than shipping no check.
+
+
+def _cursor_home(tmp_path, monkeypatch):
+    home = tmp_path / "cursor"
+    home.mkdir()
+    monkeypatch.setenv("CURSOR_HOME", str(home))
+    return home
+
+
+def _copilot_home(tmp_path, monkeypatch):
+    home = tmp_path / "copilot"
+    home.mkdir()
+    monkeypatch.setenv("COPILOT_HOME", str(home))
+    return home
+
+
+def test_cursor_absent_is_not_available(tmp_path, monkeypatch):
+    monkeypatch.setenv("CURSOR_HOME", str(tmp_path / "nope"))
+    assert sp.get_posture("cursor")["status"] == "not_available"
+
+
+def test_copilot_absent_is_not_available(tmp_path, monkeypatch):
+    monkeypatch.setenv("COPILOT_HOME", str(tmp_path / "nope"))
+    assert sp.get_posture("copilot")["status"] == "not_available"
+
+
+def test_clean_install_never_fails(tmp_path, monkeypatch):
+    """THE rule for both providers: a bare, untouched install produces zero
+    failures. Warnings are fine; a red X on a clean machine is not."""
+    _cursor_home(tmp_path, monkeypatch)
+    _copilot_home(tmp_path, monkeypatch)
+    for rt in ("cursor", "copilot"):
+        d = sp.get_posture(rt)
+        assert d["status"] == "ok", (rt, d)
+        assert d["failed"] == 0, (rt, [c for c in d["checks"] if c["status"] == "fail"])
+
+
+def test_cursor_unmeasurable_auto_run_carries_no_weight(tmp_path, monkeypatch):
+    """Cursor's auto-run level has no documented on-disk key. We report that
+    honestly rather than inventing one, and it must not move the grade."""
+    _cursor_home(tmp_path, monkeypatch)
+    check = _by_id(sp.get_posture("cursor"))["auto_run_level"]
+    assert check["weight"] == 0
+    assert "cannot be verified" in check["detail"]
+
+
+def test_cursor_flags_secret_written_into_mcp_config(tmp_path, monkeypatch):
+    home = _cursor_home(tmp_path, monkeypatch)
+    (home / "mcp.json").write_text(json.dumps({"mcpServers": {
+        "gh": {"env": {"GITHUB_TOKEN": "ghp_realsecretvalue123456"}},
+        "ok": {"env": {"API_KEY": "$FROM_ENV"}},
+    }}))
+    c = _by_id(sp.get_posture("cursor"))["mcp_secrets_inline"]
+    assert c["status"] == "fail"
+    assert "gh.env.GITHUB_TOKEN" in c["detail"]
+    # The $-reference form is a reference, not a secret, and must not be named.
+    assert "ok.env.API_KEY" not in c["detail"]
+
+
+def test_cursor_flags_invisible_unicode_in_rules(tmp_path, monkeypatch):
+    home = _cursor_home(tmp_path, monkeypatch)
+    rules = home / "rules"
+    rules.mkdir()
+    # A Unicode tag character: invisible in every editor, still read by the model.
+    (rules / "team.mdc").write_text("Be helpful.\U000E0041\n")
+    (rules / "clean.mdc").write_text("Be concise.\n")
+    c = _by_id(sp.get_posture("cursor"))["rules_invisible_unicode"]
+    assert c["status"] == "fail"
+    assert "team.mdc" in c["detail"]
+    assert "clean.mdc" not in c["detail"]
+
+
+def test_cursor_hooks_present_passes(tmp_path, monkeypatch):
+    home = _cursor_home(tmp_path, monkeypatch)
+    (home / "hooks.json").write_text(json.dumps(
+        {"hooks": {"beforeShellExecution": [{"command": "numbat"}]}, "version": 1}))
+    assert _by_id(sp.get_posture("cursor"))["pre_exec_hooks"]["status"] == "pass"
+
+
+def test_cursor_empty_hooks_object_warns(tmp_path, monkeypatch):
+    """An empty `hooks: {}` is the shape a reset leaves behind. It reads as
+    configured to a naive check, but nothing inspects anything."""
+    home = _cursor_home(tmp_path, monkeypatch)
+    (home / "hooks.json").write_text(json.dumps({"hooks": {}, "version": 1}))
+    assert _by_id(sp.get_posture("cursor"))["pre_exec_hooks"]["status"] == "warn"
+
+
+def test_cursor_sandbox_never_fails_on_closed_source(tmp_path, monkeypatch):
+    """insecure_none is the documented no-sandbox value, but we cannot read
+    the code that honours it, so it warns and never fails."""
+    home = _cursor_home(tmp_path, monkeypatch)
+    (home / "sandbox.json").write_text(json.dumps({"type": "insecure_none"}))
+    assert _by_id(sp.get_posture("cursor"))["sandbox_mode"]["status"] == "warn"
+
+
+def test_copilot_blanket_write_grant_warns_but_home_wide_fails(tmp_path, monkeypatch):
+    """A standing write grant is documented, not observable, so it warns. A
+    grant over the whole home directory is indefensible whatever the client
+    does with it, so that one fails."""
+    home = _copilot_home(tmp_path, monkeypatch)
+    (home / "permissions-config.json").write_text(json.dumps({"locations": {
+        "/Users/someone/projects/app": {"tool_approvals": [{"kind": "write"}]}}}))
+    assert _by_id(sp.get_posture("copilot"))["blanket_write_grant"]["status"] == "warn"
+
+    (home / "permissions-config.json").write_text(json.dumps({"locations": {
+        os.path.expanduser("~"): {"tool_approvals": [{"kind": "write"}]}}}))
+    c = _by_id(sp.get_posture("copilot"))["blanket_write_grant"]
+    assert c["status"] == "fail"
+
+
+def test_copilot_relative_path_grant_warns(tmp_path, monkeypatch):
+    """Documented footgun: a relative path matches by trailing components, so
+    a grant for `.env` covers a file of that name in any directory."""
+    home = _copilot_home(tmp_path, monkeypatch)
+    (home / "permissions-config.json").write_text(json.dumps({"locations": {
+        "/p": {"tool_approvals": [{"kind": "write", "paths": [".env"]}]}}}))
+    assert _by_id(sp.get_posture("copilot"))["relative_path_grants"]["status"] == "warn"
+
+
+def test_copilot_root_trusted_folder_fails(tmp_path, monkeypatch):
+    home = _copilot_home(tmp_path, monkeypatch)
+    (home / "config.json").write_text(json.dumps({"trustedFolders": ["/"]}))
+    assert _by_id(sp.get_posture("copilot"))["trusted_folders"]["status"] == "fail"
+
+
+def test_copilot_jsonc_config_is_parsed(tmp_path, monkeypatch):
+    """Copilot ships config.json with // comments. A strict json.loads returns
+    None and every downstream check silently reads an empty config."""
+    home = _copilot_home(tmp_path, monkeypatch)
+    (home / "config.json").write_text(
+        "// User settings belong in settings.json.\n"
+        "// This file is managed automatically.\n"
+        '{"trustedFolders": ["/tmp/proj"]}\n')
+    d = sp.get_posture("copilot")
+    assert "config.json" in _by_id(d)["config_found"]["detail"]
+    assert _by_id(d)["trusted_folders"]["status"] == "pass"
+
+
+def test_copilot_allow_all_in_shell_profile_fails(tmp_path, monkeypatch):
+    """Text in a file is a fact, so this one earns a fail. Commented-out lines
+    must not count."""
+    _copilot_home(tmp_path, monkeypatch)
+    fake_home = tmp_path / "fakehome"
+    fake_home.mkdir()
+    (fake_home / ".zshrc").write_text("# COPILOT_ALLOW_ALL=1 was here\nexport PATH=$PATH\n")
+    monkeypatch.setenv("HOME", str(fake_home))
+    assert _by_id(sp.get_posture("copilot"))["allow_all_switch"]["status"] == "pass"
+
+    (fake_home / ".zshrc").write_text("export COPILOT_ALLOW_ALL=1\n")
+    c = _by_id(sp.get_posture("copilot"))["allow_all_switch"]
+    assert c["status"] == "fail"
+    assert ".zshrc" in c["detail"]


### PR DESCRIPTION
Two of the 18 runtimes that returned *"No security posture checks implemented yet"* now have real checks: **Cursor** and **GitHub Copilot CLI**.

## The grading rule these providers follow

Both runtimes are **closed source**. We cannot read the code that consumes any of their settings, so a setting's presence never proves the behaviour is enforced. Checks therefore split into two grades:

| Grade | Meaning |
|---|---|
| **FAIL** | a filesystem **fact**, where "is it honored?" does not arise (a file exists or not, a mode bit, a literal byte in a file) |
| **WARN** | documented or observed-on-disk only. Never fails. |

So Cursor's `sandbox.type` and Copilot's standing write grant **warn**, while a secret written literally into `mcp.json`, invisible Unicode in a rules file, a trusted folder of `/`, and an allow-everything switch in a shell profile all **fail**, because those hold regardless of what the client does with them.

## Why the rule exists

A near miss. A proposed Cline check keyed on `executeAllCommands`, which sounded like the auto-approve switch and does default to `true`. That runtime's code **never reads the field**; the real gate is `executeSafeCommands`, which defaults to `false`. Shipping it would have emitted a **FAIL on every clean Cline install**.

A check that fails on a healthy machine teaches the operator to ignore the grade, which is worse than shipping no check at all. `test_clean_install_never_fails` asserts this directly for both providers.

## What is deliberately NOT checked

Cursor's **auto-run (Run Mode) level**. It has no documented on-disk key, and a `state.vscdb` dump turns up only telemetry flags. It ships as a **weight-0 informational row** saying we cannot see it from disk. Inventing a key would be worse than admitting the gap, and an unmeasured thing must not move the grade. That is the same principle as the weight-0 `api_key_helper` fix in #4973.

## Checks

**Cursor** (`~/.cursor`, honours `CURSOR_HOME`)
- `pre_exec_hooks`: `beforeShellExecution` / `beforeMCPExecution` present; catches the `{"hooks": {}}` shape a reset leaves behind, which reads as configured but inspects nothing.
- `mcp_secrets_inline`: **FAIL** on credential values written into `mcp.json` `env`/`headers`. `$VAR` / `env:` / `${VAR}` are references, not secrets, and are not flagged.
- `rules_invisible_unicode`: **FAIL** on Unicode tag chars (U+E0000 to U+E007F), zero-width and bidi controls in `.cursor/rules/*.mdc` or `~/.cursorrules`. One occurrence is enough; these have no legitimate use in a human-authored rules file.
- `cli_wildcard_allow`: blanket grants, or no deny rules, in `cli-config.json`.
- `sandbox_mode`: **WARN** only, including when unset (unset is unmeasured, not proven safe).

**Copilot CLI** (`~/.copilot`, honours `COPILOT_HOME`)
- `blanket_write_grant`: `{"kind": "write"}` with no path restriction **warns**; the same grant over `$HOME` or `/` **fails**.
- `relative_path_grants`: the documented footgun that a relative path matches by trailing components, so a grant for `.env` covers a file of that name in any directory.
- `trusted_folders`: **FAIL** on `/` or `$HOME`.
- `sandbox_enabled`: **WARN**, since it ships disabled and Copilot's own help text says shell commands run directly on your machine with your user account's access.
- `allow_all_switch`: **FAIL** on `COPILOT_ALLOW_ALL` or `--yolo` in a shell profile. Commented-out lines do not count.

Also fixes JSONC parsing: Copilot ships `config.json` with `//` comments, which a strict `json.loads` rejects, silently leaving every downstream check reading an empty config.

## Verification

Run against real config on a live machine: **Cursor B/80** (empty hooks object, no deny rules, no `sandbox.json`) and **Copilot B/80** (unscoped write grant on a project dir, sandbox off). No false failures on either.

Unrelated and pre-existing, confirmed red on clean `main` and left alone: `tests/test_numbat_ingest.py::test_unknown_agent_snake_cased_for_attribution` (maps `kimi` where it expects `kimi_code`). Not in CI's unit list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
