### PR TITLE
An expired license must not shadow a live paid cloud plan

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -2641,6 +2641,39 @@ def _maybe_emit_change(ent: Entitlement) -> None:
         logger.debug("entitlements: change-emit skipped: %s", exc)
 
 
+def _resolve_best_entitlement() -> Entitlement:
+    """Pick the entitlement this install actually holds, newest evidence wins
+    over stale evidence. Never raises.
+
+    Precedence used to be a plain ``license or cloud_plan or free``, which had
+    one sharp edge: :func:`_read_local_license` returns an Entitlement even
+    when it has passed its ``expiry`` (``Entitlement.expired`` existed but
+    nothing consulted it), so a DEAD license key permanently shadowed a LIVE
+    cloud plan. That is not hypothetical: ``clawmetry connect`` writes a 7-day
+    signup-trial key to ``~/.clawmetry/license.key`` for every account, so a
+    customer who then bought a cloud plan kept resolving on the trial key, and
+    once it lapsed :func:`trial_enforcement._resolver_says_unpaid_or_expired`
+    reported unpaid and the (default-ON) hard block paywalled someone who had
+    already paid. The heartbeat license refresh papers over this within a day,
+    but only for installs that are online, syncing, and recent enough to
+    understand the ``license_key`` field.
+
+    Order:
+
+    1. a LIVE local license (unchanged: the signed key is the strongest claim)
+    2. a LIVE PAID cloud plan, which is what an expired license must yield to
+    3. otherwise the old fallback chain, so the paywall copy for a genuinely
+       lapsed install is exactly what it was before
+    """
+    lic = _read_local_license()
+    if lic is not None and not lic.expired:
+        return lic
+    cloud = _read_cloud_plan()
+    if cloud is not None and cloud.is_paid and not cloud.expired:
+        return cloud
+    return lic or cloud or _oss_free()
+
+
 def get_entitlement(force: bool = False) -> Entitlement:
     """Resolve (and cache) the current entitlement. Never raises."""
     try:
@@ -2654,7 +2687,7 @@ def get_entitlement(force: bool = False) -> Entitlement:
             )
             if fresh:
                 return _cache["ent"]
-        ent = _read_local_license() or _read_cloud_plan() or _oss_free()
+        ent = _resolve_best_entitlement()
         with _lock:
             _cache.update(ent=ent, ts=time.time(), enforce=enforce)
         _maybe_emit_change(ent)

--- a/tests/test_expired_license_does_not_shadow_cloud_plan.py
+++ b/tests/test_expired_license_does_not_shadow_cloud_plan.py
@@ -1,0 +1,123 @@
+"""An EXPIRED local licence must not shadow a LIVE paid cloud plan.
+
+`clawmetry connect` writes a 7-day signup-trial key to
+``~/.clawmetry/license.key`` for every account, so a customer who then buys a
+cloud plan has BOTH a licence file and a cloud plan cache on disk. Resolution
+was ``_read_local_license() or _read_cloud_plan() or _oss_free()`` and
+``_read_local_license`` returns an Entitlement even after its expiry passed
+(``Entitlement.expired`` existed but nothing read it). So the dead trial key
+kept winning, and once it lapsed the default-ON trial hard block paywalled an
+account that had already paid.
+
+Related: tests/test_trial_hard_block.py (the block itself).
+"""
+from __future__ import annotations
+
+import importlib
+import json
+import time
+
+import pytest
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    return e, tmp_path
+
+
+def _lic(e, *, tier=None, expiry=None):
+    return e._build(tier or e.TIER_PRO, "license", node_limit=1, expiry=expiry)
+
+
+def _cloud(e, *, tier=None, expiry=None):
+    return e._build(tier or e.TIER_CLOUD_PRO, "cloud", node_limit=1, expiry=expiry)
+
+
+def _readers(monkeypatch, e, lic, cloud):
+    monkeypatch.setattr(e, "_read_local_license", lambda: lic)
+    monkeypatch.setattr(e, "_read_cloud_plan", lambda: cloud)
+
+
+def test_expired_license_yields_to_a_live_paid_cloud_plan(ent, monkeypatch):
+    """The incident: a lapsed signup-trial key next to a paid cloud plan."""
+    e, _ = ent
+    _readers(monkeypatch, e,
+             _lic(e, expiry=time.time() - 86400),
+             _cloud(e, expiry=time.time() + 300 * 86400))
+    got = e._resolve_best_entitlement()
+    assert got.source == "cloud", "the live paid plan is the real entitlement"
+    assert got.tier == e.TIER_CLOUD_PRO
+    assert not got.expired
+
+
+def test_live_license_still_wins_over_a_cloud_plan(ent, monkeypatch):
+    """Unchanged precedence: the signed key is the strongest claim."""
+    e, _ = ent
+    _readers(monkeypatch, e,
+             _lic(e, expiry=time.time() + 30 * 86400),
+             _cloud(e, expiry=time.time() + 300 * 86400))
+    assert e._resolve_best_entitlement().source == "license"
+
+
+def test_license_with_no_expiry_still_wins(ent, monkeypatch):
+    """A perpetual key has expiry None, which is not expired."""
+    e, _ = ent
+    _readers(monkeypatch, e, _lic(e, expiry=None), _cloud(e))
+    assert e._resolve_best_entitlement().source == "license"
+
+
+def test_expired_license_is_kept_when_the_cloud_plan_is_free(ent, monkeypatch):
+    """Nothing live to promote: keep the old fallback so the paywall copy for
+    a genuinely lapsed install does not change."""
+    e, _ = ent
+    _readers(monkeypatch, e,
+             _lic(e, expiry=time.time() - 86400),
+             _cloud(e, tier=e.TIER_CLOUD_FREE))
+    got = e._resolve_best_entitlement()
+    assert got.source == "license" and got.expired
+
+
+def test_expired_license_alone_is_unchanged(ent, monkeypatch):
+    e, _ = ent
+    _readers(monkeypatch, e, _lic(e, expiry=time.time() - 86400), None)
+    got = e._resolve_best_entitlement()
+    assert got.source == "license" and got.expired
+
+
+def test_no_license_no_cloud_plan_is_oss_free(ent, monkeypatch):
+    e, _ = ent
+    _readers(monkeypatch, e, None, None)
+    assert e._resolve_best_entitlement().source == "oss"
+
+
+def test_hard_block_lifts_for_a_payer_carrying_a_lapsed_trial_key(ent, monkeypatch):
+    """End to end through the real cloud-plan cache file: an expired licence
+    plus a paid cloud plan on disk must NOT be hard blocked."""
+    e, home = ent
+    (home / ".clawmetry").mkdir(parents=True, exist_ok=True)
+    (home / ".clawmetry" / "cloud_plan.json").write_text(json.dumps({
+        "plan": e.TIER_CLOUD_PRO,
+        "node_limit": 1,
+        "expiry": time.time() + 300 * 86400,
+    }))
+    monkeypatch.setattr(e, "_read_local_license",
+                        lambda: _lic(e, expiry=time.time() - 86400))
+    e.invalidate()
+
+    resolved = e.get_entitlement(force=True)
+    assert resolved.tier == e.TIER_CLOUD_PRO and resolved.source == "cloud"
+
+    import clawmetry.trial_enforcement as te
+
+    importlib.reload(te)
+    assert te.hard_block_enabled() is True, "default-ON is the premise here"
+    assert te.is_hard_blocked(resolved) is False, (
+        "a paying cloud customer must never be paywalled by the lapsed "
+        "signup-trial key that `clawmetry connect` left on disk"
+    )


### PR DESCRIPTION
## What can go wrong today

`clawmetry connect` calls `_activate_signup_trial()` at the end of every successful connect, which writes a 7-day signup-trial key to `~/.clawmetry/license.key`. A customer who then buys a **cloud** plan therefore has **both** a license file and a cloud plan cache on disk.

Resolution was:

```python
ent = _read_local_license() or _read_cloud_plan() or _oss_free()
```

and `_read_local_license()` returns an Entitlement **even when it has passed its expiry**. `Entitlement.expired` exists, but nothing in the resolution path reads it (`grep -rn "is_expired\|\.expired" clawmetry/` finds no consumer besides `block_payload`). So the dead trial key keeps winning, and 7 days after connect `trial_enforcement._resolver_says_unpaid_or_expired()` sees `source='license'` with a past expiry and returns True. With `hard_block_enabled()` default-ON, that paywalls an account that has already paid.

The heartbeat license refresh (`_maybe_install_license_from_heartbeat`) papers over this within about a day, but only for installs that are online, syncing, and on 0.12.650 or newer. A local-only install never heartbeats, and `_activate_signup_trial()` explicitly supports that case ("including when the user keeps their data local-only").

## Change

`_resolve_best_entitlement()` replaces the `or` chain:

1. a **live** local license (unchanged: the signed key is the strongest claim)
2. a **live paid** cloud plan, which is what an expired license must yield to
3. otherwise the old fallback chain, unchanged

An install with nothing live keeps the exact entitlement it had before, so the paywall copy for a genuinely lapsed install does not change.

## Tests

`tests/test_expired_license_does_not_shadow_cloud_plan.py`, 7 cases: the incident itself, live license still wins, no-expiry license still wins, expired license kept when the cloud plan is free, expired license alone unchanged, nothing on disk is OSS free, and one end to end through the real `cloud_plan.json` cache asserting `is_hard_blocked()` is False for a paying cloud customer carrying a lapsed trial key.

`tests/test_trial_hard_block.py`, `test_trial_hard_block_free_only.py`, `test_trial_enforcement_free_tier.py`, `test_entitlement_api.py`, `test_sync_cloud_plan_cache.py`: 93 passing together with the new file.

## Context

Found while investigating why a `cloud_pro` annual subscriber received "Your ClawMetry trial ends soon" and then "Your ClawMetry trial has ended", days after paying. clawmetry-cloud#2076 fixes the email half (the sweep had no notion of payment, and nothing retired the signup trial at checkout). This PR is the half that can actually lock a paying customer out.

Known follow-up, not in this PR: `parse_license()` maps `tier='trial'` to `TIER_PRO` through its forward-compatibility default, so a trial key is indistinguishable from a Pro key in the UI and in `block_payload()` copy. Worth making explicit, but it changes entitlement scope, so it does not belong in an incident fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)