### PR TITLE
fix(license): the pro wheel shipped without its declared dependencies

### DIFF
--- a/clawmetry/license.py
+++ b/clawmetry/license.py
@@ -660,6 +660,89 @@ def _unzip_wheel_into_site(wheel_path: str) -> tuple[bool, str]:
         return False, f"unzip install failed: {exc}"
 
 
+def _wheel_runtime_requires(wheel_path: str) -> list:
+    """``Requires-Dist`` entries the wheel needs at RUNTIME, minus clawmetry.
+
+    The pro wheel is installed with ``--no-deps`` (it is served by the license
+    server, not PyPI, and pip must not be allowed to touch clawmetry itself),
+    but clawmetry-pro DOES declare runtime dependencies. Nothing installed
+    them, so on a provisioned install:
+
+        clawmetry_pro/compliance/engine.py   import yaml    (Compliance Pack)
+        clawmetry_pro/adapters/deepagents.py import msgpack (DeepAgents)
+        clawmetry_pro/routes/nemoclaw.py     import yaml    (NeMo governance)
+
+    all raised ImportError behind a broad except, so three PAID features were
+    silently dead on an entitled account (found 2026-08-22: pip's own resolver
+    warned "clawmetry-pro 0.7.9 requires msgpack>=1.0, which is not installed"
+    during an unrelated upgrade).
+
+    Extras-gated requirements (``; extra == "x"``) are skipped: nothing
+    requests an extra here. Never raises -> [].
+    """
+    import re
+    import zipfile
+
+    out = []
+    try:
+        with zipfile.ZipFile(wheel_path) as zf:
+            meta = next(
+                (n for n in zf.namelist()
+                 if n.endswith(".dist-info/METADATA")), None,
+            )
+            if not meta:
+                return []
+            for line in zf.read(meta).decode("utf-8", "replace").splitlines():
+                if not line.startswith("Requires-Dist:"):
+                    continue
+                req = line.split(":", 1)[1].strip()
+                if not req or "extra ==" in req:
+                    continue
+                name = re.split(r"[<>=!~;\[ ]", req, 1)[0].strip()
+                # Never let pip resolve clawmetry itself: the whole point of
+                # --no-deps is that this interpreter's clawmetry is managed
+                # separately (and may be a pre-release the index lacks).
+                if name.lower().replace("_", "-") == "clawmetry":
+                    continue
+                if name:
+                    out.append((req, name))
+    except Exception:
+        return []
+    return out
+
+
+def _install_missing_requires(wheel_path: str) -> str:
+    """Install the wheel's declared runtime deps that are actually missing.
+
+    Best-effort and never raises: a pro pack with a missing optional dep is
+    degraded, but a provisioner that crashes here would block the pack
+    entirely. Returns a short status for the caller's detail string.
+    """
+    reqs = _wheel_runtime_requires(wheel_path)
+    if not reqs:
+        return ""
+    try:
+        from importlib import metadata as _md
+    except Exception:  # pragma: no cover - stdlib since 3.8
+        return ""
+    missing = []
+    for req, name in reqs:
+        try:
+            _md.version(name)
+        except Exception:
+            missing.append(req)
+    if not missing:
+        return ""
+    ok, detail = _pip_run(
+        ["install", "--disable-pip-version-check", *missing]
+    )
+    if ok:
+        return f"; deps installed ({', '.join(missing)})"
+    # Honest floor: say which deps are still missing rather than implying the
+    # pack is whole.
+    return f"; deps MISSING ({', '.join(missing)}: {detail})"
+
+
 def _pip_install_wheel(wheel_path: str) -> tuple[bool, str]:
     """Install ``wheel_path`` into THIS interpreter's environment (the same venv
     the daemon/dashboard run from — ``sys.executable``). The daemon picks the
@@ -686,7 +769,7 @@ def _pip_install_wheel(wheel_path: str) -> tuple[bool, str]:
     try:
         ok, detail = _pip_run(args)
         if ok:
-            return True, detail
+            return True, detail + _install_missing_requires(wheel_path)
         # pip absent? bootstrap it via ensurepip, then retry once.
         if "No module named pip" in detail or "No module named 'pip'" in detail:
             try:
@@ -696,7 +779,7 @@ def _pip_install_wheel(wheel_path: str) -> tuple[bool, str]:
                 )
                 ok2, detail2 = _pip_run(args)
                 if ok2:
-                    return True, detail2
+                    return True, detail2 + _install_missing_requires(wheel_path)
                 detail = detail2
             except Exception as ee:
                 detail = f"{detail}; ensurepip: {ee}"

--- a/tests/test_pro_wheel_declared_deps.py
+++ b/tests/test_pro_wheel_declared_deps.py
@@ -1,0 +1,137 @@
+"""Guard: the pro wheel's declared runtime deps actually get installed.
+
+The pro wheel is installed with ``--no-deps`` (it comes from the license
+server, not PyPI, and pip must not touch clawmetry itself). But clawmetry-pro
+declares runtime dependencies, and nothing installed them, so on a provisioned
+install these three PAID paths raised ImportError behind a broad except:
+
+    clawmetry_pro/compliance/engine.py   import yaml     (Compliance Pack)
+    clawmetry_pro/adapters/deepagents.py import msgpack  (DeepAgents adapter)
+    clawmetry_pro/routes/nemoclaw.py     import yaml     (NeMo governance)
+
+Found 2026-08-22 when pip's resolver warned during an unrelated upgrade:
+"clawmetry-pro 0.7.9 requires msgpack>=1.0, which is not installed".
+"""
+import os
+import sys
+import zipfile
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import pytest
+
+from clawmetry.license import _install_missing_requires, _wheel_runtime_requires
+
+
+def _make_wheel(tmp_path, requires):
+    """A minimal but REAL wheel carrying the given Requires-Dist lines."""
+    whl = tmp_path / "clawmetry_pro-0.0.1-py3-none-any.whl"
+    meta = ["Metadata-Version: 2.1", "Name: clawmetry-pro", "Version: 0.0.1"]
+    meta += [f"Requires-Dist: {r}" for r in requires]
+    with zipfile.ZipFile(whl, "w") as zf:
+        zf.writestr("clawmetry_pro/__init__.py", "")
+        zf.writestr("clawmetry_pro-0.0.1.dist-info/METADATA", "\n".join(meta) + "\n")
+        zf.writestr("clawmetry_pro-0.0.1.dist-info/WHEEL",
+                    "Wheel-Version: 1.0\nGenerator: test\nRoot-Is-Purelib: true\nTag: py3-none-any\n")
+    return str(whl)
+
+
+def test_reads_the_real_pro_dependency_set(tmp_path):
+    """The exact Requires-Dist set clawmetry-pro 0.7.9 ships."""
+    whl = _make_wheel(tmp_path, ["clawmetry", "msgpack>=1.0", "pyyaml>=5.0"])
+    reqs = _wheel_runtime_requires(whl)
+    names = sorted(n for _, n in reqs)
+    assert names == ["msgpack", "pyyaml"], (
+        "the wheel's declared runtime deps were not recovered from METADATA"
+    )
+
+
+def test_clawmetry_itself_is_never_resolved(tmp_path):
+    """--no-deps exists so pip cannot touch this interpreter's clawmetry."""
+    whl = _make_wheel(tmp_path, ["clawmetry", "clawmetry>=0.12", "msgpack>=1.0"])
+    assert all(n != "clawmetry" for _, n in _wheel_runtime_requires(whl))
+
+
+def test_extras_gated_requirements_are_skipped(tmp_path):
+    whl = _make_wheel(tmp_path, ['msgpack>=1.0', 'sphinx; extra == "docs"'])
+    assert sorted(n for _, n in _wheel_runtime_requires(whl)) == ["msgpack"]
+
+
+def test_already_satisfied_deps_trigger_no_install(tmp_path, monkeypatch):
+    """pytest is installed in every environment that runs this test."""
+    whl = _make_wheel(tmp_path, ["pytest"])
+    called = []
+    monkeypatch.setattr("clawmetry.license._pip_run",
+                        lambda args: (called.append(args), (True, "installed"))[1])
+    out = _install_missing_requires(whl)
+    assert called == [], "reinstalled a dependency that was already present"
+    assert out == ""
+
+
+def test_missing_deps_are_installed(tmp_path, monkeypatch):
+    """The regression: a declared dep that is absent must be installed."""
+    whl = _make_wheel(tmp_path, ["clawmetry", "definitely-not-installed-pkg>=1.0"])
+    called = []
+
+    def _fake_pip(args):
+        called.append(args)
+        return True, "installed"
+
+    monkeypatch.setattr("clawmetry.license._pip_run", _fake_pip)
+    out = _install_missing_requires(whl)
+    assert called, "a missing declared dependency was never installed"
+    assert "definitely-not-installed-pkg>=1.0" in called[0]
+    assert "clawmetry" not in " ".join(called[0]).replace("clawmetry.license", "")
+    assert "deps installed" in out
+
+
+def test_install_failure_is_reported_not_swallowed(tmp_path, monkeypatch):
+    """A degraded pack must say so rather than implying it is whole."""
+    whl = _make_wheel(tmp_path, ["definitely-not-installed-pkg>=1.0"])
+    monkeypatch.setattr("clawmetry.license._pip_run",
+                        lambda args: (False, "network unreachable"))
+    out = _install_missing_requires(whl)
+    assert "MISSING" in out
+
+
+def test_never_raises_on_a_broken_wheel(tmp_path):
+    bad = tmp_path / "not-a-wheel.whl"
+    bad.write_text("garbage")
+    assert _wheel_runtime_requires(str(bad)) == []
+    assert _install_missing_requires(str(bad)) == ""
+
+
+# --------------------------------------------------------------- wiring
+
+def test_pip_install_wheel_actually_installs_the_declared_deps(tmp_path, monkeypatch):
+    """The helper existing is not enough: the install path must CALL it.
+
+    Without this, _install_missing_requires can be silently unwired from
+    _pip_install_wheel and every unit test above still passes, which is the
+    exact shape of the original bug (a declared dependency nobody installs).
+    """
+    import clawmetry.license as L
+
+    whl = _make_wheel(tmp_path, ["clawmetry", "definitely-not-installed-pkg>=1.0"])
+    calls = []
+
+    def _fake_pip(args):
+        calls.append(list(args))
+        return True, "installed"
+
+    monkeypatch.setattr(L, "_pip_run", _fake_pip)
+    monkeypatch.setattr(L, "_site_packages_target", lambda: ("/tmp/sp", True))
+
+    ok, detail = L._pip_install_wheel(whl)
+    assert ok, detail
+
+    joined = [" ".join(c) for c in calls]
+    assert any(whl in c for c in joined), "the wheel itself was never installed"
+    assert any("definitely-not-installed-pkg" in c for c in joined), (
+        "_pip_install_wheel succeeded without installing the wheel's declared "
+        "runtime deps: the pro pack ships incomplete and paid features die on "
+        "ImportError"
+    )
+    # The wheel install itself must still be --no-deps.
+    wheel_call = next(c for c in calls if whl in " ".join(c))
+    assert "--no-deps" in wheel_call


### PR DESCRIPTION
## Why

Surfaced 2026-08-22 while upgrading this machine to 0.12.755. pip mentioned it in passing:

```
clawmetry-pro 0.7.9 requires msgpack>=1.0, which is not installed.
clawmetry-pro 0.7.9 requires pyyaml>=5.0, which is not installed.
```

The pro wheel is installed with `--no-deps`, and that is correct: it comes from the license server rather than PyPI, and pip must not be allowed to resolve `clawmetry` itself. But clawmetry-pro declares runtime dependencies, and nothing ever installed them.

```
Requires-Dist: clawmetry
Requires-Dist: msgpack>=1.0
Requires-Dist: pyyaml>=5.0
```

Three **paid** code paths import those:

| file | import | feature |
|---|---|---|
| `clawmetry_pro/compliance/engine.py:51` | `yaml`  (commented "hard dep of clawmetry-pro") | Compliance Pack |
| `clawmetry_pro/adapters/deepagents.py:142` | `msgpack` | DeepAgents adapter |
| `clawmetry_pro/routes/nemoclaw.py:544` | `yaml` | NeMo governance |

Each raises ImportError behind a broad except, so an entitled account quietly loses those features with nothing in the UI to explain it.

## What

After a successful wheel install, read the declared runtime requirements from the wheel's own METADATA and install the ones that are actually missing. `clawmetry` is always excluded, so `--no-deps` keeps doing the job it was added for.

Best-effort and never raises: a pack missing an optional dep is degraded, but a provisioner that crashes here would block the pack entirely. When a dep cannot be installed, the detail string reports `deps MISSING` rather than implying the pack is whole.

## Guard

`tests/test_pro_wheel_declared_deps.py`, driven against real wheels built to carry the same METADATA: the real dependency set, the clawmetry self-dep exclusion, extras-gated requirements, no-op when already satisfied, failure reporting, and a corrupt wheel.

The one that matters is the **wiring** test. It drives `_pip_install_wheel` end to end and asserts the deps actually get installed. Without it the helper can be silently disconnected from the install path and all seven other tests still pass, which is precisely the shape of the original bug: a declared dependency that nobody installs. Proven by unwiring it, which turns that test red and leaves the rest green.

Full suite: 12511 passed. The single failure (`test_local_trial_sync_gate`) is pre-existing and reproduces on a pristine `origin/main` worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)