### PR TITLE
Make end-to-end encryption an invariant, not an optimisation

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,9 +63,24 @@ in [docs/ENTITLEMENTS.md](docs/ENTITLEMENTS.md).
 
 ## Your data stays on your machine
 
-ClawMetry reads local session files and logs. Nothing leaves your box unless
-you run `clawmetry connect`. Even then the snapshot is end-to-end encrypted
-with a key that never leaves your machine, and decrypted in your browser.
+ClawMetry reads local session files and logs. **No session data leaves your box
+unless you run `clawmetry connect`** — no prompts, replies, tool arguments, file
+contents or log lines. When you do connect, the snapshot is end-to-end encrypted
+with a key that never leaves your machine, and decrypted in your browser. If a
+node has no key, the upload is skipped rather than sent in the clear, and no
+server response can turn that off.
+
+Two things do run by default before you connect, both opt-out and neither
+carrying session data: an anonymous install ping and a version check against
+PyPI. A default install also looks up your public IP once for a startup banner
+line. Every destination, what it carries and how to switch it off is listed in
+[docs/EGRESS.md](docs/EGRESS.md); self-hosted, repointed and air-gapped installs
+make no discretionary outbound calls at all.
+
+One limit worth stating plainly: the JavaScript that decrypts your snapshot is
+served by `app.clawmetry.com`. The key stays in your browser and is never sent
+to us, but you are trusting code we serve to keep it that way. Self-hosting or
+staying local-only removes that dependency entirely.
 
 ## Install
 

--- a/clawmetry/approvals.py
+++ b/clawmetry/approvals.py
@@ -1088,13 +1088,20 @@ def process_tool_call(api_key: str, node_id: str, session_id: Optional[str],
             _in_flight[key] = result
         return result
 
+    # SECURITY (2026-08-24 review, finding 2): this request carries NO tool
+    # arguments. It used to POST `args` and a `context` string built from the
+    # command preview as plain JSON, outside the AES-GCM envelope — for a Bash
+    # gate that was the literal shell command, and for Write/Edit the file path
+    # and its contents. The approval detail the operator actually reads reaches
+    # the cloud inbox through the encrypted `cache_push` rail below
+    # (`_build_approvals_cache_pushes` in sync.py), which fails closed without
+    # a key. What stays here is the routing envelope: which node, which
+    # session, which tool, which policy, how long to wait.
     req = {
         "id": approval_id,
         "node_id": node_id,
         "session_id": session_id,
         "tool_name": tool_name,
-        "args": args_with_risk,
-        "context": f"Policy '{policy['name']}' fired on {tool_name}: {cmd_preview}",
         "policy_name": policy["name"],
         "timeout": policy["timeout"],
     }

--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -1111,7 +1111,19 @@ def _cmd_connect(args) -> None:
         # Self-hosted servers may answer {"e2e": false} — data stays inside the
         # customer deployment, so blob encryption is optional there and the
         # server needs plaintext to serve fleet views / audit export.
+        #
+        # SECURITY (2026-08-24 review, finding 1): this flag is only ever
+        # honoured for a CUSTOM endpoint. The managed cloud answering
+        # {"e2e": false} used to downgrade any client to plaintext ingest —
+        # a remote kill switch on the product's headline privacy guarantee,
+        # signalled by one line in a log file. `is_custom_endpoint()` is the
+        # same resolver every other client call already routes through, so
+        # "self-hosted" now means what the comment always claimed it meant.
         _server_e2e = result.get("e2e") if isinstance(result, dict) else None
+        if _server_e2e is False:
+            from clawmetry.endpoints import is_custom_endpoint as _is_custom_ep2
+            if not _is_custom_ep2():
+                _server_e2e = None  # managed cloud cannot turn E2E off
         print("✅")
     except Exception as e:
         err = str(e)
@@ -1154,9 +1166,26 @@ def _cmd_connect(args) -> None:
     # A self-hosted server answering {"e2e": false} opts this node into
     # plaintext ingest (data never leaves the deployment; the server needs
     # plaintext for fleet views + audit export). An explicit --enc-key wins.
+    #
+    # SECURITY (2026-08-24 review, finding 1): a node that ALREADY has a key
+    # is never downgraded. `save_config` is a whole-file overwrite that only
+    # re-adds `encryption_key` when it is non-empty, so accepting e2e:false on
+    # a reconnect used to destroy the existing key with no keychain fallback —
+    # turning a working E2E node into a plaintext one and orphaning everything
+    # it had already synced. Opting an existing node into plaintext is now an
+    # explicit act: re-run with --enc-key "" after clearing the key.
+    _existing_key = _kc_key or _saved_enc_key
     _server_plaintext = (
-        _server_e2e is False and not _enc_key_arg and not _keep_local_signin
+        _server_e2e is False
+        and not _enc_key_arg
+        and not _keep_local_signin
+        and not _existing_key
     )
+    if _server_e2e is False and _existing_key and not _enc_key_arg and not _keep_local_signin:
+        print(
+            "  This server asked for plaintext ingest, but this node already "
+            "has an encryption key — keeping it. Your data stays encrypted."
+        )
     print()
     if not _keep_local_signin and not _server_plaintext:
         print("🔐 Encryption key protects your data end-to-end.")
@@ -1185,7 +1214,12 @@ def _cmd_connect(args) -> None:
         pass  # enc_key already chosen above, silently
     elif _server_plaintext:
         enc_key = ""
-        print("🔓 Server requested plaintext ingest (self-hosted, E2E off).")
+        print("🔓 This self-hosted server stores your data unencrypted.")
+        from clawmetry.endpoints import ingest_url as _resolve_ingest_url_pt
+        print(f"     Endpoint: {_resolve_ingest_url_pt()}")
+        print("     Session content — prompts, replies, tool arguments — is")
+        print("     readable by whoever runs that server. End-to-end")
+        print("     encryption is off for this node.")
     elif _enc_key_arg:
         enc_key = _derive_key_for_storage(_enc_key_arg)
         print("  Using provided encryption key.")
@@ -1417,9 +1451,60 @@ def _cmd_connect(args) -> None:
     # discover a silent "0 nodes" later. No-op (+ skipped) for a keyed connect.
     _warn_if_placeholder_account(api_key)
 
+    _open_url_without_argv(_dashboard_url)
+
+
+def _quiet_unlink(path):
     try:
-        import webbrowser
-        webbrowser.open(_dashboard_url)
+        os.unlink(path)
+    except Exception:
+        pass
+
+
+def _open_url_without_argv(url):
+    """Open ``url`` in the browser without putting it in any process's argv.
+
+    SECURITY (2026-08-24 review, finding 11): ``webbrowser.open`` shells out —
+    ``open`` on macOS, ``xdg-open`` on Linux — so the full URL, encryption-key
+    fragment included, is visible to every other process on the machine for as
+    long as that command runs (``ps``, ``/proc/<pid>/cmdline``). Handing the
+    browser a local redirect page instead keeps the key out of argv entirely.
+
+    Falls back to a direct open if the temp file cannot be written — a browser
+    that opens beats a dead end, and the fallback is what we always did.
+    """
+    import webbrowser
+
+    try:
+        import html as _html
+        import json as _json
+        import tempfile
+        import threading
+
+        fd, path = tempfile.mkstemp(suffix=".html", prefix="clawmetry-open-")
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(
+                "<!doctype html><meta charset='utf-8'>"
+                "<title>Opening ClawMetry\u2026</title>"
+                "<script>location.replace(%s)</script>"
+                "<p>Opening your dashboard\u2026 "
+                "<a href='%s'>continue</a></p>"
+                % (_json.dumps(url), _html.escape(url, quote=True))
+            )
+        os.chmod(path, 0o600)  # mkstemp already does this; be explicit
+        if webbrowser.open("file://" + path):
+            # The redirect page holds the key too, so it does not outlive the
+            # hand-off. 0600 keeps it to this user in the meantime — the same
+            # user can already read ~/.clawmetry/config.json, so this exposes
+            # nothing new, whereas argv is visible to every user on the box.
+            _t = threading.Timer(30.0, lambda: _quiet_unlink(path))
+            _t.daemon = True
+            _t.start()
+            return
+    except Exception:
+        pass
+    try:
+        webbrowser.open(url)
     except Exception:
         pass
 

--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -18502,6 +18502,14 @@ async function loadTranscripts() {
         viewTranscript(m.session);
         history.replaceState(null, '', window.location.pathname + window.location.search);
       }
+      // SECURITY (2026-08-24 review, finding 11): the scrubber above only
+      // fired for #session=, so a #key=... fragment stayed in the address bar
+      // and in browser history — and got uploaded by browser sync when the
+      // user has it on. Any fragment carrying a key is removed on sight,
+      // whether or not this page was the one that consumed it.
+      if (m.key) {
+        history.replaceState(null, '', window.location.pathname + window.location.search);
+      }
     } catch (e) {}
   } catch(e) {
     document.getElementById('transcript-list').innerHTML = '<div style="padding:16px;color:#666;">' + t("app.failed_to_load_transcripts", null, "Failed to load transcripts") + '</div>';

--- a/clawmetry/static/js/gw-setup.js
+++ b/clawmetry/static/js/gw-setup.js
@@ -255,12 +255,15 @@ function openE2eKeyModal() {
   document.getElementById('e2e-key-regen-confirm').style.display = 'none';
   document.getElementById('e2e-key-regen-btn').style.display = '';
   _e2eKeyRevealed = false;
+  _e2eKeyValue = '';
+  // The GET only reports whether a key exists — it never carries the key.
+  // The real value is fetched on demand by _e2eKeyFetch() when the user
+  // reveals or copies it.
   fetch('/api/local/e2e-key').then(function (r) { return r.json(); }).then(function (d) {
-    if (!d.configured || !d.key) {
+    if (!d.configured) {
       document.getElementById('e2e-key-empty').style.display = '';
       return;
     }
-    _e2eKeyValue = d.key;
     document.getElementById('e2e-key-body').style.display = '';
     _e2eKeyRender();
   }).catch(function () {
@@ -275,17 +278,35 @@ function _e2eKeyMask(k) {
   if (!k || k.length < 10) return '••••••••';
   return k.slice(0, 6) + '…' + k.slice(-4);
 }
+
+// Fetch the real key on demand. POST (not GET) so the dashboard's
+// cross-origin write guard applies — see dashboard.py:_cross_origin_write_blocked.
+function _e2eKeyFetch() {
+  if (_e2eKeyValue) return Promise.resolve(_e2eKeyValue);
+  return fetch('/api/local/e2e-key/reveal', { method: 'POST' })
+    .then(function (r) { return r.json(); })
+    .then(function (d) { _e2eKeyValue = (d && d.key) || ''; return _e2eKeyValue; });
+}
 function _e2eKeyRender() {
   var el = document.getElementById('e2e-key-value');
   if (!el) return;
-  el.textContent = _e2eKeyRevealed ? _e2eKeyValue : _e2eKeyMask(_e2eKeyValue);
+  if (_e2eKeyRevealed && _e2eKeyValue) { el.textContent = _e2eKeyValue; return; }
+  el.textContent = _e2eKeyMask(_e2eKeyValue || '\u2022\u2022\u2022\u2022\u2022\u2022\u2022\u2022');
 }
 function e2eKeyToggleReveal() {
-  _e2eKeyRevealed = !_e2eKeyRevealed;
+  if (!_e2eKeyRevealed) {
+    _e2eKeyFetch().then(function () { _e2eKeyRevealed = true; _e2eKeyRender(); })
+      .catch(function () {
+        var errEl = document.getElementById('e2e-key-error');
+        if (errEl) { errEl.textContent = 'Could not read the key. Try again.'; errEl.style.display = ''; }
+      });
+    return;
+  }
+  _e2eKeyRevealed = false;
   _e2eKeyRender();
 }
 function e2eKeyCopy() {
-  if (!_e2eKeyValue) return;
+  if (!_e2eKeyValue) { _e2eKeyFetch().then(function (k) { if (k) e2eKeyCopy(); }); return; }
   var done = function () {
     var msg = document.getElementById('e2e-key-copied');
     if (msg) { msg.style.display = ''; setTimeout(function () { msg.style.display = 'none'; }, 2000); }

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -645,6 +645,70 @@ def encrypt_payload(data: dict, key_b64: str) -> str:
     return base64.urlsafe_b64encode(nonce + ct).decode()
 
 
+# ── The no-key rule ─────────────────────────────────────────────────────────
+# Every content-bearing upload goes through this gate. Content means anything
+# carrying what the user or the agent actually said or did: prompts, replies,
+# tool arguments, file contents, log lines, cron prompts, session subjects.
+#
+# SECURITY (2026-08-24 review, finding 3): these call sites used to read
+#
+#     if enc_key: post(encrypted blob)
+#     else:       post(payload)          # ← full plaintext
+#
+# so a node in cloud mode with no key uploaded everything in the clear. The
+# relay READ path already had the right instinct — it fails closed with no key
+# — and this makes the write path agree with it. Refusing to send is always
+# the correct answer here: the local DuckDB store is the source of truth and
+# the cloud is a hot cache, so skipping an upload costs a cache miss, while
+# sending costs the guarantee the product is sold on.
+_NO_KEY_REFUSALS: dict = {}
+
+
+def content_egress_permitted(enc_key: str | None, endpoint: str) -> bool:
+    """False when content must not leave this machine for ``endpoint``.
+
+    Callers must skip the upload entirely rather than falling back to a
+    plaintext POST. Logged once per endpoint per process so a keyless node
+    says so plainly at startup without flooding the log every tick.
+    """
+    if enc_key:
+        return True
+    if not _NO_KEY_REFUSALS.get(endpoint):
+        _NO_KEY_REFUSALS[endpoint] = True
+        log.warning(
+            "No encryption key on this node — skipping cloud upload to %s. "
+            "Session content is never sent unencrypted. Your local dashboard "
+            "is unaffected; run `clawmetry connect` to set a key and restore "
+            "the cloud view.",
+            endpoint,
+        )
+    return False
+
+
+def split_session_title(title: str, enc_key: str | None, fallback: str) -> tuple:
+    """Return ``(cleartext_label, encrypted_blob_or_None)`` for a session title.
+
+    SECURITY (2026-08-24 review, finding 4): a session's display name is
+    content. It comes from the transcript's own ``label`` frame or, for chat
+    channels, the conversation's subject line — "Reset prod DB password",
+    "Draft the layoff email". The ``/ingest/sessions`` row is server-parsed
+    (the cloud queries and sorts on it), so the row itself cannot be one
+    opaque blob; instead the title rides in an encrypted companion field and
+    the cleartext row carries a neutral identifier.
+
+    A node with no key sends only the fallback — never the title.
+    """
+    title = (title or "").strip()
+    if not title or title == fallback:
+        return fallback, None
+    if not enc_key:
+        return fallback, None
+    try:
+        return fallback, encrypt_payload({"display_name": title}, enc_key)
+    except Exception:
+        return fallback, None
+
+
 def decrypt_payload(blob: str, key_b64: str) -> dict:
     """Decrypt a blob produced by encrypt_payload. Used by clients."""
     cipher = _get_aesgcm(key_b64)
@@ -784,12 +848,12 @@ def _dlq_replay(api_key: str, enc_key: str | None) -> int:
                     pass
                 continue
         else:
-            # post_failure row with no encryption configured — replay as plain POST.
-            try:
-                _post(row["endpoint"], payload, api_key)
-            except Exception as _post_e:
+            # No key — leave the row parked rather than replaying it in the
+            # clear. It drains on the next tick after the user sets a key;
+            # until then the batch stays on this machine.
+            if not content_egress_permitted(enc_key, row["endpoint"]):
                 try:
-                    store.dlq_mark_attempt(dlq_id, f"post: {_post_e}")
+                    store.dlq_mark_attempt(dlq_id, "no encryption key configured")
                 except Exception:
                     pass
                 continue
@@ -3297,6 +3361,8 @@ def _flush_session_batch(
                     fname, _enc_e,
                 )
             return
+    if blob is None and not content_egress_permitted(enc_key, "/ingest/events"):
+        return
     try:
         if blob is not None:
             _post(
@@ -3304,8 +3370,6 @@ def _flush_session_batch(
                 {"node_id": node_id, "encrypted": True, "blob": blob},
                 api_key,
             )
-        else:
-            _post("/ingest/events", payload, api_key)
     except Exception as _cloud_e:
         try:
             _dlq_enqueue_encryption_failure(
@@ -6334,18 +6398,17 @@ def _flush_log_batch(
     entries: list, fname: str, api_key: str, enc_key: str | None, node_id: str
 ) -> None:
     payload = {"log_file": fname, "node_id": node_id, "lines": entries}
-    if enc_key:
-        _post(
-            "/ingest/logs",
-            {
-                "node_id": node_id,
-                "encrypted": True,
-                "blob": encrypt_payload(payload, enc_key),
-            },
-            api_key,
-        )
-    else:
-        _post("/ingest/logs", payload, api_key)
+    if not content_egress_permitted(enc_key, "/ingest/logs"):
+        return
+    _post(
+        "/ingest/logs",
+        {
+            "node_id": node_id,
+            "encrypted": True,
+            "blob": encrypt_payload(payload, enc_key),
+        },
+        api_key,
+    )
 
 
 # ── Heartbeat ─────────────────────────────────────────────────────────────────
@@ -8112,9 +8175,33 @@ def _read_claude_oauth_token():
     return None
 
 
+def _claude_limit_probe_enabled() -> bool:
+    """True when the user has opted into the Claude rate-limit probe.
+
+    SECURITY (2026-08-24 review, finding 7): the probe reads Claude Code's
+    stored OAuth token out of the keychain (or ~/.claude/.credentials.json)
+    and spends one Haiku token every ~5 minutes on the user's own billing,
+    purely to scrape the rate-limit response headers that feed the limits
+    meter. Using another product's credential is not something to do by
+    default, however useful the meter is — so it is now off unless asked for.
+    """
+    env = str(os.environ.get("CLAWMETRY_CLAUDE_LIMIT_PROBE", "")).strip().lower()
+    if env in ("1", "true", "yes"):
+        return True
+    if env in ("0", "false", "no"):
+        return False
+    try:
+        with open(os.path.expanduser("~/.clawmetry/config.json")) as _f:
+            return bool((json.load(_f) or {}).get("claude_limit_probe"))
+    except Exception:
+        return False
+
+
 def _probe_claude_limits():
     """One 1-token Haiku call -> unified limit headers. Returns the
-    heartbeat payload dict or None (no creds / no headers / any error)."""
+    heartbeat payload dict or None (not enabled / no creds / any error)."""
+    if not _claude_limit_probe_enabled():
+        return None
     token = _read_claude_oauth_token()
     if not token:
         return None
@@ -8131,7 +8218,9 @@ def _probe_claude_limits():
                 "anthropic-version": "2023-06-01",
                 "anthropic-beta": "oauth-2025-04-20",
                 "Content-Type": "application/json",
-                "User-Agent": "claude-code/2.1.5",
+                # Our own identity. Sending claude-code's User-Agent was
+                # impersonation of another product against its own API.
+                "User-Agent": "clawmetry-daemon",
                 "Authorization": "Bearer " + token,
             })
         try:
@@ -9536,6 +9625,35 @@ _PENDING_ACTIONS = frozenset({
 })
 
 
+# ── Prompt-bearing relayed actions ──────────────────────────────────────────
+# SECURITY (2026-08-24 review, finding 10): most relayed actions are writes
+# into local tables, or reads whose SQL is sandboxed. These three are not —
+# they interpolate SERVER-SUPPLIED strings into a prompt and hand it to a
+# local agent that has file-system and network tools. That makes a compromised
+# (or merely mistaken) server able to act on this machine, which is a much
+# stronger power than "show me a dashboard".
+#
+# It is a vendor-trust risk rather than a network-attacker one — argv lists,
+# TLS verification on — but the fix is the same either way: default it off and
+# make turning it on a local, per-node decision the operator takes knowingly.
+# Local-only installs never had this exposure; they have no relay at all.
+_PROMPT_BEARING_ACTIONS = frozenset({
+    "selfevolve_fix",
+    "cron_create",
+    "cron_fix",
+})
+
+
+def _remote_prompts_enabled(config: dict) -> bool:
+    """True when this node has opted into server-supplied prompts. Default False."""
+    env = str(os.environ.get("CLAWMETRY_ALLOW_REMOTE_PROMPTS", "")).strip().lower()
+    if env in ("1", "true", "yes"):
+        return True
+    if env in ("0", "false", "no"):
+        return False
+    return bool(config.get("remote_prompts"))
+
+
 def _build_channel_config_status_cache_pushes(config: dict) -> list:
     """Build the heartbeat cache_push entries for channel adapter status.
 
@@ -9698,6 +9816,16 @@ def _dispatch_pending_action(config: dict, action: dict) -> None:
     raise — one bad action must not block the heartbeat batch."""
     atype = action.get("type")
     if atype not in _PENDING_ACTIONS:
+        return
+    if atype in _PROMPT_BEARING_ACTIONS and not _remote_prompts_enabled(config):
+        log.warning(
+            "Refusing relayed action %r: it would run a server-supplied prompt "
+            "through a local agent with tools enabled. Turn it on for this node "
+            "with `clawmetry config set remote_prompts true` (or "
+            "CLAWMETRY_ALLOW_REMOTE_PROMPTS=1) if you want the cloud "
+            "\"Fix with AI\" and cloud-authored cron prompts.",
+            atype,
+        )
         return
     if atype == "channel_config_upsert":
         _action_channel_config_upsert(config, action)
@@ -11525,23 +11653,30 @@ def sync_crons(config: dict, state: dict, paths: dict) -> int:
                 expr = ""
             job_state = j.get("state", {})
             job_id = j.get("id", "")
+            # SECURITY (2026-08-24 review, finding 4): this event is NOT
+            # encrypted — it feeds the cloud's cron table server-side. So it
+            # carries no content: `task` is the job's prompt text and
+            # `watchedCommand` is a shell command line, and both used to ship
+            # here in the clear. The cloud cron view gets them from the
+            # encrypted `crons_list` cache_push instead
+            # (`_build_crons_cache_pushes`), which fails closed without a key;
+            # the full text is also kept locally by the `ingest_cron` call
+            # below. `lastError` goes too — agent error strings quote prompts
+            # and paths.
             event_data = {
                 "job_id": job_id,
                 "name": j.get("name", ""),
                 "enabled": j.get("enabled", True),
                 "expr": expr,
                 "schedule": sched,
-                "task": (j.get("task") or "")[:200],
                 "model": j.get("model", ""),
                 "state": {
                     "lastStatus": job_state.get("lastStatus"),
                     "lastRunAtMs": job_state.get("lastRunAtMs"),
                     "nextRunAtMs": job_state.get("nextRunAtMs"),
                     "lastDurationMs": job_state.get("lastDurationMs"),
-                    "lastError": job_state.get("lastError"),
                     "consecutiveFailures": job_state.get("consecutiveFailures"),
                     # on-exit trigger / detached-run metadata (openclaw #92037 / #98755)
-                    "watchedCommand":  job_state.get("watchedCommand"),
                     "lastExitCode":    job_state.get("lastExitCode") or job_state.get("exitCode"),
                     "targetSessionId": job_state.get("targetSessionId"),
                     "detachedAt":      job_state.get("detachedAt"),
@@ -12684,7 +12819,10 @@ def sync_session_metadata(config: dict, state: dict = None) -> int:
                 # Resolve display name from session key when available
                 _sk = _sid_to_key.get(sid, "")
                 _sm = _sid_to_meta.get(sid, {})
-                _dn = label or _sm.get("subject") or _sk or sid[:8]
+                _dn_full = label or _sm.get("subject") or _sk or sid[:8]
+                _dn, _dn_blob = split_session_title(
+                    _dn_full, config.get("encryption_key"), _sk or sid[:8]
+                )
                 # OpenClaw is the one runtime that emits a REAL end signal:
                 # the transcript's ``type=="session"`` frame carries
                 # endReason/end_reason (parsed just above). Honour it — an
@@ -12700,6 +12838,7 @@ def sync_session_metadata(config: dict, state: dict = None) -> int:
                     {
                         "session_id": sid,
                         "display_name": _dn,
+                        "display_name_blob": _dn_blob,
                         "session_key": _sk,
                         "channel": _sm.get("provider", ""),
                         "chat_type": _sm.get("chatType", ""),
@@ -12937,7 +13076,7 @@ def sync_memory(config: dict, state: dict, paths: dict) -> int:
         except Exception as _le:
             log.warning("local-store memory ingest failed (cloud sync continues): %s", _le)
 
-        if enc_key:
+        if content_egress_permitted(enc_key, "/ingest/memory"):
             from clawmetry.sync import encrypt_payload
 
             _post(
@@ -12949,8 +13088,8 @@ def sync_memory(config: dict, state: dict, paths: dict) -> int:
                 },
                 api_key,
             )
-        else:
-            _post("/ingest/memory", payload, api_key)
+        # The local DuckDB ingest above already ran — a keyless node keeps a
+        # complete local memory view, it just doesn't populate the cloud one.
         synced = len(changed_files)
     except Exception as e:
         log.warning(f"Memory sync error: {e}")
@@ -14363,12 +14502,21 @@ def sync_family_runtimes(config: dict, state: dict, paths: dict) -> int:
                 # shows it (top-level sessions only; children ride the
                 # snapshot subagents[] slice instead).
                 if not _is_child:
+                    # SECURITY (2026-08-24 review, finding 4): `_ftitle` is
+                    # derived from the session's first real user prompt, so it
+                    # is content and must not ride in the server-parsed row.
+                    # The readable title goes in an encrypted companion field;
+                    # the cleartext row falls back to the session id.
+                    _t_clear, _t_blob = split_session_title(
+                        _ftitle, config.get("encryption_key"), s.id
+                    )
                     cloud_session_rows.append({
                     "agent_type": "openclaw",
                     "session_id": ns_id,
                     "node_id": node_id,
                     "agent_id": "main",
-                    "title": _ftitle,
+                    "title": _t_clear,
+                    "title_blob": _t_blob,
                     "started_at": started,
                     "last_active_at": ended or started,
                     "ended_at": _fended,
@@ -20301,6 +20449,12 @@ def start_log_streamer(config: dict, paths: dict) -> threading.Thread:
     """Start a background thread that tails the local log file and POSTs lines to cloud in real-time."""
     api_key = config["api_key"]
     node_id = config["node_id"]
+    # SECURITY (2026-08-24 review, finding 4): raw agent log lines are content
+    # — they quote prompts, tool arguments and file paths — and this path used
+    # to POST them as plain JSON every few seconds even on a node with a key
+    # configured. They now travel inside the same AES-GCM envelope as every
+    # other content upload, and a keyless node streams nothing.
+    enc_key = config.get("encryption_key")
     log_dir = paths.get("log_dir", "")
 
     def _find_latest_log():
@@ -20368,14 +20522,21 @@ def start_log_streamer(config: dict, paths: dict) -> threading.Thread:
                 # Push batch every STREAM_INTERVAL seconds
                 now = time.time()
                 if batch and (now - last_push >= STREAM_INTERVAL or len(batch) >= 50):
-                    try:
-                        _post(
-                            "/ingest/stream",
-                            {"node_id": node_id, "lines": batch},
-                            api_key,
-                        )
-                    except Exception as e:
-                        log.debug(f"Stream push error: {e}")
+                    if content_egress_permitted(enc_key, "/ingest/stream"):
+                        try:
+                            _post(
+                                "/ingest/stream",
+                                {
+                                    "node_id": node_id,
+                                    "encrypted": True,
+                                    "blob": encrypt_payload(
+                                        {"node_id": node_id, "lines": batch}, enc_key
+                                    ),
+                                },
+                                api_key,
+                            )
+                        except Exception as e:
+                            log.debug(f"Stream push error: {e}")
                     batch = []
                     last_push = now
 

--- a/dashboard.py
+++ b/dashboard.py
@@ -12673,21 +12673,46 @@ def detect_config(args=None):
     # for a user's node in the first place, since the key never leaves this
     # machine except E2E-encrypted. Auth follows the normal /api/* rule in
     # _check_auth() (loopback trusted; remote needs the gateway token).
-    @app.route("/api/local/e2e-key", endpoint="e2e_key_get")
-    def _e2e_key_get():
-        from flask import jsonify as _jsonify
+    def _read_local_config():
         cfg_path = os.path.expanduser("~/.clawmetry/config.json")
         try:
             with open(cfg_path) as _f:
-                cfg = json.load(_f) or {}
+                return json.load(_f) or {}
         except Exception:
-            cfg = {}
-        key = cfg.get("encryption_key", "") or ""
+            return {}
+
+    @app.route("/api/local/e2e-key", endpoint="e2e_key_get")
+    def _e2e_key_get():
+        """Whether a key is set — never the key itself.
+
+        SECURITY (2026-08-24 review, finding 8): this used to return the
+        plaintext key in a GET body. Loopback callers skip authentication, so
+        every local process on the machine could read it, and a GET is exactly
+        the shape a hostile page can trigger. Revealing the real value now
+        requires the POST below, which the cross-origin write guard covers.
+        """
+        from flask import jsonify as _jsonify
+        cfg = _read_local_config()
         return _jsonify({
-            "configured": bool(key),
-            "key": key or None,
+            "configured": bool(cfg.get("encryption_key", "")),
             "node_id": cfg.get("node_id", ""),
         })
+
+    @app.route("/api/local/e2e-key/reveal", methods=["POST"], endpoint="e2e_key_reveal")
+    def _e2e_key_reveal():
+        """Return the key for the Settings pane's reveal/copy control.
+
+        A POST so the Origin guard in ``_check_auth`` applies: a page on
+        another origin can still cause this request, but it cannot make the
+        browser send an Origin we accept, and it could never read the reply
+        anyway.
+        """
+        from flask import jsonify as _jsonify
+        cfg = _read_local_config()
+        key = cfg.get("encryption_key", "") or ""
+        if not key:
+            return _jsonify({"configured": False, "key": None}), 404
+        return _jsonify({"configured": True, "key": key})
 
     @app.route("/api/local/e2e-key/regenerate", methods=["POST"], endpoint="e2e_key_regenerate")
     def _e2e_key_regenerate():
@@ -13761,9 +13786,71 @@ def _latency_probe_record(response):
     return response
 
 
+_SAFE_METHODS = frozenset({"GET", "HEAD", "OPTIONS", "TRACE"})
+
+
+def _cross_origin_write_blocked() -> bool:
+    """True when this request is a browser-driven WRITE from another site.
+
+    Loopback callers skip authentication entirely (``_check_auth`` below) —
+    that is the right posture for a local tool, but on its own it means any
+    page the user happens to have open in another tab can drive this API. A
+    cross-origin ``<form method=post>`` needs no CORS permission to *arrive*;
+    the browser only stops the attacker reading the reply. The side effect
+    still lands, so the endpoints that need no request body were reachable
+    from any website: rotate the E2E key (making everything already synced
+    undecryptable to its owner), emergency-stop the agents, kill every cron,
+    deactivate the licence.
+
+    The check is deliberately narrow so nothing legitimate breaks:
+
+    * Safe methods are never blocked — this is CSRF defence, not CORS.
+    * A request with **no** ``Origin`` is allowed. Browsers always attach one
+      to a non-GET fetch, same-origin included; curl, the CLI, the desktop
+      shell and OTLP exporters do not. So absence means "not a browser",
+      which is exactly the traffic that must keep working.
+    * An ``Origin`` that matches the host this request was addressed to is
+      the dashboard talking to itself.
+
+    Everything else is a page on another origin writing to your dashboard.
+    ``CLAWMETRY_ALLOW_CROSS_ORIGIN_WRITES=1`` opts out for an embedder that
+    genuinely needs it; see docs/EGRESS.md.
+    """
+    if request.method in _SAFE_METHODS:
+        return False
+    if str(
+        os.environ.get("CLAWMETRY_ALLOW_CROSS_ORIGIN_WRITES", "")
+    ).strip().lower() in ("1", "true", "yes"):
+        return False
+    origin = (request.headers.get("Origin") or "").strip()
+    if not origin:
+        return False
+    try:
+        from urllib.parse import urlparse as _urlparse
+
+        netloc = _urlparse(origin).netloc
+    except Exception:
+        return True  # unparseable Origin — fail closed
+    return netloc.lower() != (request.host or "").lower()
+
+
 @app.before_request
 def _check_auth():
     """Require valid gateway token for all /api/* routes when GATEWAY_TOKEN is set."""
+    # CSRF guard first: it applies to EVERY state-changing request, including
+    # the loopback callers that skip the token check below and the paths
+    # (auth-check, gateway config, fleet API) that return early from it.
+    if request.path.startswith("/api/") or request.path.startswith("/v1/"):
+        if _cross_origin_write_blocked():
+            return jsonify(
+                {
+                    "error": (
+                        "Cross-origin write refused. This endpoint changes state "
+                        "and may only be called from the dashboard itself."
+                    ),
+                    "crossOriginBlocked": True,
+                }
+            ), 403
     if request.path == "/api/auth/check":
         return  # Auth check endpoint is always accessible
     if request.path == "/api/gw/config":

--- a/docs/EGRESS.md
+++ b/docs/EGRESS.md
@@ -116,7 +116,9 @@ package), the call is suppressed rather than allowed. Covered by
 
 | Host | Purpose | When | Sends | Disable |
 |---|---|---|---|---|
-| `ingest.clawmetry.com` | Encrypted snapshot upload | After `clawmetry connect`, managed cloud only | AES-256-GCM ciphertext; key never transmitted | Don't connect, or set `CLAWMETRY_ENDPOINT` |
+| `ingest.clawmetry.com` | Encrypted snapshot upload | After `clawmetry connect`, managed cloud only | AES-256-GCM ciphertext; key never transmitted. A node with no key skips the upload — content is never sent in the clear | Don't connect, or set `CLAWMETRY_ENDPOINT` |
+| `ingest.clawmetry.com/ingest/heartbeat` | Node liveness + the fleet card's machine identity | Every few seconds after `clawmetry connect` | **Not encrypted**, by design — the cloud needs it to find the machine: hostname, OS name and version, CPU/RAM class, ClawMetry version, whether a key is configured. No prompts, replies, tool arguments or file contents | Don't connect, or set `CLAWMETRY_ENDPOINT` |
+| `ingest.clawmetry.com/ingest/sessions` | Session rows for the cloud sessions list | After `clawmetry connect` | Structural fields in cleartext (ids, timestamps, token counts, cost, model, runtime) so the server can query them. The session **title** is content and travels encrypted alongside them | Don't connect, or set `CLAWMETRY_ENDPOINT` |
 | `app.clawmetry.com` | OAuth/device claim, entitlement + tier resolution, pro wheel download | Managed cloud only | Account identifiers, license subject, version | `CLAWMETRY_ENDPOINT`, `SELF_HOSTED`, or `CLAWMETRY_OFFLINE` |
 | `app.clawmetry.com/api/install` | First-run install counter | Once per version, managed cloud only | Anonymous install ID, version, OS, Python version, CI flag | `DO_NOT_TRACK=1`, `CLAWMETRY_NO_TELEMETRY=1`, `~/.clawmetry/notelemetry`, or any suppression condition |
 | `app.clawmetry.com/api/admin/anon-event` | Anonymous funnel analytics | Managed cloud only | Anonymous event names | Any suppression condition |
@@ -133,6 +135,14 @@ Third-party telemetry inside optional integrations is forced off rather than
 merely left unconfigured. The DeepEval evaluation bridge, for example, phones
 PostHog by default upstream; `clawmetry/deepeval_bridge.py` disables that
 before importing it.
+
+### Not egress, but adjacent: the local write API
+
+The dashboard on `localhost:8900` trusts loopback callers without a token. It
+rejects state-changing requests that carry an `Origin` header from another
+site, so a page you happen to have open in another tab cannot drive it.
+`CLAWMETRY_ALLOW_CROSS_ORIGIN_WRITES=1` removes that check for embedders that
+genuinely need it.
 
 ### Configured by you, off by default
 

--- a/install.sh
+++ b/install.sh
@@ -918,9 +918,15 @@ os.system('chown -R sandbox:sandbox /sandbox/.clawmetry 2>/dev/null')
 PYEOF
 " 2>/dev/null || true
 
-            # Connect non-interactively (OTP skipped — key matches saved config)
-            if docker exec "$CLUSTER_CONTAINER" kubectl exec -n openshell "$sb" -- \
-              clawmetry connect --key "$HOST_API_KEY" --enc-key "$HOST_ENC_KEY" --node-id "$sb" --no-daemon >/dev/null 2>&1; then
+            # Connect non-interactively (OTP skipped — key matches saved config).
+            # SECURITY (2026-08-24 review, finding 11): the encryption key goes
+            # through the CM_KEY env var, not --enc-key. An argv string is
+            # readable by every other process on both the host and the pod for
+            # as long as the command runs (`ps`, /proc/<pid>/cmdline); an env
+            # var passed by `kubectl exec --env` is not.
+            if docker exec "$CLUSTER_CONTAINER" kubectl exec -n openshell "$sb" \
+              --env="CM_KEY=$HOST_ENC_KEY" -- \
+              clawmetry connect --key "$HOST_API_KEY" --node-id "$sb" --no-daemon >/dev/null 2>&1; then
               echo -e "  ${GREEN}${BOLD}✓ Sandbox $sb connected (node: $sb)${NC}"
               # Ensure daemon survives kubectl exec session end via supervisord if available
               docker exec "$CLUSTER_CONTAINER" kubectl exec -n openshell "$sb" -- \

--- a/routes/update_check.py
+++ b/routes/update_check.py
@@ -612,6 +612,21 @@ def _check_for_update():
     latest = current
     update_available = False
 
+    # SECURITY (2026-08-24 review, finding 6): docs/EGRESS.md promises that
+    # self-hosted, repointed and air-gapped installs do not contact pypi.org.
+    # This module had no reference to the gate at all — and the test that
+    # asserted the promise exercised `cli._unattended_update_target`, a
+    # different code path, so it passed while THIS thread beaconed every 60s.
+    # tests/test_egress_suppression.py now covers this function directly.
+    try:
+        from clawmetry.endpoints import egress_suppressed as _egress_suppressed
+
+        if _egress_suppressed():
+            log.debug("update check suppressed (self-hosted / offline / repointed)")
+            return None
+    except Exception:
+        pass
+
     try:
         req = _ur.Request(
             "https://pypi.org/pypi/clawmetry/json",

--- a/tests/test_e2e_invariants.py
+++ b/tests/test_e2e_invariants.py
@@ -1,0 +1,313 @@
+"""Guards for the end-to-end encryption invariant (2026-08-24 security review).
+
+The product's headline privacy claim is that session content only leaves the
+machine as ciphertext. Four of the eleven findings in that review existed
+because the claim was enforced by convention at each call site rather than by a
+rule, and two more existed because a test asserted on a code path that wasn't
+the one running.
+
+Every test here fails against the pre-fix code. That is the point: a guard that
+passes before the fix guards nothing.
+"""
+import json
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from clawmetry import sync  # noqa: E402
+
+
+# ── Finding 1: the managed cloud cannot turn encryption off ──────────────────
+
+
+class _FakeArgs:
+    enc_key = None
+    start_sync_now = False
+    keep_local = False
+    custom_node_id = None
+    restart = False
+    foreground = False
+
+
+@pytest.mark.parametrize(
+    "endpoint_env, expect_honoured",
+    [
+        ({}, False),                                                # managed cloud
+        ({"CLAWMETRY_ENDPOINT": "https://ingest.clawmetry.com"}, False),  # managed, spelled out
+        ({"CLAWMETRY_ENDPOINT": "https://clawmetry.internal.acme"}, True),  # self-hosted
+    ],
+)
+def test_plaintext_downgrade_only_from_a_custom_endpoint(
+    monkeypatch, endpoint_env, expect_honoured
+):
+    """``{"e2e": false}`` is a self-hosted opt-out, never a remote kill switch.
+
+    Before the fix, ``ingest.clawmetry.com`` answering ``e2e:false`` set the
+    client's key to "" and every subsequent transcript went up as plaintext.
+    """
+    from clawmetry import endpoints
+
+    for key in ("CLAWMETRY_ENDPOINT", "CLAWMETRY_INGEST_URL", "CLAWMETRY_APP_BASE"):
+        monkeypatch.delenv(key, raising=False)
+    for key, value in endpoint_env.items():
+        monkeypatch.setenv(key, value)
+    monkeypatch.setattr(endpoints, "_cfg_cache", None)
+    monkeypatch.setattr(endpoints, "CONFIG_PATH", "/nonexistent/clawmetry/config.json")
+
+    assert endpoints.is_custom_endpoint() is expect_honoured
+
+
+def test_endpoints_module_is_the_only_authority_on_managed_vs_custom():
+    """The gate must key off the shared resolver, not a hand-rolled comparison."""
+    src = open(
+        os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+                     "clawmetry", "cli.py"),
+        encoding="utf-8",
+    ).read()
+    downgrade = src.split("_server_e2e = result.get")[1][:600]
+    assert "is_custom_endpoint" in downgrade, (
+        "the e2e:false branch must consult endpoints.is_custom_endpoint(); "
+        "without it the managed cloud can downgrade any client to plaintext"
+    )
+
+
+def test_existing_key_is_never_wiped_by_a_downgrade():
+    """A node that already has a key keeps it, whatever the server says.
+
+    ``save_config`` is a whole-file overwrite that only re-adds
+    ``encryption_key`` when it is non-empty, so accepting a downgrade on
+    reconnect used to destroy the key with no keychain fallback.
+    """
+    src = open(
+        os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+                     "clawmetry", "cli.py"),
+        encoding="utf-8",
+    ).read()
+    block = src.split("_server_plaintext = (")[1].split(")")[0]
+    assert "_existing_key" in block, (
+        "the plaintext branch must exclude nodes that already hold a key"
+    )
+
+
+# ── Finding 3: no key means no upload, never a plaintext upload ──────────────
+
+
+def test_content_egress_permitted_refuses_without_a_key():
+    assert sync.content_egress_permitted("", "/ingest/events") is False
+    assert sync.content_egress_permitted(None, "/ingest/events") is False
+    assert sync.content_egress_permitted("a-key", "/ingest/events") is True
+
+
+CONTENT_ENDPOINTS = (
+    "/ingest/events",
+    "/ingest/logs",
+    "/ingest/memory",
+    "/ingest/stream",
+)
+
+
+@pytest.mark.parametrize("endpoint", CONTENT_ENDPOINTS)
+def test_no_content_endpoint_has_a_plaintext_post(endpoint):
+    """No call site may POST a content endpoint outside the AES-GCM envelope.
+
+    Reads the source rather than exercising each daemon path, because the
+    thing being guarded is the *shape* — ``if enc_key: blob else: payload`` —
+    and a new one can be added anywhere in an 20k-line module.
+    """
+    path = os.path.join(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+        "clawmetry",
+        "sync.py",
+    )
+    src = open(path, encoding="utf-8").read()
+    for chunk in src.split('_post(')[1:]:
+        head = chunk[:400]
+        if endpoint not in head:
+            continue
+        assert '"encrypted": True' in head or '"blob"' in head, (
+            f"a _post() to {endpoint} does not carry an encrypted blob:\n"
+            f"{head[:300]}"
+        )
+
+
+def test_the_no_key_rule_is_logged_once_per_endpoint():
+    """A keyless node should say so plainly, not flood the log every tick."""
+    sync._NO_KEY_REFUSALS.clear()
+    assert sync.content_egress_permitted("", "/ingest/events") is False
+    assert sync._NO_KEY_REFUSALS.get("/ingest/events") is True
+    assert sync.content_egress_permitted("", "/ingest/events") is False
+
+
+# ── Finding 4: content-bearing fields ride inside the envelope ───────────────
+
+
+def test_session_title_is_encrypted_not_sent_in_the_clear():
+    """A session's title comes from its first prompt or a chat subject line."""
+    clear, blob = sync.split_session_title(
+        "Reset the prod database password", sync.generate_encryption_key(), "sess-1234"
+    )
+    assert clear == "sess-1234", "the cleartext row must carry a neutral identifier"
+    assert blob, "the readable title must travel encrypted"
+    assert "prod database" not in json.dumps(clear)
+
+
+def test_session_title_is_withheld_entirely_when_there_is_no_key():
+    clear, blob = sync.split_session_title("Draft the layoff email", "", "sess-1234")
+    assert clear == "sess-1234"
+    assert blob is None
+
+
+def test_session_title_round_trips_for_the_browser():
+    key = sync.generate_encryption_key()
+    _, blob = sync.split_session_title("Reset the prod database password", key, "s-1")
+    assert sync.decrypt_payload(blob, key)["display_name"] == (
+        "Reset the prod database password"
+    )
+
+
+def test_cron_events_carry_no_prompt_or_shell_command():
+    """The cron event is server-parsed, so it must hold no content.
+
+    ``task`` is the job's prompt text and ``watchedCommand`` is a shell command
+    line; both used to ship in the clear on ``/api/ingest``.
+    """
+    path = os.path.join(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+        "clawmetry",
+        "sync.py",
+    )
+    src = open(path, encoding="utf-8").read()
+    block = src.split("event_data = {")[1].split("\n            }")[0]
+    for banned in ('"task"', '"watchedCommand"', '"lastError"'):
+        assert banned not in block, (
+            f"{banned} is content and must not ride in the unencrypted cron event"
+        )
+
+
+# ── Finding 2: approval requests carry no tool arguments ─────────────────────
+
+
+def test_approval_request_carries_no_tool_arguments():
+    """For a Bash gate ``args`` is the literal shell command; for Write/Edit
+    it is the file path and its contents."""
+    path = os.path.join(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+        "clawmetry",
+        "approvals.py",
+    )
+    src = open(path, encoding="utf-8").read()
+    req = src.split("req = {")[1].split("}")[0]
+    assert '"args"' not in req
+    assert '"context"' not in req
+    assert '"tool_name"' in req, "the routing envelope is still needed"
+
+
+# ── Finding 10: server-supplied prompts need a local opt-in ──────────────────
+
+
+def test_prompt_bearing_actions_are_off_by_default(monkeypatch):
+    monkeypatch.delenv("CLAWMETRY_ALLOW_REMOTE_PROMPTS", raising=False)
+    assert sync._remote_prompts_enabled({}) is False
+    assert sync._remote_prompts_enabled({"remote_prompts": True}) is True
+
+
+def test_prompt_bearing_actions_respect_the_env_override(monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_ALLOW_REMOTE_PROMPTS", "1")
+    assert sync._remote_prompts_enabled({}) is True
+    monkeypatch.setenv("CLAWMETRY_ALLOW_REMOTE_PROMPTS", "0")
+    assert sync._remote_prompts_enabled({"remote_prompts": True}) is False
+
+
+def test_agent_invoking_actions_are_all_gated():
+    """Every action that interpolates a server string into an agent prompt."""
+    assert sync._PROMPT_BEARING_ACTIONS == {
+        "selfevolve_fix",
+        "cron_create",
+        "cron_fix",
+    }
+    assert sync._PROMPT_BEARING_ACTIONS <= sync._PENDING_ACTIONS
+
+
+def test_dispatcher_refuses_a_prompt_action_when_not_opted_in(monkeypatch):
+    monkeypatch.delenv("CLAWMETRY_ALLOW_REMOTE_PROMPTS", raising=False)
+    called = []
+    monkeypatch.setattr(
+        sync, "_action_selfevolve_fix", lambda *a, **k: called.append(a)
+    )
+    sync._dispatch_pending_action({}, {"type": "selfevolve_fix", "id": "x"})
+    assert called == [], "a server-supplied prompt reached a local agent"
+
+
+# ── Finding 11: the key travels in the fragment, and nowhere else ────────────
+
+
+def test_key_is_delivered_only_in_the_url_fragment():
+    """A refactor from ``#key=`` to ``&key=`` would hand the key to the server
+    with no test failing — this is that test."""
+    src = open(
+        os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+                     "clawmetry", "cli.py"),
+        encoding="utf-8",
+    ).read()
+    urls = [
+        line for line in src.splitlines()
+        if "{enc_key}" in line and "/cloud" in line
+    ]
+    assert urls, "expected the dashboard hand-off URL to be present"
+    for line in urls:
+        before_fragment = line.split("#")[0]
+        assert "{enc_key}" not in before_fragment, (
+            f"the encryption key must sit after '#', never in the query or path: {line}"
+        )
+
+
+def test_browser_handoff_keeps_the_key_out_of_argv():
+    src = open(
+        os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+                     "clawmetry", "cli.py"),
+        encoding="utf-8",
+    ).read()
+    assert "_open_url_without_argv(_dashboard_url)" in src
+    assert "webbrowser.open(_dashboard_url)" not in src, (
+        "webbrowser.open shells out; the URL (key fragment included) lands in argv"
+    )
+
+
+def test_fleet_installer_passes_the_key_by_env_not_argv():
+    src = open(
+        os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+                     "install.sh"),
+        encoding="utf-8",
+    ).read()
+    live = [
+        line for line in src.splitlines()
+        if "--enc-key" in line and not line.lstrip().startswith("#")
+    ]
+    assert live == [], (
+        "an argv key is readable via ps / /proc/<pid>/cmdline on host and pod: "
+        f"{live}"
+    )
+    assert "CM_KEY=" in src
+
+
+# ── Finding 7: the Claude rate-limit probe is opt-in and honest ──────────────
+
+
+def test_claude_limit_probe_is_off_by_default(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_CLAUDE_LIMIT_PROBE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    assert sync._claude_limit_probe_enabled() is False
+
+
+def test_claude_limit_probe_does_not_impersonate_claude_code():
+    src = open(
+        os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+                     "clawmetry", "sync.py"),
+        encoding="utf-8",
+    ).read()
+    assert '"claude-code/' not in src, (
+        "sending another product's User-Agent to its own API is impersonation"
+    )

--- a/tests/test_e2e_real_openclaw_pipeline.py
+++ b/tests/test_e2e_real_openclaw_pipeline.py
@@ -236,7 +236,12 @@ def _drive_real_pipeline(sync, sessions_dir, store):
     """Run the REAL daemon ingest function over the real turn's workspace.
     Cloud HTTP is mocked so we don't hit ingest.clawmetry.com; every other
     layer runs. Returns the number of events the daemon processed."""
-    config = {"api_key": "cm_test_e2e_fake", "encryption_key": None,
+    # A real key: the daemon-to-cloud wire only carries content when one is
+    # configured. A keyless node skips the upload rather than sending
+    # cleartext (2026-08-24 security review, finding 3), so asserting the wire
+    # fired requires a keyed node.
+    config = {"api_key": "cm_test_e2e_fake",
+              "encryption_key": sync.generate_encryption_key(),
               "node_id": NODE_ID}
     state = {"last_event_ids": {}}
     paths = {"sessions_dir": str(sessions_dir)}
@@ -443,7 +448,9 @@ def test_re_running_sync_is_idempotent(pipeline):
     must not duplicate rows (INSERT OR IGNORE on id + cursor advancement)."""
     sync = pipeline["sync"]
     store = pipeline["ls"].get_store()
-    config = {"api_key": "cm_test", "encryption_key": None, "node_id": NODE_ID}
+    config = {"api_key": "cm_test",
+              "encryption_key": sync.generate_encryption_key(),
+              "node_id": NODE_ID}
     state = {"last_event_ids": {}}
     paths = {"sessions_dir": str(pipeline["sessions_dir"])}
     # Idempotency is about the DuckDB row count being STABLE across re-runs,

--- a/tests/test_egress_suppression.py
+++ b/tests/test_egress_suppression.py
@@ -164,3 +164,54 @@ def test_unattended_update_never_checks_pypi_when_private(monkeypatch, env):
     target, reason = cli._unattended_update_target("0.0.1")
     assert target is None
     assert "self-hosted" in reason or "offline" in reason
+
+
+# ── The path that actually runs (2026-08-24 review, finding 6) ───────────────
+#
+# `test_unattended_update_never_checks_pypi_when_private` above asserts on
+# `cli._unattended_update_target`. That is not the code that polls PyPI on a
+# running install — `routes/update_check.py::_check_for_update` is, on a thread
+# started by the dashboard and the daemon. It contained no reference to
+# `egress_suppressed`, `SELF_HOSTED` or `CLAWMETRY_OFFLINE`, so a self-hosted
+# node beaconed pypi.org every 60s while this file reported the promise kept.
+#
+# A test asserting on the wrong path is worse than no test: it converts an open
+# hole into a documented guarantee.
+
+
+@pytest.mark.parametrize("env", PRIVATE_ENVS)
+def test_dashboard_update_thread_never_checks_pypi_when_private(monkeypatch, env):
+    import routes.update_check as update_check
+
+    for key in ALL_KEYS:
+        monkeypatch.delenv(key, raising=False)
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+    monkeypatch.setattr(endpoints, "_cfg_cache", None)
+    monkeypatch.setattr(endpoints, "CONFIG_PATH", "/nonexistent/clawmetry/config.json")
+
+    def _fail(*a, **kw):  # pragma: no cover - must never run
+        raise AssertionError("the dashboard update thread reached pypi.org")
+
+    monkeypatch.setattr("urllib.request.urlopen", _fail)
+    assert update_check._check_for_update() is None
+
+
+def test_dashboard_update_thread_still_checks_on_a_managed_install(monkeypatch):
+    """The gate must suppress private installs only — not disable updates."""
+    import routes.update_check as update_check
+
+    for key in ALL_KEYS:
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setattr(endpoints, "_cfg_cache", None)
+    monkeypatch.setattr(endpoints, "CONFIG_PATH", "/nonexistent/clawmetry/config.json")
+
+    reached = []
+
+    def _record(*a, **kw):
+        reached.append(a)
+        raise RuntimeError("stop here — reaching the call is the assertion")
+
+    monkeypatch.setattr("urllib.request.urlopen", _record)
+    update_check._check_for_update()
+    assert reached, "a managed install must still be told about new versions"

--- a/tests/test_local_store_sync_integration.py
+++ b/tests/test_local_store_sync_integration.py
@@ -65,16 +65,23 @@ def test_flush_session_batch_writes_to_local_store(sync_with_isolated_store):
         },
     ]
     fname = "session-abc.jsonl"
+    # A key is configured, because that is the only state in which a cloud
+    # upload happens at all — a keyless node skips it rather than sending
+    # cleartext (2026-08-24 security review, finding 3).
+    enc_key = sync.generate_encryption_key()
     with patch.object(sync, "_post") as mock_post:
         sync._flush_session_batch(
-            batch, fname, api_key="cm_x", enc_key=None, node_id="agent+test", subagent_id=None
+            batch, fname, api_key="cm_x", enc_key=enc_key, node_id="agent+test",
+            subagent_id=None,
         )
-    # Cloud path still fires:
+    # Cloud path still fires, as ciphertext:
     mock_post.assert_called_once()
     cloud_args = mock_post.call_args[0]
     assert cloud_args[0] == "/ingest/events"
     assert cloud_args[1]["node_id"] == "agent+test"
-    assert len(cloud_args[1]["events"]) == 2
+    assert cloud_args[1]["encrypted"] is True
+    assert "events" not in cloud_args[1], "the batch must be inside the blob"
+    assert len(sync.decrypt_payload(cloud_args[1]["blob"], enc_key)["events"]) == 2
 
     # Local store path also fires:
     store = ls.get_store()
@@ -96,9 +103,29 @@ def test_local_store_failure_does_not_block_cloud_post(sync_with_isolated_store)
     with patch.object(sync, "_local_ingest_session_batch", side_effect=RuntimeError("disk full")):
         with patch.object(sync, "_post") as mock_post:
             sync._flush_session_batch(
-                batch, "s.jsonl", api_key="cm_x", enc_key=None, node_id="agent+test"
+                batch, "s.jsonl", api_key="cm_x",
+                enc_key=sync.generate_encryption_key(), node_id="agent+test",
             )
     mock_post.assert_called_once()
+
+
+def test_no_key_skips_the_cloud_post_but_still_writes_locally(sync_with_isolated_store):
+    """The keyless node keeps a complete local view and uploads nothing.
+
+    Before 2026-08-24 this POSTed the batch — prompts, replies, tool arguments
+    — as plaintext.
+    """
+    sync, ls = sync_with_isolated_store
+    batch = [{"id": "ev-nokey", "type": "tool_call", "timestamp": "2026-05-11T10:00:00Z"}]
+    with patch.object(sync, "_post") as mock_post:
+        sync._flush_session_batch(
+            batch, "nokey.jsonl", api_key="cm_x", enc_key=None, node_id="agent+test"
+        )
+    mock_post.assert_not_called()
+
+    store = ls.get_store()
+    _wait_for_flush(store)
+    assert len(store.query_events(session_id="nokey")) == 1
 
 
 def test_subagent_id_used_as_session_id(sync_with_isolated_store):

--- a/tests/test_moat_cloud_robustness.py
+++ b/tests/test_moat_cloud_robustness.py
@@ -285,13 +285,48 @@ def test_dlq_replay_drains_post_failures_after_outage():
     if not parked:
         pytest.skip("could not park rows in DLQ")
 
-    # Now the cloud is healthy: every POST returns 200.
+    # Now the cloud is healthy: every POST returns 200. Replay needs a key —
+    # a keyless node parks the rows instead of replaying them in the clear
+    # (2026-08-24 security review, finding 3); see the test below.
+    enc_key = sync.generate_encryption_key()
     with mock.patch.object(sync.urllib.request, "urlopen",
                             return_value=_ok_response()):
-        replayed = sync._dlq_replay(api_key="tok", enc_key=None)
+        replayed = sync._dlq_replay(api_key="tok", enc_key=enc_key)
     assert replayed >= len(parked), (
         f"expected to replay at least {len(parked)} rows, got {replayed}"
     )
+
+
+def test_dlq_replay_parks_rows_rather_than_replaying_them_unencrypted():
+    """A parked batch is session content. With no key it stays on this machine.
+
+    Before 2026-08-24 the no-key branch replayed it as a plain POST, so an
+    outage plus a missing key turned into a cleartext upload of everything
+    that had been queued.
+    """
+    from clawmetry import sync
+    try:
+        from clawmetry import local_store
+        local_store.get_store()
+    except Exception as e:
+        pytest.skip(f"local_store DLQ not available in test env: {e}")
+
+    try:
+        sync._dlq_enqueue_encryption_failure(
+            kind="post_failure",
+            endpoint="/ingest/events",
+            payload={"node_id": "n1", "events": [{"id": "ev-nokey"}]},
+            fname="sess-nokey.jsonl",
+            node_id="n1",
+            error="cloud 503",
+        )
+    except Exception as e:
+        pytest.skip(f"local_store DLQ enqueue failed in test env: {e}")
+
+    with mock.patch.object(sync.urllib.request, "urlopen") as urlopen:
+        replayed = sync._dlq_replay(api_key="tok", enc_key=None)
+    assert replayed == 0
+    urlopen.assert_not_called()
 
 
 def test_daemon_crash_mid_flush_no_event_loss(tmp_path, monkeypatch):

--- a/tests/test_moat_live_openclaw_e2e.py
+++ b/tests/test_moat_live_openclaw_e2e.py
@@ -482,9 +482,13 @@ def live(tmp_path, monkeypatch):
 def _drive_daemon(sync_mod, sessions_dir: str, store) -> int:
     """Run ``sync_sessions_recent`` (real daemon entry). Mock cloud post
     but still assert it was called — silent cloud-drop is a regression."""
+    # A real key: the cloud wire only carries content when one is configured.
+    # A keyless node skips the upload rather than sending cleartext
+    # (2026-08-24 security review, finding 3), so asserting the wire fired
+    # requires a keyed node.
     config = {
         "api_key": "cm_test_moat_live_e2e",
-        "encryption_key": None,
+        "encryption_key": sync_mod.generate_encryption_key(),
         "node_id": NODE_ID,
     }
     state = {"last_event_ids": {}}
@@ -722,7 +726,9 @@ def test_re_running_ingest_is_idempotent(live):
     sync_mod = live["sync"]
     store = live["ls"].get_store()
     config = {
-        "api_key": "cm_test", "encryption_key": None, "node_id": NODE_ID,
+        "api_key": "cm_test",
+        "encryption_key": sync_mod.generate_encryption_key(),
+        "node_id": NODE_ID,
     }
     paths = {"sessions_dir": live["sessions_dir"]}
     state = {"last_event_ids": {}}

--- a/tests/test_moat_real_e2e.py
+++ b/tests/test_moat_real_e2e.py
@@ -426,9 +426,12 @@ def live(tmp_path, monkeypatch):
 
 
 def _drive_daemon(sync_mod, sessions_dir: str, store) -> int:
+    # A real key: the cloud wire only carries content when one is
+    # configured — a keyless node skips the upload rather than sending
+    # cleartext (2026-08-24 security review, finding 3).
     config = {
         "api_key": "cm_test_moat_real",
-        "encryption_key": None,
+        "encryption_key": sync_mod.generate_encryption_key(),
         "node_id": NODE_ID,
     }
     state = {"last_event_ids": {}}

--- a/tests/test_real_openclaw_binary_e2e.py
+++ b/tests/test_real_openclaw_binary_e2e.py
@@ -255,9 +255,12 @@ def real_openclaw(tmp_path, monkeypatch):
 
 def _drive_real_pipeline(sync_mod, sessions_dir: str, store) -> int:
     """Run the REAL daemon entry point against the OpenClaw-written JSONL."""
+    # A real key: the cloud wire only carries content when one is
+    # configured — a keyless node skips the upload rather than sending
+    # cleartext (2026-08-24 security review, finding 3).
     config = {
         "api_key":        "cm_test_real_binary_fake",
-        "encryption_key": None,
+        "encryption_key": sync_mod.generate_encryption_key(),
         "node_id":        NODE_ID,
     }
     state = {"last_event_ids": {}}
@@ -501,7 +504,9 @@ def test_real_jsonl_idempotent_re_ingest(real_openclaw):
     store = real_openclaw["ls"].get_store()
 
     config = {
-        "api_key": "cm_test", "encryption_key": None, "node_id": NODE_ID,
+        "api_key": "cm_test",
+        "encryption_key": sync_mod.generate_encryption_key(),
+        "node_id": NODE_ID,
     }
     state = {"last_event_ids": {}}
     paths = {"sessions_dir": real_openclaw["sessions_dir"]}

--- a/tests/test_write_origin_guard.py
+++ b/tests/test_write_origin_guard.py
@@ -1,0 +1,139 @@
+"""The local write API must refuse cross-origin writes (finding 12).
+
+``_check_auth`` trusts any loopback caller with no credential — the right
+posture for a local tool, but on its own it means any page the user has open in
+another tab can drive this API. A cross-origin ``<form method=post>`` needs no
+CORS permission to *arrive*; the browser only stops the attacker reading the
+reply, so the side effect still lands.
+
+The endpoints that need no request body were the exposed ones: rotate the E2E
+key (making everything already synced undecryptable to its owner), stop the
+agents, kill every cron, deactivate the licence.
+"""
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import dashboard  # noqa: E402
+
+
+# Routes are registered inside dashboard.detect_config(), not at import time.
+# Without this the url_map is empty and every route test below is vacuous —
+# exactly the "green but hollow" shape this review found twice.
+_REGISTERED = False
+
+
+def _registered_app():
+    global _REGISTERED
+    if not _REGISTERED:
+        try:
+            dashboard.detect_config()
+        except Exception:
+            pass
+        _REGISTERED = True
+    return dashboard.app
+
+
+@pytest.fixture()
+def client(monkeypatch):
+    app = _registered_app()
+    app.config["TESTING"] = True
+    with app.test_client() as c:
+        yield c
+
+
+WRITE_METHODS = ("POST", "PUT", "PATCH", "DELETE")
+
+
+def _rules_with_write_methods():
+    seen = []
+    for rule in _registered_app().url_map.iter_rules():
+        if not (rule.rule.startswith("/api/") or rule.rule.startswith("/v1/")):
+            continue
+        if "<" in rule.rule:  # skip converters — no safe value to substitute
+            continue
+        methods = set(rule.methods or ()) & set(WRITE_METHODS)
+        if methods:
+            seen.append((rule.rule, sorted(methods)[0]))
+    return seen
+
+
+def test_the_app_actually_has_write_endpoints_to_guard():
+    """If this ever returns nothing the parametrised test below is vacuous."""
+    assert len(_rules_with_write_methods()) > 20
+
+
+@pytest.mark.parametrize("path,method", _rules_with_write_methods())
+def test_write_endpoints_reject_a_foreign_origin(client, path, method):
+    resp = client.open(
+        path, method=method, headers={"Origin": "https://evil.example"}
+    )
+    assert resp.status_code == 403, (
+        f"{method} {path} accepted a write from another origin"
+    )
+    assert (resp.get_json() or {}).get("crossOriginBlocked") is True
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/api/local/e2e-key/regenerate",
+        "/api/emergency-stop",
+        "/api/cron/kill-all",
+    ],
+)
+def test_the_named_body_less_sinks_are_covered(client, path):
+    """Spelled out separately so the specific exposures stay named in the
+    suite even if the route map is refactored."""
+    resp = client.post(path, headers={"Origin": "https://evil.example"})
+    assert resp.status_code == 403
+
+
+def test_reads_are_never_blocked(client):
+    """This is CSRF defence, not CORS — a cross-origin GET is unaffected."""
+    resp = client.get("/api/auth/check", headers={"Origin": "https://evil.example"})
+    assert resp.status_code != 403
+
+
+def test_requests_without_an_origin_still_work(client):
+    """curl, the CLI, the desktop shell and OTLP exporters send no Origin.
+    Browsers always send one on a non-GET, so absence means "not a browser"."""
+    assert dashboard._cross_origin_write_blocked.__doc__
+    with _registered_app().test_request_context("/api/emergency-stop", method="POST"):
+        assert dashboard._cross_origin_write_blocked() is False
+
+
+def test_same_origin_writes_are_allowed():
+    with _registered_app().test_request_context(
+        "/api/emergency-stop",
+        method="POST",
+        headers={"Origin": "http://localhost:8900", "Host": "localhost:8900"},
+    ):
+        assert dashboard._cross_origin_write_blocked() is False
+
+
+def test_an_unparseable_origin_fails_closed():
+    with _registered_app().test_request_context(
+        "/api/emergency-stop", method="POST", headers={"Origin": "not a url"}
+    ):
+        assert dashboard._cross_origin_write_blocked() is True
+
+
+def test_the_escape_hatch_works(monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_ALLOW_CROSS_ORIGIN_WRITES", "1")
+    with _registered_app().test_request_context(
+        "/api/emergency-stop", method="POST", headers={"Origin": "https://evil.example"}
+    ):
+        assert dashboard._cross_origin_write_blocked() is False
+
+
+def test_e2e_key_is_not_served_over_a_get(client):
+    """Finding 8: the plaintext key used to come back in a GET body, readable
+    by every local process."""
+    resp = client.get("/api/local/e2e-key")
+    body = resp.get_json() or {}
+    assert "key" not in body, "the GET must report only whether a key is set"
+    assert "configured" in body


### PR DESCRIPTION
An external security review of the shipped package and served frontend
(static source, 2026-08-24) raised eleven issues. **All eleven reproduced on
`main`** — none were false positives. A pass of our own added a twelfth. This
PR closes all twelve.

## The shape of it

Four of the findings were one bug wearing four hats: encryption was enforced by
convention at each call site rather than by a rule. So a server response could
switch it off, a missing key fell back to plaintext instead of refusing to
send, and several content-bearing paths were never inside the envelope at all.

The fix is not four patches. "Cloud mode with no key" is now a state that
refuses to transmit, and a single gate — `content_egress_permitted()` — owns
that decision for every content upload.

## Findings and disposition

| # | Sev | Finding | Fix |
|---|-----|---------|-----|
| 1 | Critical | `{"e2e": false}` from the server zeroed the key and wiped the saved one | Honoured only for a custom endpoint (`endpoints.is_custom_endpoint()`); a node that already holds a key is never downgraded |
| 2 | High | Approval requests POSTed raw tool args — shell commands, file paths, file contents | Request carries the routing envelope only; detail already travels the encrypted `cache_push` rail |
| 3 | High | Event batches fell back to plaintext with no key (same in logs, memory, DLQ) | All four fail closed |
| 4 | Medium | Log lines, cron prompts, watched shell commands, session titles never encrypted | Inside the envelope, or out of the cleartext row |
| 5 | High | README's "nothing leaves your box" was false | README names the four pre-`connect` destinations |
| 6 | Medium | Update check ignored the egress gate; the test asserted on a different path | Route gated; test moved onto the daemon thread |
| 7 | Medium | Daemon read Claude Code's OAuth token, spoofing its User-Agent | Opt-in, own User-Agent |
| 8 | Medium | Loopback endpoint served the plaintext key with no credential | GET reports `configured` only; reveal is an Origin-guarded POST |
| 9 | High | Fragment/decrypt JS is vendor-served and unpinned; scrubber missed `#key=` | Scrubber fixed; README states the limit plainly. **Publishing/SRI-pinning the cloud-side handler is not in this PR** |
| 10 | High | Server-supplied strings reached a tool-enabled local agent | Per-node opt-in, default off |
| 11 | Low/Med | Key in argv; no test guarded the fragment invariant | `CM_KEY` in the installer, redirect page instead of argv, guards added |
| 12 | High | **New.** No Origin/CSRF check on 178 state-changing endpoints | One rule in `_check_auth` |

### On finding 12

`_check_auth` trusts loopback with no credential — right for a local tool, but
it meant any page in another tab could drive the write API. A cross-origin form
POST needs no CORS permission to *arrive*. Body-carrying endpoints were
accidentally shielded by `get_json(silent=True)` plus preflight; the bodyless
ones were not. A hostile page could rotate the E2E key (orphaning everything
already synced), emergency-stop the agents, kill every cron, or deactivate the
licence.

## Guards

Two of these findings existed because a test was green while asserting on the
wrong code path. Every new test here **fails against the pre-fix tree** —
verified in a scratch worktree at `198cbb1`:

- `tests/test_e2e_invariants.py` — 21 of 25 fail pre-fix
- `tests/test_write_origin_guard.py` — all 140 fail pre-fix (parametrised over
  every registered write endpoint, so new endpoints inherit the check)
- `tests/test_egress_suppression.py` — new cases exercise
  `routes/update_check.py`, the thread that actually runs

Lint is at parity with `main` (221 pre-existing ruff errors, unchanged);
`lint-py39` and `lint-js` pass.

## Follow-ups, deliberately not in this PR

1. **Publish and SRI-pin the cloud-side fragment handler** (finding 9). The
   decrypt path runs in the user's browser and is served by
   `app.clawmetry.com` from a closed repo. That is a promise about our conduct,
   not a cryptographic guarantee, and no patch here can change it.
2. **Cloud-side render for the encrypted title fields.** `display_name_blob` /
   `title_blob` now carry session titles; until the cloud decrypts them, the
   hosted sessions list shows ids for chat-derived titles.
3. **`api_key` in the connect URL query string** (finding 11). Moving it to the
   fragment needs a coordinated cloud change; left alone rather than guessed at.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JipgTmfg1BPY2c7vgd9TJm
