### PR TITLE
feat(trace): publish a captured bundle to trace.clawmetry.com

### DIFF
--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -4646,9 +4646,30 @@ def _trace_capture(rest) -> int:
     print(f"  bundle  {json_path}")
     print(f"  review  {html_path}")
     print()
-    print("  Nothing was published. Open the HTML, confirm it is safe to share,")
-    print("  then publish once the cloud endpoint exists (PRD 4e).")
-    return 0
+
+    if "--publish" not in rest:
+        print("  Nothing was published. Open the review page, confirm it is safe")
+        print("  to share, then re-run with --publish.")
+        return 0
+
+    # Publication is a separate, explicit step: the thing being written is a
+    # public web page containing the contents of somebody's terminal.
+    if not pr:
+        print("  --publish needs --pr <number> so the trace has a URL.")
+        return 1
+    print("  Publishing…")
+    res = trace_capture.publish(bundle)
+    if res.get("ok"):
+        print(f"  LIVE  {res.get('url')}")
+        print()
+        print("  Anyone with the link can read it, with no account.")
+        print("  Re-running capture --publish for the same PR replaces it.")
+        return 0
+    print(f"  Publish failed: {res.get('error')}")
+    if res.get("detail"):
+        print(f"  {res['detail']}")
+    print("  The bundle is still on disk; nothing was sent.")
+    return 1
 
 
 def trace_main(argv) -> int:

--- a/clawmetry/trace_capture.py
+++ b/clawmetry/trace_capture.py
@@ -279,3 +279,63 @@ def build_bundle(
             "workflows": [],
         },
     }
+
+
+# ── publish (PRD §4b step 4) ───────────────────────────────────────────────
+
+def publish(bundle: dict, *, app_url: str | None = None,
+            api_key: str | None = None, timeout: int = 60) -> dict:
+    """Upload a bundle and return ``{"ok", "url"}`` or ``{"ok": False, "error"}``.
+
+    Publishing is deliberately a SEPARATE step from capture. Capture writes to
+    disk and stops; a human looks at the review page and decides. Publication
+    is a write in the CLAUDE.md sense (user-initiated, scoped, reversible,
+    attributed), and the thing being written is a public web page containing
+    the contents of somebody's terminal.
+
+    Requires an account key: the server rejects anonymous publishes because
+    otherwise anyone could put a fabricated trace at any pull request's URL.
+    """
+    import json as _json
+    import urllib.error
+    import urllib.request
+
+    if not isinstance(bundle, dict) or not bundle.get("project") or not bundle.get("pr"):
+        return {"ok": False, "error": "bundle needs a project and a pr to publish"}
+
+    if api_key is None:
+        try:
+            with open(os.path.expanduser("~/.clawmetry/config.json")) as fh:
+                api_key = (_json.load(fh) or {}).get("api_key")
+        except Exception:
+            api_key = None
+    if not api_key:
+        return {"ok": False,
+                "error": "no account key found; run `clawmetry connect` first"}
+
+    if app_url is None:
+        try:
+            from clawmetry.endpoints import app_url as _au
+            app_url = _au()
+        except Exception:
+            app_url = "https://app.clawmetry.com"
+
+    body = _json.dumps(bundle, default=str).encode("utf-8")
+    req = urllib.request.Request(
+        app_url.rstrip("/") + "/api/pr-trace/publish",
+        data=body, method="POST",
+        headers={"Content-Type": "application/json",
+                 "Authorization": "Bearer " + api_key},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return _json.loads(resp.read().decode("utf-8", "replace"))
+    except urllib.error.HTTPError as exc:
+        detail = ""
+        try:
+            detail = exc.read().decode("utf-8", "replace")[:300]
+        except Exception:
+            pass
+        return {"ok": False, "error": f"HTTP {exc.code}", "detail": detail}
+    except Exception as exc:
+        return {"ok": False, "error": str(exc)[:200]}

--- a/tests/test_trace_capture.py
+++ b/tests/test_trace_capture.py
@@ -280,3 +280,71 @@ def test_guard_catches_a_real_external_resource():
     """Revert-proof: the guard must fail on the thing it claims to prevent."""
     injected = '<html><head><script src="https://cdn.example.com/x.js"></script></head></html>'
     assert _external_resource_loads(injected) == ["https://cdn.example.com/x.js"]
+
+
+# ── publish ────────────────────────────────────────────────────────────────
+
+def test_publish_refuses_without_an_account_key(monkeypatch, tmp_path):
+    """AC-TRACE-002.2 -- publication is never anonymous.
+
+    The server rejects keyless publishes because otherwise anyone could put a
+    fabricated trace at any pull request's URL. The client refuses first so the
+    bundle never leaves the machine on a doomed request.
+    """
+    monkeypatch.setenv("HOME", str(tmp_path))
+    b = _build([_commit(session="claude_code:s1")], ["claude_code:s1"],
+               tc.ATTR_EXACT, {"claude_code:s1": []}, pr="42")
+    res = tc.publish(b, api_key=None)
+    assert res["ok"] is False
+    assert "connect" in res["error"]
+
+
+def test_publish_refuses_a_bundle_with_no_target():
+    """A bundle with no project or pr has no URL to live at."""
+    assert tc.publish({}, api_key="cm_x")["ok"] is False
+    assert tc.publish({"project": "o/r"}, api_key="cm_x")["ok"] is False
+
+
+def test_publish_posts_to_the_pr_trace_endpoint(monkeypatch):
+    """Pins the endpoint and the auth header.
+
+    /api/pr-trace/, NOT /api/trace/ -- the latter is the Tracing tab's
+    /api/trace/<session_id> and colliding there would shadow a shipped route.
+    """
+    seen = {}
+
+    class _Resp:
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
+        def read(self): return b'{"ok":true,"url":"https://trace.clawmetry.com/x"}'
+
+    def _fake_urlopen(req, timeout=None):
+        seen["url"] = req.full_url
+        seen["auth"] = req.headers.get("Authorization")
+        seen["body"] = req.data
+        return _Resp()
+
+    import urllib.request
+    monkeypatch.setattr(urllib.request, "urlopen", _fake_urlopen)
+    b = _build([_commit(session="claude_code:s1")], ["claude_code:s1"],
+               tc.ATTR_EXACT, {"claude_code:s1": []}, pr="42")
+    res = tc.publish(b, app_url="https://app.example.com", api_key="cm_test")
+    assert res["ok"] is True
+    assert seen["url"] == "https://app.example.com/api/pr-trace/publish"
+    assert seen["auth"] == "Bearer cm_test"
+    assert b"owner/repo" in seen["body"]
+
+
+def test_publish_surfaces_an_http_error_without_raising(monkeypatch):
+    """A failed publish must report and leave the bundle on disk, never crash."""
+    import urllib.error, urllib.request, io
+
+    def _boom(req, timeout=None):
+        raise urllib.error.HTTPError(req.full_url, 401, "Unauthorized", {},
+                                     io.BytesIO(b'{"error":"no key"}'))
+
+    monkeypatch.setattr(urllib.request, "urlopen", _boom)
+    b = _build([_commit(session="claude_code:s1")], ["claude_code:s1"],
+               tc.ATTR_EXACT, {"claude_code:s1": []}, pr="42")
+    res = tc.publish(b, app_url="https://app.example.com", api_key="cm_test")
+    assert res["ok"] is False and "401" in res["error"]


### PR DESCRIPTION
Adds `clawmetry trace capture --publish`, the missing link between the local capture that shipped in 0.12.760 and the hosted resolver that just landed in clawmetry-cloud#2092. Until now capture wrote a bundle to disk and there was nowhere to send it.

## Publication stays a separate, explicit step

Without `--publish` the behaviour is unchanged: write the bundle and the review page, print where they are, send nothing.

The thing being written when you do pass it is a public web page containing the contents of somebody's terminal. That makes it a write in the CLAUDE.md sense (user-initiated, scoped, reversible, attributed), so it gets an explicit gesture rather than happening as a side effect of capture.

## Requires an account key

The server rejects anonymous publishes, because otherwise anyone could put a fabricated trace at any pull request's URL. The client checks first so a doomed request never carries the bundle off the machine. A failed publish reports the error and leaves the bundle on disk.

## Endpoint is pinned by a test

Posts to `/api/pr-trace/publish`, **not** `/api/trace/`. The latter is the Tracing tab's `/api/trace/<session_id>`, and colliding there would shadow a shipped route. A test pins both the endpoint and the auth header so a rename cannot silently point this at the wrong one.

## Verification

28 tests, py3.9 annotation check clean, ruff clean, AC ratchet holding at 9/77.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012UjuRS7Xn4JJGacSgRMbrK