### PR TITLE
fix(verification): register the AC gate's guard files (follow-up to #5089)

### DIFF
--- a/FLYWHEEL.md
+++ b/FLYWHEEL.md
@@ -149,7 +149,9 @@ This repo (and `clawmetry-cloud` / `clawmetry-pro` / `clawmetry-mac` / `clawmetr
 - The dashboard's "Sync Blueprint with Code" agent action (or the Software Factory MCP skill, `npx skills add 8090-inc/software-factory-plugin`) can do this for you; point it at the specific PR/CHANGELOG entry rather than asking for a blanket sync of everything.
 - A red `drift-bot` check is a real signal like any other CI failure (§4) — fix the documentation gap, don't merge past it.
 
-Separately, **check [Pending Work Orders](https://factory.8090.ai) regularly**, not just when drift-bot fires. Work Orders are the actual tickets Software Factory queues from Requirements/Blueprints; picking them up (not just reacting to drift after the fact) is how the docs and the code stay one thing instead of drifting apart again next week.
+**Work Orders are a strategic backlog, not the work queue.** The factory holds 23 of them. As of 2026-08-22, zero are completed and zero of the last 60 commits reference one; what actually ships is cost fixes, compat fixes and signing guards that nobody wrote a ticket for. That is not a discipline failure to correct, it is how a solo repo with a fast flywheel really works, and this file used to instruct you to "check Pending Work Orders regularly" which nobody did and nothing broke.
+
+So: read the board when you want to know what the product is *supposed* to become next. Do not treat it as a queue you are behind on, and do not open a Work Order for routine work. Open one when a piece of work is genuinely the next thing you intend to build and you want it specified before you start. Requirements and Blueprints are the parts of the factory that carry their weight (see §1f and §1g); the ticket layer is optional and currently unused.
 
 ## 1g. Every acceptance criterion is traceable to a test
 

--- a/tests/test_guard_census.py
+++ b/tests/test_guard_census.py
@@ -109,7 +109,22 @@ def _live_ratchets() -> dict:
     ) as fh:
         mutation_config = json.load(fh)
 
+    import importlib.util
+
+    ac_spec = importlib.util.spec_from_file_location(
+        "check_ac_coverage",
+        os.path.join(REPO_ROOT, "scripts", "check_ac_coverage.py"),
+    )
+    ac_gate = importlib.util.module_from_spec(ac_spec)
+    ac_spec.loader.exec_module(ac_gate)
+    ac_declared, _ac_mentioned = ac_gate.scan_tests()
+    ac_manifest = ac_gate.load_manifest()
+    ac_covered = sum(
+        1 for c in ac_manifest["criteria"] if c["id"] in ac_declared
+    )
+
     return {
+        "acceptance_criteria_covered": ac_covered,
         "e2e_gate_required_specs": len(e2e_gate.REQUIRED_SPECS),
         "pip_install_matrix_legs": pip_spec.min_count if pip_spec else 0,
         "workflow_files_parsed": len(workflows),

--- a/verification/guards.json
+++ b/verification/guards.json
@@ -100,6 +100,26 @@
       "path": "tests/test_mutation_ratchet_is_deterministic.py",
       "why": "A ratchet that moves on its own fails PRs that changed nothing relevant, and the only escapes are lowering the baseline or re-running until it passes. The score really did move (53/50/47 on one commit) because a same-length mutation could execute stale .pyc bytecode.",
       "min_bytes": 3500
+    },
+    {
+      "path": "scripts/check_ac_coverage.py",
+      "why": "AC-OBS-CEA-001.2 forbade a $0.00 cost window before #5079 shipped one; the criterion existed and nothing could fail on it. This file is what makes an acceptance criterion failable.",
+      "min_bytes": 5000
+    },
+    {
+      "path": "docs/acceptance_criteria.json",
+      "why": "The mirror of the 77 acceptance criteria this repo implements. Emptying it makes the AC gate pass vacuously: zero criteria means zero uncovered, and the ratchet reports success while enforcing nothing.",
+      "min_bytes": 12000
+    },
+    {
+      "path": "docs/ac_coverage_baseline.json",
+      "why": "The AC ratchet itself. Repopulating it with every criterion re-opens every door the gate closed, silently, because the gate would still report OK.",
+      "min_bytes": 1500
+    },
+    {
+      "path": "tests/test_ac_coverage_guard.py",
+      "why": "Pins the AC gate's declaration rule. Without it the first draft's loophole returns, where a file naming a criterion it does NOT cover marks that criterion covered.",
+      "min_bytes": 3000
     }
   ],
   "ratchets": {
@@ -126,6 +146,10 @@
     "mutation_targets": {
       "value": 2,
       "why": "Modules under mutation testing. Dropping a target removes the only measurement that can see a weakened assertion."
+    },
+    "acceptance_criteria_covered": {
+      "value": 9,
+      "why": "Acceptance criteria (of 77) declared by at least one test. Was 0 across 964 test files. A criterion no test references is prose, not a guard: that is how #5079 shipped a $0.00 cost window that AC-OBS-CEA-001.2 had forbidden for months."
     }
   }
 }


### PR DESCRIPTION
Follow-up to #5089. Two things did not make it into that merge: GitHub had the PR head pinned at `2ee4e3a7d` when it landed at 21:42Z, so commits pushed after that point stayed behind, and `drift-bot` was red at merge time over a finding that is still unfixed.

The result is that **main has the AC traceability gate with none of its own guard files registered**.

## 1. The gate joins the guard census

Main grew a six-layer verification architecture (#5082) while #5089 was open. Its census is the ratchet registry, and the AC gate is a ratchet, so it registers there rather than running alongside as an unrelated second system.

Drift Bot's finding on #5089 was correct: the blueprint's GuardCensus component and ADR-002 require every guard file to be declared. Three of the four can each disable the gate on their own while CI stays green:

| File | How it silently disables the gate |
|---|---|
| `docs/acceptance_criteria.json` | Empty it and the gate passes vacuously: zero criteria means zero uncovered, so the ratchet reports OK while enforcing nothing |
| `docs/ac_coverage_baseline.json` | Refill it with all 77 and every door the gate closed re-opens, still green |
| `tests/test_ac_coverage_guard.py` | Delete it and the declaration-rule loophole returns, where naming a criterion you do NOT cover marks it covered |

`acceptance_criteria_covered` also joins `ratchets` at 9, measured live from the real manifest by `_live_ratchets()` so the baseline is measured rather than aspirational. Two ratchets now enforce the same direction from opposite ends: `ac_coverage_baseline.json` fails when a criterion loses its test, the census fails when the total drops below 9.

Not added to `verification/matrix.json`: those cells are product-and-platform shipping surfaces (does pip install work on Windows 3.11). This is a process guard, so the census is its correct home.

The blueprint was right and the code was incomplete, so this is a code fix. No spec was edited to match the implementation.

## 2. FLYWHEEL §1f: the Work Order board is a strategic backlog, not the work queue

The board holds 23 Work Orders; zero are completed and zero of the last 60 commits reference one. FLYWHEEL told you to check Pending Work Orders regularly, nobody did, and nothing broke. A process doc that lies about its own process erodes trust in the parts that are load bearing. Requirements and Blueprints carry their weight (§1f drift-bot, §1g AC traceability); the ticket layer is optional and currently unused.

## Verified

* AC gate green at 9/77 on top of current main
* 75/75 across `test_guard_census.py` (46, up from 40), `test_ac_coverage_guard.py` (16) and `test_verification_matrix.py` (13)
* Diff is exactly three files

## Note on the merge

#5089 merged with `drift-bot` red. Per FLYWHEEL §4 that is a real signal rather than a flaky check, and here it was pointing at a genuine hole now live on main. Worth checking whether the branch protection rule actually requires `drift-bot`, because it did not stop that merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RBgTZ4GY8oWyQePbNaAR8G
