### PR TITLE
fix(nemoclaw): NemoClaw was never detected on a standard install

### DIFF
--- a/clawmetry/adapters/nemo.py
+++ b/clawmetry/adapters/nemo.py
@@ -1155,12 +1155,14 @@ class NemoClawAdapter(AgentAdapter):
         try:
             from clawmetry import local_store as _ls
             store = _ls.get_store(read_only=True)
-            rows = store._fetch(
-                "SELECT COUNT(*) FROM events WHERE agent_type = ?",
-                ["nemoclaw"],
-            )
-            if rows:
-                n = int(rows[0][0])
+            # MUST be a query_* shape, not ``_fetch``. Outside the daemon
+            # process this is a ``_ProxyStore``, which refuses private helpers
+            # and returns None, so the raw-SQL form made ``detected`` False on
+            # every standard install (the daemon holds the writer lock) while
+            # logging a warning into ``clawmetry status``. NemoClaw is one of
+            # the two FREE runtimes, so it silently vanished from the runtime
+            # list for anyone not running single-process.
+            n = int(store.query_event_count(runtime="nemoclaw") or 0)
         except Exception as exc:
             logger.debug("nemoclaw detect read failed: %s", exc)
         meta: dict = {"event_count": n}

--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -6713,6 +6713,33 @@ class LocalStore:
         params.append(int(limit))
         return [_row_to_event(r, _EVENT_COLS) for r in self._fetch(sql, params)]
 
+    def query_event_count(self, *, runtime: str | None = None) -> int:
+        """Count events, optionally for one runtime. Proxyable by design.
+
+        Callers outside the daemon process reach LocalStore through
+        ``_ProxyStore``, which forwards ``query_*`` methods over the daemon's
+        HTTP proxy and REFUSES private helpers: ``_fetch`` would be arbitrary
+        SQL over the RPC. A caller that reached for ``store._fetch("SELECT
+        COUNT(*) ...")`` therefore got a warning and ``None`` on every standard
+        install, where the daemon holds the writer lock. ``NemoClawAdapter.
+        detect()`` did exactly that, so NemoClaw, one of the two FREE runtimes,
+        was never detected outside single-process boots (found 2026-08-22 in
+        `clawmetry status` output). Counting is the whole need, so expose it as
+        a first-class shape instead.
+        """
+        sql = "SELECT COUNT(*) FROM events"
+        params: list = []
+        if runtime:
+            sql += " WHERE agent_type = ?"
+            params.append(str(runtime))
+        rows = self._fetch(sql, params)
+        if not rows:
+            return 0
+        try:
+            return int(rows[0][0])
+        except (TypeError, ValueError, IndexError):
+            return 0
+
     def query_events_by_ingest(
         self,
         *,

--- a/routes/local_query.py
+++ b/routes/local_query.py
@@ -587,6 +587,12 @@ def http_query():
 
 _DAEMON_METHODS = frozenset({
     "query_events",
+    # Runtime event counts. NemoClawAdapter.detect() used to run
+    # ``store._fetch("SELECT COUNT(*) ...")``, which _ProxyStore refuses
+    # (private helpers would be arbitrary SQL over the RPC), so on every
+    # standard install -- where the daemon owns the writer lock -- the call
+    # returned None and NemoClaw, a FREE runtime, was never detected.
+    "query_event_count",
     # Emergency-stop cwd lookup: routes/sessions.py:api_session_stop routes
     # family sids through process_control and needs the session's working
     # directory (sessions.cwd) to resolve the pid — read via the daemon so

--- a/tests/test_adapter_detect_through_daemon_proxy.py
+++ b/tests/test_adapter_detect_through_daemon_proxy.py
@@ -1,0 +1,148 @@
+"""Guard: runtime detection must survive the daemon proxy.
+
+Outside the daemon process ``local_store.get_store()`` returns a
+``_ProxyStore`` that forwards ``query_*`` methods over the daemon's HTTP proxy
+and REFUSES private helpers, because ``_fetch`` would be arbitrary SQL over the
+RPC. It logs a warning and returns None.
+
+``NemoClawAdapter.detect()`` ran ``store._fetch("SELECT COUNT(*) ...")``, so on
+every standard install (the daemon owns the writer lock) it got None, counted
+zero, and reported ``detected=False``. NemoClaw is one of the two FREE
+runtimes, so it silently vanished from the runtime list, and the refusal
+warning printed into `clawmetry status`. Found 2026-08-22.
+
+Enrichment paths that DOCUMENT a proxy degradation (e.g.
+``_nemoclaw_child_texts``) are deliberately not covered here: degrading extra
+detail is an honest floor, whereas failing to detect the runtime at all is not.
+"""
+import ast
+import inspect
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import pytest
+
+
+class _FakeProxyStore:
+    """Mimics _ProxyStore: query_* works, private helpers are refused."""
+
+    def __init__(self, count=0):
+        self._count = count
+        self.fetch_attempts = 0
+
+    def __getattr__(self, name):
+        if name.startswith("_"):
+            # _ProxyStore logs and returns a callable yielding None.
+            def _refused(*a, **k):
+                object.__getattribute__(self, "__dict__")["fetch_attempts"] = \
+                    object.__getattribute__(self, "__dict__").get("fetch_attempts", 0) + 1
+                return None
+            return _refused
+        raise AttributeError(name)
+
+    def query_event_count(self, *, runtime=None):
+        return self._count
+
+
+def test_query_event_count_is_daemon_allowlisted():
+    """An unlisted method 400s and the caller swallows it as 'no data'."""
+    from routes.local_query import _DAEMON_METHODS
+
+    assert "query_event_count" in _DAEMON_METHODS
+
+
+def test_local_store_exposes_query_event_count():
+    from clawmetry.local_store import LocalStore
+
+    assert hasattr(LocalStore, "query_event_count")
+    sig = inspect.signature(LocalStore.query_event_count)
+    assert "runtime" in sig.parameters
+
+
+def test_nemoclaw_is_detected_through_a_proxy_store(monkeypatch):
+    """The regression: real data present, store is a proxy -> must detect."""
+    from clawmetry.adapters.nemo import NemoClawAdapter
+    import clawmetry.local_store as _ls
+
+    fake = _FakeProxyStore(count=42)
+    monkeypatch.setattr(_ls, "get_store", lambda *a, **k: fake)
+
+    res = NemoClawAdapter().detect()
+    assert res.detected is True, (
+        "NemoClaw has 42 events but detect() reported not-detected: it is "
+        "reading through a path the daemon proxy refuses"
+    )
+    assert res.meta.get("event_count") == 42
+    assert fake.fetch_attempts == 0, "detect() still reached for a private helper"
+
+
+def test_nemoclaw_absent_still_reports_not_detected(monkeypatch):
+    """The fix must not turn detection into 'always true'."""
+    from clawmetry.adapters.nemo import NemoClawAdapter
+    import clawmetry.local_store as _ls
+
+    monkeypatch.setattr(_ls, "get_store", lambda *a, **k: _FakeProxyStore(count=0))
+    assert NemoClawAdapter().detect().detected is False
+
+
+# ------------------------------------------------------------- class guard
+
+def _adapter_classes():
+    """Auto-discover adapters so a NEW one is covered without editing this."""
+    import importlib
+    import pkgutil
+
+    import clawmetry.adapters as pkg
+
+    out = []
+    for mod in pkgutil.iter_modules(pkg.__path__):
+        try:
+            m = importlib.import_module(f"clawmetry.adapters.{mod.name}")
+        except Exception:
+            continue
+        for attr in dir(m):
+            obj = getattr(m, attr)
+            if (isinstance(obj, type) and attr.endswith("Adapter")
+                    and hasattr(obj, "detect")
+                    and obj.__module__ == m.__name__):
+                out.append((mod.name, attr, obj))
+    return out
+
+
+def test_adapters_discovered():
+    assert _adapter_classes(), "no adapters discovered"
+
+
+def test_no_adapter_detect_uses_a_non_proxyable_helper():
+    """detect() may not call a private store helper.
+
+    Detection runs in the dashboard and CLI processes, where the store is a
+    proxy. A private helper there is silently None, which reads as 'runtime
+    not installed'.
+    """
+    offenders = []
+    for mod_name, cls_name, cls in _adapter_classes():
+        try:
+            src = inspect.getsource(cls.detect)
+        except (OSError, TypeError):
+            continue
+        try:
+            tree = ast.parse(__import__("textwrap").dedent(src))
+        except SyntaxError:
+            continue
+        for node in ast.walk(tree):
+            if (isinstance(node, ast.Call)
+                    and isinstance(node.func, ast.Attribute)
+                    and node.func.attr.startswith("_")
+                    and not node.func.attr.startswith("__")):
+                # store._fetch(...) and friends
+                if isinstance(node.func.value, ast.Name) and \
+                        node.func.value.id in ("store", "store_obj", "_store"):
+                    offenders.append(f"{mod_name}.{cls_name}.detect -> {node.func.attr}()")
+    assert not offenders, (
+        "adapter detect() calls a helper the daemon proxy refuses, so the "
+        "runtime will read as not-installed on any standard install: "
+        + ", ".join(offenders)
+    )


### PR DESCRIPTION
## Why

Found in `clawmetry status` output while verifying 0.12.755. This line was printing between the OpenClaw and PicoClaw rows:

```
local_store: _fetch() is not proxyable through the daemon; call a query_* method instead (returning None)
```

It is not just a stray warning. `NemoClawAdapter.detect()` counted its events with raw SQL:

```python
store = _ls.get_store(read_only=True)
rows = store._fetch("SELECT COUNT(*) FROM events WHERE agent_type = ?", ["nemoclaw"])
```

Outside the daemon process, `get_store()` returns a `_ProxyStore` that forwards `query_*` methods over the daemon's HTTP proxy and deliberately refuses private helpers, since `_fetch` would be arbitrary SQL over the RPC. It logs and returns `None`.

So on **every standard install**, where the daemon owns the writer lock, `detect()` read `None`, counted zero, and reported `detected=False`. NemoClaw is one of only two FREE runtimes, and it silently disappeared from the runtime list for anyone not running single-process.

Verified against the live daemon on this machine:

```
POST /__local_query__/query_events       -> 200
POST /__local_query__/_fetch             -> 400 BAD REQUEST
```

The file's own docstring elsewhere already warns about exactly this pattern, which is what makes it worth a mechanical guard rather than a one-line fix.

## What

Adds `LocalStore.query_event_count(runtime=...)` as a first-class shape, allowlists it in `_DAEMON_METHODS`, and points `detect()` at it. `make lint-daemon-allowlist` stays green.

## Deliberately not changed

`_nemoclaw_child_texts` and the openclaw transcript reader also use `_fetch`, but both **document** that they degrade to a reduced result through the proxy. Degrading extra enrichment is an honest floor; failing to detect the runtime at all is not. Blanket-banning `_fetch` in adapters would have swept up those conscious decisions, so the guard targets detection specifically.

## Guard

`tests/test_adapter_detect_through_daemon_proxy.py`:

- drives `detect()` against a store that behaves like `_ProxyStore` (query_* works, private helpers return `None`) and asserts NemoClaw is detected with data present, still absent without it, and never reaches for a private helper
- an auto-discovering class check that walks **every** adapter's `detect()` and fails if it calls a private store helper, so a new adapter is covered with no list to maintain

Revert-proof: pre-fix `detect()` fails 2 of 6, restored passes 6.

Regression check: same `nemo or local_query or daemon or allowlist or query_contract` subset run against a pristine `origin/main` worktree and the failure names diffed. Identical 40 pre-existing failures, zero new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)