### PR TITLE
Publish the browser-side decrypt path, and get the account key out of the URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,10 +77,25 @@ line. Every destination, what it carries and how to switch it off is listed in
 [docs/EGRESS.md](docs/EGRESS.md); self-hosted, repointed and air-gapped installs
 make no discretionary outbound calls at all.
 
-One limit worth stating plainly: the JavaScript that decrypts your snapshot is
-served by `app.clawmetry.com`. The key stays in your browser and is never sent
-to us, but you are trusting code we serve to keep it that way. Self-hosting or
-staying local-only removes that dependency entirely.
+The decryption happens in your browser, in code we serve you. That used to be
+a promise; it is now something you can check. Every line that touches your key
+lives in one readable file, [`clawmetry/static/js/cm-e2e.js`](clawmetry/static/js/cm-e2e.js),
+which ships inside the wheel and is served verbatim, pinned with a Subresource
+Integrity hash. To confirm the browser runs what we published:
+
+```bash
+curl -s https://app.clawmetry.com/static/js/cm-e2e.js -o served.js
+pip download --no-deps clawmetry==$(clawmetry --version | tr -d 'a-z ') -d /tmp/cm
+unzip -p /tmp/cm/clawmetry-*.whl clawmetry/static/js/cm-e2e.js > published.js
+diff served.js published.js && echo identical
+```
+
+What that does not prove: we serve the page that loads the file, so we could
+serve a different page. Integrity hashes protect you from a compromised CDN,
+not from the vendor. What you gain is that any substitution has to be
+deliberate, visible in the page source, and different from an artifact on PyPI
+that anyone can fetch. Self-hosting or staying local-only removes the
+dependency entirely.
 
 ## Install
 

--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -1427,12 +1427,24 @@ def _cmd_connect(args) -> None:
                 pass
         return
 
-    # Open browser with encryption key in URL fragment (never sent to server)
-    # The #key=... fragment stays client-side — true E2E encryption
+    # Hand off to the browser entirely in the URL FRAGMENT. A fragment is
+    # never transmitted, so nothing here reaches a server log, a Referer
+    # header, or an intermediary.
+    #
+    # SECURITY (2026-08-24 review, finding 11): the account key used to ride
+    # in the query string as `/cloud?token=<key>`. A `cm_` key is a whole
+    # account credential and the server records the request line, so every
+    # connect wrote one into Cloud Logging in plaintext, where it stayed for
+    # the retention window; it also sat in the user's browser history. The
+    # cloud page's setup bridge now reads `#token=` and hands it to the
+    # one-step-onboarding claim in a POST body instead.
     _node_id = config.get("node_id", "")
     from clawmetry.endpoints import app_url as _resolve_app_url2
     _app_base_done = _resolve_app_url2()
-    _dashboard_url = f"{_app_base_done}/cloud?token={api_key}#key={enc_key}&node={_node_id}"
+    _dashboard_url = (
+        f"{_app_base_done}/cloud"
+        f"#token={api_key}&key={enc_key}&node={_node_id}"
+    )
 
     # Cloud includes the local dashboard too (the onboard copy promises
     # BOTH app.clawmetry.com and localhost:8900) — make it true, best-effort.

--- a/clawmetry/static/js/cm-e2e.js
+++ b/clawmetry/static/js/cm-e2e.js
@@ -1,0 +1,201 @@
+/* cm-e2e.js — everything in the browser that touches your encryption key.
+ *
+ * WHY THIS FILE EXISTS, AND WHY IT IS HERE
+ *
+ * ClawMetry says your cloud snapshot is end-to-end encrypted with a key that
+ * never leaves your machine. The encryption itself is done by the daemon on
+ * your computer and is auditable in this repository. The DECRYPTION happens in
+ * your browser, in JavaScript that app.clawmetry.com serves you.
+ *
+ * An external security review in August 2026 made the obvious point: if the
+ * code that receives your key and decrypts your data is written by us, served
+ * by us on every page load, and published nowhere, then "end-to-end encrypted"
+ * is a promise about our conduct rather than something you can check. Every
+ * other part of the claim was verifiable and this part was not.
+ *
+ * So this file is the whole of it — the code that reads the key out of the URL
+ * fragment, decides where to store it, and decrypts blobs with it — and it
+ * lives in the public repository, ships inside the versioned wheel on PyPI,
+ * and is served verbatim. The hosted dashboard's Flask app points its static
+ * folder at the installed package, so the bytes your browser runs are the
+ * bytes published under that version. Nothing is minified or bundled, on
+ * purpose: a build step would put something between what you can read and what
+ * you run.
+ *
+ * HOW TO CHECK THAT FOR YOURSELF
+ *
+ *   curl -s https://app.clawmetry.com/static/js/cm-e2e.js -o served.js
+ *   pip download --no-deps clawmetry==<version> -d /tmp/cm
+ *   unzip -p /tmp/cm/clawmetry-<version>-py3-none-any.whl \
+ *         clawmetry/static/js/cm-e2e.js > published.js
+ *   diff served.js published.js && echo "identical"
+ *
+ * The page also pins this file with a Subresource Integrity hash, so you can
+ * compare the `integrity=` attribute in the page source against
+ * `openssl dgst -sha384 -binary published.js | openssl base64 -A`.
+ *
+ * WHAT THIS DOES NOT PROVE
+ *
+ * We serve the page that loads this file, so we could serve a different page.
+ * SRI protects you from a compromised CDN, not from the vendor. What it buys
+ * you is that a substitution has to be deliberate, visible in the page source,
+ * and different from a published artifact anyone can fetch — instead of an
+ * invisible change to an unpublished blob. If you need a guarantee that does
+ * not involve trusting us at all, run local-only or self-host; both remove
+ * this file from the picture entirely.
+ *
+ * THE INVARIANTS THIS FILE KEEPS
+ *
+ *   1. The key arrives in the URL FRAGMENT. Browsers never transmit a
+ *      fragment, so it does not reach our logs, a Referer header, or any
+ *      intermediary.
+ *   2. The key is removed from the address bar as soon as it is read, so it
+ *      does not linger in history or get carried off by browser sync.
+ *   3. The key is imported as non-extractable and decrypt-only, so nothing
+ *      later in the page can read it back out of the crypto subsystem.
+ *   4. The key is never put in a request. Not a body, not a header, not a
+ *      query parameter. Search this file for `fetch` and you will find one
+ *      call, and it carries the ACCOUNT token, never the encryption key.
+ */
+(function () {
+  'use strict';
+
+  /* base64url -> bytes. Tolerates missing padding, which is how the daemon
+   * emits both the key and the blob. */
+  function b64url(s) {
+    s = String(s || '').replace(/-/g, '+').replace(/_/g, '/');
+    while (s.length % 4) s += '=';
+    var bin = atob(s);
+    var out = new Uint8Array(bin.length);
+    for (var i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+    return out;
+  }
+
+  /* A key is either real AES key material (16/24/32 bytes of base64url) or a
+   * passphrase the user typed. A passphrase is hashed to 32 bytes so it can be
+   * used as an AES-256 key. This mirrors _derive_key_for_storage on the daemon
+   * side; the daemon additionally salts and scrypts a typed passphrase before
+   * storing it, so what reaches here is normally already real key material. */
+  function normalizeKey(k) {
+    try {
+      var raw = b64url(k);
+      if (raw.byteLength === 16 || raw.byteLength === 24 || raw.byteLength === 32) {
+        return Promise.resolve(k);
+      }
+    } catch (e) { /* not base64 — fall through to hashing */ }
+    var enc = new TextEncoder().encode(k);
+    return crypto.subtle.digest('SHA-256', enc).then(function (hash) {
+      var b = new Uint8Array(hash), s = '';
+      for (var i = 0; i < b.length; i++) s += String.fromCharCode(b[i]);
+      return btoa(s).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+    });
+  }
+
+  /* Where a node's key lives in localStorage. Namespaced by node AND by the
+   * first 16 chars of the account token, so two accounts used in one browser
+   * cannot read each other's keys out of shared storage. */
+  function storageKeyFor(nodeId, accountToken) {
+    var acct = String(accountToken || '').slice(0, 16);
+    if (!nodeId || !acct) return null;
+    return 'cm-enc-key-' + nodeId + '-' + acct;
+  }
+
+  /* AES-256-GCM, nonce = first 12 bytes, matching encrypt_payload in
+   * clawmetry/sync.py. importKey is given extractable=false and ['decrypt'],
+   * so the key cannot be read back out or used to encrypt anything. Returns
+   * null rather than throwing: a blob we cannot read is an empty card, never
+   * a broken page. */
+  function decryptBlob(blob, keyB64) {
+    try {
+      return normalizeKey(keyB64).then(function (nk) {
+        return crypto.subtle.importKey(
+          'raw', b64url(nk), { name: 'AES-GCM' }, false, ['decrypt']
+        );
+      }).then(function (ck) {
+        var raw = b64url(blob);
+        return crypto.subtle.decrypt(
+          { name: 'AES-GCM', iv: raw.slice(0, 12) }, ck, raw.slice(12)
+        );
+      }).then(function (pt) {
+        return JSON.parse(new TextDecoder().decode(pt));
+      }).catch(function () { return null; });
+    } catch (e) {
+      return Promise.resolve(null);
+    }
+  }
+
+  /* Read the hand-off out of the URL fragment and clear it.
+   *
+   * `clawmetry connect` opens:
+   *     https://app.clawmetry.com/cloud#token=<account>&key=<enc>&node=<id>
+   *
+   * Both values are in the fragment. Until August 2026 the account token was
+   * in the query string instead, which meant every connect wrote a live
+   * account credential into the server's request log and the user's history.
+   */
+  function consumeFragment() {
+    var h = window.location.hash || '';
+    if (h.indexOf('key=') < 0 && h.indexOf('token=') < 0) return;
+
+    var hp = new URLSearchParams(h.substring(1));
+    var token = hp.get('token') || '';
+    var key = hp.get('key') || '';
+    var node = hp.get('node') || window.CLOUD_NODE_ID || '';
+
+    if (token && token.indexOf('cm_') === 0) {
+      try { localStorage.setItem('clawmetry-token', token); } catch (e) {}
+      /* One-step onboarding. The server can no longer see the token in the
+       * URL, so it is handed over in a POST body, which is not part of the
+       * logged request line. Best effort: the daemon also learns about the
+       * claim by polling /api/cloud/claim-status. This is the only request in
+       * this file, and it carries the ACCOUNT token, never the encryption
+       * key. */
+      try {
+        fetch('/api/cloud/auto-claim', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ token: token })
+        }).catch(function () {});
+      } catch (e) {}
+    }
+
+    if (key && node) {
+      var resolvedToken = token;
+      if (!resolvedToken) {
+        resolvedToken = window.CLOUD_TOKEN || '';
+        if (!resolvedToken) {
+          try { resolvedToken = localStorage.getItem('clawmetry-token') || ''; } catch (e) {}
+        }
+      }
+      var sk = storageKeyFor(node, resolvedToken);
+      if (sk) {
+        try {
+          localStorage.setItem(sk, key);
+          localStorage.removeItem('cm-enc-skipped-' + sk);
+        } catch (e) {}
+      }
+    }
+
+    /* Clear the fragment unconditionally, even on a path that stored nothing.
+     * A key left in the address bar ends up in history and, when the user has
+     * browser sync on, on the vendor's servers. */
+    try {
+      history.replaceState(null, '', window.location.pathname + window.location.search);
+    } catch (e) {}
+  }
+
+  window.cmE2E = {
+    b64url: b64url,
+    normalizeKey: normalizeKey,
+    storageKeyFor: storageKeyFor,
+    decryptBlob: decryptBlob,
+    consumeFragment: consumeFragment
+  };
+
+  /* Names the rest of the dashboard already binds to. Kept so this file is
+   * the single implementation rather than a second copy of one. */
+  window._cmNormKey = normalizeKey;
+  window.cmDecryptBlob = decryptBlob;
+
+  consumeFragment();
+})();

--- a/tests/test_e2e_invariants.py
+++ b/tests/test_e2e_invariants.py
@@ -11,6 +11,7 @@ passes before the fix guards nothing.
 """
 import json
 import os
+import re
 import sys
 
 import pytest
@@ -244,24 +245,57 @@ def test_dispatcher_refuses_a_prompt_action_when_not_opted_in(monkeypatch):
 # ── Finding 11: the key travels in the fragment, and nowhere else ────────────
 
 
-def test_key_is_delivered_only_in_the_url_fragment():
-    """A refactor from ``#key=`` to ``&key=`` would hand the key to the server
-    with no test failing — this is that test."""
+def _dashboard_handoff_url():
+    """The hand-off URL as one string, however it is spelled in source.
+
+    Reads the ``_dashboard_url = ...`` assignment and joins it, so an
+    f-string split across several lines (which is how it is written now)
+    cannot make this guard silently match nothing and pass.
+    """
     src = open(
         os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
                      "clawmetry", "cli.py"),
         encoding="utf-8",
     ).read()
-    urls = [
-        line for line in src.splitlines()
-        if "{enc_key}" in line and "/cloud" in line
-    ]
-    assert urls, "expected the dashboard hand-off URL to be present"
-    for line in urls:
-        before_fragment = line.split("#")[0]
-        assert "{enc_key}" not in before_fragment, (
-            f"the encryption key must sit after '#', never in the query or path: {line}"
+    marker = "_dashboard_url = "
+    i = src.index(marker)
+    chunk = src[i:i + 600]
+    # Keep only the quoted pieces, which is where the URL actually lives.
+    parts = re.findall(r'f?"([^"]*)"', chunk)
+    joined = "".join(parts)
+    assert "/cloud" in joined, f"could not recover the hand-off URL from: {chunk[:200]}"
+    return joined
+
+
+def test_credentials_are_delivered_only_in_the_url_fragment():
+    """Both secrets must sit after ``#``.
+
+    A fragment is never transmitted. A refactor from ``#key=`` to ``&key=``,
+    or from ``#token=`` back to ``?token=``, hands a live credential to the
+    server, its access log and the browser's history — and would otherwise
+    ship with a green suite. That is not hypothetical: the account key rode in
+    the query string until 2026-08-24 and was measured landing in Cloud
+    Logging about 180 times a day.
+    """
+    url = _dashboard_handoff_url()
+    assert "#" in url, f"the hand-off URL has no fragment at all: {url}"
+    before_fragment, fragment = url.split("#", 1)
+
+    for secret in ("{enc_key}", "{api_key}"):
+        assert secret in url, f"{secret} is no longer in the hand-off URL: {url}"
+        assert secret not in before_fragment, (
+            f"{secret} must sit after '#', never in the query or path: {url}"
         )
+        assert secret in fragment
+
+
+def test_handoff_url_has_no_query_string_at_all():
+    """Nothing in the query string means nothing to leak or to audit later."""
+    url = _dashboard_handoff_url()
+    before_fragment = url.split("#", 1)[0]
+    assert "?" not in before_fragment, (
+        f"the hand-off URL grew a query string again: {url}"
+    )
 
 
 def test_browser_handoff_keeps_the_key_out_of_argv():

--- a/tests/test_published_e2e_js.py
+++ b/tests/test_published_e2e_js.py
@@ -1,0 +1,171 @@
+"""The browser-side decrypt path is published, and it really works.
+
+The August 2026 security review's finding 9 was that the JavaScript which
+receives the encryption key and decrypts the snapshot is served by
+app.clawmetry.com and published nowhere, so "end-to-end encrypted" rested on
+trusting vendor conduct rather than on anything a user could check.
+
+``clawmetry/static/js/cm-e2e.js`` is the answer: it holds every line in the
+browser that touches the key, it ships in the wheel, and the hosted dashboard
+serves it from the installed package.
+
+The test that matters here is `test_published_js_decrypts_real_daemon_output`.
+It encrypts with the real `encrypt_payload` the daemon uses and decrypts with
+the real published JavaScript under node. Asserting the file merely *contains*
+"AES-GCM" would pass against a file that cannot decrypt anything.
+"""
+import json
+import os
+import shutil
+import subprocess
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from clawmetry.sync import encrypt_payload, generate_encryption_key  # noqa: E402
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+E2E_JS = os.path.join(REPO, "clawmetry", "static", "js", "cm-e2e.js")
+
+_BROWSER_SHIMS = """
+const { webcrypto } = require('crypto');
+globalThis.crypto = webcrypto;
+globalThis.atob = s => Buffer.from(s, 'base64').toString('binary');
+globalThis.btoa = s => Buffer.from(s, 'binary').toString('base64');
+globalThis.TextEncoder = require('util').TextEncoder;
+globalThis.TextDecoder = require('util').TextDecoder;
+globalThis.localStorage = { store:{},
+  getItem(k){return this.store[k]||null;},
+  setItem(k,v){this.store[k]=v;},
+  removeItem(k){delete this.store[k];} };
+globalThis.window = globalThis;
+globalThis.history = { calls: [], replaceState(a,b,url){ this.calls.push(url); } };
+globalThis.location = { hash:'', pathname:'/cloud', search:'' };
+globalThis.fetch = (url, opts) => { globalThis.__fetches.push([url, opts]); return Promise.resolve({}); };
+globalThis.__fetches = [];
+"""
+
+
+def _node(script_body, location_hash=""):
+    """Run the published file under node with browser shims and return stdout."""
+    if not shutil.which("node"):
+        pytest.skip("node not available")
+    js = open(E2E_JS, encoding="utf-8").read()
+    prog = (
+        _BROWSER_SHIMS
+        + f"globalThis.location.hash = {json.dumps(location_hash)};\n"
+        + js
+        + "\n"
+        + script_body
+    )
+    import tempfile
+
+    with tempfile.NamedTemporaryFile("w", suffix=".js", delete=False) as fh:
+        fh.write(prog)
+        path = fh.name
+    try:
+        r = subprocess.run(["node", path], capture_output=True, text=True, timeout=60)
+        assert r.returncode == 0, f"node failed: {r.stderr[:600]}"
+        return r.stdout.strip()
+    finally:
+        os.unlink(path)
+
+
+def test_the_published_file_exists_and_is_not_bundled():
+    assert os.path.exists(E2E_JS), "the published decrypt path is missing"
+    src = open(E2E_JS, encoding="utf-8").read()
+    assert len(src) > 2000, "suspiciously small — is this a stub?"
+    # A minified or bundled file cannot be audited by the person relying on it.
+    longest = max(len(line) for line in src.splitlines())
+    assert longest < 400, (
+        f"a {longest}-char line suggests minification; this file must stay readable"
+    )
+
+
+def test_published_js_decrypts_real_daemon_output():
+    """The whole point: our encrypt, their decrypt, real crypto both sides."""
+    key = generate_encryption_key()
+    payload = {
+        "display_name": "Reset the prod database password",
+        "events": [{"id": "ev-1", "tool": "Bash"}],
+        "n": 42,
+    }
+    blob = encrypt_payload(payload, key)
+    out = _node(
+        f"window.cmE2E.decryptBlob({json.dumps(blob)}, {json.dumps(key)})"
+        f".then(r => console.log(JSON.stringify(r)));"
+    )
+    assert json.loads(out) == payload
+
+
+def test_a_wrong_key_returns_null_rather_than_throwing():
+    """An unreadable blob is an empty card, never a broken page."""
+    blob = encrypt_payload({"x": 1}, generate_encryption_key())
+    out = _node(
+        f"window.cmE2E.decryptBlob({json.dumps(blob)}, "
+        f"{json.dumps(generate_encryption_key())})"
+        f".then(r => console.log(JSON.stringify(r)));"
+    )
+    assert out == "null"
+
+
+def test_the_key_is_imported_non_extractable_and_decrypt_only():
+    src = open(E2E_JS, encoding="utf-8").read()
+    assert "'raw', b64url(nk), { name: 'AES-GCM' }, false, ['decrypt']" in src, (
+        "importKey must stay extractable=false with ['decrypt'] only, so nothing "
+        "later in the page can read the key back out or encrypt with it"
+    )
+
+
+def test_the_encryption_key_is_never_put_in_a_request():
+    """One fetch in the file, and it must not carry the key."""
+    key = "SECRETKEYVALUE1234567890"
+    token = "cm_acct_abcdef123456"
+    out = _node(
+        "console.log(JSON.stringify(globalThis.__fetches));",
+        location_hash=f"#token={token}&key={key}&node=mac",
+    )
+    fetches = json.loads(out)
+    assert len(fetches) == 1, f"expected exactly one request, got {fetches}"
+    url, opts = fetches[0]
+    blob = json.dumps([url, opts])
+    assert key not in blob, "the encryption key reached a request"
+    assert token in blob, "the account token is what the claim call carries"
+    assert url == "/api/cloud/auto-claim"
+
+
+def test_the_fragment_is_cleared_from_the_address_bar():
+    """A key left in the URL lands in history and in browser sync."""
+    out = _node(
+        "console.log(JSON.stringify(globalThis.history.calls));",
+        location_hash="#token=cm_acct_abcdef123456&key=SECRETKEY123456&node=mac",
+    )
+    calls = json.loads(out)
+    assert calls, "consumeFragment never cleared the fragment"
+    for url in calls:
+        assert "key=" not in (url or ""), f"the key survived in the URL: {url}"
+        assert "token=" not in (url or ""), f"the token survived in the URL: {url}"
+
+
+def test_the_key_is_stored_namespaced_by_account():
+    """Two accounts in one browser must not read each other's keys."""
+    out = _node(
+        "console.log(JSON.stringify(Object.keys(globalThis.localStorage.store)));",
+        location_hash="#token=cm_acct_abcdef123456&key=SECRETKEY123456&node=mac",
+    )
+    keys = json.loads(out)
+    assert any(k.startswith("cm-enc-key-mac-cm_acct_abcdef") for k in keys), keys
+
+
+def test_storage_key_requires_both_node_and_account():
+    out = _node(
+        "console.log(JSON.stringify([window.cmE2E.storageKeyFor('', 'cm_x'),"
+        " window.cmE2E.storageKeyFor('mac', ''),"
+        " window.cmE2E.storageKeyFor('mac', 'cm_acct_abcdef123456')]));"
+    )
+    a, b, c = json.loads(out)
+    assert a is None and b is None
+    # slice(0, 16) of the account token — the namespace, not the whole key
+    assert c == "cm-enc-key-mac-cm_acct_abcdef12"


### PR DESCRIPTION
The two findings deliberately left open when the rest of the August 2026 security review shipped in 0.12.764. Both were called out in #5150 as needing a coordinated cloud change; the cloud half is in clawmetry-cloud and degrades cleanly if this lands first.

## Finding 9: the decrypt path is now published and pinned

The reviewer's point was precise: the code that parses `#key=`, writes it to `localStorage`, and decrypts your snapshot is served by `app.clawmetry.com` and was not in this repository. So the entire E2E property rested on "a promise about vendor conduct, not a cryptographic guarantee."

Every line in the browser that touches the key now lives in **`clawmetry/static/js/cm-e2e.js`** — the fragment reader, key normalisation, the storage namespace, and the AES-GCM decrypt. It is unminified on purpose, ships inside the wheel, and the hosted dashboard's Flask `static_folder` already points at the installed package, so the served bytes *are* the published bytes for that version. The cloud loads it with a Subresource Integrity hash computed from the file on disk.

The README carries the commands to verify it:

```bash
curl -s https://app.clawmetry.com/static/js/cm-e2e.js -o served.js
unzip -p clawmetry-<version>-py3-none-any.whl clawmetry/static/js/cm-e2e.js > published.js
diff served.js published.js
```

This does not make us untrusted-vendor-proof and the README says so: we serve the page that loads the file. What it buys is that a substitution has to be deliberate, visible in page source, and different from an artifact on PyPI anyone can fetch.

## Finding 11: the account key is out of the query string

`clawmetry connect` opened `/cloud?token=<account key>`. A `cm_` key is a full account credential and servers log the request line, so every connect wrote one into Cloud Logging in plaintext, and left it in browser history. Measured on 2026-08-22 at roughly 180 keys a day across five endpoints.

Both secrets now travel in the fragment, which browsers never transmit:

```
/cloud#token=<account>&key=<enc>&node=<id>
```

One-step onboarding still works: the cloud reads the token from the fragment and hands it to the claim in a POST body, which is not part of the logged request line. The server keeps accepting `?token=` so already-installed CLIs are unaffected.

## Guards

`tests/test_published_e2e_js.py` runs the published file under node against blobs from the real `encrypt_payload`, so it proves the file **actually decrypts** rather than that it contains the string `AES-GCM`. It also pins: non-extractable decrypt-only import, the key never reaching a request, the fragment always cleared, and per-account storage namespacing.

`test_credentials_are_delivered_only_in_the_url_fragment` now covers the token too, and reads the URL as one joined string so an f-string split across lines cannot make the guard match nothing and pass silently. Both new assertions were confirmed red against the old URL shape before being accepted.

Lint is at parity with main (221 pre-existing ruff errors, unchanged); `lint-py39` and `lint-js` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JipgTmfg1BPY2c7vgd9TJm
