### PR TITLE
fix(sync): spending never mixes a live number with a stale one

### DIFF
--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -16272,6 +16272,37 @@ def _backfill_benign_errors_once(store) -> None:
         log.debug("benign-error backfill failed: %s", _e)
 
 
+def _resolve_spending(daily_usage, state_spending):
+    """Pick the today/week/month spend triple from ONE source.
+
+    A real $0.00 is a FACT, not a missing value. The pre-fix expression was
+
+        "today": float(_du.get("todayCost") or _state.get("today") or 0)
+
+    which treats 0.0 as falsy, so a genuinely-idle window silently rendered
+    the stale ``state.json`` number instead of zero. Each key also fell back
+    INDEPENDENTLY, so one payload could carry a live ``week`` beside a stale
+    ``today`` and the cloud hero card showed three numbers from three
+    different eras (reported 2026-08-22: today and month byte-identical,
+    week not).
+
+    ``_build_daily_usage()`` returns {} on failure, so "absent" IS
+    distinguishable from "zero": key on presence, and take the whole triple
+    from one source so the payload is internally consistent. ``source`` is
+    surfaced so the cloud can tell a real $0 from a degraded read.
+    """
+    live = daily_usage or {}
+    stale = state_spending or {}
+    keys = (("today", "todayCost"), ("week", "weekCost"), ("month", "monthCost"))
+    if all(live.get(src_key) is not None for _, src_key in keys):
+        out = {out_key: float(live.get(src_key)) for out_key, src_key in keys}
+        out["source"] = "live"
+        return out
+    out = {out_key: float(stale.get(out_key) or 0) for out_key, _ in keys}
+    out["source"] = "state"
+    return out
+
+
 def _build_daily_usage(days=14):
     """14-day token/cost history for the cloud Cost tab.
 
@@ -19418,11 +19449,7 @@ def sync_system_snapshot(config: dict, state: dict, paths: dict) -> int:
     # the real four-figure month — trust-destroying. Computing dailyUsage
     # once here and reusing it bounds the cost.
     _du = _build_daily_usage()
-    spending = {
-        "today": float(_du.get("todayCost") or state.get("spending", {}).get("today") or 0),
-        "week":  float(_du.get("weekCost")  or state.get("spending", {}).get("week")  or 0),
-        "month": float(_du.get("monthCost") or state.get("spending", {}).get("month") or 0),
-    }
+    spending = _resolve_spending(_du, state.get("spending", {}))
 
     # LLM Context Inspector parity (2026-05-23): expose the SAME fields
     # the OSS /api/overview now adds so the Context tab reads one value

--- a/tests/test_spending_live_stale_mixing.py
+++ b/tests/test_spending_live_stale_mixing.py
@@ -1,0 +1,67 @@
+"""Guard: the snapshot's spending triple never mixes live and stale eras.
+
+Regression reported 2026-08-22 by a paying customer: app.clawmetry.com showed
+"$22.73 today, $7.25/week, $22.73/mo" and flipped to a different triple every
+few seconds. Root cause was an `or` chain in ``sync_system_snapshot``:
+
+    "today": float(_du.get("todayCost") or _state.get("today") or 0)
+
+`or` treats a legitimate 0.0 as missing, so an idle window silently fell back
+to the stale ``state.json`` value -- per key, independently, so a single
+payload could carry a live `week` beside a stale `today`.
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from clawmetry.sync import _resolve_spending
+
+
+def test_real_zero_is_not_treated_as_missing():
+    """A live $0.00 stays $0.00 -- it must NOT fall back to stale state."""
+    live = {"todayCost": 0.0, "weekCost": 0.0, "monthCost": 0.0}
+    stale = {"today": 22.73, "week": 7.25, "month": 22.73}
+    out = _resolve_spending(live, stale)
+    assert out["today"] == 0.0, "a real $0 today was overwritten by stale state"
+    assert out["week"] == 0.0
+    assert out["month"] == 0.0
+    assert out["source"] == "live"
+
+
+def test_partial_zero_does_not_mix_eras():
+    """The exact customer shape: idle today, real spend this week.
+
+    Pre-fix, `today` fell back to stale ($22.73) while `week` stayed live
+    ($7.25) -- three numbers from two different eras in one payload.
+    """
+    live = {"todayCost": 0.0, "weekCost": 7.25, "monthCost": 24.11}
+    stale = {"today": 22.73, "week": 999.0, "month": 22.73}
+    out = _resolve_spending(live, stale)
+    assert out == {"today": 0.0, "week": 7.25, "month": 24.11, "source": "live"}
+
+
+def test_failed_read_falls_back_wholesale_and_is_labelled():
+    """_build_daily_usage() returns {} on failure -> use stale, and SAY so."""
+    out = _resolve_spending({}, {"today": 1.5, "week": 2.5, "month": 3.5})
+    assert out == {"today": 1.5, "week": 2.5, "month": 3.5, "source": "state"}
+
+
+def test_partial_live_payload_is_not_half_trusted():
+    """A live dict missing a key is a degraded read, not a licence to mix."""
+    out = _resolve_spending(
+        {"todayCost": 5.0, "weekCost": None, "monthCost": 9.0},
+        {"today": 1.0, "week": 2.0, "month": 3.0},
+    )
+    assert out["source"] == "state"
+    assert out["today"] == 1.0
+
+
+def test_both_sources_empty_is_zero_not_a_crash():
+    out = _resolve_spending({}, {})
+    assert out == {"today": 0.0, "week": 0.0, "month": 0.0, "source": "state"}
+
+
+def test_never_crashes_on_none():
+    out = _resolve_spending(None, None)
+    assert out["today"] == 0.0 and out["source"] == "state"


### PR DESCRIPTION
## Why

A paying customer reported on 2026-08-22 that app.clawmetry.com, localhost:8900 and the desk device all showed different costs, and that the hosted numbers flipped between two sets every few seconds.

One of the causes is here. The snapshot's spending triple was built with an `or` chain:

```python
"today": float(_du.get("todayCost") or _state.get("today") or 0),
"week":  float(_du.get("weekCost")  or _state.get("week")  or 0),
"month": float(_du.get("monthCost") or _state.get("month") or 0),
```

`or` treats a legitimate `0.0` as missing. Two consequences:

1. **A real $0.00 was overwritten by stale data.** An idle window fell back to the `state.json` number that the comment directly above this code already calls out as "almost always stale".
2. **Each key fell back independently**, so a single payload could carry a live `week` next to a stale `today`. That is the customer's exact reading: today and month byte-identical at $22.73, week at $7.25, from two different eras.

## What

`_build_daily_usage()` already returns `{}` on failure, so "absent" is distinguishable from "zero" without any new plumbing. This extracts `_resolve_spending()`, keys on presence instead of truthiness, and takes the whole triple from one source so the payload is internally consistent.

Adds `spending.source` (`"live"` or `"state"`) so the cloud can tell a real $0.00 from a degraded read rather than rendering stale data as if it were current. Verified no consumer iterates the `spending` dict, so the extra key is additive and safe.

## Verification

Guard: `tests/test_spending_live_stale_mixing.py`, covering the real-zero case, the customer's mixed-era shape, wholesale fallback, partial live payloads, and None inputs.

Revert-proof per FLYWHEEL section 3:

```
pre-fix `or` semantics restored -> 6 failed
fix restored                    -> 6 passed
```

Does not change behaviour when the live read succeeds and is non-zero, which is the common path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)