### PR TITLE
setup.py: put every supported runtime in the PyPI keywords

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -144,7 +144,13 @@ setup(
         "Topic :: Software Development :: Quality Assurance",
         "Topic :: System :: Monitoring",
     ],
-    keywords="clawmetry openclaw moltbot dashboard observability ai agent monitoring opentelemetry",
+    keywords=(
+        "clawmetry observability governance monitoring dashboard "
+        "ai agent llm llm-observability opentelemetry cost-tracking "
+        "claude-code codex cursor github-copilot gemini-cli cline openhands "
+        "opencode aider goose qwen devin kimi grok n8n antigravity deepseek "
+        "hermes exo openclaw nemoclaw nanoclaw picoclaw moltbot"
+    ),
     license="MIT",
     project_urls={
         "Homepage": "https://clawmetry.com",


### PR DESCRIPTION
## Why

Chasing down why the internet still calls this "ClawMetry for OpenClaw", the PyPI keywords turned out to be one of the upstream sources feeding it:

```
keywords="clawmetry openclaw moltbot dashboard observability ai agent monitoring opentelemetry"
```

Of 26 supported runtimes, the keywords named exactly two, and one of them is OpenClaw. The `description` field is already generated from `runtime_count`, so it self-heals on every release, but `keywords` is a hardcoded string and has not moved.

That matters because PyPI keywords drive PyPI's own search, and they get ingested by the package aggregators that then reprint our positioning. A developer searching PyPI for `claude-code observability` or `cursor monitoring` does not find us today.

## What

Rewrites `keywords` to cover all 26 runtimes plus the category terms, as a wrapped tuple so it stays readable and diffs cleanly when a runtime is added.

No behaviour change, packaging metadata only.

## Verify after release

```
curl -s https://pypi.org/pypi/clawmetry/json | python3 -c "import sys,json;print(json.load(sys.stdin)['info']['keywords'])"
```

## Related

Part of a sweep correcting OpenClaw-only framing on external surfaces. Also filed psincraian/pepy#791 (pepy is serving our May summary and version) and stritti/clawmetry-docker#41 (third-party Docker image README).