### PR TITLE
[RELEASE] PR Trace, the local half (carries #5115)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+### Release: PR Trace, the local half (carries #5115) (2026-08-23)
+- Ships `clawmetry trace init` and `clawmetry trace capture` to PyPI. See the feature entry below for what they do and what they deliberately do not do yet.
+- Nothing publishes anywhere. Capture writes a bundle and a review page to disk and tells you where. The hosted resolver and viewer are separate work in the cloud repo.
+
 ### Feature: link a pull request to the agent session that produced it (2026-08-23)
 - **Who this reaches:** anyone whose pull requests are written with help from an AI agent, and anyone who reviews those pull requests. It is opt in per repository and changes nothing until you run one command.
 - **What you can do now:** `clawmetry trace init` installs a commit hook, and from then on every commit made inside an agent session carries a `Clawmetry-Session` trailer naming that session. `clawmetry trace capture --range A..B --pr 123` then turns a commit range into a bundle of what the agent actually did, plus a single self contained HTML page you can open in a browser. The default view is the list of prompts a human typed, in order, because that is the question a reviewer actually has.


### PR DESCRIPTION
Publishes the local half of PR Trace (carries #5115).

## What reaches users

```
clawmetry trace init                              # install the commit hook
clawmetry trace capture --range A..B --pr 123     # bundle + review page
```

`init` writes a `Clawmetry-Session` trailer on every commit made inside an agent
session, which is the join a PR trace needs and which did not exist before.
`capture` turns a commit range into a bundle plus a self-contained HTML page
whose default view is the prompts a human typed, in order.

## What this release does NOT do

Nothing publishes to the network. `capture` writes to disk and says so. The
hosted resolver, the public viewer and the GitHub App are separate work in
clawmetry-cloud, so this is useful on its own but it is not the full product.

## Why ship the local half now

Coverage starts when the hook is installed and cannot be backfilled: transcripts
are rotated by the runtimes that write them, and the store keeps only the most
recent sessions per runtime. Every day the hook is not installed is a trace
permanently lost, so the hook is worth shipping ahead of everything that
consumes it.

## Verification carried from #5115

- 45 tests across the two new modules, green.
- Real end to end on a real repo and a real session: agent commit stamped, human
  commit not stamped, foreign hook never clobbered, bundle resolved `exact` with
  a real cost, rendered page has no network requests and escapes prompt text.
- Publication redaction checked against a real bundle: no home paths, no emails.
- 34 CI checks pass, including the required E2E Gate.
- drift-bot is red on a documentation gap. It is filed as a pending Blueprint
  suggestion in Software Factory (contracts plus ADR-016) and flagged in the PR
  body and a PR comment. It is not a branch-protection required check, and the
  gap is documented rather than silent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012UjuRS7Xn4JJGacSgRMbrK
