### PR TITLE
fix(brain): hosted Activity labelled every Claude Code run "OpenClaw · ?"

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -7844,15 +7844,37 @@ function toggleBrainSequence(el) {
   if (chev) chev.style.transform = open ? 'rotate(0deg)' : 'rotate(90deg)';
 }
 
+// The event's session identity, across every feed shape. Read all three keys
+// or the cloud feed silently loses its identity:
+//   local  (routes/brain.py)  -> sessionId + src, BOTH namespaced `claude_code:<uuid>`
+//   cloud  (transformEvents)  -> `source` only, and the daemon already stripped
+//                                the namespace (sync.py _rows_to_brain_events
+//                                stamps the BARE uuid so the desk device can
+//                                match it), plus an explicit `runtime` field.
+// Reading only sessionId/src left every cloud event with an empty id, which is
+// how the hosted Brain labelled real Claude Code runs "OpenClaw \u00b7 ?" and
+// bucketed every session into one fake "unknown" run (founder screenshot,
+// 2026-08-22).
+function _brainSeqSid(ev) {
+  return (ev && (ev.sessionId || ev.src || ev.source)) || '';
+}
+
 // Human label for one block: the runtime + short session id, so a feed mixing
 // Claude Code with Antigravity says which is which.
 function _brainSeqLabel(ev) {
-  var sid = (ev && (ev.sessionId || ev.src)) || '';
-  var rt = 'openclaw', native = sid;
+  var sid = _brainSeqSid(ev);
+  // Runtime comes from the ONE canonical resolver (_cmRuntimeOf), never a
+  // local re-parse: the namespace only survives on the local feed, so a
+  // prefix-only rule defaults every cloud event to openclaw. _cmRuntimeOf
+  // falls back to the explicit runtime/agent_type field the cloud does send.
+  var rt = (typeof _cmRuntimeOf === 'function')
+    ? _cmRuntimeOf({sessionId: sid, runtime: (ev && (ev.runtime || ev.agent_type)) || ''})
+    : 'openclaw';
+  var native = sid;
   var i = sid.indexOf(':');
   if (i > 0 && sid.charAt(i + 1) !== ':') {
     var pfx = sid.slice(0, i).toLowerCase();
-    if (_CM_RT_PREFIXES && _CM_RT_PREFIXES[pfx]) { rt = pfx; native = sid.slice(i + 1); }
+    if (_CM_RT_PREFIXES && _CM_RT_PREFIXES[pfx]) { native = sid.slice(i + 1); }
   }
   var label = (_CM_RT_LABEL && _CM_RT_LABEL[rt]) || rt;
   // Orchestration children are namespaced "<parent>::wf_<run>::agent-<id>"
@@ -7906,7 +7928,7 @@ function _brainLoadOrchSummaries(events) {
   if (nowMs - _brainOrchLastFetch < 10000) return;  // poll at most every 10s
   var seen = {}, ids = [];
   (events || []).forEach(function(ev) {
-    var sid = ev.sessionId || ev.src || '';
+    var sid = _brainSeqSid(ev);
     if (!sid || sid.indexOf('::') >= 0 || seen[sid]) return;
     seen[sid] = 1;
     ids.push(sid);
@@ -7934,7 +7956,7 @@ function _brainGroupSequences(rows) {
   var order = [], buckets = {}, turnOf = {};
   rows.forEach(function(row) {
     var ev = row.ev || {};
-    var sess = (ev.sessionId || ev.src || 'unknown');
+    var sess = _brainSeqSid(ev) || 'unknown';
     if (turnOf[sess] === undefined) turnOf[sess] = 0;
     var key = sess + '#' + turnOf[sess];
     if (!buckets[key]) { buckets[key] = []; order.push(key); }
@@ -7976,7 +7998,7 @@ function _brainGroupSequences(rows) {
     var errBadge = errs
       ? '<span class="brain-seq-errs" title="' + errs + ' failed tool call' + (errs === 1 ? '' : 's') + ' in this run">\u26a0 ' + errs + '</span>'
       : '';
-    var seqSid = ((g[0].ev || {}).sessionId || (g[0].ev || {}).src || '');
+    var seqSid = _brainSeqSid(g[0].ev);
     out += '<div class="brain-seq" id="' + _brainSeqDomId(key) + '" data-sess="' + escHtml(seqSid) + '">'
         +  '<div class="brain-seq-head" onclick="toggleBrainSequence(this)">'
         +  '<span class="brain-seq-chevron">\u203a</span>'

--- a/tests/brain_sequences.test.mjs
+++ b/tests/brain_sequences.test.mjs
@@ -7,13 +7,22 @@ const endMarker = '\n// Reasoning Chain Viewer';
 const endBlock = src.indexOf(endMarker, start);
 const code = src.slice(start, endBlock);
 const escHtml = s => String(s).replace(/[&<>"]/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]));
-const _CM_RT_PREFIXES = {claude_code:1, codex:1, s:1};
-const _CM_RT_LABEL = {claude_code:'Claude Code', codex:'Codex', s:'S'};
+const _CM_RT_PREFIXES = {openclaw:1, claude_code:1, codex:1, s:1};
+const _CM_RT_LABEL = {openclaw:'OpenClaw', claude_code:'Claude Code', codex:'Codex', s:'S'};
+const _CM_OTLP_RT = {};
 const brainSourceColor = () => '#888';
 const t = (k, _a, d) => d;
 const document = undefined;
-const fn = new Function('escHtml', '_CM_RT_PREFIXES', '_CM_RT_LABEL', 'brainSourceColor', 't', code + '; return {_brainGroupSequences, _brainSeqDuration};');
-const {_brainGroupSequences, _brainSeqDuration} = fn(escHtml, _CM_RT_PREFIXES, _CM_RT_LABEL, brainSourceColor, t);
+// Pull the REAL runtime resolver out of app.js rather than stubbing it: the
+// bug this suite guards was _brainSeqLabel re-implementing runtime detection
+// instead of deferring to _cmRuntimeOf, so a stub would hide the regression.
+const rtStart = src.indexOf('function _cmRuntimeOf(');
+const rtEnd = src.indexOf('\n}', rtStart) + 2;
+const rtCode = src.slice(rtStart, rtEnd);
+const fn = new Function('escHtml', '_CM_RT_PREFIXES', '_CM_RT_LABEL', '_CM_OTLP_RT', 'brainSourceColor', 't',
+  rtCode + '\n' + code + '; return {_brainGroupSequences, _brainSeqDuration, _brainSeqLabel, _cmRuntimeOf};');
+const {_brainGroupSequences, _brainSeqDuration, _brainSeqLabel, _cmRuntimeOf} =
+  fn(escHtml, _CM_RT_PREFIXES, _CM_RT_LABEL, _CM_OTLP_RT, brainSourceColor, t);
 
 const T = (min) => new Date(Date.UTC(2026, 7, 1, 0, min, 0)).toISOString();
 let pass = 0, fail = 0;
@@ -96,6 +105,50 @@ check('exactly one block is badged', (eout.match(/brain-seq-errs/g)||[]).length 
 check('error lane gets the red ring', (eout.match(/brain-lane-bar-err/g)||[]).length === 1);
 check('lane tooltip carries the error count', eout.includes('2 errors'));
 check('clean feed has no error chrome', !out.includes('brain-seq-errs') && !out.includes('brain-lane-bar-err'));
+
+// ── Cloud feed shape (regression: "OpenClaw \u00b7 ?") ──────────────────────
+// The hosted Brain gets its events from clawmetry-cloud's transformEvents,
+// which emits {time, source, sourceLabel, type, detail, color, runtime} and
+// NO sessionId/src — and the daemon already stripped the `claude_code:`
+// namespace off the id (sync.py _rows_to_brain_events). Reading only
+// sessionId/src therefore produced an empty id and the hardcoded openclaw
+// default, so every Claude Code run on app.clawmetry.com rendered as
+// "OpenClaw \u00b7 ?" and all runs collapsed into one bogus lane.
+// Founder screenshot 2026-08-22, node Macbook-Pro.local, ?runtime=claude_code.
+const C = (uuid, min, html, type) =>
+  ({ev:{source:uuid, sourceLabel:uuid, runtime:'claude_code', time:T(min), type:type}, html:html});
+const cloudRows = [
+  C('42d6441e-c368-4956-a385-25454d56d94e', 10, '<c4>'),
+  C('07e1bba1-1c79-4230-b28e-000000000000', 9, '<d3>'),
+  C('42d6441e-c368-4956-a385-25454d56d94e', 8, '<c3>'),
+  C('07e1bba1-1c79-4230-b28e-000000000000', 6, '<d2>'),
+  C('42d6441e-c368-4956-a385-25454d56d94e', 4, '<c2>'),
+  C('42d6441e-c368-4956-a385-25454d56d94e', 0, '<c1>'),
+  C('07e1bba1-1c79-4230-b28e-000000000000', 0, '<d1>'),
+];
+const cout = _brainGroupSequences(cloudRows);
+check('cloud shape: runtime label is the real runtime, not openclaw',
+  cout.includes('Claude Code') && !cout.includes('OpenClaw'));
+check('cloud shape: session id rendered, never "?"',
+  cout.includes('42d6441e') && cout.includes('07e1bba1') && !cout.includes('\u00b7 ?'));
+check('cloud shape: one block per SESSION, not one "unknown" bucket',
+  (cout.match(/class="brain-seq"/g)||[]).length === 2);
+check('cloud shape: one swimlane lane per session',
+  (cout.match(/class="brain-lane"/g)||[]).length === 2);
+check('cloud shape: blocks anchor to their session id',
+  (cout.match(/data-sess="42d6441e-c368-4956-a385-25454d56d94e"/g)||[]).length === 1);
+
+// Single-event label unit checks across all three feed shapes.
+check('label: local namespaced sessionId',
+  _brainSeqLabel({sessionId:'claude_code:42d6441e-c368-4956'}) === 'Claude Code \u00b7 42d6441e');
+check('label: cloud bare source + runtime field',
+  _brainSeqLabel({source:'42d6441e-c368-4956', runtime:'claude_code'}) === 'Claude Code \u00b7 42d6441e');
+check('label: truncated src still resolves the runtime',
+  _brainSeqLabel({src:'codex:9f1c2b3a-dead'}) === 'Codex \u00b7 9f1c2b3a');
+check('label: a genuine bare-uuid OpenClaw session is still OpenClaw',
+  _brainSeqLabel({sessionId:'682c73e4-aaaa-bbbb'}) === 'OpenClaw \u00b7 682c73e4');
+check('label: no identity at all degrades safely',
+  _brainSeqLabel({}) === 'OpenClaw \u00b7 ?');
 
 console.log(`\n${pass} passed, ${fail} failed`);
 process.exit(fail ? 1 : 0);

--- a/tests/test_brain_sequences_js.py
+++ b/tests/test_brain_sequences_js.py
@@ -1,0 +1,43 @@
+"""Runner for the Node-based Brain run-grouping unit tests.
+
+``tests/brain_sequences.test.mjs`` extracts the sequence helpers from the
+shipped ``clawmetry/static/js/app.js`` (plus the real ``_cmRuntimeOf``
+resolver) and asserts that a Brain feed groups into one block per agent run,
+labels each run with its actual runtime, and renders the swimlane.
+
+The suite existed for months with NO runner -- nothing in the Makefile or any
+workflow ever executed it, so it was a test that could not fail. This wrapper
+wires it into the normal pytest run. It also carries the regression guard for
+the hosted-Brain label bug (every Claude Code run rendered "OpenClaw . ?"
+because the cloud feed carries ``source`` + ``runtime`` instead of a
+namespaced ``sessionId``).
+
+Skipped (not failed) when ``node`` is not on PATH.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+
+import pytest
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_JS_TEST = os.path.join(_HERE, "brain_sequences.test.mjs")
+
+
+@pytest.mark.skipif(
+    shutil.which("node") is None,
+    reason="node not on PATH; JS unit tests only run when Node is available",
+)
+def test_brain_sequences_js_suite() -> None:
+    proc = subprocess.run(
+        ["node", _JS_TEST],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    output = (proc.stdout or "") + (proc.stderr or "")
+    assert proc.returncode == 0, "brain sequence JS tests failed:\n" + output
+    assert "0 failed" in output, "no clean summary line in output:\n" + output


### PR DESCRIPTION
## The bug

On app.clawmetry.com the Activity (Brain) tab labelled every run `OpenClaw · ?`, even with the runtime switcher pinned to Claude Code. Reported from a live node (`Macbook-Pro.local`, `?runtime=claude_code`, 596 sessions) where the runs were plainly Claude Code.

Two separate things were wrong in one line of output: the runtime was wrong (`OpenClaw`) and the session id was missing (`?`). The swimlane drew three lanes for what were actually two sessions.

## Root cause

`_brainSeqLabel` re-implemented runtime detection instead of using the canonical resolver:

```js
var sid = (ev && (ev.sessionId || ev.src)) || '';
var rt = 'openclaw', native = sid;      // default, never revisited
```

It recovered the runtime only from a `runtime:` prefix on the session id. Neither input survives the cloud path:

1. `sync.py::_rows_to_brain_events` deliberately stamps the **bare** uuid (`_sid.rsplit(":", 1)[-1]`) so the desk device can match it. That strips the prefix, which is the runtime discriminator.
2. `clawmetry-cloud`'s `transformEvents` emits `{time, source, sourceLabel, type, detail, color, runtime}`. There is no `sessionId` and no `src` on a cloud brain event.

So `sid` was empty (rendered `?`) and `rt` stayed at its hardcoded default (`OpenClaw`), while the correct value sat unread in `ev.runtime`. `_cmRuntimeOf`, the resolver every other surface uses, reads that field and gets it right, which is why the header switcher filtered correctly while the label did not.

The empty id also meant `_brainGroupSequences` bucketed every cloud event under `'unknown'`, so the swimlane was showing turn-splits of one imaginary merged session rather than one lane per run.

## The fix

* New `_brainSeqSid(ev)` reads `sessionId || src || source`.
* `_brainSeqLabel` resolves the runtime through `_cmRuntimeOf` instead of its own prefix parse.
* Applied to all four readers of the old pair, not just the reported one: the label, the bucket key, the block's `data-sess` anchor, and `_brainLoadOrchSummaries` (which for the same reason collected zero ids in cloud, so orchestration badges never painted there either; the cloud side answers that call from the snapshot via the `cm-cloud-session-orchestration` interceptor, so this adds no network traffic).

## Verification

Against live data, not fixtures. 51 real events from `/api/brain-history`, replayed through the shipped helpers in both the local shape and the cloud shape:

```
live LOCAL events: 51
distinct labels: Claude Code · 42d6441e | Claude Code · 07e1bba1
blocks: 2  lanes: 2   contains "· ?": false
cloud-shaped labels: Claude Code · 42d6441e | Claude Code · 07e1bba1
cloud blocks: 2  lanes: 2  has "· ?": false
```

Both shapes now produce identical, correct output. Live cloud verification follows the release and the cloud pin.

## Guard

`tests/brain_sequences.test.mjs` gains the cloud feed shape plus per-shape label unit checks (namespaced `sessionId`, bare `source` + `runtime`, truncated `src`, a genuine bare-uuid OpenClaw session, and no identity at all). Revert-proofed: 6 checks fail on the un-fixed code, all 36 pass with it.

That suite had **no runner**. Nothing in the Makefile or any workflow ever executed it, so it was a test that could not fail. `tests/test_brain_sequences_js.py` now wires it into the normal pytest run, matching the existing `test_brain_time_range_js.py` pattern.

## Notes

Frontend only, in `clawmetry/static/js/app.js`. The cloud serves this file from the pip wheel, so this needs a `[RELEASE]` and a cloud pin bump to reach app.clawmetry.com. Software Factory records updated (drift-bot finding closed): Blueprint `Runtime and Session Observability` v25 gains an `ActivityRunGrouper` component, three run-identity contracts, and ADR-015; requirements `Runtime and Session Observability` v9 and `Local Agent Observability` v6 gain the matching acceptance criteria. Written in external terms with no private function names, and placed inside the existing top-level sections rather than appended, since drift-bot reads only a prefix of a long blueprint and this one is now 45k.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
