### PR TITLE
fix(trace): strip provider identifiers before publication

### DIFF
--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -4650,6 +4650,14 @@ def _trace_capture(rest) -> int:
     if "--publish" not in rest:
         print("  Nothing was published. Open the review page, confirm it is safe")
         print("  to share, then re-run with --publish.")
+        print()
+        print("  Redaction removed: API keys and tokens, private keys, home paths,")
+        print("  email addresses, IP addresses, and provider ids (Stripe and the")
+        print("  like). It does NOT know what is commercially sensitive. An agent")
+        print("  session sees everything your terminal saw, so read the page for:")
+        print("    - pricing, revenue or roadmap discussion")
+        print("    - internal hostnames, ticket ids, customer names")
+        print("    - anything you would not put in the repository itself")
         return 0
 
     # Publication is a separate, explicit step: the thing being written is a

--- a/clawmetry/trace_capture.py
+++ b/clawmetry/trace_capture.py
@@ -161,6 +161,23 @@ _HOME = re.compile(r"/(?:home|Users)/[^/\s\"']+")
 _EMAIL = re.compile(r"\b[\w.+-]+@[\w-]+\.[\w.]{2,}\b")
 _IPV4 = re.compile(r"\b(?:\d{1,3}\.){3}\d{1,3}\b")
 
+#: Identifiers that are not secrets but should not be handed out. Found on the
+#: first real publish attempt: a trace of a session that had merely READ
+#: deploy.yml carried eight live Stripe price ids, because an agent session
+#: sees everything the developer's terminal saw. Secret redaction had nothing
+#: to say about them -- they are not credentials -- and that is the gap this
+#: closes. The rule is narrow on purpose: provider-issued identifiers with a
+#: recognisable shape, not an attempt to guess at commercial sensitivity,
+#: which is what the human review gate is for.
+_VENDOR_IDS = (
+    re.compile(r"\bprice_1[A-Za-z0-9]{16,}"),          # Stripe price
+    re.compile(r"\b(?:sk|pk|rk)_(?:live|test)_[A-Za-z0-9]{16,}"),  # Stripe key
+    re.compile(r"\bcus_[A-Za-z0-9]{14,}"),             # Stripe customer
+    re.compile(r"\bsub_[A-Za-z0-9]{14,}"),             # Stripe subscription
+    re.compile(r"\bacct_[A-Za-z0-9]{16,}"),            # Stripe account
+    re.compile(r"\bprod_[A-Za-z0-9]{14,}"),            # Stripe product
+)
+
 
 def redact_for_publication(text: str) -> str:
     """Scrub secrets (via :mod:`clawmetry.redaction`) then private detail."""
@@ -168,6 +185,8 @@ def redact_for_publication(text: str) -> str:
         return text
     try:
         out = redaction.redact_text(text)
+        for pat in _VENDOR_IDS:
+            out = pat.sub("[vendor-id]", out)
         out = _HOME.sub("~", out)
         out = _EMAIL.sub("[email]", out)
         out = _IPV4.sub("[ip]", out)

--- a/tests/test_trace_capture.py
+++ b/tests/test_trace_capture.py
@@ -348,3 +348,37 @@ def test_publish_surfaces_an_http_error_without_raising(monkeypatch):
                tc.ATTR_EXACT, {"claude_code:s1": []}, pr="42")
     res = tc.publish(b, app_url="https://app.example.com", api_key="cm_test")
     assert res["ok"] is False and "401" in res["error"]
+
+
+# ── vendor identifiers ─────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("raw,gone", [
+    ("STRIPE_PRICE_MONTHLY=price_1TcBFeEj3JIGZB1MtqWYDF59", "price_1TcBFe"),
+    ("sk_live_" + "A" * 24, "sk_live_"),
+    ("pk_test_" + "B" * 24, "pk_test_"),
+    ("cus_" + "C" * 16, "cus_"),
+    ("sub_" + "D" * 16, "sub_"),
+    ("acct_" + "E" * 20, "acct_"),
+    ("prod_" + "F" * 16, "prod_"),
+])
+def test_provider_identifiers_are_removed_before_publication(raw, gone):
+    """Found on the first real publish attempt.
+
+    A trace of a session that had merely READ deploy.yml carried eight live
+    Stripe price ids. Secret redaction had nothing to say about them because
+    they are not credentials, and an agent session sees everything the
+    developer's terminal saw.
+    """
+    assert gone not in tc.redact_for_publication(raw)
+
+
+def test_redaction_does_not_guess_at_commercial_sensitivity():
+    """Deliberate boundary.
+
+    Prices, roadmaps and strategy are not pattern-matchable, and a regex that
+    tried would create false confidence in exactly the place a human must
+    look. That judgement belongs to the review gate, which is why capture
+    prints what redaction does and does not cover.
+    """
+    text = "we should charge $19 per seat and give it free to OSS maintainers"
+    assert tc.redact_for_publication(text) == text


### PR DESCRIPTION
Found on the first real publish attempt, by auditing the bundle instead of trusting the redaction that had already run.

## What was in it

A trace of a session that had merely **read** `deploy.yml` carried **eight live Stripe price ids**. Secret redaction had nothing to say about them, correctly: they are not credentials. But an agent session sees everything the developer's terminal saw, and publication puts that on the open internet.

After this change, the same session's bundle: **0 Stripe ids, 8 `[vendor-id]` markers.**

## Narrow on purpose

Covers provider-issued identifiers with recognisable shapes (Stripe price, key, customer, subscription, account, product). It is **not** an attempt to guess at commercial sensitivity.

That boundary is now explicit rather than implied. Capture prints what redaction covers and, more importantly, what it does not:

```
Redaction removed: API keys and tokens, private keys, home paths,
email addresses, IP addresses, and provider ids (Stripe and the like).
It does NOT know what is commercially sensitive. An agent session sees
everything your terminal saw, so read the page for:
  - pricing, revenue or roadmap discussion
  - internal hostnames, ticket ids, customer names
  - anything you would not put in the repository itself
```

A regex that pretended to catch strategy discussion would create false confidence exactly where a human has to look. A test pins that boundary: a sentence about charging $19 per seat passes through untouched, and must.

## Why this matters more than it looks

The PRD said this in §4f before any of it was written: secret redaction *"targets credentials, not confidential content"*. The first real publish attempt walked straight into it. The human review gate caught it, which is the gate working, but a live Stripe id should never have been publishable in the first place.

36 tests, py3.9 clean, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012UjuRS7Xn4JJGacSgRMbrK