### PR TITLE
[RELEASE] Fleet cards say which machine they are (carries #5097)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1112,6 +1112,14 @@
 
 ## [Unreleased]
 
+### Fix: you can tell which machine is which again (2026-08-22)
+- **Why:** with more than a couple of machines connected, the fleet list stopped being readable. Every card showed an identifier and little else, so working out which physical machine a card meant was guesswork. That matters most in the moment you need it: to read a machine's secret key you have to go to that machine, and nothing on the screen told you which one to go to.
+- **What:** each machine now says what it is. A card reads like "Ubuntu 24.04 - x86_64 - 8 cores - 16 GB" next to the machine's own name, so you can recognise your own laptop, your server and your spare box at a glance. The operating system is named the way you would say it, not as a kernel version, because those are near enough identical on every machine and tell you nothing.
+- **What:** where a runtime runs on several machines, the card now names them instead of only counting them. "6 nodes" became the actual machines, with the rest a click away.
+- **What:** network addresses are deliberately NOT part of this. They stay encrypted on your machine and are shown only on that machine's own page, which already needs its key. What travels is the sort of thing you could read off a sticker on the case, and nothing that says where the machine is or how to reach it.
+- **What:** a machine that cannot report one of these details simply leaves it out. Nothing shows "unknown" or a zero in its place, and a machine still running an older version looks exactly as it did before.
+- **Verified:** in a real browser against a rendered fleet, both that the details appear and that no address does.
+
 ### Fix: set up from the terminal, then asked to set up again in the browser (2026-08-22)
 - **Why:** someone who installed ClawMetry and connected their account from the terminal opened the dashboard and was met by the first-run welcome screen, asked to choose how ClawMetry should run and to sign in a second time. The terminal knew perfectly well who they were: running `clawmetry status` on the same machine printed their account and their plan. Two answers to the same question on one machine, and the wrong one is the one you are looking at.
 - **What:** every way of finishing setup now leaves the same mark. Connecting your account, signing in, running the setup wizard, activating a licence key, or completing setup in the desktop app all record the choice you made, so the browser only ever asks the question when nothing on the machine has answered it. A plain install that has never chosen still sees the welcome screen, which is the whole point of it.


### PR DESCRIPTION
Carries #5097 (merged). Cloud half already merged as clawmetry-cloud#2084.

**What ships**
- The daemon reports its machine's specs on the plaintext heartbeat: hostname, OS name and version, architecture, core count, RAM. The fleet card renders `Ubuntu 24.04 · x86_64 · 8 cores · 16 GB`, so a person can tell their machines apart.
- Network addresses stay in the E2E-encrypted snapshot and are never sent in cleartext. They remain visible in the node's Machine panel, which already requires that node's key.
- The OS is named as a person names it, not as a kernel version. Unreadable values are omitted rather than shown as `unknown` or `0`.
- The Machine panel and the heartbeat now share one RAM reader, so they cannot disagree about the same machine.

**Why the split.** All of this identity had been moved into the encrypted snapshot. That snapshot opens only with the node's own key — the very thing you walk to the machine to fetch — so the encrypted copy could not help anyone find the machine. Specs identify; addresses locate. Only the first half needs to be readable.

**Verified before merge**
- `tests/test_heartbeat_machine_specs.py`, 8 tests, including an assertion that no address prefix can appear in the plaintext payload.
- Cloud side: 5 unit tests (specs round-trip; `local_ips` dropped even when sent) and 3 Playwright tests reading the **rendered** card — the original bug was markup that silently produced nothing, which an API-level assertion would not have caught.
- 35 of 36 checks green on #5097 (1 skipped), drift-bot clean on both repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0138ySWEXGWEayXCPDqWrw21