### PR TITLE
feat(trace): capture takes no arguments

### DIFF
--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -4567,9 +4567,25 @@ def _trace_capture(rest) -> int:
         return rest[rest.index(name) + 1] if name in rest[:-1] else default
 
     repo = _opt("--repo") or _os.getcwd()
-    commit_range = _opt("--range") or "HEAD~1..HEAD"
-    pr = _opt("--pr")
     out_dir = _opt("--out") or "."
+
+    # Zero-arg by default. CLAUDE.md: "users should never need to configure
+    # anything manually." A revision range is the most manual thing there is,
+    # and the first person to run this hit exactly that -- they were on a
+    # branch where `origin/main..HEAD` meant something they did not intend.
+    commit_range = _opt("--range")
+    if not commit_range:
+        commit_range = trace_capture.infer_range(repo)
+        if not commit_range:
+            print("Nothing to trace: this branch has no commits of its own yet.")
+            print("Commit something, then run `clawmetry trace capture` again.")
+            return 1
+        print(f"  branch       {trace_capture._git(repo, 'rev-parse', '--abbrev-ref', 'HEAD').strip()}"
+              f"  (vs {trace_capture.default_branch(repo)})")
+
+    pr = _opt("--pr")
+    if not pr and "--no-pr" not in rest:
+        pr = trace_capture.infer_pr(repo)
 
     commits = trace_capture.read_commits(repo, commit_range)
     if not commits:
@@ -4593,9 +4609,17 @@ def _trace_capture(rest) -> int:
 
     session_ids, attribution = trace_capture.resolve_sessions(commits, sessions)
     if not session_ids:
+        stamped = sum(1 for c in commits if c.get("session_id"))
+        branch = trace_capture._git(repo, "rev-parse", "--abbrev-ref", "HEAD").strip()
         print(f"No sessions resolved for {commit_range}.")
-        print("If these commits predate `clawmetry trace init`, they cannot be")
-        print("backfilled -- see PRD-pr-trace.md 3a.")
+        print(f"  examined {len(commits)} commit(s) on {branch}; "
+              f"{stamped} carried a Clawmetry-Session trailer")
+        if stamped == 0:
+            print("  Those commits were made before `clawmetry trace init` ran here.")
+            print("  Coverage starts at install and cannot be backfilled: transcripts")
+            print("  rotate and the store keeps only recent sessions (PRD 3a).")
+        else:
+            print("  The trailers name sessions the local store no longer has.")
         return 1
 
     meta = {s["session_id"]: s for s in sessions if s.get("session_id")}

--- a/clawmetry/trace_capture.py
+++ b/clawmetry/trace_capture.py
@@ -339,3 +339,66 @@ def publish(bundle: dict, *, app_url: str | None = None,
         return {"ok": False, "error": f"HTTP {exc.code}", "detail": detail}
     except Exception as exc:
         return {"ok": False, "error": str(exc)[:200]}
+
+
+# ── inference: nobody should type a revision range ─────────────────────────
+
+def default_branch(repo: str) -> str:
+    """The branch a pull request would target. Asks the remote, not a guess."""
+    head = _git(repo, "symbolic-ref", "refs/remotes/origin/HEAD").strip()
+    if head:
+        return head.rsplit("/", 1)[-1]
+    for cand in ("main", "master"):
+        if _git(repo, "rev-parse", "--verify", f"origin/{cand}").strip():
+            return cand
+    return "main"
+
+
+def infer_range(repo: str) -> str | None:
+    """The commits this branch adds, as a pull request would see them.
+
+    Uses the merge base rather than ``origin/main..HEAD`` so a branch that has
+    not been rebased does not sweep in everything that landed on the default
+    branch meanwhile.
+    """
+    base = default_branch(repo)
+    ref = f"origin/{base}"
+    if not _git(repo, "rev-parse", "--verify", ref).strip():
+        ref = base
+    mb = _git(repo, "merge-base", ref, "HEAD").strip()
+    if not mb:
+        return None
+    if _git(repo, "rev-parse", "HEAD").strip() == mb:
+        return None  # nothing on this branch yet
+    return f"{mb}..HEAD"
+
+
+def infer_pr(repo: str, timeout: int = 15) -> str | None:
+    """The open pull request for this branch, if there is one.
+
+    Asks the forge's public API for the branch's PR. Unauthenticated, because
+    this must work before anyone has connected anything; a private repo simply
+    returns nothing and the caller falls back to asking.
+    """
+    import json as _json
+    import urllib.request
+
+    branch = _git(repo, "rev-parse", "--abbrev-ref", "HEAD").strip()
+    project = project_from_remote(repo)
+    if not branch or branch == "HEAD" or not project or "/" not in project:
+        return None
+    owner = project.split("/")[0]
+    url = (f"https://api.github.com/repos/{project}/pulls"
+           f"?head={owner}:{branch}&state=open&per_page=1")
+    try:
+        req = urllib.request.Request(url, headers={
+            "Accept": "application/vnd.github+json",
+            "User-Agent": "clawmetry-trace",
+        })
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            rows = _json.loads(resp.read().decode("utf-8", "replace"))
+        if isinstance(rows, list) and rows:
+            return str(rows[0].get("number") or "") or None
+    except Exception as exc:
+        logger.debug("PR lookup failed: %s", exc)
+    return None

--- a/tests/test_trace_capture.py
+++ b/tests/test_trace_capture.py
@@ -348,3 +348,62 @@ def test_publish_surfaces_an_http_error_without_raising(monkeypatch):
                tc.ATTR_EXACT, {"claude_code:s1": []}, pr="42")
     res = tc.publish(b, app_url="https://app.example.com", api_key="cm_test")
     assert res["ok"] is False and "401" in res["error"]
+
+
+# ── inference: no revision ranges in the interface ─────────────────────────
+
+def _repo_with_commits(tmp_path):
+    import subprocess
+    r = str(tmp_path)
+    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=r, check=True)
+    subprocess.run(["git", "config", "user.email", "a@b.c"], cwd=r, check=True)
+    subprocess.run(["git", "config", "user.name", "T"], cwd=r, check=True)
+    (tmp_path / "a.txt").write_text("1")
+    subprocess.run(["git", "add", "-A"], cwd=r, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "base"], cwd=r, check=True)
+    subprocess.run(["git", "checkout", "-q", "-b", "feature"], cwd=r, check=True)
+    (tmp_path / "a.txt").write_text("2")
+    subprocess.run(["git", "commit", "-q", "-am", "work"], cwd=r, check=True)
+    return r
+
+
+def test_range_is_inferred_from_the_merge_base(tmp_path):
+    """CLAUDE.md: users should never need to configure anything manually.
+
+    A revision range is the most manual thing an interface can ask for, and
+    the first person to run this hit exactly that: they were on a branch where
+    `origin/main..HEAD` meant something they did not intend.
+    """
+    repo = _repo_with_commits(tmp_path)
+    rng = tc.infer_range(repo)
+    assert rng and rng.endswith("..HEAD")
+    commits = tc.read_commits(repo, rng)
+    assert [c["subject"] for c in commits] == ["work"], "only this branch's work"
+
+
+def test_inferred_range_uses_merge_base_not_branch_tip(tmp_path):
+    """A branch behind the default must not sweep in what landed meanwhile."""
+    import subprocess
+    repo = _repo_with_commits(tmp_path)
+    subprocess.run(["git", "checkout", "-q", "main"], cwd=repo, check=True)
+    (tmp_path / "b.txt").write_text("x")
+    subprocess.run(["git", "add", "-A"], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "landed on main"], cwd=repo, check=True)
+    subprocess.run(["git", "checkout", "-q", "feature"], cwd=repo, check=True)
+    commits = tc.read_commits(repo, tc.infer_range(repo))
+    assert [c["subject"] for c in commits] == ["work"]
+
+
+def test_no_range_when_the_branch_adds_nothing(tmp_path):
+    import subprocess
+    repo = _repo_with_commits(tmp_path)
+    subprocess.run(["git", "checkout", "-q", "main"], cwd=repo, check=True)
+    assert tc.infer_range(repo) is None
+
+
+def test_default_branch_falls_back_without_a_remote(tmp_path):
+    assert tc.default_branch(_repo_with_commits(tmp_path)) in ("main", "master")
+
+
+def test_pr_inference_never_raises_without_a_remote(tmp_path):
+    assert tc.infer_pr(_repo_with_commits(tmp_path)) is None


### PR DESCRIPTION
`clawmetry trace capture --range origin/main..HEAD --pr 5125` asks a user to type a git revision range and look up a pull request number. CLAUDE.md says **"users should never need to configure anything manually"**, so that was a violation of a stated convention, not a missing convenience.

It also broke on first contact exactly the way you would expect: run from a checkout sitting on an unrelated branch, `origin/main..HEAD` resolved to two old commits that predated the hook, and the tool reported no sessions without saying which commits it looked at or why none qualified.

## Now

```
clawmetry trace capture
```

| inferred | how |
|---|---|
| range | `merge-base(origin/<default>, HEAD)..HEAD` |
| branch | from HEAD, printed so the scope is visible |
| pr | the open PR for this branch, from the forge's public API |

The merge base rather than `origin/main..HEAD`, so a branch that has not been rebased does not sweep in whatever landed on the default branch meanwhile. PR lookup is unauthenticated because this has to work before anyone has connected anything; a private repo returns nothing and we carry on.

`--range`, `--pr` and `--no-pr` remain as escape hatches.

## The failure message diagnoses itself

"Commits made before you installed the hook" is the first wall every new user hits, so it now says so:

```
No sessions resolved for <range>.
  examined 2 commit(s) on feat/x; 0 carried a Clawmetry-Session trailer
  Those commits were made before `clawmetry trace init` ran here.
  Coverage starts at install and cannot be backfilled.
```

33 tests, including one pinning that a stale branch traces its own work rather than the default branch's. py3.9 clean, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012UjuRS7Xn4JJGacSgRMbrK