### PR TITLE
Refuse to ship an unsigned desktop artifact on a release tag

### DIFF
--- a/.github/workflows/desktop-artifacts.yml
+++ b/.github/workflows/desktop-artifacts.yml
@@ -32,6 +32,16 @@ jobs:
       HAS_SIGN: ${{ secrets.MACOS_SIGN_IDENTITY != '' }}
     steps:
       - uses: actions/checkout@v7
+
+      # Same rule as the Windows job: signing is optional everywhere except
+      # a release tag. An unsigned .dmg is refused by Gatekeeper outright,
+      # so shipping one is a broken download, not a degraded one.
+      - name: Require signing on release tags
+        if: startsWith(github.ref, 'refs/tags/v') && env.HAS_SIGN != 'true'
+        shell: bash
+        run: |
+          echo "::error::${{ github.ref_name }} would ship an UNSIGNED macOS build. Set MACOS_SIGN_IDENTITY + MACOS_CERT_P12_BASE64."
+          exit 1
       - uses: actions/setup-python@v7
         with:
           python-version: "3.11"
@@ -246,6 +256,19 @@ jobs:
       HAS_WIN_CERT: ${{ secrets.WINDOWS_CERT_PFX_BASE64 != '' && !(secrets.AZURE_CLIENT_ID != '' && secrets.AZ_SIGN_PROFILE != '') }}
     steps:
       - uses: actions/checkout@v7
+      # A tag build that quietly produces an UNSIGNED artifact is worse
+      # than a failed build: it reaches users as "unknown publisher", and
+      # on Windows an unsigned uninstaller stub is blocked by Smart App
+      # Control, leaving the app impossible to remove from Settings > Apps.
+      # Signing config is optional everywhere EXCEPT a release tag, where
+      # it is mandatory. Runs before the build so a misconfiguration costs
+      # seconds, not a full compile.
+      - name: Require signing on release tags
+        if: startsWith(github.ref, 'refs/tags/v') && env.HAS_AZ_SIGN != 'true' && env.HAS_WIN_CERT != 'true'
+        shell: bash
+        run: |
+          echo "::error::${{ github.ref_name }} would ship an UNSIGNED Windows build. Set AZURE_CLIENT_ID + AZ_SIGN_PROFILE (Artifact Signing) or WINDOWS_CERT_PFX_BASE64."
+          exit 1
       - uses: actions/setup-python@v7
         with:
           python-version: "3.11"

--- a/tests/test_desktop_release_signing_required.py
+++ b/tests/test_desktop_release_signing_required.py
@@ -1,0 +1,113 @@
+"""A release tag must never ship an unsigned desktop artifact.
+
+Signing config is optional for forks, PRs and dev builds. On a `v*.*.*` tag it
+is mandatory, because the artifact goes straight to users:
+
+- an unsigned .exe hits the SmartScreen wall, and its unsigned NSIS uninstaller
+  stub is blocked by Smart App Control, leaving the app impossible to remove
+  from Settings > Apps
+- an unsigned .dmg is refused by Gatekeeper outright
+
+Both failure modes are silent in CI: the build goes green and simply omits the
+signature. This guard makes that loud instead.
+
+Scope is AUTO-DISCOVERED from the workflow rather than hard-coded, so a new
+signing job (or a renamed one) is covered without anyone remembering to edit
+this file. FLYWHEEL.md: "prefer guards that AUTO-DISCOVER their scope over
+hand-maintained allowlists, which silently drift."
+"""
+
+import pathlib
+import re
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+WORKFLOW = (
+    pathlib.Path(__file__).resolve().parents[1]
+    / ".github"
+    / "workflows"
+    / "desktop-artifacts.yml"
+)
+
+# A job that hoists signing-secret presence into job-level env is, by this
+# repo's own convention, a job that can sign. See the comment in the macOS job:
+# `secrets` is illegal in step-level `if:`, so presence checks live in `env:`.
+SIGN_FLAG = re.compile(r"^HAS_.*(SIGN|CERT)", re.IGNORECASE)
+
+GUARD_NAME = "Require signing on release tags"
+
+
+def _workflow():
+    return yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+
+
+def _signable_jobs(wf):
+    out = {}
+    for name, cfg in (wf.get("jobs") or {}).items():
+        flags = [k for k in (cfg.get("env") or {}) if SIGN_FLAG.match(k)]
+        if flags:
+            out[name] = (cfg, flags)
+    return out
+
+
+def test_workflow_parses_and_has_signing_jobs():
+    """Fail loudly if the convention changes, rather than vacuously passing."""
+    jobs = _signable_jobs(_workflow())
+    assert jobs, (
+        "No job exposes a HAS_*SIGN/CERT env flag. Either signing was removed, "
+        "or the convention changed and this guard is now blind. Fix the guard."
+    )
+
+
+def test_every_signable_job_refuses_to_ship_unsigned_on_a_tag():
+    for job_name, (cfg, flags) in _signable_jobs(_workflow()).items():
+        steps = cfg.get("steps") or []
+        guards = [s for s in steps if s.get("name") == GUARD_NAME]
+        assert guards, (
+            f"job {job_name!r} can sign but has no {GUARD_NAME!r} step, so a "
+            f"release tag could ship an unsigned artifact silently"
+        )
+        guard = guards[0]
+
+        cond = guard.get("if", "")
+        assert "refs/tags/v" in cond, (
+            f"{job_name}: guard must only fire on release tags, got if: {cond!r}"
+        )
+        assert any(f"env.{f}" in cond for f in flags), (
+            f"{job_name}: guard must test one of {flags} so it actually "
+            f"reflects whether signing is configured, got if: {cond!r}"
+        )
+        assert "exit 1" in (guard.get("run") or ""), (
+            f"{job_name}: guard must fail the build, not merely warn"
+        )
+
+        # Fail fast: cheaper to catch a misconfiguration in seconds than after
+        # a full compile, and it keeps the failure unambiguous.
+        idx = steps.index(guard)
+        builds = [
+            i
+            for i, s in enumerate(steps)
+            if "build" in (s.get("name") or "").lower()
+        ]
+        if builds:
+            assert idx < min(builds), (
+                f"{job_name}: guard must run before the build steps"
+            )
+
+
+def test_windows_verify_asserts_a_countersignature():
+    """Signed-but-not-timestamped is a three-day fuse, so assert it explicitly.
+
+    Artifact Signing certificates are valid for three days by design. Without
+    an RFC 3161 countersignature a release verifies fine at publish and then
+    reads as "unknown publisher" on every user's machine within the week, which
+    is worse than unsigned because it looks like tampering.
+    """
+    win = (_workflow().get("jobs") or {}).get("windows") or {}
+    body = "\n".join((s.get("run") or "") for s in (win.get("steps") or []))
+    assert "TimeStamperCertificate" in body, (
+        "the Windows job must assert the countersignature is present; "
+        "signtool's /tw only 'generates a warning' and cannot gate a build"
+    )


### PR DESCRIPTION
Follow-up to #5062, which made Windows signing work. This makes it impossible to silently stop working.

## The gap

Signing config is optional, which is correct for forks, PRs and dev builds. But it is optional on a release tag too, so if a secret is ever rotated away, the Artifact Signing identity validation lapses (it expires and must be renewed), or the certificate profile is deleted, the job stays **green** and simply omits the signature.

That failure is silent and it reaches users:

| Platform | What ships |
|---|---|
| Windows | SmartScreen wall, and the unsigned NSIS uninstaller stub is blocked by Smart App Control, so the app cannot be removed from Settings → Apps at all |
| macOS | Gatekeeper refuses the `.dmg` outright |

`release-on-merge.yml` pushes the `v*` tag that triggers this workflow, and the `release` job needs all three build jobs, so failing a build job is what actually stops a bad artifact reaching users.

## The change

A `Require signing on release tags` step in both signable jobs. It fires only on `refs/tags/v*`, and only when no signing backend is configured. It runs **before** the build, so a misconfiguration costs seconds rather than a full compile.

Guards both jobs, not just the Windows one that prompted this, per the FLYWHEEL rule about auditing the class rather than the instance. Linux has no signing path and correctly needs no guard.

## The guard that catches it

`tests/test_desktop_release_signing_required.py` **auto-discovers** signable jobs from the `HAS_*SIGN/CERT` job-env convention rather than hard-coding a job list, so a new or renamed signing job is covered without anyone remembering to update it. It also fails loudly if that convention itself changes, rather than passing vacuously.

Revert-proofs, all red before the fix and green after:

| Break | Test says |
|---|---|
| remove the guard steps | `job 'macos' can sign but has no 'Require signing on release tags' step` |
| weaken `exit 1` to `exit 0` | `macos: guard must fail the build, not merely warn` |
| drop `TimeStamperCertificate` | `must assert the countersignature is present` |

The third covers the other silent failure mode. Artifact Signing certificates are valid for three days by design, so an un-countersigned release verifies fine at publish and then reads as "unknown publisher" on every user's machine within the week, which is worse than unsigned because it looks like tampering.

## Verification

A `workflow_dispatch` run on this branch confirmed the guard **skips** on non-tag builds and both jobs still pass, so normal development is unaffected.

Production state confirmed signed after #5062 shipped in v0.12.752:

```
clawmetry.com/download/windows
  PE certificate table: 15632 bytes -> SIGNED
  publisher: CN=InstaLabs LLC, O=InstaLabs LLC, L=Sheridan, S=Wyoming, C=US

clawmetry.com/download/mac
  Authority=Developer ID Application: InstaLabs LLC (8LVH596RA5)
  source=Notarized Developer ID
```

The Software Factory blueprint "Desktop Application Distribution" was updated to v19: the stale "There is still NO Windows code signing" claim is corrected, the EV follow-up is closed as delivered-differently, and ADR-012 records why Artifact Signing was chosen over EV.

🤖 Generated with [Claude Code](https://claude.com/claude-code)