### PR TITLE
Tell the fleet which machine each node actually is

### DIFF
--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -6851,17 +6851,143 @@ def _pick_heartbeat_interval(resp_json: dict | None) -> int:
     )
 
 
+def _machine_specs() -> dict:
+    """Which machine is this? — hostname, OS, arch, RAM, cores.
+
+    Deliberately EXCLUDES network addresses. Local IPs stay in the
+    E2E-encrypted snapshot (machineInfo) where the cloud cannot read them;
+    these five fields are what a person needs to recognise their own machine
+    in a fleet list, and none of them is an address anything can be reached at.
+
+    Every value is best effort and omitted rather than guessed: a fleet card
+    showing "Ubuntu 24.04 - 16 GB" is useful, one showing "unknown - 0 GB" is
+    worse than showing nothing at all.
+    """
+    import socket as _socket
+
+    specs: dict = {}
+    try:
+        specs["hostname"] = _socket.gethostname() or ""
+    except Exception:
+        pass
+    # OS as a PERSON names it ("Ubuntu 24.04", "macOS 15.3"), not as the kernel
+    # does ("Linux 6.8.0-45-generic"). The kernel string is the wrong answer to
+    # "which of my machines is this" — every Linux box gives roughly the same one.
+    system = ""
+    try:
+        system = platform.system()
+    except Exception:
+        pass
+    try:
+        if system == "Linux":
+            name = version = ""
+            with open("/etc/os-release", encoding="utf-8") as fh:
+                for line in fh:
+                    key, _, val = line.partition("=")
+                    val = val.strip().strip('"')
+                    if key == "NAME":
+                        name = val
+                    elif key == "VERSION_ID":
+                        version = val
+            specs["os"] = name or "Linux"
+            specs["os_release"] = version
+        elif system == "Darwin":
+            specs["os"] = "macOS"
+            specs["os_release"] = (platform.mac_ver() or ("",))[0] or ""
+        elif system == "Windows":
+            specs["os"] = "Windows"
+            specs["os_release"] = (platform.win32_ver() or ("",))[0] or ""
+        elif system:
+            specs["os"] = system
+            specs["os_release"] = platform.release()
+    except Exception:
+        if system:
+            specs["os"] = system
+    try:
+        specs["arch"] = platform.machine() or ""
+    except Exception:
+        pass
+    try:
+        import multiprocessing as _mp
+
+        specs["cpu_count"] = int(_mp.cpu_count())
+    except Exception:
+        pass
+    ram = _total_ram_gb()
+    if ram:
+        specs["ram_gb"] = ram
+    return {k: v for k, v in specs.items() if v not in ("", None)}
+
+
+def _total_ram_gb() -> float:
+    """Installed RAM in GB, or 0.0 when it cannot be read.
+
+    Three platform paths and no dependency on psutil, which is optional here.
+    """
+    try:
+        system = platform.system()
+        if system == "Linux":
+            with open("/proc/meminfo", encoding="utf-8") as fh:
+                for line in fh:
+                    if line.startswith("MemTotal:"):
+                        return round(int(line.split()[1]) / 1024 / 1024, 1)
+        elif system == "Darwin":
+            out = subprocess.check_output(["sysctl", "-n", "hw.memsize"], timeout=2)
+            return round(int(out.strip()) / 1024 / 1024 / 1024, 1)
+        elif system == "Windows":
+            import ctypes
+
+            class _MemStatus(ctypes.Structure):
+                _fields_ = [
+                    ("dwLength", ctypes.c_ulong),
+                    ("dwMemoryLoad", ctypes.c_ulong),
+                    ("ullTotalPhys", ctypes.c_ulonglong),
+                    ("ullAvailPhys", ctypes.c_ulonglong),
+                    ("ullTotalPageFile", ctypes.c_ulonglong),
+                    ("ullAvailPageFile", ctypes.c_ulonglong),
+                    ("ullTotalVirtual", ctypes.c_ulonglong),
+                    ("ullAvailVirtual", ctypes.c_ulonglong),
+                    ("ullAvailExtendedVirtual", ctypes.c_ulonglong),
+                ]
+
+            st = _MemStatus()
+            st.dwLength = ctypes.sizeof(_MemStatus)
+            ctypes.windll.kernel32.GlobalMemoryStatusEx(ctypes.byref(st))
+            return round(st.ullTotalPhys / 1024 / 1024 / 1024, 1)
+    except Exception:
+        pass
+    return 0.0
+
+
 def _build_node_meta() -> dict:
     """Routing-safe node metadata for the PLAINTEXT heartbeat.
 
-    The machine fingerprint (os, arch, ram_gb, cpu_count, local_ips) used to
-    live here and the cloud stored it in cleartext. It now rides the
-    E2E-encrypted snapshot (machineInfo, see _build_machine_info); only
-    routing/entitlement fields the cloud legitimately needs in cleartext stay
-    here. Best-effort: failures yield an empty value rather than raising — the
+    Carries what the cloud needs to ROUTE and ENTITLE a node, plus the machine
+    specs that let a person tell their own machines apart (see
+    :func:`_machine_specs`).
+
+    History, because this line moved once already: the full machine
+    fingerprint used to live here in cleartext, and was moved wholesale into
+    the E2E-encrypted snapshot. That took the network addresses out of the
+    cloud's reach, which was the point — and it also took away every way to
+    tell which physical machine a fleet card meant, because the snapshot can
+    only be decrypted with THAT node's key, which is the very thing you go to
+    the machine to fetch. Founder live-hit 2026-08-22, on an account with 18
+    nodes: "it's really confusing to know who owns this instance".
+
+    So the split is now drawn where the risk actually is: identity you would
+    read off a sticker on the case (hostname, OS, arch, RAM, cores) rides the
+    plaintext heartbeat; network addresses stay E2E-encrypted in machineInfo
+    and surface only in a view whose key the viewer already holds.
+
+    Best-effort: failures yield an empty value rather than raising — the
     heartbeat MUST keep flowing even on weird platforms.
     """
     meta: dict = {}
+    try:
+        meta.update(_machine_specs())
+    except Exception:
+        pass
     # Pro-adapter + auto-update status so the cloud Fleet can show whether an
     # entitled node is actually running clawmetry-pro (the paid runtime
     # adapters) and keeping itself current — turning the "I'm on Pro but Claude
@@ -12999,23 +13125,18 @@ def _build_machine_info():
             )
         # Kernel
         items.append({"label": "Kernel", "value": platform.release(), "status": "ok"})
-        # RAM + all local IPs. These moved here from the plaintext heartbeat's
-        # node_meta: the machine fingerprint is now E2E-encrypted in the snapshot
-        # and never sent in cleartext. The "Local IPs" label contains "IP" so the
-        # cloud Network-modal interceptor picks it up too.
+        # RAM (shared reader with the heartbeat's machine specs, so the two
+        # surfaces can never disagree about how much memory this box has).
+        #
+        # The LOCAL IPS below are the part that stays E2E-only: the heartbeat
+        # now carries the machine's specs in cleartext so a person can pick
+        # their own machine out of a fleet list, but nothing the machine can be
+        # REACHED at ever leaves here unencrypted. That line is drawn in
+        # _build_node_meta; keep both sides of it in sync.
         try:
-            _ramgb = ""
-            if platform.system() == "Linux":
-                with open("/proc/meminfo") as _mf:
-                    for _line in _mf:
-                        if _line.startswith("MemTotal:"):
-                            _ramgb = str(round(int(_line.split()[1]) / 1024 / 1024, 1))
-                            break
-            elif platform.system() == "Darwin":
-                _mem = subprocess.check_output(["sysctl", "-n", "hw.memsize"], timeout=2)
-                _ramgb = str(round(int(_mem.strip()) / 1024 / 1024 / 1024, 1))
+            _ramgb = _total_ram_gb()
             if _ramgb:
-                items.append({"label": "RAM", "value": _ramgb + " GB", "status": "ok"})
+                items.append({"label": "RAM", "value": f"{_ramgb} GB", "status": "ok"})
         except Exception:
             pass
         try:

--- a/tests/test_heartbeat_machine_specs.py
+++ b/tests/test_heartbeat_machine_specs.py
@@ -1,0 +1,120 @@
+"""The heartbeat carries enough to tell one of your machines from another.
+
+Founder live-hit 2026-08-22 on an 18-node account: "it's really confusing to
+know who owns this instance". Every identifying field had been moved into the
+E2E-encrypted snapshot, which can only be opened with THAT node's key — the
+very thing you walk to the machine to fetch. So the fleet card had nothing to
+show but an opaque node id.
+
+The line drawn here, and pinned by these tests: specs you could read off a
+sticker on the case travel in cleartext; anything the machine can be REACHED
+at does not.
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from clawmetry import sync  # noqa: E402
+
+
+def test_specs_identify_this_machine():
+    specs = sync._machine_specs()
+    assert specs.get("hostname"), "a fleet card with no hostname identifies nothing"
+    assert specs.get("os"), "OS is how you tell the Linux box from the laptop"
+    assert specs.get("arch")
+    assert isinstance(specs.get("cpu_count"), int) and specs["cpu_count"] >= 1
+
+
+def test_specs_never_carry_a_network_address():
+    """The privacy line. Local IPs stay in the E2E snapshot."""
+    specs = sync._machine_specs()
+    assert "local_ips" not in specs
+    assert "ip" not in specs
+    blob = repr(specs)
+    for marker in ("192.168.", "10.0.", "172.16."):
+        assert marker not in blob, f"{marker} address leaked into the plaintext heartbeat"
+
+
+def test_node_meta_carries_specs_alongside_routing_fields():
+    meta = sync._build_node_meta()
+    assert meta.get("hostname")
+    assert meta.get("os")
+    # Routing/entitlement fields must survive the addition.
+    assert "pro_version" in meta
+    assert "auto_update" in meta
+    assert "local_ips" not in meta
+
+
+def test_os_is_named_the_way_a_person_names_it(monkeypatch):
+    """"Ubuntu 24.04", not "Linux 6.8.0-45-generic" — every Linux box gives
+    roughly the same kernel string, which identifies nothing."""
+    monkeypatch.setattr(sync.platform, "system", lambda: "Linux")
+    release = 'NAME="Ubuntu"\nVERSION_ID="24.04"\nPRETTY_NAME="Ubuntu 24.04.1 LTS"\n'
+
+    import builtins
+
+    real_open = builtins.open
+
+    def fake_open(path, *a, **k):
+        if str(path) == "/etc/os-release":
+            import io
+
+            return io.StringIO(release)
+        return real_open(path, *a, **k)
+
+    monkeypatch.setattr(builtins, "open", fake_open)
+    specs = sync._machine_specs()
+    assert specs["os"] == "Ubuntu"
+    assert specs["os_release"] == "24.04"
+
+
+def test_unreadable_os_release_omits_rather_than_guesses(monkeypatch):
+    """A card reading "unknown - 0 GB" is worse than one showing nothing."""
+    monkeypatch.setattr(sync.platform, "system", lambda: "Linux")
+
+    import builtins
+
+    real_open = builtins.open
+
+    def boom(path, *a, **k):
+        if str(path) == "/etc/os-release":
+            raise OSError("no such file")
+        return real_open(path, *a, **k)
+
+    monkeypatch.setattr(builtins, "open", boom)
+    monkeypatch.setattr(sync, "_total_ram_gb", lambda: 0.0)
+    specs = sync._machine_specs()
+    assert "ram_gb" not in specs, "0 GB must be omitted, not reported"
+    assert specs.get("os") in (None, "Linux") or specs["os"], "never a blank value"
+    assert "" not in specs.values()
+
+
+def test_specs_never_raise_on_a_hostile_platform(monkeypatch):
+    """The heartbeat must keep flowing even where every probe fails."""
+    monkeypatch.setattr(sync.platform, "system", lambda: (_ for _ in ()).throw(RuntimeError("nope")))
+    monkeypatch.setattr(sync.platform, "machine", lambda: (_ for _ in ()).throw(RuntimeError("nope")))
+    specs = sync._machine_specs()
+    assert isinstance(specs, dict)
+    meta = sync._build_node_meta()
+    assert isinstance(meta, dict)
+
+
+def test_ram_reader_is_shared_with_the_machine_popup(monkeypatch):
+    """One reader, so the fleet card and the Machine popup cannot disagree
+    about how much memory the box has."""
+    monkeypatch.setattr(sync, "_total_ram_gb", lambda: 64.0)
+    assert sync._machine_specs().get("ram_gb") == 64.0
+    items = {i["label"]: i["value"] for i in sync._build_machine_info()["items"]}
+    assert items.get("RAM") == "64.0 GB"
+
+
+def test_machine_popup_still_carries_the_local_ips():
+    """The addresses did not disappear — they moved nowhere. They are still in
+    the E2E-encrypted snapshot, readable only with this node's key."""
+    labels = {i["label"] for i in sync._build_machine_info()["items"]}
+    assert "Local IPs" in labels or "IP" in labels


### PR DESCRIPTION
## The problem

On an 18-node account, a fleet card cannot tell you which physical machine it means. That matters most in exactly the moment you need it: to read a node's E2E key you have to go to that machine, and nothing on the card says which one it is.

## Why it broke

Hostname, OS, arch, cores, RAM and local IPs were moved wholesale out of the plaintext heartbeat into the E2E-encrypted snapshot (`machineInfo`). Taking the **addresses** out of the cloud's reach was right. Taking the **specs** with them was not: the snapshot opens only with that node's key, which is the very thing you walk to the machine to fetch. Chicken-and-egg.

The cloud card kept its markup for `hostname · OS · arch · cores · GB`. The fields behind it stopped arriving, so it rendered nothing, and every card looked alike.

## The line, redrawn

| rides the plaintext heartbeat | stays E2E-encrypted |
|---|---|
| hostname, os, os_release, arch, cpu_count, ram_gb | local_ips |

Identity you could read off a sticker on the case travels in cleartext. Anything the machine can be **reached at** does not, and surfaces only in the Machine panel, whose key the viewer already holds.

## Details worth knowing

- **The OS is named the way a person names it.** `Ubuntu 24.04`, `macOS 15.3`, `Windows 11` — read from `/etc/os-release`, `platform.mac_ver()`, `platform.win32_ver()`. Not `Linux 6.8.0-45-generic`: every Linux box gives roughly the same kernel string, which identifies nothing.
- **Unreadable values are omitted, not guessed.** A card reading `unknown · 0 GB` is worse than one showing nothing.
- **RAM has one reader.** The Machine popup now shares it with the heartbeat, so the two surfaces cannot disagree about the same box.
- **Nothing can raise.** Every probe is best-effort; the heartbeat keeps flowing on platforms where all of them fail.

On this machine: `{'hostname': 'Macbook-Pro-4.local', 'os': 'macOS', 'os_release': '26.3.1', 'arch': 'arm64', 'cpu_count': 12, 'ram_gb': 32.0}`

## Verification

`tests/test_heartbeat_machine_specs.py` — 8 tests: the specs identify this machine; **no network address can appear in them** (asserted against the literal `192.168.`/`10.0.`/`172.16.` prefixes); routing fields survive; the OS is named the human way; unreadable values are omitted; nothing raises on a platform where every probe fails; the RAM reader is shared; the Machine popup still carries the IPs.

Cloud side (persist + render) ships alongside in clawmetry-cloud and is back-compatible: a daemon without these fields simply leaves the card on the node id, as today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0138ySWEXGWEayXCPDqWrw21