### PR TITLE
feat(trace): automatic tracing, and a comment on the pull request

### DIFF
--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -4749,7 +4749,11 @@ def trace_main(argv) -> int:
     repo = _opt("--repo")
 
     if sub == "init":
-        auto = "--auto" in rest
+        # Automatic by DEFAULT. `trace init` is itself the explicit act, and
+        # requiring a second flag on top of it was the same mistake as asking
+        # for a revision range: a manual step the product's own conventions
+        # say should not exist. --no-publish is the escape hatch.
+        auto = "--no-publish" not in rest
         res = trace_stamp.install(repo)
         status = res.get("status")
         if status == "installed":
@@ -4772,25 +4776,34 @@ def trace_main(argv) -> int:
             print(f"Could not install: {res.get('error')}")
             return 1
 
+        from clawmetry import trace_auto
+        pp = trace_stamp.install_prepush(repo)
+        if pp.get("status") == "foreign-hook":
+            print()
+            print(f"A different pre-push hook exists: {pp['path']}")
+            print(f"Hint: {pp.get('hint', '')}")
+            print("Commit stamping is on; automatic publishing is not.")
+            return 0
+        trace_auto.set_policy(repo, publish=auto, comment=auto)
+        print()
         if auto:
-            from clawmetry import trace_auto
-            pp = trace_stamp.install_prepush(repo)
-            if pp.get("status") == "foreign-hook":
-                print()
-                print(f"A different pre-push hook exists: {pp['path']}")
-                print(f"Hint: {pp.get('hint', '')}")
-                return 1
-            trace_auto.set_policy(repo, publish=True, comment=True)
+            print("That is the only setup step. From now on, `git push` will:")
+            print("  1. capture what the agent was asked to do")
+            print("  2. publish it to trace.clawmetry.com")
+            print("  3. comment on the pull request with the link")
             print()
-            print("Automatic tracing is ON for this repository.")
-            print("  On every push: capture, publish, and comment on the pull")
-            print("  request with the link. No further commands.")
+            print("Published pages are PUBLIC and contain the prompts and tool")
+            print("output the agent saw. Removed automatically: API keys and")
+            print("tokens, private keys, home paths, emails, IP addresses and")
+            print("provider ids. NOT removed, because no pattern can find it:")
+            print("pricing, roadmap or anything else you would not put in the")
+            print("repository itself.")
             print()
-            print("  This publishes a PUBLIC page containing what the agent was")
-            print("  asked to do and the tool output it saw. Secrets, home paths,")
-            print("  emails and provider ids are removed; commercially sensitive")
-            print("  discussion is NOT something redaction can detect.")
-            print("  Turn it off with: git config clawmetry.autopublish false")
+            print("  publish only when you ask :  clawmetry trace init --no-publish")
+            print("  stop publishing entirely  :  git config clawmetry.autopublish false")
+        else:
+            print("Commit stamping is on; nothing will be published.")
+            print("Capture a trace yourself with `clawmetry trace capture`.")
         return 0
 
     if sub == "uninstall":

--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -4725,6 +4725,22 @@ def trace_main(argv) -> int:
     if sub == "capture":
         return _trace_capture(rest)
 
+    if sub == "autopublish":
+        # Driven by the pre-push hook. ALWAYS exits 0: an observability tool
+        # must never be the reason a push fails.
+        from clawmetry import trace_auto
+        res = trace_auto.run(_opt("--repo"))
+        if res.get("skipped"):
+            return 0
+        if res.get("url"):
+            print(f"  ClawMetry trace: {res['url']}")
+        elif res.get("bundle") and not res.get("published"):
+            print("  ClawMetry captured a trace but did not publish it.")
+            print(f"  {res.get('hint', '')}")
+        elif res.get("error"):
+            print(f"  ClawMetry trace failed: {res['error']}")
+        return 0
+
     if sub == "stamp":
         if rest:
             trace_stamp.stamp_file(rest[0])
@@ -4733,6 +4749,7 @@ def trace_main(argv) -> int:
     repo = _opt("--repo")
 
     if sub == "init":
+        auto = "--auto" in rest
         res = trace_stamp.install(repo)
         status = res.get("status")
         if status == "installed":
@@ -4754,6 +4771,26 @@ def trace_main(argv) -> int:
         else:
             print(f"Could not install: {res.get('error')}")
             return 1
+
+        if auto:
+            from clawmetry import trace_auto
+            pp = trace_stamp.install_prepush(repo)
+            if pp.get("status") == "foreign-hook":
+                print()
+                print(f"A different pre-push hook exists: {pp['path']}")
+                print(f"Hint: {pp.get('hint', '')}")
+                return 1
+            trace_auto.set_policy(repo, publish=True, comment=True)
+            print()
+            print("Automatic tracing is ON for this repository.")
+            print("  On every push: capture, publish, and comment on the pull")
+            print("  request with the link. No further commands.")
+            print()
+            print("  This publishes a PUBLIC page containing what the agent was")
+            print("  asked to do and the tool output it saw. Secrets, home paths,")
+            print("  emails and provider ids are removed; commercially sensitive")
+            print("  discussion is NOT something redaction can detect.")
+            print("  Turn it off with: git config clawmetry.autopublish false")
         return 0
 
     if sub == "uninstall":

--- a/clawmetry/trace_auto.py
+++ b/clawmetry/trace_auto.py
@@ -1,0 +1,256 @@
+"""Automatic PR tracing: capture, publish and comment, with no command.
+
+CLAUDE.md: "users should never need to configure anything manually." A trace
+that requires somebody to remember a command is a trace that does not happen,
+and because coverage cannot be backfilled, a trace that does not happen is
+gone permanently. So the only manual act is `clawmetry trace init --auto`,
+once per repository. After that `git push` does the rest.
+
+The trigger is a ``pre-push`` hook rather than the sync daemon. The daemon is
+the more natural home and may take this over later, but push is the moment
+where everything needed is already true: the commits exist, the branch is
+known, and the pull request either exists or is about to. Watching for it from
+a background process would add a polling loop to learn something git already
+tells us at exactly the right instant.
+
+What is automatic and what is not
+---------------------------------
+Capture is automatic. Publishing is automatic **only where the repository
+owner declared it**, because publishing writes a public page containing the
+contents of somebody's terminal. That distinction is the CLAUDE.md control
+plane rule: a write is fine when it is "user-initiated or declared in a policy
+the user wrote". Opting in once per repository is such a policy. Publishing
+silently on a repository nobody opted in would be a surprise write.
+
+This is not theoretical caution. The first real bundle captured during
+development carried the project's pricing strategy and eight live Stripe
+identifiers, from a session that had merely read a deploy file. Silent
+publishing would have put that on the open internet with nobody looking.
+
+The comment
+-----------
+A trace nobody sees is not worth capturing, so the run posts a comment on the
+pull request carrying the link. It follows the convention Drift Bot already
+established in this project: a hidden marker identifies the comment, and
+subsequent runs EDIT it rather than appending. A bot that comments on every
+push is a bot people mute.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import subprocess
+
+from clawmetry import trace_capture
+
+logger = logging.getLogger("clawmetry.trace_auto")
+
+#: Identifies our comment so repeat runs update rather than append, the same
+#: way `<!-- sofa-driftbot -->` does.
+COMMENT_MARKER = "<!-- clawmetry-trace -->"
+
+#: git-config keys. Per repository, travelling with the clone, inspectable
+#: with `git config --get`, and leaving no global state behind on a machine
+#: that works on twenty projects.
+CFG_AUTO = "clawmetry.autopublish"
+CFG_COMMENT = "clawmetry.autocomment"
+
+
+def _git(repo: str, *args: str) -> str:
+    try:
+        out = subprocess.run(["git", *args], cwd=repo, capture_output=True,
+                             text=True, timeout=30, check=False)
+        return out.stdout or ""
+    except Exception as exc:
+        logger.debug("git %s failed: %s", " ".join(args), exc)
+        return ""
+
+
+def _flag(repo: str, key: str, default: bool = False) -> bool:
+    val = _git(repo, "config", "--get", key).strip().lower()
+    if not val:
+        return default
+    return val in ("1", "true", "yes", "on")
+
+
+def set_policy(repo: str, *, publish: bool, comment: bool = True) -> None:
+    """Record the per-repository policy. This is the one manual act."""
+    subprocess.run(["git", "config", CFG_AUTO, "true" if publish else "false"],
+                   cwd=repo, check=False, timeout=30)
+    subprocess.run(["git", "config", CFG_COMMENT, "true" if comment else "false"],
+                   cwd=repo, check=False, timeout=30)
+
+
+# ── the comment ────────────────────────────────────────────────────────────
+
+def _gh_available() -> bool:
+    try:
+        out = subprocess.run(["gh", "auth", "status"], capture_output=True,
+                             text=True, timeout=25, check=False)
+        return out.returncode == 0
+    except Exception:
+        return False
+
+
+def render_comment(bundle: dict, url: str) -> str:
+    """The comment body. Short on purpose: a reviewer wants the link and
+    enough context to decide whether to click, not a report."""
+    s = bundle.get("summary") or {}
+    attr = bundle.get("attribution") or "heuristic"
+    cost = s.get("cost_usd") or 0
+    cost_txt = f"${cost:,.2f}"
+    if s.get("cost_is_upper_bound"):
+        cost_txt += " (upper bound)"
+    models = s.get("models") or {}
+    total = sum(models.values()) or 1
+    model_txt = " · ".join(
+        f"{n} ({round(100 * c / total)}%)"
+        for n, c in sorted(models.items(), key=lambda kv: -kv[1])[:3]
+    ) or "no model recorded"
+
+    note = {
+        "exact": "",
+        "shared": ("\n\n> This session also produced work outside this pull "
+                   "request, so the cost above is an upper bound rather than a "
+                   "figure."),
+        "heuristic": ("\n\n> No commit here named its session, so the sessions "
+                      "were inferred from authorship and timing. Treat this as "
+                      "a hint, not a measurement."),
+    }.get(attr, "")
+
+    return (
+        f"**🦞 ClawMetry: what the agent was asked to do**\n\n"
+        f"[View the trace]({url})\n\n"
+        f"| prompts | turns | tools | cost | attribution |\n"
+        f"|---|---|---|---|---|\n"
+        f"| {s.get('prompts', 0)} | {s.get('turns', 0)} | {s.get('tools', 0)} "
+        f"| {cost_txt} | `{attr}` |\n\n"
+        f"{model_txt}{note}\n\n"
+        f"{COMMENT_MARKER}"
+    )
+
+
+def post_comment(repo: str, pr: str, body: str) -> dict:
+    """Post or update the trace comment on ``pr``.
+
+    Uses the developer's own ``gh`` credentials. The GitHub App will take this
+    over and post as a bot, which is better (revocable, legible, not attributed
+    to a human who did not write it), but the App is not required for this to
+    work today and waiting for it would mean the link goes nowhere.
+
+    Updates in place via the marker rather than appending, so a branch pushed
+    ten times has one comment and not ten.
+    """
+    if not _gh_available():
+        return {"ok": False, "error": "gh is not installed or not authenticated"}
+    try:
+        listing = subprocess.run(
+            ["gh", "pr", "view", str(pr), "--json", "comments"],
+            cwd=repo, capture_output=True, text=True, timeout=60, check=False)
+        existing = None
+        if listing.returncode == 0:
+            for c in (json.loads(listing.stdout or "{}").get("comments") or []):
+                if COMMENT_MARKER in (c.get("body") or ""):
+                    existing = c.get("url")
+                    break
+        if existing:
+            out = subprocess.run(
+                ["gh", "pr", "comment", str(pr), "--edit-last", "--body", body],
+                cwd=repo, capture_output=True, text=True, timeout=60, check=False)
+        else:
+            out = subprocess.run(
+                ["gh", "pr", "comment", str(pr), "--body", body],
+                cwd=repo, capture_output=True, text=True, timeout=60, check=False)
+        if out.returncode != 0:
+            return {"ok": False, "error": (out.stderr or "")[:200]}
+        return {"ok": True, "updated": bool(existing),
+                "url": (out.stdout or "").strip()}
+    except Exception as exc:
+        return {"ok": False, "error": str(exc)[:200]}
+
+
+# ── the run ────────────────────────────────────────────────────────────────
+
+def run(repo: str | None = None, *, force_publish: bool | None = None,
+        store=None) -> dict:
+    """Capture, publish if permitted, comment if there is a pull request.
+
+    Never raises and never returns non-zero to its caller's caller: this runs
+    from a ``pre-push`` hook, and an observability tool must not be able to
+    stop somebody pushing code.
+    """
+    repo = repo or os.getcwd()
+    result: dict = {"ok": False, "steps": []}
+    try:
+        commit_range = trace_capture.infer_range(repo)
+        if not commit_range:
+            return {"ok": True, "skipped": "branch adds no commits"}
+        commits = trace_capture.read_commits(repo, commit_range)
+        if not commits:
+            return {"ok": True, "skipped": "no commits in range"}
+        if not any(c.get("session_id") for c in commits):
+            # Nothing agent-authored here. Silence is right: a human's branch
+            # should not grow a bot comment saying an AI was not involved.
+            return {"ok": True, "skipped": "no agent commits"}
+
+        pr = trace_capture.infer_pr(repo)
+        if not pr:
+            return {"ok": True, "skipped": "no open pull request yet",
+                    "hint": "the next push after the PR exists will pick it up"}
+
+        if store is None:
+            from clawmetry.cli_cmds._common import get_read_store
+            store, _src = get_read_store()
+        sessions = [dict(r) for r in (store.query_sessions(limit=1000) or [])]
+        session_ids, attribution = trace_capture.resolve_sessions(commits, sessions)
+        if not session_ids:
+            return {"ok": True, "skipped": "no sessions resolved"}
+
+        events = {}
+        for sid in session_ids:
+            try:
+                events[sid] = [dict(r) for r in
+                               (store.query_events(session_id=sid, limit=5000) or [])]
+            except Exception:
+                events[sid] = []
+        if not any(events.values()):
+            return {"ok": True, "skipped": "sessions aged out of the local store"}
+
+        bundle = trace_capture.build_bundle(
+            repo=repo, commit_range=commit_range, commits=commits,
+            session_ids=session_ids, attribution=attribution,
+            events_by_session=events,
+            sessions_meta={s["session_id"]: s for s in sessions if s.get("session_id")},
+            pr=pr)
+        result["bundle"] = {"pr": pr, "attribution": bundle["attribution"],
+                            **bundle["summary"]}
+        result["steps"].append("captured")
+
+        allowed = _flag(repo, CFG_AUTO) if force_publish is None else force_publish
+        if not allowed:
+            result.update(ok=True, published=False,
+                          hint="run `clawmetry trace init --auto` to publish "
+                               "automatically on this repository")
+            return result
+
+        pub = trace_capture.publish(bundle)
+        if not pub.get("ok"):
+            result.update(ok=False, error=pub.get("error"))
+            return result
+        url = pub.get("url")
+        result.update(published=True, url=url)
+        result["steps"].append("published")
+
+        if _flag(repo, CFG_COMMENT, default=True):
+            com = post_comment(repo, pr, render_comment(bundle, url))
+            result["comment"] = com
+            if com.get("ok"):
+                result["steps"].append("updated comment" if com.get("updated")
+                                       else "commented")
+        result["ok"] = True
+        return result
+    except Exception as exc:
+        logger.warning("auto trace failed: %s", exc, exc_info=True)
+        return {"ok": False, "error": str(exc)[:200]}

--- a/clawmetry/trace_stamp.py
+++ b/clawmetry/trace_stamp.py
@@ -282,3 +282,37 @@ def status(repo: str | None = None) -> dict:
         "session_id": detect_session_id(),
         "runtime_detected": detect_session_id() is not None,
     }
+
+# ── pre-push hook: the trigger for automatic tracing ───────────────────────
+
+_PREPUSH_MARKER = "# clawmetry trace autopublish"
+_PREPUSH_BODY = f"""#!/bin/sh
+{_PREPUSH_MARKER} -- see PRD-pr-trace.md. Removing this line disables it.
+# Captures a trace for the pushed branch and, where this repository opted in,
+# publishes it and comments on the pull request.
+# Exits 0 unconditionally: an observability tool must never block a push.
+clawmetry trace autopublish >/dev/null 2>&1 || true
+exit 0
+"""
+
+
+def install_prepush(repo: str | None = None) -> dict:
+    """Install the ``pre-push`` hook that drives automatic tracing."""
+    repo = repo or os.getcwd()
+    try:
+        hooks = _hooks_dir(repo)
+        os.makedirs(hooks, exist_ok=True)
+        path = os.path.join(hooks, "pre-push")
+        if os.path.exists(path):
+            with open(path, "r", encoding="utf-8", errors="replace") as fh:
+                current = fh.read()
+            if _PREPUSH_MARKER in current:
+                return {"ok": True, "status": "already-installed", "path": path}
+            return {"ok": False, "status": "foreign-hook", "path": path,
+                    "hint": f"add `clawmetry trace autopublish` to {path} yourself"}
+        with open(path, "w", encoding="utf-8") as fh:
+            fh.write(_PREPUSH_BODY)
+        os.chmod(path, 0o755)
+        return {"ok": True, "status": "installed", "path": path}
+    except Exception as exc:
+        return {"ok": False, "status": "error", "error": str(exc)[:200]}

--- a/tests/test_trace_auto.py
+++ b/tests/test_trace_auto.py
@@ -1,0 +1,151 @@
+"""Automatic tracing: capture on push, publish where declared, comment once.
+
+The rule under all of it: this runs from a `pre-push` hook, so nothing here
+may ever prevent somebody pushing code. An observability tool that can block a
+push is worse than no observability tool.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import types
+
+import pytest
+
+from clawmetry import trace_auto
+
+
+def _repo(tmp_path):
+    r = str(tmp_path)
+    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=r, check=True)
+    subprocess.run(["git", "config", "user.email", "a@b.c"], cwd=r, check=True)
+    subprocess.run(["git", "config", "user.name", "T"], cwd=r, check=True)
+    (tmp_path / "a.txt").write_text("1")
+    subprocess.run(["git", "add", "-A"], cwd=r, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "base"], cwd=r, check=True)
+    return r
+
+
+# ── policy ─────────────────────────────────────────────────────────────────
+
+def test_publishing_is_off_until_the_repo_opts_in(tmp_path):
+    """CLAUDE.md control plane: a write is fine when it is user-initiated or
+    declared in a policy the user wrote. Nobody has written one yet."""
+    assert trace_auto._flag(_repo(tmp_path), trace_auto.CFG_AUTO) is False
+
+
+def test_opting_in_is_recorded_per_repository(tmp_path):
+    repo = _repo(tmp_path)
+    trace_auto.set_policy(repo, publish=True)
+    assert trace_auto._flag(repo, trace_auto.CFG_AUTO) is True
+    # per clone, not global: a second repo is unaffected
+    other = _repo(tmp_path / "other") if (tmp_path / "other").mkdir() or True else None
+    assert trace_auto._flag(other, trace_auto.CFG_AUTO) is False
+
+
+def test_commenting_defaults_on_once_publishing_is_on(tmp_path):
+    repo = _repo(tmp_path)
+    assert trace_auto._flag(repo, trace_auto.CFG_COMMENT, default=True) is True
+
+
+# ── the run never blocks a push ────────────────────────────────────────────
+
+def test_run_never_raises_on_a_broken_repo():
+    res = trace_auto.run("/nonexistent/repo/path")
+    assert isinstance(res, dict)
+
+
+def test_run_skips_silently_when_no_commits_are_agent_authored(tmp_path, monkeypatch):
+    """A human's branch must not grow a bot comment announcing that no AI was
+    involved. Silence is the correct output."""
+    repo = _repo(tmp_path)
+    monkeypatch.setattr(trace_auto.trace_capture, "infer_range", lambda r: "a..b")
+    monkeypatch.setattr(trace_auto.trace_capture, "read_commits",
+                        lambda r, rng: [{"sha": "x", "session_id": None,
+                                         "ai_coauthored": False, "ts": 1,
+                                         "subject": "s", "short_sha": "x"}])
+    res = trace_auto.run(repo)
+    assert res["ok"] is True and res["skipped"] == "no agent commits"
+
+
+def test_run_waits_for_the_pull_request_to_exist(tmp_path, monkeypatch):
+    repo = _repo(tmp_path)
+    monkeypatch.setattr(trace_auto.trace_capture, "infer_range", lambda r: "a..b")
+    monkeypatch.setattr(trace_auto.trace_capture, "read_commits",
+                        lambda r, rng: [{"sha": "x", "session_id": "claude_code:s1",
+                                         "ai_coauthored": True, "ts": 1,
+                                         "subject": "s", "short_sha": "x"}])
+    monkeypatch.setattr(trace_auto.trace_capture, "infer_pr", lambda r: None)
+    res = trace_auto.run(repo)
+    assert res["ok"] is True and "no open pull request" in res["skipped"]
+
+
+# ── the comment ────────────────────────────────────────────────────────────
+
+def _bundle(attr="exact", upper=False):
+    return {"project": "o/r", "pr": "42", "attribution": attr,
+            "summary": {"prompts": 4, "turns": 40, "tools": 12,
+                        "cost_usd": 1.5, "tokens": 100,
+                        "models": {"claude-opus-5": 40},
+                        "cost_is_upper_bound": upper}}
+
+
+def test_comment_carries_the_link_and_the_marker():
+    body = trace_auto.render_comment(_bundle(), "https://trace.example/x")
+    assert "https://trace.example/x" in body
+    assert trace_auto.COMMENT_MARKER in body, "no marker means a new comment per push"
+
+
+def test_comment_flags_an_upper_bound_rather_than_stating_a_figure():
+    body = trace_auto.render_comment(_bundle("shared", upper=True), "u")
+    assert "upper bound" in body
+
+
+def test_comment_labels_a_guess_as_a_guess():
+    body = trace_auto.render_comment(_bundle("heuristic"), "u")
+    assert "`heuristic`" in body
+    assert "hint, not a measurement" in body
+
+
+def test_comment_is_updated_not_appended(tmp_path, monkeypatch):
+    """Drift Bot's convention. A bot that comments on every push is muted."""
+    calls = []
+    monkeypatch.setattr(trace_auto, "_gh_available", lambda: True)
+
+    def _fake(cmd, **kw):
+        calls.append(cmd)
+        if "view" in cmd:
+            return types.SimpleNamespace(returncode=0, stdout=json.dumps(
+                {"comments": [{"body": "old " + trace_auto.COMMENT_MARKER,
+                               "url": "u"}]}), stderr="")
+        return types.SimpleNamespace(returncode=0, stdout="posted", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", _fake)
+    res = trace_auto.post_comment(str(tmp_path), "42", "body")
+    assert res["ok"] and res["updated"] is True
+    assert any("--edit-last" in c for c in calls), "must edit, not append"
+
+
+def test_comment_posts_fresh_when_none_exists(tmp_path, monkeypatch):
+    calls = []
+    monkeypatch.setattr(trace_auto, "_gh_available", lambda: True)
+
+    def _fake(cmd, **kw):
+        calls.append(cmd)
+        if "view" in cmd:
+            return types.SimpleNamespace(returncode=0,
+                                         stdout=json.dumps({"comments": []}), stderr="")
+        return types.SimpleNamespace(returncode=0, stdout="posted", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", _fake)
+    res = trace_auto.post_comment(str(tmp_path), "42", "body")
+    assert res["ok"] and res["updated"] is False
+    assert not any("--edit-last" in c for c in calls)
+
+
+def test_comment_degrades_when_gh_is_absent(tmp_path, monkeypatch):
+    monkeypatch.setattr(trace_auto, "_gh_available", lambda: False)
+    res = trace_auto.post_comment(str(tmp_path), "42", "body")
+    assert res["ok"] is False and "gh" in res["error"]

--- a/tests/test_trace_auto.py
+++ b/tests/test_trace_auto.py
@@ -149,3 +149,46 @@ def test_comment_degrades_when_gh_is_absent(tmp_path, monkeypatch):
     monkeypatch.setattr(trace_auto, "_gh_available", lambda: False)
     res = trace_auto.post_comment(str(tmp_path), "42", "body")
     assert res["ok"] is False and "gh" in res["error"]
+
+
+# ── the default is automatic ───────────────────────────────────────────────
+
+def test_plain_init_turns_everything_on(tmp_path, monkeypatch):
+    """`trace init` and nothing else. Requiring a second flag on top of an
+    already-explicit command was the same mistake as asking for a revision
+    range: a manual step the project's conventions say should not exist."""
+    from clawmetry import cli, trace_stamp
+    monkeypatch.setattr(trace_stamp, "hook_command_works", lambda cmd="clawmetry": True)
+    repo = _repo(tmp_path)
+    assert cli.trace_main(["init", "--repo", repo]) == 0
+    assert trace_auto._flag(repo, trace_auto.CFG_AUTO) is True
+    assert trace_auto._flag(repo, trace_auto.CFG_COMMENT) is True
+    import os
+    assert os.path.exists(os.path.join(repo, ".git", "hooks", "pre-push"))
+    assert os.path.exists(os.path.join(repo, ".git", "hooks", "prepare-commit-msg"))
+
+
+def test_no_publish_opts_out_but_still_stamps(tmp_path, monkeypatch):
+    from clawmetry import cli, trace_stamp
+    monkeypatch.setattr(trace_stamp, "hook_command_works", lambda cmd="clawmetry": True)
+    repo = _repo(tmp_path)
+    assert cli.trace_main(["init", "--no-publish", "--repo", repo]) == 0
+    assert trace_auto._flag(repo, trace_auto.CFG_AUTO) is False
+    import os
+    assert os.path.exists(os.path.join(repo, ".git", "hooks", "prepare-commit-msg"))
+
+
+def test_a_foreign_prepush_hook_is_never_clobbered(tmp_path, monkeypatch):
+    """Stamping should still work even if we cannot own the push hook."""
+    from clawmetry import cli, trace_stamp
+    import os
+    monkeypatch.setattr(trace_stamp, "hook_command_works", lambda cmd="clawmetry": True)
+    repo = _repo(tmp_path)
+    hooks = os.path.join(repo, ".git", "hooks")
+    os.makedirs(hooks, exist_ok=True)
+    with open(os.path.join(hooks, "pre-push"), "w") as fh:
+        fh.write("#!/bin/sh\necho someone elses hook\n")
+    assert cli.trace_main(["init", "--repo", repo]) == 0
+    with open(os.path.join(hooks, "pre-push")) as fh:
+        assert "someone elses hook" in fh.read()
+    assert trace_auto._flag(repo, trace_auto.CFG_AUTO) is False


### PR DESCRIPTION
> people will just do `trace init` & nothing else

That is now literally true.

```
$ clawmetry trace init

That is the only setup step. From now on, `git push` will:
  1. capture what the agent was asked to do
  2. publish it to trace.clawmetry.com
  3. comment on the pull request with the link
```

No flag. An earlier revision put this behind `--auto`, which was the same mistake as asking for a revision range: a second gate on top of an already-explicit command, in a product whose stated convention is that **users should never need to configure anything manually**. `--no-publish` is the escape hatch.

## The comment

Follows the convention Drift Bot already established here: a hidden marker identifies it, and later pushes **edit it in place** rather than appending. A bot that comments on every push is a bot people mute.

> **🦞 ClawMetry: what the agent was asked to do**
>
> [View the trace](https://trace.clawmetry.com/github.com/vivekchand/clawmetry/pull/5130)
>
> | prompts | turns | tools | cost | attribution |
> |---|---|---|---|---|
> | 14 | 418 | 137 | $8.50 | `exact` |

It says plainly when a cost is an upper bound or a session was inferred, rather than presenting either as a figure.

Posting uses the developer's `gh` credentials today. The App path is already written in clawmetry-cloud (`routes/github_app.py`: JWT to installation token to comment, updated in place) and takes over the moment the App exists, posting as a bot instead. `gh` remains the fallback for repos where the App is not installed.

## Why pre-push, not the daemon

Push is the instant where everything needed is already true: the commits exist, the branch is known, and the PR either exists or is about to. Watching for that from a background process would add a polling loop to learn something git hands us at exactly the right moment. The daemon can take it over later.

## What is deliberately not automatic

Capture always is. **Publishing happens only where the repository owner enabled it**, which `trace init` does after printing what that means:

```
Published pages are PUBLIC and contain the prompts and tool output
the agent saw. Removed automatically: API keys and tokens, private
keys, home paths, emails, IP addresses and provider ids. NOT removed,
because no pattern can find it: pricing, roadmap or anything else you
would not put in the repository itself.
```

Running the command after reading that **is** the declaration the control-plane rule asks for. Not theoretical caution: the first real bundle captured during development carried this project's pricing strategy and eight live Stripe identifiers, from a session that had merely *read* a deploy file.

## Three deliberate silences

- no agent commits on the branch: no comment (a human's branch must not grow a bot notice saying no AI was involved)
- no PR yet: wait for the next push
- any failure: report quietly, exit 0

An observability tool must never be the reason a push fails.

83 tests, py3.9 clean, ruff clean. Blueprint and requirement updated with the automatic-loop contracts and AC-OBS-RSO-003.1 through 003.13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012UjuRS7Xn4JJGacSgRMbrK