### PR TITLE
fix(cost): a failed DuckDB read is not a window that cost $0.00

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -58,6 +58,7 @@ import time
 import threading
 import select
 from datetime import datetime, timezone, timedelta
+from typing import Optional
 from flask import (
     Flask,
     render_template_string,
@@ -895,7 +896,7 @@ def _otel_cost_is_fresh(since_ts: float) -> bool:
     return False
 
 
-def _duckdb_cost_since(since_iso: str) -> float:
+def _duckdb_cost_since(since_iso: str) -> Optional[float]:
     """Sum billable-turn USD over the ``events`` table since ``since_iso``.
 
     Reuses the v3-aware helpers from ``clawmetry.local_store`` so every
@@ -932,7 +933,13 @@ def _duckdb_cost_since(since_iso: str) -> float:
             store = local_store.get_store(read_only=True)
             rows = store.query_aggregates(since=since_iso)
         except Exception:
-            return 0.0
+            # A read that FAILED is not a window that cost $0.00. Returning
+            # 0.0 here made a transient daemon-proxy timeout or writer-lock
+            # contention indistinguishable from a genuinely idle window, and
+            # the caller then published that zero as fact. Signal absence.
+            return None
+    if rows is None:
+        return None
     total = 0.0
     for r in rows or []:
         try:
@@ -1000,10 +1007,18 @@ def _get_budget_status():
             duck_daily   = _duckdb_cost_since(daily_iso)
             duck_weekly  = _duckdb_cost_since(weekly_iso)
             duck_monthly = _duckdb_cost_since(monthly_iso)
+            # These are three INDEPENDENT reads. Pre-fix each one degraded to
+            # 0.0 on failure, so a transient timeout on the daily call while
+            # the monthly call succeeded published daily=$0.00 next to a real
+            # month -- a triple mixing fact and failure, flipping back on the
+            # next poll. That is the "numbers change every few seconds" a
+            # customer reported on 2026-08-22. Promote all three or none.
+            _duck = (duck_daily, duck_weekly, duck_monthly)
+            _duck_ok = all(v is not None for v in _duck)
             # Only switch sources when DuckDB has *something* to report.
             # An empty store on a brand-new install should look the same as
             # an empty OTLP buffer (daily_spent=0), not crash the evaluator.
-            if duck_monthly > 0 or duck_weekly > 0 or duck_daily > 0:
+            if _duck_ok and any(v > 0 for v in _duck):
                 daily_spent   = duck_daily
                 weekly_spent  = duck_weekly
                 monthly_spent = duck_monthly

--- a/tests/test_budget_duckdb_failure_vs_zero.py
+++ b/tests/test_budget_duckdb_failure_vs_zero.py
@@ -1,0 +1,83 @@
+"""Guard: a failed DuckDB cost read is never published as $0.00.
+
+Reported 2026-08-22 by a paying customer: the dashboard's cost numbers
+"sporadically toggle" between two sets of values every few seconds.
+
+``_get_budget_status`` makes THREE independent ``_duckdb_cost_since`` calls
+(daily / weekly / monthly). Pre-fix each returned 0.0 on ANY exception, so a
+transient daemon-proxy timeout or DuckDB writer-lock contention on one call
+while another succeeded published a triple that mixed a real number with a
+failure-zero, then flipped back on the next poll.
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import pytest
+
+import dashboard as _d
+
+
+def test_failed_read_returns_none_not_zero(monkeypatch):
+    """Both the proxy path and the direct path failing means UNKNOWN."""
+    def _boom(*a, **k):
+        raise RuntimeError("daemon proxy timeout")
+
+    monkeypatch.setattr(
+        "routes.local_query.local_store_via_daemon", _boom, raising=False
+    )
+    import clawmetry.local_store as _ls
+    monkeypatch.setattr(_ls, "get_store", _boom, raising=False)
+
+    assert _d._duckdb_cost_since("2026-08-22T00:00:00+00:00") is None
+
+
+def test_empty_store_is_zero_not_none(monkeypatch):
+    """A store that answers with no rows genuinely cost $0.00."""
+    monkeypatch.setattr(
+        "routes.local_query.local_store_via_daemon",
+        lambda *a, **k: [],
+        raising=False,
+    )
+    assert _d._duckdb_cost_since("2026-08-22T00:00:00+00:00") == 0.0
+
+
+def _budget_with(monkeypatch, values):
+    """Run _get_budget_status with _duckdb_cost_since returning `values` in
+    call order (daily, weekly, monthly), and an empty OTLP ring."""
+    calls = iter(values)
+    monkeypatch.setattr(_d, "_duckdb_cost_since", lambda *_a, **_k: next(calls))
+    monkeypatch.setattr(_d, "_otel_cost_is_fresh", lambda *_a, **_k: False)
+    with _d._metrics_lock:
+        _d.metrics_store["cost"] = []
+    return _d._get_budget_status()
+
+
+def test_partial_failure_never_publishes_a_mixed_triple(monkeypatch):
+    """Daily read fails, monthly succeeds.
+
+    Pre-fix: daily=0.0 (a failure) was published beside monthly=24.11 (a
+    fact), because `duck_monthly > 0` alone promoted the whole triple.
+    """
+    out = _budget_with(monkeypatch, [None, 7.25, 24.11])
+    assert out["daily_spent"] == 0.0
+    assert out["monthly_spent"] == 0.0, (
+        "a failure-zero daily was published next to a real monthly: "
+        "the triple mixed fact and failure"
+    )
+
+
+def test_all_reads_succeed_still_promotes(monkeypatch):
+    """The fix must not break the common path it was built for (#1404)."""
+    out = _budget_with(monkeypatch, [1.72, 8.58, 21.26])
+    assert out["daily_spent"] == 1.72
+    assert out["weekly_spent"] == 8.58
+    assert out["monthly_spent"] == 21.26
+
+
+def test_genuinely_idle_store_reports_zero(monkeypatch):
+    """All three succeed and are zero: an idle node, not a broken one."""
+    out = _budget_with(monkeypatch, [0.0, 0.0, 0.0])
+    assert out["daily_spent"] == 0.0
+    assert out["monthly_spent"] == 0.0


### PR DESCRIPTION
## Why

Second cause of the cost problems a paying customer reported on 2026-08-22. Their words: localhost:8900 "sporadically toggles" between two sets of cost values. (First cause: #5078.)

`_get_budget_status` makes three **independent** `_duckdb_cost_since` calls, one per window. Each returned `0.0` on any exception, so a transient daemon-proxy timeout or DuckDB writer-lock contention looked exactly like a window that genuinely cost nothing. The promotion guard was:

```python
if duck_monthly > 0 or duck_weekly > 0 or duck_daily > 0:
    daily_spent, weekly_spent, monthly_spent = duck_daily, duck_weekly, duck_monthly
```

So a single successful call promoted the entire triple, publishing the other two failure-zeros as fact. On the next poll the timeout lands on a different call and the numbers change again. Both known-flaky seams are in this path already: the daemon proxy times out under load, and the read-only direct fallback contends with the daemon's writer lock.

## What

`_duckdb_cost_since` now returns `Optional[float]`. `None` means the read failed, `0.0` still means the window really cost nothing. The caller promotes all three or none, so a degraded read leaves the previous source in place rather than publishing a triple that mixes fact and failure.

Uses `typing.Optional` rather than `float | None`, since this file has to import on Python 3.9 (see #5075).

Deliberately not bundled: these are still three separate round trips through the daemon proxy, which is also a request-volume issue under FLYWHEEL section 1e. Collapsing them into one query changes the window semantics, so it belongs with the window unification work, not here.

## Verification

Guard: `tests/test_budget_duckdb_failure_vs_zero.py`, covering failure returning None, an empty store still returning 0.0, the partial-failure mixed triple, the healthy path, and a genuinely idle node.

Revert-proof per FLYWHEEL section 3:

```
pre-fix semantics restored -> 2 failed, 3 passed
fix restored               -> 5 passed
```

Adjacent suites green: `test_budget_cap`, `test_per_agent_budget`, `test_alerts_evaluator_duckdb`, `test_cost_optimizer_local_store_v3` (45 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)