### PR TITLE
fix(test): main has been red for three weeks on a guard for deleted UI

### DIFF
--- a/tests/test_local_trial_sync_gate.py
+++ b/tests/test_local_trial_sync_gate.py
@@ -241,7 +241,24 @@ def test_gw_setup_modal_retired_not_just_suppressed():
     assert "_gwApplyRuntimeDetection" not in src
 
 
-def test_no_agent_banner_suppressed_for_entitled_runtimes():
+def test_no_agent_banner_retired_not_just_suppressed():
+    """The two-runtime "No OpenClaw or NVIDIA NemoClaw detected" banner was
+    removed outright by #4415 (2026-08-02), along with its
+    ``checkAgentPresence`` poller: it framed the world as OpenClaw-or-NemoClaw
+    while ClawMetry observes 20+ runtimes, so it told a user running Claude
+    Code to go install a different agent, and it rendered on cloud node pages
+    where the pod can never filesystem-detect anything.
+
+    This guard used to pin the SUPPRESSION logic (that an all-entitled
+    detection set counted as agent-present). That literal went away with the
+    banner, so the guard has been red on main ever since while asserting a
+    behaviour the product no longer has. Pin the retirement instead, the same
+    way ``test_gw_setup_modal_retired_not_just_suppressed`` above does for the
+    setup modal: a suppressed banner can come back, a deleted one cannot.
+    """
     src = _read("clawmetry/static/js/app.js")
-    assert "_detected.every(function(r){ return r && r.entitled; })" in src, \
-        "checkAgentPresence must treat all-entitled detected runtimes as agent-present"
+    assert "checkAgentPresence" not in src, \
+        "the checkAgentPresence poller is back; #4415 removed it"
+    assert "_detected.every(function(r){ return r && r.entitled; })" not in src, \
+        "the no-agent banner's suppression logic is back, which means the " \
+        "banner is back; it must stay retired (#4415)"


### PR DESCRIPTION
## Why

`main` is currently red. `test_no_agent_banner_suppressed_for_entitled_runtimes` fails on a pristine `origin/main` worktree, and has since 2026-08-02.

It asserted that `app.js` still contains the suppression logic for the "No OpenClaw or NVIDIA NemoClaw detected" banner:

```js
_detected.every(function(r){ return r && r.entitled; })
```

#4415 removed that banner outright, along with its `checkAgentPresence` poller. The reasons were good: it framed the world as OpenClaw-or-NemoClaw while ClawMetry observes 20+ runtimes, so it told a user with 521 Claude Code sessions to go install a different agent, and it rendered on cloud node pages where the pod can never filesystem-detect a runtime.

The guard was simply left behind, asserting a behaviour the product deliberately no longer has.

## What

Rewritten to pin the **retirement** rather than the suppression, matching `test_gw_setup_modal_retired_not_just_suppressed` directly above it in the same file, which already does exactly this for the retired setup modal. A suppressed banner can come back; a deleted one cannot.

It now fails if either `checkAgentPresence` or the suppression literal reappears.

## Verification

Proven to have teeth: appending the poller back into `app.js` turns it red, removing it turns it green. `tests/test_local_trial_sync_gate.py` goes from 1 failed / 9 passed to 10 passed.

Found while baselining an unrelated change against pristine `main`, which is the only reason it surfaced at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)