### PR TITLE
fix(ci): the lint step never linted, and the cloud pin never follows a release

### DIFF
--- a/.github/workflows/auto-deploy-cloud.yml
+++ b/.github/workflows/auto-deploy-cloud.yml
@@ -8,6 +8,16 @@ on:
       - 'clawmetry/**'
       - 'setup.py'
       - 'CHANGELOG.md'
+  # The push trigger alone CANNOT pin a release. A `[RELEASE]` merge fires it
+  # while PyPI still serves the PREVIOUS version, so it re-pins the old one and
+  # goes green; the `chore: bump to vX [skip ci]` commit that actually creates
+  # the new version is skip-ci and can never re-trigger it. Net effect: the
+  # cloud silently stays a version behind until someone dispatches this by hand
+  # (2026-08-22: 0.12.755 shipped and cloud sat on 0.12.754). Re-run once
+  # release-on-merge has finished so the pin sees the version it published.
+  workflow_run:
+    workflows: ["Auto-release on [RELEASE] merge"]
+    types: [completed]
   workflow_dispatch:
 
 jobs:
@@ -41,11 +51,22 @@ jobs:
       - name: Wait for version on PyPI
         run: |
           V="${{ steps.oss_version.outputs.version }}"
+          # Poll what PIP reads, not the JSON API. pypi.org/pypi/<v>/json goes
+          # live minutes BEFORE the simple index that pip resolves against, so
+          # this wait used to pass while `pip install clawmetry==$V` still
+          # failed with "No matching distribution found" -- which is exactly
+          # how the cloud pin PR for 0.12.755 went red on the MOAT roundtrip
+          # and API v1 E2E jobs and had to be re-run by hand (2026-08-22).
+          # `pip index versions` resolves through the same index pip installs
+          # from, so a pass here means the pin PR's CI can actually install it.
           for i in $(seq 1 30); do
-            if curl -fsSL "https://pypi.org/pypi/clawmetry/$V/json" >/dev/null 2>&1; then
-              echo "clawmetry==$V is on PyPI"; exit 0
+            # Prove installability the same way the cloud PR's CI will, so a
+            # pass here cannot mean anything weaker. A substring grep would
+            # also match 0.12.75 inside 0.12.755.
+            if pip download "clawmetry==$V" --no-deps --dest /tmp/_pinwait >/dev/null 2>&1; then
+              echo "clawmetry==$V is installable from the index"; exit 0
             fi
-            echo "waiting for clawmetry==$V on PyPI (attempt $i)..."; sleep 20
+            echo "waiting for clawmetry==$V on the pip index (attempt $i)..."; sleep 20
           done
           echo "::warning::clawmetry==$V not on PyPI after wait; continuing (cloud CI will gate the merge)"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,8 +83,16 @@ jobs:
 
       - name: Install ruff (fast linter)
         run: pip install ruff
+      # `W503` is a flake8 code that ruff does not implement, so ruff exited
+      # with "invalid value 'W503' for '--ignore <RULE_CODE>'" on every run
+      # since this step was added. `|| true` swallowed the usage error, so the
+      # step reported success while linting exactly nothing. Dropping the
+      # invalid code makes it run; it reports ~143 findings on dashboard.py
+      # (89 E402 from the documented late-import pattern, the rest whitespace
+      # inside the embedded HTML string literals), so it stays advisory rather
+      # than becoming a gate that would fail main on day one.
       - name: Lint (warnings only, don't fail)
-        run: ruff check dashboard.py --select E,W --ignore E501,W503 || true
+        run: ruff check dashboard.py --select E,W --ignore E501,E402 || true
 
       # The advertised runtime count lives in prose across the README, its
       # translations, FLYWHEEL.md, the CLI and the desktop copy, and every one

--- a/tests/test_ci_workflow_invocations_are_real.py
+++ b/tests/test_ci_workflow_invocations_are_real.py
@@ -1,0 +1,146 @@
+"""Guard: CI steps that silently do nothing.
+
+Two real defects, both of which reported success for months:
+
+1. `ci.yml` ran `ruff check ... --ignore E501,W503`. `W503` is a flake8 code
+   ruff does not implement, so ruff exited with a usage error on every run and
+   `|| true` swallowed it. The step was green and linted nothing.
+
+2. `auto-deploy-cloud.yml` had no trigger that fires after a release, so the
+   cloud pin silently stayed a version behind. The fix adds a `workflow_run`
+   trigger, and a `workflow_run` naming a workflow that does not exist never
+   fires and never warns, which would reintroduce the same silence.
+
+Both checks derive their scope from the workflow files, so a NEW step or
+trigger is covered without editing this test.
+"""
+import glob
+import os
+import re
+import shutil
+import subprocess
+import sys
+
+import pytest
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+WORKFLOWS = sorted(glob.glob(os.path.join(ROOT, ".github", "workflows", "*.yml")))
+
+
+def _read(path):
+    with open(path, encoding="utf-8") as fh:
+        return fh.read()
+
+
+def test_workflows_exist():
+    assert WORKFLOWS, "no workflow files discovered"
+
+
+# ---------------------------------------------------------- ruff invocations
+
+_RUFF_RE = re.compile(r"ruff check\s+(?P<args>[^\n|&]+)")
+
+
+def _ruff_invocations():
+    for wf in WORKFLOWS:
+        for m in _RUFF_RE.finditer(_read(wf)):
+            yield os.path.basename(wf), m.group("args").strip()
+
+
+@pytest.mark.skipif(shutil.which("ruff") is None and
+                    subprocess.run([sys.executable, "-m", "ruff", "--version"],
+                                   capture_output=True).returncode != 0,
+                    reason="ruff not installed")
+def test_every_ruff_invocation_is_accepted_by_ruff():
+    """A rule code ruff does not know makes the whole step a no-op."""
+    found = list(_ruff_invocations())
+    assert found, "no ruff invocation found to validate"
+    for wf, args in found:
+        # Re-run the exact flags against a trivially clean file: we are
+        # validating the FLAGS, not the codebase. A usage error (exit 2)
+        # means the step can never lint anything.
+        probe = os.path.join(ROOT, "setup.py")
+        flags = [a for a in args.split() if a.startswith("-")or "=" in a]
+        # keep flag values (e.g. "E,W" after --select)
+        parts, keep = args.split(), []
+        for i, tok in enumerate(parts):
+            if tok.startswith("-"):
+                keep.append(tok)
+                if i + 1 < len(parts) and not parts[i + 1].startswith("-"):
+                    keep.append(parts[i + 1])
+        r = subprocess.run(
+            [sys.executable, "-m", "ruff", "check", probe, *keep],
+            capture_output=True, text=True, cwd=ROOT,
+        )
+        assert "invalid value" not in (r.stderr or ""), (
+            f"{wf}: ruff rejects its own flags ({' '.join(keep)}): "
+            f"{r.stderr.strip().splitlines()[0] if r.stderr.strip() else ''}. "
+            "The step reports success while linting nothing."
+        )
+
+
+# ------------------------------------------------- workflow_run trigger names
+
+# NB: a workflow name may itself contain "]" (this repo has
+# "Auto-release on [RELEASE] merge"), so capture the whole line and pull the
+# QUOTED items out rather than matching up to the first closing bracket.
+_WF_RUN_RE = re.compile(
+    r"workflow_run:\s*\n\s*workflows:\s*(?P<names>.+)$", re.MULTILINE
+)
+_QUOTED_RE = re.compile(r'"([^"]+)"|\'([^\']+)\'')
+_NAME_RE = re.compile(r'^name:\s*(?P<name>.+?)\s*$', re.MULTILINE)
+
+
+def _declared_workflow_names():
+    names = set()
+    for wf in WORKFLOWS:
+        m = _NAME_RE.search(_read(wf))
+        if m:
+            names.add(m.group("name").strip().strip('"').strip("'"))
+    return names
+
+
+def test_workflow_run_triggers_name_a_real_workflow():
+    """A workflow_run naming a non-existent workflow never fires, silently."""
+    declared = _declared_workflow_names()
+    checked = 0
+    for wf in WORKFLOWS:
+        for m in _WF_RUN_RE.finditer(_read(wf)):
+            for a, b in _QUOTED_RE.findall(m.group("names")):
+                ref = (a or b).strip()
+                if not ref:
+                    continue
+                checked += 1
+                assert ref in declared, (
+                    f"{os.path.basename(wf)}: workflow_run references "
+                    f"{ref!r}, which is not the `name:` of any workflow. "
+                    f"It will never fire. Declared names: {sorted(declared)}"
+                )
+    assert checked > 0, "no workflow_run trigger found to validate"
+
+
+def test_cloud_pin_can_follow_a_release():
+    """The specific regression: the cloud pin must have a post-release trigger.
+
+    A `[RELEASE]` merge fires the push trigger while PyPI still serves the old
+    version, and the follow-up version-bump commit is `[skip ci]`, so without a
+    release-completion trigger the cloud stays a version behind.
+    """
+    src = _read(os.path.join(ROOT, ".github", "workflows", "auto-deploy-cloud.yml"))
+    assert "workflow_run:" in src, (
+        "auto-deploy-cloud.yml has no workflow_run trigger, so nothing pins "
+        "the cloud after a release completes"
+    )
+
+
+def test_pypi_wait_polls_the_index_pip_reads():
+    """Waiting on the JSON API passes minutes before pip can install."""
+    src = _read(os.path.join(ROOT, ".github", "workflows", "auto-deploy-cloud.yml"))
+    assert "pypi.org/pypi/clawmetry/$V/json" not in src, (
+        "the PyPI wait polls the JSON API, which goes live before the simple "
+        "index pip resolves against; the pin PR's CI then fails with "
+        "'No matching distribution found'"
+    )
+    assert "pip download" in src or "pip index versions" in src, (
+        "the PyPI wait must prove installability through pip's own index"
+    )


### PR DESCRIPTION
Two CI steps that have been reporting success while doing nothing. Both were found while shipping 0.12.755.

## 1. The lint step has never linted

```
ruff check dashboard.py --select E,W --ignore E501,W503 || true
```

`W503` is a flake8 code that ruff does not implement, so ruff exits with `invalid value 'W503' for '--ignore <RULE_CODE>'` on every run. `|| true` swallows the usage error, so the step goes green having linted nothing, ever.

Dropping the invalid code makes it run. It then reports ~143 findings on dashboard.py:

| count | rule | what |
|---|---|---|
| 89 | E402 | module import not at top of file, the late-import pattern CLAUDE.md documents. Now ignored. |
| 53 | W291/W293 | trailing and blank-line whitespace, almost all inside the embedded HTML string literals |
| 1 | E702 | multiple statements on one line |

Only 6 of the whitespace findings are safely auto-fixable; the rest sit inside string literals where a fix would change the string contents. So this stays advisory rather than becoming a gate that fails main on day one. Worth a follow-up to burn down, but not silently, and not in a PR about CI plumbing.

## 2. The cloud pin cannot follow a release

The push trigger fires on the `[RELEASE]` merge commit, at which point PyPI still serves the **previous** version, so the job re-pins the old version and goes green. The `chore: bump to vX [skip ci]` commit that actually creates the new version is skip-ci and can never re-trigger it.

Net effect: the cloud silently stays a version behind. 0.12.755 shipped today and the cloud sat on 0.12.754 until I dispatched the workflow by hand.

Adds a `workflow_run` trigger on the release workflow completing.

**And the PyPI wait was checking the wrong thing.** It polled `pypi.org/pypi/clawmetry/$V/json`, which goes live minutes before the simple index pip resolves against. The wait passed while `pip install clawmetry==$V` still failed with "No matching distribution found", which is exactly how the 0.12.755 pin PR went red on `MOAT cloud-side roundtrip E2E` and `API v1 E2E` and needed a manual re-run. It now proves installability with `pip download`, the same path the cloud PR's CI takes.

## Guard

`tests/test_ci_workflow_invocations_are_real.py`, auto-discovering over the workflow files rather than a hand-maintained list:

- re-runs each ruff invocation's own flags and fails if ruff rejects them
- resolves every `workflow_run` reference against the declared workflow `name:` values, because a trigger naming a workflow that does not exist never fires and never warns

That second check earned its place immediately: it caught that this repo's release workflow is named `Auto-release on [RELEASE] merge`, with a `]` inside the name that a naive bracket parse truncates.

Revert-proof: pre-fix workflows fail 4 of 5 checks, restored passes 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)