### PR TITLE
fix(sync): attribute sessions to their real runtime, and stop `status` blocking on a wheel download

### DIFF
--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -3336,10 +3336,16 @@ def _cmd_status(args) -> None:
             # Mirroring the live plan here makes the gate reflect the real plan
             # immediately and seeds the entitlement resolver so paid runtimes
             # flip on without waiting for the daemon. Best-effort; never raises.
+            # ``allow_provision=False``: mirroring the plan must stay a local
+            # file write. Without it this line reached auto_provision_pro and
+            # a plain `clawmetry status` spent ~80s downloading the pro wheel
+            # (20s entitlement probe + 60s wheel GET) whenever the first
+            # resolved address was unreachable — the daemon, not a status
+            # read, owns provisioning.
             if _acct_plan:
                 try:
                     from clawmetry.sync import _persist_cloud_plan_to_disk as _pcp
-                    _pcp(_acct_plan)
+                    _pcp(_acct_plan, allow_provision=False)
                 except Exception:
                     pass
             if _acct_email:

--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -2185,7 +2185,10 @@ class LocalStore:
                             " 'openclaw'"
                         ).fetchone()[0]
                         # Wipe ALL THREE rollup tables, not just the two this
-                        # migration dirties. ``backfill_rollups`` gates on
+                        # migration dirties. Blueprint "Runtime and Session
+                        # Observability" states this as a contract: correcting
+                        # stored attribution and clearing the derived rollups
+                        # are ONE step. ``backfill_rollups`` gates on
                         # ``COUNT(model_daily) + COUNT(runtime_daily) +
                         # COUNT(session)`` and skips with "rollups_populated"
                         # if that sum is non-zero — so leaving

--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -215,7 +215,7 @@ def _on_disk_bytes() -> int:
         pass
     return total
 
-SCHEMA_VERSION = 11
+SCHEMA_VERSION = 12
 
 # ── Two-layer schema (multi-agent) ──────────────────────────────────────────
 #
@@ -2146,6 +2146,65 @@ class LocalStore:
                         log.exception(
                             "local store: v11 rollup wipe FAILED — schema "
                             "version will NOT be stamped; next boot will retry"
+                        )
+                        migration_failed = True
+                        _migration_err = str(exc)
+                if not migration_failed and current < 12:
+                    # v11 -> v12: SESSION runtime re-attribution. v11 fixed the
+                    # EVENT side (rollup tokens/cost) but left the sessions
+                    # table, whose agent_type came from
+                    # ``s.get("agent_type") or "openclaw"`` in
+                    # ``sync._local_ingest_sessions_batch``. The family
+                    # adapters never set agent_type, so every Claude Code /
+                    # Codex / Cursor session was stored as 'openclaw'.
+                    # ``_refresh_runtime_day_session_counts_locked`` filters
+                    # ``WHERE agent_type = ?``, so those runtimes rolled up
+                    # with sessions=0 and the Fleet card showed them stuck on
+                    # "detected here / syncing to cloud" forever, even though
+                    # their events (split by session-id prefix) rendered fine
+                    # in Brain/Activity.
+                    #
+                    # Re-stamp from the authoritative ``<runtime>:<uuid>``
+                    # session_id prefix, then wipe the rollups so the standard
+                    # startup backfill recomputes the session counts.
+                    try:
+                        _prefix_list = ", ".join(
+                            "'" + p + "'" for p in _NON_OPENCLAW_RUNTIME_PREFIXES
+                        )
+                        self._conn.execute(
+                            f"""
+                            UPDATE sessions
+                               SET agent_type = split_part(session_id, ':', 1)
+                             WHERE agent_type = 'openclaw'
+                               AND split_part(session_id, ':', 1)
+                                   IN ({_prefix_list})
+                            """
+                        )
+                        _n = self._conn.execute(
+                            "SELECT COUNT(*) FROM sessions WHERE agent_type <>"
+                            " 'openclaw'"
+                        ).fetchone()[0]
+                        # Wipe ALL THREE rollup tables, not just the two this
+                        # migration dirties. ``backfill_rollups`` gates on
+                        # ``COUNT(model_daily) + COUNT(runtime_daily) +
+                        # COUNT(session)`` and skips with "rollups_populated"
+                        # if that sum is non-zero — so leaving
+                        # rollup_model_daily behind means the startup backfill
+                        # never runs and the runtime/session rollups stay
+                        # EMPTY forever. v11 wiped all three for this reason.
+                        self._conn.execute("DELETE FROM rollup_model_daily")
+                        self._conn.execute("DELETE FROM rollup_runtime_daily")
+                        self._conn.execute("DELETE FROM rollup_session")
+                        log.info(
+                            "local store: v12 re-attributed session runtimes "
+                            "from the session-id prefix (%d non-openclaw "
+                            "session row(s)); rollups wiped for rebuild", _n,
+                        )
+                    except Exception as exc:
+                        log.exception(
+                            "local store: v12 session re-attribution FAILED — "
+                            "schema version will NOT be stamped; next boot "
+                            "will retry"
                         )
                         migration_failed = True
                         _migration_err = str(exc)

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -1266,7 +1266,9 @@ _HEARTBEAT_PLAN_TO_TIER = {
 }
 
 
-def _sync_auto_update_with_plan(tier: str | None) -> None:
+def _sync_auto_update_with_plan(
+    tier: str | None, *, allow_provision: bool = True,
+) -> None:
     """Entitled accounts (Trial / Starter / Pro / Enterprise) keep the node
     current automatically: enable the opt-in ``auto_update`` flag so the
     daemon's update-check worker installs new releases (riding the 48h
@@ -1276,7 +1278,12 @@ def _sync_auto_update_with_plan(tier: str | None) -> None:
     Safety: respects an explicit opt-out (``CLAWMETRY_AUTO_UPDATE`` in
     0/false/no/off), only ever ENABLES (never auto-disables, so a user's manual
     choice survives a downgrade), and no-ops for free / inactive plans. Best
-    effort — never raises."""
+    effort — never raises.
+
+    ``allow_provision=False`` keeps this side-effect-free over the network:
+    the local auto-update flag is still reconciled, but the clawmetry-pro
+    wheel download is skipped. Read-only callers (``clawmetry status``) must
+    pass it."""
     try:
         if not tier or tier == "cloud_free":
             return
@@ -1301,12 +1308,32 @@ def _sync_auto_update_with_plan(tier: str | None) -> None:
     # clawmetry-pro IMMEDIATELY rather than waiting up to ~30 min for the
     # entitlement watcher, so the paid runtimes (Claude Code, Codex, …) start
     # syncing within a cycle or two of the upgrade — no daemon restart needed.
+    if not allow_provision:
+        # Read-only caller (e.g. ``clawmetry status``): mirroring the plan must
+        # not turn into a wheel download. ``auto_provision_pro`` does a 20s
+        # entitlement probe plus a 60s wheel GET, so on a node whose first
+        # resolved address is unreachable (broken IPv6 is the common one —
+        # glibc prefers AAAA and ``socket.create_connection`` has no Happy
+        # Eyeballs, so it burns the FULL timeout before trying IPv4) a plain
+        # status read blocked for ~85s (founder live-hit 2026-08-23).
+        return
     try:
         if tier and tier != "cloud_free":
             from clawmetry.license import (
                 _pro_installed_version as _pv2,
                 auto_provision_pro as _app2,
+                ensure_pro_on_path as _epop2,
             )
+            # A prior install may live in the HOME-owned fallback dir (used
+            # when the interpreter's site-packages is read-only, e.g. a
+            # root-owned /opt install driven by a --user daemon). That dir is
+            # only on sys.path if something put it there, and the daemon's
+            # startup call runs BEFORE the first provision creates it — so
+            # without this, ``_pv2()`` returned None on every heartbeat and the
+            # daemon re-provisioned pro forever, logging "provisioned … will
+            # sync on the next cycle" every cycle under one PID (founder
+            # live-hit 2026-08-23).
+            _epop2()
             if not _pv2():
                 _cfg2 = load_config() or {}
                 _ak2 = _cfg2.get("api_key", "")
@@ -1366,6 +1393,8 @@ def _persist_cloud_plan_to_disk(
     trial_days_left=None,
     trial_end=None,
     trial_used=None,
+    *,
+    allow_provision: bool = True,
 ) -> None:
     """Mirror the heartbeat plan into ``~/.clawmetry/cloud_plan.json`` so the
     dashboard process (which runs ``clawmetry.entitlements.get_entitlement``)
@@ -1382,10 +1411,16 @@ def _persist_cloud_plan_to_disk(
     optimisation, the daemon still works without it. When ``plan`` is unknown
     or signals an inactive state (``trial_expired``, ``None``) the cache file
     is removed instead of written, so the resolver falls back to OSS-free
-    rather than granting a dead plan."""
+    rather than granting a dead plan.
+
+    ``allow_provision=False`` makes the call network-free (see
+    ``_sync_auto_update_with_plan``); ``clawmetry status`` uses it so a status
+    read can never block on fetching the pro wheel."""
     tier = _HEARTBEAT_PLAN_TO_TIER.get(str(plan or "").strip().lower())
     # Entitled plan → keep this node current automatically (opt-out + 48h rail).
-    _sync_auto_update_with_plan(tier)
+    # ``allow_provision`` is forwarded so a read-only caller can mirror the plan
+    # without triggering a blocking clawmetry-pro wheel download.
+    _sync_auto_update_with_plan(tier, allow_provision=allow_provision)
     # Idempotent reconcile: this is now called on EVERY heartbeat (not just on a
     # plan change), so short-circuit when the on-disk cache already reflects this
     # tier. We compare only the ``plan`` field (the entitlement-relevant part) so
@@ -4146,6 +4181,44 @@ def _session_git_branch(row: dict) -> str | None:
     return _first_alias(row, _GIT_BRANCH_ALIASES)
 
 
+def _session_agent_type(row: dict, session_id: str) -> str:
+    """Which runtime a session belongs to, for the ``sessions.agent_type``
+    column.
+
+    This used to be ``row.get("agent_type") or "openclaw"``. The family
+    adapters (Claude Code, Codex, Cursor, …) don't set ``agent_type`` — they
+    carry the runtime in ``runtime`` and, authoritatively, in the
+    ``<runtime>:<uuid>`` ``session_id`` prefix that ``local_store`` already
+    keys its event-side runtime split on. So every paid-runtime session was
+    stamped ``openclaw``, which made
+    ``_refresh_runtime_day_session_counts_locked`` (``WHERE agent_type = ?``)
+    count zero sessions for those runtimes. The Brain/Activity tabs looked
+    fine — they group events by the ``session_id`` prefix — while the Fleet
+    card, which reads the session counts, showed the runtime stuck on
+    "detected here / syncing to cloud" forever (founder live-hit
+    2026-08-23: Claude Code · 537 pending on Linux while the Mac's 49 synced).
+
+    Resolution order: explicit ``agent_type`` → ``runtime`` → the
+    ``session_id`` prefix when it names a known non-OpenClaw runtime →
+    ``openclaw``. The prefix is checked against
+    ``local_store._NON_OPENCLAW_RUNTIME_PREFIXES`` so a genuine OpenClaw
+    session id containing a colon can never be mistaken for a runtime.
+    """
+    for key in ("agent_type", "runtime"):
+        val = row.get(key)
+        if isinstance(val, str) and val.strip():
+            return val.strip()
+    prefix = str(session_id or "").split(":", 1)[0].strip().lower()
+    if prefix:
+        try:
+            from clawmetry.local_store import _NON_OPENCLAW_RUNTIME_PREFIXES
+            if prefix in _NON_OPENCLAW_RUNTIME_PREFIXES:
+                return prefix
+        except Exception:
+            pass
+    return "openclaw"
+
+
 def _local_ingest_sessions_batch(rows: list, node_id: str) -> None:
     """Mirror a batch of session rows (the same dicts we push to /ingest/sessions)
     into the local DuckDB ``sessions`` table. Batched: ONE
@@ -4177,7 +4250,7 @@ def _local_ingest_sessions_batch(rows: list, node_id: str) -> None:
             and v
         }
         session_rows.append({
-            "agent_type": s.get("agent_type") or "openclaw",
+            "agent_type": _session_agent_type(s, sid),
             "session_id": sid,
             "node_id": node_id,
             "agent_id": s.get("agent_id") or "main",

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -1324,6 +1324,9 @@ def _sync_auto_update_with_plan(
                 auto_provision_pro as _app2,
                 ensure_pro_on_path as _epop2,
             )
+            # Blueprint "Extended Runtime Support": provisioning is
+            # idempotent against an already-installed package, including one in
+            # the user-owned fallback location.
             # A prior install may live in the HOME-owned fallback dir (used
             # when the interpreter's site-packages is read-only, e.g. a
             # root-owned /opt install driven by a --user daemon). That dir is

--- a/docs/ac_coverage_baseline.json
+++ b/docs/ac_coverage_baseline.json
@@ -8,7 +8,7 @@
     "after coverage improves, so the ratchet is tightened in the same PR.",
     "Regenerate with: python3 scripts/check_ac_coverage.py --update-baseline"
   ],
-  "covered_count": 9,
+  "covered_count": 10,
   "total_count": 77,
   "uncovered": [
     "AC-GOV-001.1",
@@ -47,7 +47,6 @@
     "AC-OBS-002.1",
     "AC-OBS-002.2",
     "AC-OBS-002.3",
-    "AC-OBS-003.1",
     "AC-OBS-003.2",
     "AC-OBS-003.3",
     "AC-OBS-CEA-001.2",

--- a/tests/test_session_runtime_attribution.py
+++ b/tests/test_session_runtime_attribution.py
@@ -21,6 +21,12 @@ so claude_code rolled up with sessions=0 and the Fleet card had nothing to
 mark synced. The event side was fine because it splits on the session_id
 prefix, which is why Activity worked and Fleet did not.
 
+Specification: the "Runtime and Session Observability" blueprint now states the
+resolution order this module enforces, and states that the session-side and
+event-side runtime splits must agree. That second contract is the one this bug
+broke: events were attributed correctly while sessions were not, so the two
+per-runtime views disagreed instead of failing visibly.
+
 Acceptance criteria covered:
 
 * AC-OBS-003.1 -- when the system recognizes a supported runtime, it associates

--- a/tests/test_session_runtime_attribution.py
+++ b/tests/test_session_runtime_attribution.py
@@ -1,0 +1,104 @@
+"""Sessions must carry their OWN runtime, not a blanket 'openclaw'.
+
+Founder live-hit 2026-08-23: the Fleet showed `Claude Code · 537` stuck on
+"detected here — syncing to cloud" on the Linux node while the Mac's
+`Claude Code · 49` synced green — and the Brain/Activity tab on that same
+Linux node was streaming live Claude Code events the whole time.
+
+Root cause: ``sync._local_ingest_sessions_batch`` stamped
+
+    "agent_type": s.get("agent_type") or "openclaw"
+
+but the family adapters never set ``agent_type`` — they carry the runtime in
+``runtime`` and in the ``<runtime>:<uuid>`` session_id prefix. So every paid
+runtime's sessions were written as 'openclaw'. Live store at the time:
+
+    query_rollup_sessions(limit=500) -> 152 rows, Counter({'openclaw': 152})
+    ...including session_id 'claude_code:36f12caf-...' labelled openclaw.
+
+``_refresh_runtime_day_session_counts_locked`` filters ``WHERE agent_type = ?``,
+so claude_code rolled up with sessions=0 and the Fleet card had nothing to
+mark synced. The event side was fine because it splits on the session_id
+prefix, which is why Activity worked and Fleet did not.
+
+Acceptance criteria covered:
+
+* AC-OBS-003.1 -- when the system recognizes a supported runtime, it associates
+  that runtime's activity with it: ``test_batch_ingest_stamps_the_real_runtime``
+  proves a Claude Code / Codex session is stored under its own runtime instead
+  of being folded into openclaw.
+"""
+
+import pytest
+
+from clawmetry.sync import _session_agent_type
+from clawmetry.local_store import _NON_OPENCLAW_RUNTIME_PREFIXES
+
+
+def test_runtime_from_session_id_prefix():
+    """The prefix is authoritative when the adapter sets no explicit field."""
+    assert _session_agent_type({}, "claude_code:66bfb3ac-b2b8-4700") == "claude_code"
+    assert _session_agent_type({}, "codex:abc-123") == "codex"
+    assert _session_agent_type({}, "cursor:xyz") == "cursor"
+
+
+def test_explicit_agent_type_wins():
+    got = _session_agent_type({"agent_type": "goose"}, "claude_code:1")
+    assert got == "goose"
+
+
+def test_runtime_field_is_used_when_agent_type_absent():
+    got = _session_agent_type({"runtime": "aider"}, "whatever")
+    assert got == "aider"
+
+
+@pytest.mark.parametrize(
+    "sid",
+    [
+        "",
+        "main",
+        "some-plain-uuid-with-no-prefix",
+        # A colon alone must not invent a runtime, or an OpenClaw session key
+        # would be silently re-homed under a bogus runtime name.
+        "telegram:12345",
+        "unknown_runtime:abc",
+    ],
+)
+def test_openclaw_remains_the_default(sid):
+    assert _session_agent_type({}, sid) == "openclaw"
+
+
+def test_every_known_prefix_round_trips():
+    """Guards the constant and the helper against drifting apart."""
+    for prefix in _NON_OPENCLAW_RUNTIME_PREFIXES:
+        assert _session_agent_type({}, f"{prefix}:sid-1") == prefix
+
+
+def test_batch_ingest_stamps_the_real_runtime(monkeypatch):
+    """End-to-end through the batch builder: the rows handed to the store must
+    carry per-runtime agent_type, since that column is what the Fleet counts."""
+    import clawmetry.sync as sync
+
+    captured = {}
+
+    class _FakeStore:
+        def ingest_sessions_batch(self, rows):
+            captured["rows"] = rows
+
+    monkeypatch.setattr("clawmetry.local_store.get_store", lambda: _FakeStore())
+
+    sync._local_ingest_sessions_batch(
+        [
+            {"session_id": "claude_code:aaa", "total_tokens": 10},
+            {"session_id": "codex:bbb", "total_tokens": 20},
+            {"session_id": "plain-openclaw-session", "total_tokens": 30},
+        ],
+        node_id="node-1",
+    )
+
+    by_id = {r["session_id"]: r["agent_type"] for r in captured["rows"]}
+    assert by_id == {
+        "claude_code:aaa": "claude_code",
+        "codex:bbb": "codex",
+        "plain-openclaw-session": "openclaw",
+    }

--- a/tests/test_status_no_blocking_provision.py
+++ b/tests/test_status_no_blocking_provision.py
@@ -1,0 +1,96 @@
+"""`clawmetry status` is a READ. It must never download the pro wheel.
+
+Founder live-hit 2026-08-23: `clawmetry status --show-key` took 85s on a Linux
+box while taking ~2s on a Mac. cProfile put 82.6s of it inside
+``socket.connect`` across 8 hanging connects, reached via
+
+    _cmd_status
+      -> sync._persist_cloud_plan_to_disk        (the "self-heal plan cache" line)
+        -> sync._sync_auto_update_with_plan
+          -> license.auto_provision_pro          (20s entitlement probe)
+            -> license._provision_pro_wheel      (60s wheel GET)
+
+The box had a global IPv6 address and a default route from RA, but no working
+IPv6 path. glibc therefore ordered AAAA first, and
+``socket.create_connection`` walks getaddrinfo results strictly in order with
+no Happy Eyeballs — so each call burned its FULL timeout before ever trying
+the IPv4 address that answered in 23ms.
+
+The timeouts are the daemon's business, not a status read's. These tests pin
+the ``allow_provision=False`` contract that keeps the read local.
+"""
+
+import clawmetry.sync as sync
+
+
+def test_persist_cloud_plan_skips_provision_when_disallowed(monkeypatch):
+    """allow_provision=False must not reach the network provisioner."""
+    called = []
+
+    def _boom(*a, **kw):  # pragma: no cover - must never run
+        called.append(a)
+        raise AssertionError("auto_provision_pro must not run for a read")
+
+    monkeypatch.setattr("clawmetry.license.auto_provision_pro", _boom)
+    monkeypatch.setattr("clawmetry.license._pro_installed_version", lambda: None)
+
+    sync._sync_auto_update_with_plan("cloud_pro", allow_provision=False)
+
+    assert called == []
+
+
+def test_persist_cloud_plan_forwards_the_flag(monkeypatch):
+    """_persist_cloud_plan_to_disk must thread allow_provision through rather
+    than silently provisioning on behalf of its caller."""
+    seen = {}
+
+    def _fake(tier, *, allow_provision=True):
+        seen["tier"] = tier
+        seen["allow_provision"] = allow_provision
+
+    monkeypatch.setattr(sync, "_sync_auto_update_with_plan", _fake)
+    # Keep the write side inert — this test is about the flag, not the cache.
+    monkeypatch.setattr(sync, "_CLOUD_PLAN_CACHE_PATH", "/nonexistent/cloud_plan.json")
+
+    try:
+        sync._persist_cloud_plan_to_disk("cloud_pro", allow_provision=False)
+    except Exception:
+        # The cache write may fail on the bogus path; the forwarding already
+        # happened and is what we assert on.
+        pass
+
+    assert seen["allow_provision"] is False
+
+
+def test_cli_status_passes_allow_provision_false():
+    """The status handler must call the mirror with allow_provision=False.
+
+    Asserted on the source because the surrounding handler prints a full
+    status report and reaches the network for the account lookup; the
+    regression we are guarding is exactly this one keyword going missing.
+    """
+    import inspect
+    import clawmetry.cli as cli
+
+    src = inspect.getsource(cli._cmd_status)
+    assert "_pcp(_acct_plan, allow_provision=False)" in src, (
+        "clawmetry status must mirror the cloud plan without provisioning; "
+        "dropping allow_provision=False reintroduces the 85s status hang"
+    )
+
+
+def test_provision_still_runs_by_default(monkeypatch):
+    """The daemon path is unchanged: provisioning is opt-out, not removed."""
+    ran = []
+
+    monkeypatch.setattr("clawmetry.license.ensure_pro_on_path", lambda: None)
+    monkeypatch.setattr("clawmetry.license._pro_installed_version", lambda: None)
+    monkeypatch.setattr(
+        "clawmetry.license.auto_provision_pro",
+        lambda key, node=None: (ran.append(key), (False, ""))[1],
+    )
+    monkeypatch.setattr(sync, "load_config", lambda: {"api_key": "cm_test", "node_id": "n1"})
+
+    sync._sync_auto_update_with_plan("cloud_pro")
+
+    assert ran == ["cm_test"]

--- a/tests/test_v12_session_runtime_migration.py
+++ b/tests/test_v12_session_runtime_migration.py
@@ -1,0 +1,146 @@
+"""v11 -> v12 migration: re-attribute mislabeled session runtimes.
+
+v11 fixed the EVENT side of the same bug class (rollup tokens/cost attributed
+to openclaw for every family runtime). It left the ``sessions`` table alone,
+so nodes that had already ingested Claude Code / Codex / Cursor sessions kept
+a table full of rows stamped 'openclaw'. Those rows are what
+``_refresh_runtime_day_session_counts_locked`` counts, so the Fleet card stayed
+on "detected here / syncing to cloud" even after the ingest path was fixed.
+
+Fixing ingest forward-only is not enough — the existing rows have to be
+re-stamped, or an established node never recovers.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import duckdb
+import pytest
+
+
+@pytest.fixture()
+def store(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_READ", "1")
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    s = ls.get_store()
+    yield s
+    try:
+        s.stop(flush=True)
+    except Exception:
+        pass
+
+
+def test_migration_restamps_family_sessions(tmp_path, monkeypatch):
+    db = tmp_path / "events.duckdb"
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(db))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_READ", "1")
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+
+    # Build the schema, then rewind to v11 and plant the pre-fix rows exactly
+    # as the old ingest path wrote them: correct session_id, wrong agent_type.
+    s = ls.get_store()
+    s.ingest_sessions_batch([
+        {
+            "agent_type": "openclaw",
+            "session_id": "claude_code:66bfb3ac",
+            "node_id": "n1",
+            "started_at": "2026-08-23T10:00:00+00:00",
+            "last_active_at": "2026-08-23T11:00:00+00:00",
+        },
+        {
+            "agent_type": "openclaw",
+            "session_id": "codex:deadbeef",
+            "node_id": "n1",
+            "started_at": "2026-08-23T10:00:00+00:00",
+            "last_active_at": "2026-08-23T11:00:00+00:00",
+        },
+        {
+            "agent_type": "openclaw",
+            "session_id": "a-real-openclaw-session",
+            "node_id": "n1",
+            "started_at": "2026-08-23T10:00:00+00:00",
+            "last_active_at": "2026-08-23T11:00:00+00:00",
+        },
+    ])
+    s.stop(flush=True)
+
+    con = duckdb.connect(str(db))
+    con.execute("DELETE FROM schema_version WHERE version >= 12")
+    con.execute(
+        "UPDATE sessions SET agent_type = 'openclaw'"
+    )  # simulate the pre-fix state for every row
+    assert con.execute(
+        "SELECT COUNT(*) FROM sessions WHERE agent_type <> 'openclaw'"
+    ).fetchone()[0] == 0
+    con.close()
+
+    # Reopening runs _migrate, which should apply v12.
+    importlib.reload(ls)
+    s2 = ls.get_store()
+    rows = dict(
+        s2._fetch("SELECT session_id, agent_type FROM sessions", [])
+    )
+    s2.stop(flush=True)
+
+    assert rows["claude_code:66bfb3ac"] == "claude_code"
+    assert rows["codex:deadbeef"] == "codex"
+    # A session with no runtime prefix must stay put.
+    assert rows["a-real-openclaw-session"] == "openclaw"
+
+
+def test_v12_wipes_all_three_rollup_tables():
+    """v12 must clear rollup_model_daily too, not just the two tables it dirties.
+
+    Caught against a copy of a real node's DuckDB, not by unit test:
+    ``backfill_rollups`` decides whether to run with
+
+        COUNT(rollup_model_daily) + COUNT(rollup_runtime_daily)
+                                  + COUNT(rollup_session)
+
+    and returns ``{'skipped': True, 'reason': 'rollups_populated'}`` when that
+    sum is non-zero. A v12 that wiped only runtime+session left model_daily
+    populated, so the startup backfill never ran and the runtime/session
+    rollups stayed EMPTY — strictly worse than the bug being fixed. v11 wipes
+    all three for exactly this reason.
+    """
+    import inspect
+    import clawmetry.local_store as ls
+
+    src = inspect.getsource(ls.LocalStore._migrate)
+    v12 = src.split("current < 12", 1)[1].split("Step 4", 1)[0]
+    for table in ("rollup_model_daily", "rollup_runtime_daily", "rollup_session"):
+        assert f'DELETE FROM {table}' in v12, (
+            f"v12 must wipe {table} or backfill_rollups skips as "
+            f"'rollups_populated' and the rollups never rebuild"
+        )
+
+
+def test_session_counts_roll_up_per_runtime(store):
+    """The payoff: once agent_type is right, the per-runtime session count the
+    Fleet reads is non-zero instead of 0."""
+    store.ingest_sessions_batch([
+        {
+            "agent_type": "claude_code",
+            "session_id": "claude_code:s1",
+            "node_id": "n1",
+            "started_at": "2026-08-23T10:00:00+00:00",
+            "last_active_at": "2026-08-23T10:30:00+00:00",
+        },
+        {
+            "agent_type": "claude_code",
+            "session_id": "claude_code:s2",
+            "node_id": "n1",
+            "started_at": "2026-08-23T12:00:00+00:00",
+            "last_active_at": "2026-08-23T12:30:00+00:00",
+        },
+    ])
+
+    rows = store.query_rollup_runtime_daily()
+    cc = [r for r in rows if r["runtime"] == "claude_code"]
+    assert cc, f"claude_code missing from the runtime rollup: {rows}"
+    assert sum(r["sessions"] for r in cc) == 2


### PR DESCRIPTION
## Why

Diagnosing a `clawmetry status --show-key` that took **85s** on a Linux node while the same command on a Mac returned in ~2s turned up two independent bugs. One of them explains a Fleet card that had been stuck on "syncing to cloud" indefinitely.

## 1. Sessions were all attributed to `openclaw`

`_local_ingest_sessions_batch` stamped `s.get("agent_type") or "openclaw"`. The family adapters never set `agent_type`; they carry the runtime in `runtime` and, authoritatively, in the `<runtime>:<uuid>` session_id prefix that `local_store` already keys its event side on. So every paid runtime's sessions were written as `openclaw`. On the reporting node:

```
query_rollup_sessions(limit=500) -> 152 rows, Counter({'openclaw': 152})
...including session_id 'claude_code:36f12caf-...' labelled openclaw.
```

`_refresh_runtime_day_session_counts_locked` filters `WHERE agent_type = ?`, so `claude_code` rolled up with `sessions=0` and the Fleet card had nothing to mark synced. `Claude Code · 537` sat on "detected here / syncing to cloud" forever, while the Mac's 49 sessions showed green. Brain and Activity looked correct the whole time, because they group events by the session-id prefix. That mismatch is what made this read as a sync problem when it was an attribution problem.

`_session_agent_type()` now resolves `agent_type`, then `runtime`, then the session-id prefix (validated against `_NON_OPENCLAW_RUNTIME_PREFIXES`), then `openclaw`. Same bug class v11 fixed on the event side; `routes/quality.py` had already worked around it downstream.

**Schema v12** re-stamps existing rows, because forward-only would leave every established node broken. Verified against a copy of a real node's DuckDB:

| | before | after |
|---|---|---|
| `sessions` by `agent_type` | `openclaw: 201` | `openclaw: 147`, `claude_code: 48` |
| claude_code rollup, Aug 23 | `sessions: 0` | `sessions: 13`, 784,350 tokens |
| openclaw rollup, Aug 23 | 12 | 12 (unchanged) |

v12 wipes all **three** rollup tables, not just the two it dirties. `backfill_rollups` gates on the summed count across `rollup_model_daily + rollup_runtime_daily + rollup_session` and skips as `rollups_populated` otherwise, so wiping only two leaves the rollups permanently empty, which is worse than the bug. That one was caught by running the migration against real data rather than by unit test, and is now pinned by `test_v12_wipes_all_three_rollup_tables`.

## 2. `clawmetry status` did a blocking pro wheel download

The "self-heal the plan cache" line reached `_persist_cloud_plan_to_disk` then `_sync_auto_update_with_plan` then `auto_provision_pro`: a 20s entitlement probe plus a 60s wheel GET, from a read command. cProfile on the slow node:

```
85.396s  _cmd_status
 83.079s   urllib urlopen (5 calls)
  82.648s    socket.connect (8 calls)
```

That node advertised a global IPv6 address and a default route via RA, but its IPv6 path black-holed (google, cloudflare and clawmetry all hung on connect; IPv4 answered in 23ms). glibc ordered AAAA first and `socket.create_connection` walks getaddrinfo results strictly in order with no Happy Eyeballs, so each call burned its full timeout before reaching the address that worked.

Those timeouts belong to the daemon, not to a status read. `allow_provision` is threaded through and the CLI passes `False`. Daemon behaviour is unchanged.

This also fixes a related loop. Pro installs to the HOME owned fallback dir when site-packages is read-only (root-owned `/opt` driven by a `--user` daemon), and that dir reaches `sys.path` only through `ensure_pro_on_path()`, whose startup call runs *before* the first provision creates it. `_pro_installed_version()` therefore returned `None` on every heartbeat and the daemon re-provisioned pro forever under one PID, logging "provisioned ... will sync on the next cycle" every ~90s. Calling `ensure_pro_on_path()` before the idempotency check ends it.

## Verification

- **Revert proofs** (each guard fails on the un-fixed code, passes when restored):
  - revert the ingest line, `test_batch_ingest_stamps_the_real_runtime` fails
  - drop `allow_provision=False`, `test_cli_status_passes_allow_provision_false` fails
  - wipe only two rollup tables, `test_v12_wipes_all_three_rollup_tables` fails
- **17 new tests** across 3 files; **99 existing** session and ingest tests pass (`test_local_store_sync_integration`, `test_ingest_bulk_flush`, `test_session_location_local_store`, `test_attention_detector`).
- Migration exercised against a copy of a real node's DuckDB, not only fixtures.
- On the live node: `clawmetry status --show-key` went from 85.5s to 2.6s once IPv6 preference was corrected, and the re-provision loop went from every ~90s to zero recurrences in 5 minutes.
- Gates: `lint-py39`, `lint-runtime-count`, `lint-daemon-allowlist`, `lint-ac-coverage` all pass.

## Acceptance criteria

Declares **AC-OBS-003.1** ("when the system recognizes a supported runtime, the system shall associate its activity with that runtime"), which is this bug stated as a criterion. Ratchet tightened 9/77 to 10/77 in `docs/ac_coverage_baseline.json`.

## Blueprints (§1f)

Drift Bot flagged this on the first run, and it was right: the "Runtime and Session Observability" blueprint did not document how `sessions.agent_type` is derived, and tied that gap to AC-OBS-003.1 and to this bug. The blueprint now carries two contracts:

- the fixed resolution order (explicit `agent_type`, then `runtime`, then the `session_id` namespace, then `openclaw`), with the namespace accepted only when it names a known non-OpenClaw runtime;
- the requirement that the session-side and event-side runtime splits agree, which is the invariant this bug violated. Events were attributed correctly while sessions were not, so the two per-runtime views disagreed with each other instead of failing visibly.

Still worth writing up separately, and not done here: `backfill_rollups` gates on the summed count across all three rollup tables, so any future migration that wipes a subset silently disables the rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LS1etvFPPYCReaBRBCtGCB
