### PR TITLE
fix(trace): refuse to install a hook the PATH binary cannot run

### DIFF
--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -4709,6 +4709,12 @@ def trace_main(argv) -> int:
             print("Earlier commits cannot be backfilled (PRD-pr-trace.md §3a).")
         elif status == "already-installed":
             print(f"Already installed -> {res['path']}")
+        elif status == "stale-binary":
+            print("Not installing: the `clawmetry` on your PATH has no `trace`")
+            print("command, so the hook would be written and then silently do")
+            print("nothing on every commit.")
+            print(f"  {res.get('hint', '')}")
+            return 1
         elif status == "foreign-hook":
             print(f"A different prepare-commit-msg hook exists: {res['path']}")
             print(f"Hint: {res.get('hint', '')}")

--- a/clawmetry/trace_stamp.py
+++ b/clawmetry/trace_stamp.py
@@ -179,6 +179,27 @@ exit 0
 """
 
 
+def hook_command_works(cmd: str = "clawmetry") -> bool:
+    """Can the binary the hook will call actually run ``trace stamp``?
+
+    Found by dogfooding: `trace init` happily wrote a hook calling `clawmetry
+    trace stamp` on a machine whose PATH `clawmetry` was an older release with
+    no `trace` command. The hook ends in `|| true` so a commit is never
+    blocked, which is correct, and it meant the hook silently did nothing.
+    Every commit looked fine and no trailer was written, which is the worst
+    shape a failure can take here: coverage cannot be backfilled, so the
+    traces lost while it went unnoticed are lost permanently.
+    """
+    try:
+        out = subprocess.run(
+            [cmd, "trace", "--help"],
+            capture_output=True, text=True, timeout=20, check=False,
+        )
+        return "trace" in (out.stdout or "") and out.returncode == 0
+    except Exception:
+        return False
+
+
 def _hooks_dir(repo: str) -> str:
     out = subprocess.run(
         ["git", "rev-parse", "--git-path", "hooks"],
@@ -188,13 +209,23 @@ def _hooks_dir(repo: str) -> str:
     return rel if os.path.isabs(rel) else os.path.join(repo, rel)
 
 
-def install(repo: str | None = None) -> dict:
+def install(repo: str | None = None, *, verify_binary: bool = True) -> dict:
     """Install the ``prepare-commit-msg`` hook in ``repo``.
 
     Refuses to clobber an unrelated existing hook — chaining someone else's
-    hook script is their call, not ours.
+    hook script is their call, not ours — and refuses to install a hook that
+    cannot run, which is a quieter and worse failure (see
+    :func:`hook_command_works`).
     """
     repo = repo or os.getcwd()
+    if verify_binary and not hook_command_works():
+        return {
+            "ok": False,
+            "status": "stale-binary",
+            "hint": ("the `clawmetry` on your PATH has no `trace` command, so the "
+                     "hook would silently do nothing. Upgrade with "
+                     "`pip install -U clawmetry` and re-run."),
+        }
     try:
         hooks = _hooks_dir(repo)
         os.makedirs(hooks, exist_ok=True)

--- a/tests/test_trace_stamp.py
+++ b/tests/test_trace_stamp.py
@@ -28,6 +28,20 @@ def _clear_runtime_env(monkeypatch):
         monkeypatch.delenv(var, raising=False)
 
 
+@pytest.fixture(autouse=True)
+def _assume_current_binary(monkeypatch):
+    """Default the hook-runnability check to True.
+
+    `install()` refuses to write a hook the PATH binary cannot run. That is
+    correct behaviour and it depends on the MACHINE, so leaving it live would
+    make every install test pass or fail according to which clawmetry the
+    developer happens to have installed. The tests that care about the check
+    override this fixture explicitly.
+    """
+    monkeypatch.setattr(trace_stamp, "hook_command_works",
+                        lambda cmd="clawmetry": True)
+
+
 # ── detection ──────────────────────────────────────────────────────────────
 
 def test_detects_claude_code_session_and_prefixes_it(monkeypatch):
@@ -190,3 +204,40 @@ def test_stamp_file_round_trip(tmp_path, monkeypatch):
 
 def test_stamp_file_on_missing_path_does_not_raise():
     assert trace_stamp.stamp_file("/nonexistent/COMMIT_EDITMSG") is False
+
+
+# ── the hook must be able to run ───────────────────────────────────────────
+
+def test_install_refuses_when_the_binary_has_no_trace_command(tmp_path, monkeypatch):
+    """Found by dogfooding, not by review.
+
+    `trace init` wrote a hook calling `clawmetry trace stamp` on a machine
+    whose PATH clawmetry was an older release. The hook ends in `|| true`, so
+    every commit succeeded and no trailer was ever written. Silence is the
+    worst shape this failure can take: coverage cannot be backfilled, so the
+    traces lost while nobody noticed are lost for good.
+    """
+    monkeypatch.setattr(trace_stamp, "hook_command_works", lambda cmd="clawmetry": False)
+    repo = _git_repo(tmp_path)
+    res = trace_stamp.install(repo)
+    assert res["ok"] is False and res["status"] == "stale-binary"
+    assert "pip install -U clawmetry" in res["hint"]
+    assert not os.path.exists(os.path.join(repo, ".git", "hooks", "prepare-commit-msg"))
+
+
+def test_install_proceeds_when_the_binary_is_current(tmp_path, monkeypatch):
+    monkeypatch.setattr(trace_stamp, "hook_command_works", lambda cmd="clawmetry": True)
+    res = trace_stamp.install(_git_repo(tmp_path))
+    assert res["ok"] is True and res["status"] == "installed"
+
+
+def test_verify_can_be_skipped_for_callers_that_know_better(tmp_path, monkeypatch):
+    monkeypatch.setattr(trace_stamp, "hook_command_works", lambda cmd="clawmetry": False)
+    res = trace_stamp.install(_git_repo(tmp_path), verify_binary=False)
+    assert res["ok"] is True
+
+
+def test_hook_command_works_is_false_for_a_missing_binary(monkeypatch):
+    # This one tests the real probe, so step out of the autouse stub above.
+    monkeypatch.undo()
+    assert trace_stamp.hook_command_works("clawmetry-does-not-exist") is False


### PR DESCRIPTION
Found by dogfooding, on the machine that built the feature.

`clawmetry trace init` writes a hook that shells out to `clawmetry trace stamp`. On a machine whose PATH `clawmetry` is an older release, that command does not exist. The hook ends in `|| true` so a commit is never blocked, which is the right contract and is exactly what hid the problem: every commit succeeded, no trailer was ever written, and nothing said so. `trace status` even reported `hook installed: yes`, because the file was there.

**Silence is the worst shape this failure can take.** Coverage cannot be backfilled, so every trace lost while it goes unnoticed is lost permanently. It is the one failure mode in this feature with no recovery path.

`install()` now probes `clawmetry trace --help` first and refuses with a `stale-binary` status and an upgrade hint, rather than writing a hook that will do nothing. `verify_binary=False` exists for callers that know better.

The install tests get an autouse fixture stubbing the probe to True, because the real check depends on which clawmetry the developer has installed, and hook-mechanics tests should not pass or fail on that.

Proven to fail on the unfixed code rather than assumed to. 55 tests, py3.9 clean, ruff clean.

This PR is also the first commit in this repo to carry a `Clawmetry-Session` trailer, so it is the one I will publish as the first real trace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012UjuRS7Xn4JJGacSgRMbrK