### PR TITLE
fix(entitlements): fail open on resolver exception even under enforce

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -52,7 +52,7 @@ import logging
 import os
 import threading
 import time
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 
 logger = logging.getLogger("clawmetry.entitlements")
 
@@ -2489,6 +2489,25 @@ def _oss_free() -> Entitlement:
     return _build(TIER_OSS, "oss", node_limit=1, expiry=None)
 
 
+def _fail_open_free() -> Entitlement:
+    """Fallback entitlement used only when :func:`get_entitlement` catches an
+    unexpected exception. ``grace`` is forced ``True`` regardless of
+    :func:`is_enforced`, so every ``allows_*`` check returns ``True`` and a
+    resolver bug cannot paywall a paying customer's agent after the enforce
+    date lands. The ``source`` string is distinct from ``"oss"`` so telemetry
+    and support can tell a real OSS install apart from a fail-open fallback.
+
+    See ``CLAUDE.md`` -- "Fail open on entitlement, closed on policy. If a
+    licence/entitlement lookup errors or is ambiguous, the agent KEEPS
+    RUNNING -- only a policy the user actually declared may block or kill.
+    A billing bug must never stop a customer's agent."
+    """
+    ent = _build(TIER_OSS, "resolver_error", node_limit=1, expiry=None)
+    if not ent.grace:
+        ent = replace(ent, grace=True)
+    return ent
+
+
 def _read_local_license() -> Entitlement | None:
     try:
         if not os.path.isfile(_LICENSE_PATH):
@@ -2623,8 +2642,12 @@ def get_entitlement(force: bool = False) -> Entitlement:
         _maybe_emit_change(ent)
         return ent
     except Exception as exc:
-        logger.warning("entitlements: resolution failed, defaulting to OSS free: %s", exc)
-        return _oss_free()
+        logger.warning(
+            "entitlements: resolution failed, failing open (grace) so the "
+            "agent keeps running: %s",
+            exc,
+        )
+        return _fail_open_free()
 
 
 def invalidate() -> None:

--- a/tests/test_entitlements.py
+++ b/tests/test_entitlements.py
@@ -137,6 +137,61 @@ def test_corrupt_cloud_plan_falls_back_to_oss(ent, tmp_path):
     assert en.tier == ent.TIER_OSS  # never raises, falls through
 
 
+def test_get_entitlement_fails_open_on_resolver_exception(ent, monkeypatch):
+    """Contract: an unexpected exception inside get_entitlement must return a
+    fail-open verdict -- ``grace`` forced ``True`` so every ``allows_*`` check
+    still passes even when :func:`is_enforced` is ``True``. Enforces the
+    "fail open on entitlement, closed on policy" rule from ``CLAUDE.md``:
+    a billing/resolver bug must never paywall a paying customer's agent."""
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+
+    def boom(*_a, **_kw):
+        raise RuntimeError("synthetic resolver failure")
+
+    # Detonate the primary resolver path so the outer try/except takes over.
+    monkeypatch.setattr(ent, "_read_local_license", boom)
+    monkeypatch.setattr(ent, "_read_cloud_plan", boom)
+
+    en = ent.get_entitlement(force=True)
+
+    assert en.grace is True, "resolver failure must not flip an install into enforce mode"
+    assert en.source == "resolver_error", "distinct source so telemetry can spot the fallback"
+    assert en.tier == ent.TIER_OSS
+    # The whole point: paid runtimes and paid features stay unlocked even when
+    # CLAWMETRY_ENFORCE is on, because the resolver couldn't answer.
+    assert en.allows_runtime("claude_code") is True
+    assert en.allows_runtime("openclaw") is True
+    assert en.allows_feature("custom_alerts") is True
+    assert en.allows_feature("multi_node") is True
+    assert en.allows_feature("otel_export") is True
+
+
+def test_get_entitlement_fail_open_does_not_poison_cache(ent, monkeypatch):
+    """A fail-open verdict must not be cached as if it were the real entitlement:
+    once the resolver recovers, the next call must reflect reality."""
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+
+    calls = {"n": 0}
+
+    def flaky(*_a, **_kw):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise RuntimeError("transient")
+        return None  # recovered -- no license present
+
+    monkeypatch.setattr(ent, "_read_local_license", flaky)
+
+    first = ent.get_entitlement(force=True)
+    assert first.source == "resolver_error"
+
+    # A subsequent call must re-resolve rather than serve the fail-open verdict
+    # from cache. Without force=True the cache-fresh check would short-circuit
+    # to whatever is cached; verify the fail-open path did not populate it.
+    second = ent.get_entitlement()
+    assert second.source == "oss", "fail-open verdict must not be cached"
+    assert second.grace is False, "real enforce-mode verdict returns after recovery"
+
+
 def test_to_dict_shape(ent):
     d = ent.get_entitlement(force=True).to_dict()
     for key in ("tier", "source", "grace", "enforced", "retention_days",

--- a/tests/test_entitlements_cache.py
+++ b/tests/test_entitlements_cache.py
@@ -132,7 +132,11 @@ def test_installed_cloud_plan_visible_after_invalidate(ent, tmp_path):
 
 
 def test_resolver_failure_falls_back_to_oss_free(ent, monkeypatch):
-    """If the resolver raises, get_entitlement returns an OSS-free entitlement."""
+    """If the resolver raises, get_entitlement returns an OSS-tier entitlement
+    that FAILS OPEN: ``grace`` is forced ``True`` even under
+    ``CLAWMETRY_ENFORCE``, and the ``source`` is ``"resolver_error"`` so a
+    real OSS install is distinguishable from a transient billing bug in
+    telemetry. See ``clawmetry/entitlements.py::_fail_open_free``."""
     def _boom():
         raise RuntimeError("simulated license read explosion")
 
@@ -142,7 +146,7 @@ def test_resolver_failure_falls_back_to_oss_free(ent, monkeypatch):
 
     en = ent.get_entitlement()
     assert en.tier == ent.TIER_OSS
-    assert en.source == "oss"
+    assert en.source == "resolver_error"
     assert en.grace is True
 
 


### PR DESCRIPTION
## Summary

- `get_entitlement()`'s outer `try/except` previously fell back to `_oss_free()`, which honours `is_enforced()` and yields a `grace=False` OSS-tier entitlement in enforce mode. After the enforce rollout that means a transient resolver bug (corrupt cache, license file inaccessible, an internal helper that starts raising) paywalls a paying customer — exactly the failure mode `CLAUDE.md` bans with *"fail open on entitlement, closed on policy: a billing bug must never stop a customer's agent."*
- Add `_fail_open_free()`, which builds an OSS-tier entitlement with `grace=True` forced regardless of `is_enforced()` and a distinct `source="resolver_error"` so telemetry can tell a real OSS install apart from a resolver fallback. Route the exception branch of `get_entitlement()` through it. The verdict is still not cached (the existing code path only writes the cache on the happy path), so a transient failure never persists past its recovery.
- Pin the contract with two tests in `tests/test_entitlements.py`; update the existing `test_resolver_failure_falls_back_to_oss_free` in `tests/test_entitlements_cache.py` to assert the new `source="resolver_error"` marker (`tier` and `grace` unchanged).

Zero behaviour change while `CLAWMETRY_ENFORCE` is unset (the default today): the happy path still returns `_oss_free()` with `source="oss"` in grace mode. The fail-open helper only fires when the resolver itself raises — a path exercised by `test_resolver_failure_falls_back_to_oss_free` and now `test_get_entitlement_fails_open_on_resolver_exception`.

## Test plan

- [x] `python -m py_compile clawmetry/entitlements.py tests/test_entitlements.py tests/test_entitlements_cache.py`
- [x] `ruff check clawmetry/entitlements.py tests/test_entitlements.py tests/test_entitlements_cache.py`
- [x] `pytest tests/test_entitlements.py tests/test_entitlements_cache.py tests/test_entitlement_api.py tests/test_entitlement_change_emit.py tests/test_entitlement_expiry.py tests/test_entitlements_catalogue.py tests/test_entitlement_resolution_diagnostic.py` — 179 passed
- [x] Downstream sweep: `pytest tests/test_is_pro_user_license_branch.py tests/test_trial_enforcement_free_tier.py tests/test_trial_hard_block_free_only.py tests/test_family_ingest_entitlement_gate.py tests/test_license.py tests/test_license_audit.py tests/test_sync_cloud_plan_cache.py tests/test_cli_status_plan_line.py` — 181 passed
- [x] Verified no production code branches on `entitlement.source == "oss"` (grepped `clawmetry/`, `routes/`, `dashboard.py`).
- [x] Verified the one flake surfaced by the broader `pytest -k 'resolver or fail_open or fallback or entitlement_*'` sweep (`test_fallback_mints_trial_after_subprocess_failure`) reproduces identically on `origin/main` with the diff stashed — it is a pre-existing test-order flake, unrelated to this change.

## Local operator verification checklist

Only doable on the operator's host (this PR was authored in a remote sandbox with no access to the daemon, `~/.openclaw`, the live snapshot, or a browser):

- [ ] `cp clawmetry/entitlements.py ~/.clawmetry/lib/python*/site-packages/clawmetry/entitlements.py`
- [ ] `find ~/.clawmetry/lib -name __pycache__ -exec rm -rf {} +`
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
- [ ] `curl -s http://localhost:8900/api/entitlement | jq '{tier, source, grace, enforced}'` — under normal operation, `source` stays `"oss"` (or `"cloud"` / `"license"` for paid installs). It should never surface `"resolver_error"` on a healthy install; that string appearing in the wild is a signal to look at daemon logs.
- [ ] Grep `~/.clawmetry/sync.log` for `entitlements: resolution failed, failing open` — should be absent under normal operation.
- [ ] Sanity: temporarily `chmod 000 ~/.clawmetry/license.key` (if present) then `curl /api/entitlement` — expect `grace=true` and paid runtimes still allowed, then `chmod 600` to restore.
- [ ] Decrypt the live snapshot, browser-check the dashboard loads unchanged.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NWVywkxrscp59Erwm6V3tA)_