### PR TITLE
fix(ci): make drift-bot a required check, and give the list one source of truth

### DIFF
--- a/.github/workflows/c6-health.yml
+++ b/.github/workflows/c6-health.yml
@@ -73,15 +73,14 @@ jobs:
           # mechanism.
           # "E2E Gate (required)" is the aggregator job from e2e-gate.yml (PR #4111,
           # merged 2026-07-27); it polls the 4 underlying OSS E2E workflows.
-          # "drift-bot" is a commit status from the 8090-software-factory app.
+          # drift-bot is required too, but aggregated inside "E2E Gate (required)"
+          # (scripts/e2e_gate.py), not named separately here.
           ALL_CHECKS = {
               "clawmetry": [
                   "E2E Gate (required)",
-                  "drift-bot",
               ],
               "clawmetry-cloud": [
                   "Cloud golden-path browser E2E",
-                  "drift-bot",
               ],
               "clawmetry-landing": [
                   "Landing golden path (C3)",

--- a/.github/workflows/c6-health.yml
+++ b/.github/workflows/c6-health.yml
@@ -66,15 +66,22 @@ jobs:
           }
 
           # All 3 repos and their required checks.
-          # Keep in sync with REQUIRED_CHECKS in scripts/apply_required_status_checks.py.
+          # This is inline YAML and cannot import the Python source, so it is a
+          # genuine copy. tests/test_c6_required_checks_single_source.py asserts
+          # it matches REQUIRED_CHECKS in scripts/apply_required_status_checks.py
+          # and fails when they drift, because a "keep in sync" comment is not a
+          # mechanism.
           # "E2E Gate (required)" is the aggregator job from e2e-gate.yml (PR #4111,
           # merged 2026-07-27); it polls the 4 underlying OSS E2E workflows.
+          # "drift-bot" is a commit status from the 8090-software-factory app.
           ALL_CHECKS = {
               "clawmetry": [
                   "E2E Gate (required)",
+                  "drift-bot",
               ],
               "clawmetry-cloud": [
                   "Cloud golden-path browser E2E",
+                  "drift-bot",
               ],
               "clawmetry-landing": [
                   "Landing golden path (C3)",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,6 +158,15 @@ jobs:
       - name: Guard census (verification surface may not shrink)
         run: python3 -m pytest tests/test_guard_census.py -q
 
+      # Which checks block a merge was written down in three places, each with a
+      # "keep in sync" comment on top: the script that applies them, the script
+      # that reports them, and the workflow that alerts on them. This repo has
+      # already paid for that arrangement once, when three cost surfaces each
+      # defined "this week" for themselves (#5080). A merge gate that disagrees
+      # with its own health report is the same bug aimed at what reaches main.
+      - name: Required-checks list has one source of truth
+        run: python3 -m pytest tests/test_c6_required_checks_single_source.py -q
+
       # Every merge-blocking check must have a path to green WITHOUT privileged
       # secrets. A gated check that requires one leaves forks, outside
       # contributors, and everyone with an open PR at credential-rotation time

--- a/scripts/apply_required_status_checks.py
+++ b/scripts/apply_required_status_checks.py
@@ -78,26 +78,11 @@ REQUIRED_CHECKS: list[tuple[str, str]] = [
     ("clawmetry",         "E2E Gate (required)"),
     ("clawmetry-cloud",   "Cloud golden-path browser E2E"),
     ("clawmetry-landing", "Landing golden path (C3)"),
-    # drift-bot: the Software Factory Blueprint/Requirement sync check.
-    #
-    # FLYWHEEL 1f has called a red drift-bot non-negotiable for months, and it
-    # was enforced by nothing: #5089 merged with it red on 2026-08-22, and
-    # clawmetry-cloud #2089 merged with it red the day after. A rule that lives
-    # only in prose gets broken by whoever is in a hurry.
-    #
-    # It is a COMMIT STATUS posted by the 8090-software-factory GitHub App, not
-    # an Actions workflow, so there is no re-run button. That is precisely why
-    # it must block BEFORE the merge: red is permanent once merged, and fixing
-    # the Blueprint afterwards never turns that PR green.
-    #
-    # Safe to require, unlike visual-diff below: verified 2026-08-23 that the
-    # app posts a status on every PR rather than a filtered subset (30/30 most
-    # recent clawmetry PRs, 10/10 clawmetry-cloud). So it cannot strand a PR on
-    # "Expected -- Waiting for status to be reported", and the path to green
-    # belongs to the author: fix the Blueprint or the code, push, the app
-    # re-evaluates.
-    ("clawmetry",         "drift-bot"),
-    ("clawmetry-cloud",   "drift-bot"),
+    # drift-bot is deliberately NOT here. It is required, but it is aggregated
+    # behind "E2E Gate (required)" in scripts/e2e_gate.py rather than named as a
+    # second branch-protection context, because ADR-001 says protection names
+    # exactly one context. Adding a second would make the merge gate and its own
+    # architecture disagree, which is the quiet kind of drift.
 ]
 
 # Checks previously added as required that must be actively removed.

--- a/scripts/apply_required_status_checks.py
+++ b/scripts/apply_required_status_checks.py
@@ -78,6 +78,26 @@ REQUIRED_CHECKS: list[tuple[str, str]] = [
     ("clawmetry",         "E2E Gate (required)"),
     ("clawmetry-cloud",   "Cloud golden-path browser E2E"),
     ("clawmetry-landing", "Landing golden path (C3)"),
+    # drift-bot: the Software Factory Blueprint/Requirement sync check.
+    #
+    # FLYWHEEL 1f has called a red drift-bot non-negotiable for months, and it
+    # was enforced by nothing: #5089 merged with it red on 2026-08-22, and
+    # clawmetry-cloud #2089 merged with it red the day after. A rule that lives
+    # only in prose gets broken by whoever is in a hurry.
+    #
+    # It is a COMMIT STATUS posted by the 8090-software-factory GitHub App, not
+    # an Actions workflow, so there is no re-run button. That is precisely why
+    # it must block BEFORE the merge: red is permanent once merged, and fixing
+    # the Blueprint afterwards never turns that PR green.
+    #
+    # Safe to require, unlike visual-diff below: verified 2026-08-23 that the
+    # app posts a status on every PR rather than a filtered subset (30/30 most
+    # recent clawmetry PRs, 10/10 clawmetry-cloud). So it cannot strand a PR on
+    # "Expected -- Waiting for status to be reported", and the path to green
+    # belongs to the author: fix the Blueprint or the code, push, the app
+    # re-evaluates.
+    ("clawmetry",         "drift-bot"),
+    ("clawmetry-cloud",   "drift-bot"),
 ]
 
 # Checks previously added as required that must be actively removed.

--- a/scripts/c6_required_checks_status.py
+++ b/scripts/c6_required_checks_status.py
@@ -36,14 +36,29 @@ import sys
 
 OWNER = os.environ.get("OWNER", "vivekchand")
 
-# Keep in sync with REQUIRED_CHECKS in scripts/apply_required_status_checks.py
-# and c6-health.yml. "E2E Gate (required)" aggregates the underlying OSS
-# checks (see scripts/e2e_gate.py), so one entry here replaces the whole list.
-EXPECTED = {
-    "clawmetry": ["E2E Gate (required)"],
-    "clawmetry-cloud": ["Cloud golden-path browser E2E"],
-    "clawmetry-landing": ["Landing golden path (C3)"],
-}
+# DERIVED, not duplicated. This list used to be a hand-maintained copy of
+# REQUIRED_CHECKS with a "keep in sync" comment on top, which is the same
+# arrangement that let three cost surfaces disagree about what a week is. A
+# comment is not a mechanism. Importing the real list means adding a required
+# check in one place cannot leave this reporter quietly describing the old set.
+#
+# "E2E Gate (required)" aggregates the underlying OSS checks (scripts/e2e_gate.py),
+# so one entry covers that whole family.
+def _expected_from_source():
+    import importlib.util
+
+    src_path = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                            "apply_required_status_checks.py")
+    spec = importlib.util.spec_from_file_location("_c6_required", src_path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    grouped: dict = {}
+    for repo, check in mod.REQUIRED_CHECKS:
+        grouped.setdefault(repo, []).append(check)
+    return grouped
+
+
+EXPECTED = _expected_from_source()
 
 AUTHORITATIVE = ["clawmetry"]
 CROSS_REPO = ["clawmetry-cloud", "clawmetry-landing"]

--- a/scripts/close-c6.sh
+++ b/scripts/close-c6.sh
@@ -11,9 +11,10 @@
 #   Applies the required status checks declared in REQUIRED_CHECKS in
 #   scripts/apply_required_status_checks.py, which is the single source of
 #   truth. That currently means:
-#     clawmetry         : E2E Gate (required), drift-bot
-#     clawmetry-cloud   : Cloud golden-path browser E2E, drift-bot
+#     clawmetry         : E2E Gate (required)
+#     clawmetry-cloud   : Cloud golden-path browser E2E
 #     clawmetry-landing : Landing golden path (C3)
+#   "E2E Gate (required)" aggregates the rest, drift-bot included.
 #   This comment is illustrative; the script reads the Python list, so it
 #   cannot apply something different from what is declared there.
 #

--- a/scripts/close-c6.sh
+++ b/scripts/close-c6.sh
@@ -8,10 +8,14 @@
 #   bash scripts/close-c6.sh
 #
 # What this does:
-#   Adds 3 required status checks to main branch protection across 3 repos:
-#     clawmetry         : E2E Gate (required)
-#     clawmetry-cloud   : Cloud golden-path browser E2E
+#   Applies the required status checks declared in REQUIRED_CHECKS in
+#   scripts/apply_required_status_checks.py, which is the single source of
+#   truth. That currently means:
+#     clawmetry         : E2E Gate (required), drift-bot
+#     clawmetry-cloud   : Cloud golden-path browser E2E, drift-bot
 #     clawmetry-landing : Landing golden path (C3)
+#   This comment is illustrative; the script reads the Python list, so it
+#   cannot apply something different from what is declared there.
 #
 #   "E2E Gate (required)" is an aggregator (e2e-gate.yml, PR #4111) that
 #   polls the 4 underlying OSS E2E workflows and reports one conclusion.

--- a/scripts/e2e_gate.py
+++ b/scripts/e2e_gate.py
@@ -98,6 +98,20 @@ REQUIRED_SPECS = [
     # Property tests over the store, plus the mutation ratchet that keeps the
     # rest of these guards from decaying into tautologies.
     Spec("Store invariants", "Store invariants (property-based)"),
+
+    # Blueprint/Requirement sync with 8090 Software Factory. FLYWHEEL 1f has
+    # called a red drift-bot non-negotiable for months while nothing enforced
+    # it: #5089 merged with it red, and clawmetry-cloud #2089 the day after.
+    #
+    # It belongs HERE rather than as a second branch-protection context. ADR-001
+    # says protection names exactly one context and this file aggregates behind
+    # it; adding a second name would have been a quieter kind of drift, where
+    # the merge gate and its own architecture disagree.
+    #
+    # Unlike everything above, drift-bot is a COMMIT STATUS from the
+    # 8090-software-factory GitHub App, not an Actions check run. It never
+    # appears in /check-runs, which is why list_commit_statuses exists.
+    Spec("Drift Bot", "drift-bot"),
 ]
 
 
@@ -230,6 +244,55 @@ def list_check_runs(repo, sha, token):
     return runs
 
 
+# A commit status carries `state`, a check run carries `status` + `conclusion`.
+# Normalising the former into the latter lets evaluate() stay one code path.
+# "error" is GitHub's transport-level failure and blocks exactly like "failure";
+# treating it as anything softer would let a broken reporter merge.
+_STATUS_STATE_TO_CONCLUSION = {
+    "success": "success",
+    "failure": "failure",
+    "error": "failure",
+}
+
+
+def list_commit_statuses(repo, sha, token):
+    """Fetch commit statuses for a SHA, shaped like check runs.
+
+    Commit statuses are a different API from check runs and do not appear in
+    /check-runs at all. drift-bot is posted this way by the
+    8090-software-factory app, so a gate that only reads check runs cannot see
+    it -- which is precisely how it stayed unenforceable while FLYWHEEL called
+    it non-negotiable.
+
+    The combined endpoint already collapses to the most recent status per
+    context, so no extra de-duplication is needed here.
+    """
+    url = f"https://api.github.com/repos/{repo}/commits/{sha}/status?per_page=100"
+    req = urllib.request.Request(url, headers=_headers(token))
+    try:
+        with urllib.request.urlopen(req) as resp:
+            data = json.loads(resp.read())
+    except urllib.error.HTTPError as exc:
+        print(f"  warn: commit-status API {exc.code}: {exc.read()[:200]!r}")
+        return []
+
+    shaped = []
+    for status in data.get("statuses", []):
+        context = status.get("context") or ""
+        if not context:
+            continue
+        state = status.get("state")
+        conclusion = _STATUS_STATE_TO_CONCLUSION.get(state)
+        if conclusion is None:
+            # "pending", or anything GitHub adds later: not yet decided. Report
+            # it as still running so the gate WAITS instead of passing on a
+            # status that has not been posted yet.
+            shaped.append({"name": context, "status": "in_progress", "conclusion": None})
+        else:
+            shaped.append({"name": context, "status": "completed", "conclusion": conclusion})
+    return shaped
+
+
 def main():
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--repo", default=os.environ.get("REPO", ""))
@@ -273,7 +336,11 @@ def main():
     while True:
         elapsed = int(time.monotonic() - start)
         try:
+            # Both surfaces, because the required set spans both: Actions
+            # report as check runs, the Software Factory app as a commit
+            # status. Reading only one is how drift-bot went unenforced.
             runs = list_check_runs(args.repo, sha, token)
+            runs += list_commit_statuses(args.repo, sha, token)
         except Exception as exc:  # noqa: BLE001 - keep polling through blips
             print(f"  [{elapsed}s] warn: fetch failed: {exc}")
             time.sleep(POLL_INTERVAL)

--- a/tests/test_c6_required_checks_single_source.py
+++ b/tests/test_c6_required_checks_single_source.py
@@ -1,0 +1,97 @@
+"""The required-checks list must have exactly one source of truth.
+
+Which status checks block a merge was, until this file existed, written down in
+three places: ``REQUIRED_CHECKS`` in ``scripts/apply_required_status_checks.py``
+(which applies them), ``EXPECTED`` in ``scripts/c6_required_checks_status.py``
+(which reports them), and ``ALL_CHECKS`` inline in
+``.github/workflows/c6-health.yml`` (which alerts on them). Each carried a
+"keep in sync" comment, and a comment is not a mechanism.
+
+This repo has already paid for that arrangement elsewhere: three cost surfaces
+each defined "this week" for themselves, and #5080 had to go and reconcile
+them. A merge gate that disagrees with its own health report is the same bug
+with worse consequences, because the thing it silently gets wrong is what is
+allowed to reach main.
+
+``c6_required_checks_status.py`` now imports the real list, so that copy is
+gone by construction. The workflow is inline YAML and cannot import Python, so
+it stays a copy and this file is what stops it drifting.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+import os
+import re
+import textwrap
+
+import pytest
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+APPLY_SCRIPT = os.path.join(REPO_ROOT, "scripts", "apply_required_status_checks.py")
+STATUS_SCRIPT = os.path.join(REPO_ROOT, "scripts", "c6_required_checks_status.py")
+HEALTH_WORKFLOW = os.path.join(REPO_ROOT, ".github", "workflows", "c6-health.yml")
+
+
+def _load(path: str, name: str):
+    spec = importlib.util.spec_from_file_location(name, path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _grouped_required() -> dict:
+    mod = _load(APPLY_SCRIPT, "_apply_required")
+    grouped: dict = {}
+    for repo, check in mod.REQUIRED_CHECKS:
+        grouped.setdefault(repo, []).append(check)
+    return grouped
+
+
+def _workflow_all_checks() -> dict:
+    """Pull the ALL_CHECKS literal out of the workflow's inline Python block."""
+    with open(HEALTH_WORKFLOW, encoding="utf-8") as fh:
+        text = fh.read()
+    match = re.search(r"ALL_CHECKS = (\{.*?\n\s*\})\n", text, re.S)
+    assert match, "ALL_CHECKS literal not found in c6-health.yml"
+    return ast.literal_eval(textwrap.dedent(match.group(1)))
+
+
+def test_health_workflow_matches_the_required_checks_source():
+    required = _grouped_required()
+    workflow = _workflow_all_checks()
+    assert {k: sorted(v) for k, v in workflow.items()} == {
+        k: sorted(v) for k, v in required.items()
+    }, (
+        "c6-health.yml ALL_CHECKS has drifted from REQUIRED_CHECKS in "
+        "scripts/apply_required_status_checks.py. Update the workflow to match; "
+        "do not edit this test to agree with the drift."
+    )
+
+
+def test_status_reporter_derives_rather_than_duplicates():
+    """EXPECTED must be computed from REQUIRED_CHECKS, not retyped beside it."""
+    status = _load(STATUS_SCRIPT, "_c6_status")
+    assert {k: sorted(v) for k, v in status.EXPECTED.items()} == {
+        k: sorted(v) for k, v in _grouped_required().items()
+    }
+
+
+def test_drift_bot_is_required_on_the_repos_that_run_it():
+    """Regression pin for the rule FLYWHEEL 1f states.
+
+    #5089 merged with drift-bot red, and clawmetry-cloud #2089 the day after,
+    because the rule lived only in prose. drift-bot is a commit status with no
+    re-run button: red is permanent once merged, so it has to block before.
+    """
+    required = _grouped_required()
+    for repo in ("clawmetry", "clawmetry-cloud"):
+        assert "drift-bot" in required.get(repo, []), (
+            "drift-bot must stay a required check on %s" % repo
+        )
+
+
+@pytest.mark.parametrize("repo", ["clawmetry", "clawmetry-cloud", "clawmetry-landing"])
+def test_every_declared_repo_has_at_least_one_required_check(repo):
+    assert _grouped_required().get(repo), "%s declares no required check" % repo

--- a/tests/test_c6_required_checks_single_source.py
+++ b/tests/test_c6_required_checks_single_source.py
@@ -24,6 +24,7 @@ import ast
 import importlib.util
 import os
 import re
+import sys
 import textwrap
 
 import pytest
@@ -37,6 +38,10 @@ HEALTH_WORKFLOW = os.path.join(REPO_ROOT, ".github", "workflows", "c6-health.yml
 def _load(path: str, name: str):
     spec = importlib.util.spec_from_file_location(name, path)
     mod = importlib.util.module_from_spec(spec)
+    # Register before executing: @dataclass resolves annotations through
+    # sys.modules[cls.__module__], which is None for a module that is still
+    # only half-imported, and e2e_gate.py defines frozen dataclasses at import.
+    sys.modules[name] = mod
     spec.loader.exec_module(mod)
     return mod
 
@@ -78,20 +83,101 @@ def test_status_reporter_derives_rather_than_duplicates():
     }
 
 
-def test_drift_bot_is_required_on_the_repos_that_run_it():
+def test_drift_bot_gates_through_the_aggregator():
     """Regression pin for the rule FLYWHEEL 1f states.
 
     #5089 merged with drift-bot red, and clawmetry-cloud #2089 the day after,
     because the rule lived only in prose. drift-bot is a commit status with no
     re-run button: red is permanent once merged, so it has to block before.
+
+    It gates from inside REQUIRED_SPECS rather than as a second
+    branch-protection context: ADR-001 says protection names exactly one
+    context, and scripts/e2e_gate.py is that context. The first attempt at this
+    added a second name and drift-bot itself flagged the contradiction.
     """
-    required = _grouped_required()
-    for repo in ("clawmetry", "clawmetry-cloud"):
-        assert "drift-bot" in required.get(repo, []), (
-            "drift-bot must stay a required check on %s" % repo
+    gate = _load(os.path.join(REPO_ROOT, "scripts", "e2e_gate.py"), "_e2e_gate")
+    patterns = [s.pattern for s in gate.REQUIRED_SPECS]
+    assert "drift-bot" in patterns, (
+        "drift-bot must stay in REQUIRED_SPECS; a check not listed there "
+        "cannot block a merge"
+    )
+
+
+def test_branch_protection_names_exactly_one_context_per_repo():
+    """ADR-001. A second context is drift between the gate and its design."""
+    for repo, checks in _grouped_required().items():
+        assert len(checks) == 1, (
+            "%s declares %d required contexts; ADR-001 allows one, with "
+            "everything else aggregated behind it" % (repo, len(checks))
         )
 
 
 @pytest.mark.parametrize("repo", ["clawmetry", "clawmetry-cloud", "clawmetry-landing"])
 def test_every_declared_repo_has_at_least_one_required_check(repo):
     assert _grouped_required().get(repo), "%s declares no required check" % repo
+
+
+# ── commit statuses are a second surface the gate must read ─────────────────
+
+def _gate():
+    return _load(os.path.join(REPO_ROOT, "scripts", "e2e_gate.py"), "_e2e_gate")
+
+
+@pytest.mark.parametrize("state,expected_status,expected_conclusion", [
+    ("success", "completed", "success"),
+    ("failure", "completed", "failure"),
+    # GitHub's transport-level failure. Blocks exactly like "failure": a broken
+    # reporter must not be softer than a reporting failure.
+    ("error", "completed", "failure"),
+    # Not decided yet -- the gate must WAIT, never pass.
+    ("pending", "in_progress", None),
+    # Anything GitHub adds later defaults to "keep waiting", not "let it through".
+    ("some_future_state", "in_progress", None),
+])
+def test_commit_status_states_map_to_check_run_shape(
+    monkeypatch, state, expected_status, expected_conclusion
+):
+    gate = _gate()
+    payload = {"statuses": [{"context": "drift-bot", "state": state}]}
+
+    class _Resp:
+        def read(self):
+            import json as _j
+            return _j.dumps(payload).encode()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    monkeypatch.setattr(gate.urllib.request, "urlopen", lambda *a, **k: _Resp())
+    shaped = gate.list_commit_statuses("o/r", "sha", "tok")
+    assert shaped == [
+        {"name": "drift-bot", "status": expected_status, "conclusion": expected_conclusion}
+    ]
+
+
+def test_a_pending_drift_bot_does_not_pass_the_gate():
+    """The failure that matters: a status not yet posted must not read as green."""
+    gate = _gate()
+    spec = next(s for s in gate.REQUIRED_SPECS if s.pattern == "drift-bot")
+    runs = [{"name": "drift-bot", "status": "in_progress", "conclusion": None}]
+    (result,) = gate.evaluate([spec], runs)
+    assert result.state == "pending"
+
+
+def test_a_failed_drift_bot_fails_the_gate():
+    gate = _gate()
+    spec = next(s for s in gate.REQUIRED_SPECS if s.pattern == "drift-bot")
+    runs = [{"name": "drift-bot", "status": "completed", "conclusion": "failure"}]
+    (result,) = gate.evaluate([spec], runs)
+    assert result.state == "failed"
+
+
+def test_a_missing_drift_bot_does_not_pass_the_gate():
+    """No status at all must block, not silently satisfy the spec."""
+    gate = _gate()
+    spec = next(s for s in gate.REQUIRED_SPECS if s.pattern == "drift-bot")
+    (result,) = gate.evaluate([spec], [])
+    assert result.state == "pending"

--- a/verification/guards.json
+++ b/verification/guards.json
@@ -124,8 +124,8 @@
   ],
   "ratchets": {
     "e2e_gate_required_specs": {
-      "value": 11,
-      "why": "Number of checks aggregated by the merge gate. Was 4 before L0, which let a red CI merge. Adding checks is good; removing them re-opens the hole."
+      "value": 12,
+      "why": "Number of checks aggregated by the merge gate. Was 4 before L0, which let a red CI merge. Raised to 12 when drift-bot joined: it is a commit status, not a check run, so the gate had to learn to read both surfaces before it could block on it. Adding checks is good; removing them re-opens the hole."
     },
     "pip_install_matrix_legs": {
       "value": 4,


### PR DESCRIPTION
FLYWHEEL §1f has called a red `drift-bot` non-negotiable for months. Nothing enforced it. **#5089 merged on 2026-08-22 with drift-bot red**, and `clawmetry-cloud` #2089 merged the same way the day after.

## Why it was unenforceable

Not an oversight in branch protection. `drift-bot` is a **commit status** posted by the `8090-software-factory` app, not an Actions check run. Verified against this PR's own head SHA:

```
/commits/<sha>/status      -> context=drift-bot state=failure
/commits/<sha>/check-runs  -> 0 matches
```

`scripts/e2e_gate.py`, which *is* the merge gate, only ever read check runs. It was structurally incapable of blocking on drift-bot. That is the real reason the rule stayed prose.

## What lands

`list_commit_statuses()` reads the combined-status endpoint and normalises each status into check-run shape, so `evaluate()` stays one code path. The poll loop now reads **both** surfaces, and `Spec("Drift Bot", "drift-bot")` joins `REQUIRED_SPECS` (11 to 12, ratchet bumped).

State mapping is deliberately conservative:

| GitHub state | Mapped to | Why |
|---|---|---|
| `success` | passed | |
| `failure` | failed | |
| `error` | failed | transport-level failure must not be softer than a reporting failure |
| `pending` | waiting | a status not yet posted must never read as green |
| anything future | waiting | unknown defaults to blocking, not passing |

## Drift Bot failed the first attempt, and was right

My first commit added drift-bot as a **second branch-protection context**. Drift Bot flagged it against ADR-001, which says protection names exactly one context with everything aggregated behind it. That would have worked and would have left the merge gate disagreeing with its own architecture, which is the quiet drift this layer exists to catch. The Blueprint was right and the code was wrong, so the code changed.

A new test now asserts ADR-001 directly: each repo declares exactly one required context. Live protection is back to `["E2E Gate (required)"]` with `enforce_admins: true`.

## The list had four sources of truth

Found while doing this. Each carried a "keep in sync" comment, which is not a mechanism.

| File | Symbol |
|---|---|
| `scripts/apply_required_status_checks.py` | `REQUIRED_CHECKS` |
| `scripts/c6_required_checks_status.py` | `EXPECTED` |
| `.github/workflows/c6-health.yml` | `ALL_CHECKS` |
| `scripts/close-c6.sh` | usage header |

The reporter now **imports** the real list, so that copy is gone by construction. The YAML cannot import, so it stays a copy pinned by a test that fails on drift. This repo already paid for this arrangement once, when three cost surfaces each defined "this week" and #5080 had to reconcile them.

## Verified

93 passed across `test_c6_required_checks_single_source`, `test_guard_census`, `test_e2e_gate`. `e2e_gate.py --list` shows 12 specs. Guards fail on: pending drift-bot, failed drift-bot, **missing** drift-bot, YAML drift, and a second declared context.

## Two things this does NOT fix

**1. `clawmetry-cloud` cannot have branch protection at all.** Private repo on a free plan; the API returns `403: Upgrade to GitHub Pro or make this repository public`. That is why #2089 merged red and why it will recur. FLYWHEEL's rule is unenforceable there regardless of this PR.

**2. `tests/test_c6_push_non_blocking.py` is red on unmodified main and referenced by no workflow**, so it has been broken and invisible. Same shape as #5088. Its `test_readonly_push_path_exits_zero_when_unconfigured` asserts the read-only path must exit 0, while the code deliberately exits 1 as a "red badge = forcing signal". One of the two is wrong. Not wired into CI here, because adding a failing check with no agreed path to green is the trap that rule exists to prevent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RBgTZ4GY8oWyQePbNaAR8G
