### PR TITLE
Say "not recorded by this runtime" instead of showing $0.00

### DIFF
--- a/clawmetry/runtime_records.py
+++ b/clawmetry/runtime_records.py
@@ -1,0 +1,363 @@
+"""What each runtime actually records — so a surface can say "not recorded"
+instead of rendering a zero.
+
+The Observe pillar's real gap was never breadth, it was consistency. Coverage
+is honest *per adapter*, but the surfaces above the adapters (the Cost tab, the
+Efficiency grade, model attribution) are call-event driven: they sum per-call
+token/cost rows. A runtime that never writes per-call cost to disk therefore
+renders as a $0.00 / grade-less / empty panel, which reads as **ClawMetry is
+broken** rather than **this runtime does not record that**.
+
+Those are opposite messages to a buyer. "Cursor spent $0.00 this month" is a
+false statement about their spend; "Cursor does not record cost where ClawMetry
+can read it" is a true statement about Cursor. This module is the difference:
+one declared table of what each runtime persists, so every surface can tell an
+idle runtime apart from a token-blind one and say *which* and *why*.
+
+Ground truth is ``docs/compatibility.md`` — the per-runtime table we maintain
+from real installs and real captures. Each entry below carries the exact
+sentence from that runtime's row that justifies its verdict, and
+``tests/test_runtime_records.py`` fails if the sentence is no longer in the doc.
+So the table cannot quietly drift away from the documented reality, and a new
+runtime cannot be added to the catalogue without someone deciding what it
+records.
+
+Deliberately NOT in here: how ClawMetry reads any of it. No store paths, no
+filenames, no table or column names, no env vars. This module answers "what
+will the operator see", which is the half we publish.
+"""
+from __future__ import annotations
+
+# ── signal states ────────────────────────────────────────────────────────
+# The runtime writes it; ClawMetry reads it straight off the runtime's own
+# record. Numbers are the runtime's, not ours.
+ON_DISK = "on_disk"
+# The runtime does not write it, but ClawMetry can compute it from something
+# the runtime DOES write (cost from token counts x published model prices).
+# Real, and labelled as derived so nobody mistakes it for a vendor invoice.
+DERIVED = "derived"
+# The runtime keeps no record ClawMetry can read. There is no number to show
+# and no way to compute one. This is the state that must never render as 0.
+UNAVAILABLE = "unavailable"
+# Not yet verified against a real capture of this runtime. Honest ignorance —
+# rendered as "not verified", never as a zero and never as a claim.
+UNKNOWN = "unknown"
+
+_STATES = frozenset({ON_DISK, DERIVED, UNAVAILABLE, UNKNOWN})
+
+# Signals a surface can ask about. Deliberately short: these are the three the
+# broken-looking panels actually depend on. Adding a fourth means being able to
+# answer it for all 26 runtimes, which is the bar that keeps this table true.
+SIGNALS = ("tokens", "cost", "model")
+
+
+def _e(tokens, cost, model, evidence, *, note="", doc_label=None, doc_file="docs/compatibility.md"):
+    return {
+        "tokens": tokens,
+        "cost": cost,
+        "model": model,
+        "evidence": evidence,
+        "note": note,
+        "doc_label": doc_label,
+        "doc_file": doc_file,
+    }
+
+
+# Keyed by the runtime ids in ``clawmetry.entitlements.ALL_RUNTIMES``.
+RUNTIME_RECORDS: dict[str, dict] = {
+    # ── OpenClaw family ──────────────────────────────────────────────────
+    "openclaw": _e(
+        ON_DISK, ON_DISK, ON_DISK,
+        "Tokens and pre-computed cost",
+        doc_file="docs/RUNTIME_FAMILY.md",
+        note="OpenClaw writes both token counts and its own cost figure, so "
+             "every cost surface reads the runtime's own numbers.",
+    ),
+    "nemoclaw": _e(
+        ON_DISK, ON_DISK, ON_DISK,
+        "OpenClaw v3 JSONL",
+        doc_label="NVIDIA NemoClaw",
+        note="NemoClaw records in the OpenClaw shape, so it carries the same "
+             "tokens and cost OpenClaw does.",
+    ),
+    "picoclaw": _e(
+        UNAVAILABLE, UNAVAILABLE, ON_DISK,
+        "Tokens/cost not on disk",
+        note="PicoClaw records the conversation and which model answered, but "
+             "no token counts and no cost. Transcripts, tool calls and model "
+             "attribution are complete; spend is not something PicoClaw keeps.",
+    ),
+    "nanoclaw": _e(
+        UNAVAILABLE, UNAVAILABLE, UNAVAILABLE,
+        "Model/tokens/cost not on disk",
+        note="NanoClaw records the conversation only. Transcripts and message "
+             "counts are complete; model, tokens and cost are not written "
+             "anywhere ClawMetry can read.",
+    ),
+    "hermes": _e(
+        ON_DISK, ON_DISK, ON_DISK,
+        "pre-computed tokens/cost",
+        note="Hermes computes and stores its own tokens and cost, so cost "
+             "surfaces read the runtime's numbers rather than ours.",
+    ),
+    # ── coding agents that record usage but not money ────────────────────
+    "claude_code": _e(
+        ON_DISK, DERIVED, ON_DISK,
+        "token usage",
+        note="Claude Code records token usage per turn but not a dollar "
+             "figure. ClawMetry prices those tokens at published rates, so "
+             "cost here is an API-equivalent estimate, not a vendor invoice — "
+             "on a Claude subscription the incremental cost is $0.",
+    ),
+    "codex": _e(
+        ON_DISK, DERIVED, ON_DISK,
+        "token usage",
+        note="Codex records token usage but no dollar figure. ClawMetry "
+             "prices those tokens at published rates, so cost is an "
+             "API-equivalent estimate rather than a vendor invoice.",
+    ),
+    "aider": _e(
+        ON_DISK, DERIVED, ON_DISK,
+        "token counts",
+        note="Aider records token counts per exchange but no cost. ClawMetry "
+             "prices them at published rates.",
+    ),
+    "goose": _e(
+        ON_DISK, DERIVED, ON_DISK,
+        "real token totals",
+        note="Goose records real token totals but no cost figure. ClawMetry "
+             "prices them at published rates.",
+    ),
+    "qwen_code": _e(
+        ON_DISK, DERIVED, ON_DISK,
+        "real token usage",
+        note="Qwen Code records real token usage but no cost figure. "
+             "ClawMetry prices it at published rates.",
+    ),
+    "grok": _e(
+        ON_DISK, DERIVED, ON_DISK,
+        "per-turn token split",
+        note="Grok records a per-turn token split and which model served it, "
+             "but no cost. ClawMetry prices the tokens at published rates.",
+    ),
+    "gemini_cli": _e(
+        ON_DISK, DERIVED, ON_DISK,
+        "Per-turn token split",
+        note="Gemini CLI records a per-turn token split and the model id, but "
+             "no cost. ClawMetry prices the tokens at published rates.",
+    ),
+    # ── runtimes that record money themselves ────────────────────────────
+    "opencode": _e(
+        ON_DISK, ON_DISK, ON_DISK,
+        "real tokens + cost",
+        note="opencode stores both tokens and cost, so the numbers shown are "
+             "the runtime's own.",
+    ),
+    "pi": _e(
+        ON_DISK, ON_DISK, ON_DISK,
+        "real tokens + cost",
+        note="Pi stores both tokens and cost, so the numbers shown are the "
+             "runtime's own.",
+    ),
+    "deepagents": _e(
+        ON_DISK, ON_DISK, ON_DISK,
+        "real tokens + cost",
+        doc_label="Deep Agents",
+        note="Deep Agents stores both tokens and cost, so the numbers shown "
+             "are the runtime's own.",
+    ),
+    "antigravity": _e(
+        ON_DISK, ON_DISK, ON_DISK,
+        "token split (prompt/thinking/response) and cost",
+        note="Antigravity records a per-generation token split and cost, "
+             "including background generations that burn tokens with no "
+             "visible turn.",
+    ),
+    "copilot": _e(
+        ON_DISK, ON_DISK, ON_DISK,
+        "vendor-billed AI-credit cost",
+        doc_label="GitHub Copilot",
+        note="Copilot records a cache-aware token split and the AI-credit "
+             "cost the vendor actually bills, so this is a real charge rather "
+             "than an estimate.",
+    ),
+    "exo": _e(
+        ON_DISK, ON_DISK, ON_DISK,
+        "Per-call usage + cost persisted by Exo itself",
+        note="Exo persists per-call usage and cost itself, so the numbers "
+             "shown are the runtime's own.",
+    ),
+    "cline": _e(
+        ON_DISK, ON_DISK, ON_DISK,
+        "Cost in USD is on disk",
+        note="Cline records cost in USD directly, which is rare — the figure "
+             "shown is the runtime's own, not a price-list estimate.",
+    ),
+    "openhands": _e(
+        ON_DISK, ON_DISK, ON_DISK,
+        "Tokens and per-call cost live in the sidecar",
+        note="OpenHands records tokens and per-call cost. Its cost reads 0.00 "
+             "both for a free local model and for a pricing lookup it could "
+             "not resolve, so a genuine zero and a missing price look alike.",
+    ),
+    # ── partial / conditional ────────────────────────────────────────────
+    "n8n": _e(
+        ON_DISK, ON_DISK, ON_DISK,
+        "tokens + cost where the model sub-node records usage",
+        note="n8n records tokens and cost only for workflow steps whose model "
+             "node reports usage. Steps that do not report leave real spend "
+             "uncounted, so an n8n total is a floor, not a full bill.",
+    ),
+    # ── token-blind runtimes ─────────────────────────────────────────────
+    "cursor": _e(
+        UNAVAILABLE, UNAVAILABLE, ON_DISK,
+        "No billed cost on disk (server-side)",
+        note="Cursor bills server-side and keeps no token or cost record on "
+             "the machine. Transcripts and model attribution are complete; "
+             "spend has to come from Cursor's own billing page.",
+    ),
+    "deepseek_harness": _e(
+        UNAVAILABLE, UNAVAILABLE, ON_DISK,
+        "Transcripts, model, tool calls",
+        doc_label="DeepSeek Harness",
+        note="DeepSeek Harness records the conversation, the model and tool "
+             "calls, but no token counts and no cost.",
+    ),
+    "kimi": _e(
+        UNKNOWN, UNKNOWN, UNAVAILABLE,
+        "Model id is not written to disk",
+        doc_label="Kimi CLI",
+        note="Kimi CLI does not write the model id, so model attribution is "
+             "blank by design. Whether it records usage has not been verified "
+             "against a real capture yet.",
+    ),
+    "qm": _e(
+        UNAVAILABLE, UNAVAILABLE, UNAVAILABLE,
+        "delegates to Pi / opencode / Codex / Claude Code, which show up as "
+        "their own runtimes",
+        note="QM orchestrates other runtimes rather than calling models "
+             "itself. Its spend appears under the runtime that did the work, "
+             "so a QM total of zero is correct, not missing data.",
+    ),
+    "devin": _e(
+        UNKNOWN, UNKNOWN, UNKNOWN,
+        "Sessions and tool calls",
+        note="Not yet verified against a real capture. Sessions and tool "
+             "calls are read; whether usage and cost are recorded has not "
+             "been confirmed, so no number is claimed either way.",
+    ),
+}
+
+
+def record_for(runtime: str | None) -> dict:
+    """What ``runtime`` records. Unknown ids get the all-``UNKNOWN`` shape
+    rather than an exception — a surface asking about a runtime we have never
+    heard of must still render something honest."""
+    key = (runtime or "").strip().lower()
+    entry = RUNTIME_RECORDS.get(key)
+    if entry is None:
+        return {"tokens": UNKNOWN, "cost": UNKNOWN, "model": UNKNOWN,
+                "evidence": "", "note": "", "doc_label": None,
+                "doc_file": "docs/compatibility.md"}
+    return entry
+
+
+def state_of(runtime: str | None, signal: str) -> str:
+    """State of one signal (``tokens`` / ``cost`` / ``model``) for a runtime."""
+    return record_for(runtime).get(signal, UNKNOWN)
+
+
+def is_recorded(runtime: str | None, signal: str) -> bool:
+    """True when a real number can be shown for ``signal`` — either the
+    runtime wrote it or ClawMetry can derive it. False means the panel must
+    say so instead of rendering a zero."""
+    return state_of(runtime, signal) in (ON_DISK, DERIVED)
+
+
+def unrecorded_signals(runtime: str | None) -> list[str]:
+    """Signals this runtime does not record at all. Empty for a runtime that
+    records everything, and empty for ``UNKNOWN`` — unverified is not the same
+    claim as absent."""
+    rec = record_for(runtime)
+    return [s for s in SIGNALS if rec.get(s) == UNAVAILABLE]
+
+
+def unverified_signals(runtime: str | None) -> list[str]:
+    """Signals we have not verified for this runtime."""
+    rec = record_for(runtime)
+    return [s for s in SIGNALS if rec.get(s, UNKNOWN) == UNKNOWN]
+
+
+def _label(runtime: str | None) -> str:
+    try:
+        from clawmetry.entitlements import RUNTIME_LABELS
+        return RUNTIME_LABELS.get((runtime or "").strip().lower()) or (runtime or "this runtime")
+    except Exception:
+        return runtime or "this runtime"
+
+
+def coverage_payload(runtime: str | None, *, has_data: bool = False) -> dict:
+    """The block every cost/usage/efficiency surface attaches when it is
+    scoped to one runtime.
+
+    ``has_data`` is whether the surface actually found rows. It is what
+    separates the two empty states that look identical today:
+
+      * ``status="not_recorded"`` — the runtime keeps no such record. Show the
+        reason. A zero here would be a false statement about the user's spend.
+      * ``status="unverified"``  — we have not confirmed what this runtime
+        records. Say that; claim nothing.
+      * ``status="no_activity"`` — the runtime records it fine and there was
+        simply nothing in the window. A zero here is true.
+      * ``status="ok"``          — real data.
+
+    Always returns a dict; never raises.
+    """
+    try:
+        rt = (runtime or "").strip().lower()
+        rec = record_for(rt)
+        label = _label(rt)
+        missing = unrecorded_signals(rt)
+        unverified = unverified_signals(rt)
+        cost_state = rec.get("cost", UNKNOWN)
+
+        if has_data:
+            status = "ok"
+        elif cost_state == UNAVAILABLE:
+            status = "not_recorded"
+        elif cost_state == UNKNOWN:
+            status = "unverified"
+        else:
+            status = "no_activity"
+
+        if status == "not_recorded":
+            headline = f"Not recorded by {label}"
+        elif status == "unverified":
+            headline = f"Not verified for {label}"
+        elif status == "no_activity":
+            headline = f"No activity for {label} in this window"
+        else:
+            headline = ""
+
+        return {
+            "runtime": rt,
+            "runtime_label": label,
+            "status": status,
+            "headline": headline,
+            "detail": rec.get("note") or "",
+            "records": {s: rec.get(s, UNKNOWN) for s in SIGNALS},
+            "unrecorded": missing,
+            "unverified": unverified,
+            # True only when the surface must suppress its number entirely.
+            # A UI reading one boolean gets the safe behaviour by default.
+            "suppress_zero": status in ("not_recorded", "unverified"),
+            "cost_is_estimate": cost_state == DERIVED,
+        }
+    except Exception:
+        return {
+            "runtime": (runtime or ""), "runtime_label": (runtime or ""),
+            "status": "unverified", "headline": "", "detail": "",
+            "records": {s: UNKNOWN for s in SIGNALS},
+            "unrecorded": [], "unverified": list(SIGNALS),
+            "suppress_zero": False, "cost_is_estimate": False,
+        }

--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -11326,6 +11326,24 @@ function _cmSetRuntimeFilter(v, reload) {
   if (typeof reload === 'function') reload();
 }
 function _cmRuntimeLabel(rt) { return _CM_RT_LABEL[rt] || rt; }
+
+// Empty-state copy for a runtime-scoped cost surface.
+//
+// Three empty states look identical on screen and mean opposite things:
+//   * the runtime keeps no cost record   -> the number will NEVER arrive
+//   * we have not verified this runtime  -> we should claim nothing
+//   * the runtime was simply idle        -> zero is the true answer
+// The server attaches `coverage` (clawmetry/runtime_records.py) so the UI
+// stops saying "yet" to the first two. Falls back to the old wording when
+// coverage is absent (older daemon, or a node-wide request).
+function _cmCoverageNoteHtml(cov, rtLabel) {
+  if (cov && cov.suppress_zero) {
+    var head = '<strong>' + escHtml(cov.headline || '') + '</strong>';
+    var why = cov.detail ? '<div style="margin-top:3px;">' + escHtml(cov.detail) + '</div>' : '';
+    return head + why;
+  }
+  return 'No cost data recorded for <strong>' + escHtml(rtLabel) + '</strong> yet.';
+}
 // Runtime to use for CLIENT-SIDE prefix filtering of a node-wide blob (Brain
 // list/chart, Tracing, model attribution, active tasks, transcripts). A foreign
 // OTLP app has no session-id prefix, so a prefix filter would empty the view —
@@ -16841,6 +16859,18 @@ function _renderEfficiencyCardInner(card, eff) {
   }
   if (eff.insufficient_data || !eff.grade) {
     card.style.display = '';
+    // The grade is computed from per-call cost. A runtime that never records
+    // per-call cost cannot ever produce one, so "collecting… appears after
+    // about a day" would be a promise we can't keep. eff.coverage says which
+    // case this is; it is absent for node-wide (mixed-runtime) requests.
+    var _cvE = eff.coverage;
+    if (_cvE && _cvE.suppress_zero) {
+      card.innerHTML = '<div style="padding:16px;color:var(--text-muted);font-size:13px;">'
+        + '<div style="font-weight:600;color:var(--text-secondary);margin-bottom:4px;">'
+        + escHtml(_cvE.headline || '') + '</div>'
+        + escHtml(_cvE.detail || '') + '</div>';
+      return;
+    }
     card.innerHTML = '<div style="padding:16px;color:var(--text-muted);font-size:13px;">⏳ '
       + escHtml(t('efficiency.collecting', null, 'Collecting efficiency data. Your grade appears after about a day of activity.')) + '</div>';
     return;
@@ -17137,7 +17167,12 @@ async function loadUsage() {
     var _uEmptyEl = document.getElementById('usage-runtime-empty-note');
     if (_uRt && _uRt !== 'all' && !data.today && !data.week && !data.month) {
       var _uRtLabel = _cmRuntimeLabel(_uRt);
-      var _uEmptyHtml = '<div id="usage-runtime-empty-note" style="margin:8px 0 12px;padding:9px 13px;border-radius:8px;background:rgba(99,102,241,0.07);border:1px solid rgba(99,102,241,0.25);font-size:12px;color:var(--text-secondary);">No cost data recorded for <strong>' + escHtml(_uRtLabel) + '</strong> yet.</div>';
+      // "yet" is only true for a runtime that DOES record cost and happened
+      // to be idle. For a runtime that never writes per-call cost, "yet"
+      // promises a number that will never arrive. data.coverage knows which.
+      var _uEmptyHtml = '<div id="usage-runtime-empty-note" style="margin:8px 0 12px;padding:9px 13px;border-radius:8px;background:rgba(99,102,241,0.07);border:1px solid rgba(99,102,241,0.25);font-size:12px;color:var(--text-secondary);">'
+        + _cmCoverageNoteHtml(data.coverage, _uRtLabel)
+        + '</div>';
       // Anchor on the section title (not the chart div) so the note stays
       // visible when QW4 hides the empty chart section below it.
       var _uAnchor = document.getElementById('usage-chart-title') || document.getElementById('usage-chart');

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -14904,6 +14904,38 @@ def _runtime_of_session(sid: str) -> str:
     return "openclaw"
 
 
+def _build_runtime_records():
+    """Per-runtime "what does this runtime record" verdicts for the snapshot.
+
+    The Cost tab and the Efficiency card are call-event driven: with no
+    per-call cost rows they render $0.00 / "grade appears after about a day".
+    For a runtime that never writes per-call cost, both are false. Locally the
+    handlers attach the verdict themselves; on cloud there are no handlers, so
+    the verdict has to travel in the snapshot for the interceptor to attach.
+
+    Static (a declared table, not a measurement) and small. Best-effort: any
+    failure yields ``{}`` and the UI keeps its older, vaguer wording.
+    """
+    try:
+        from clawmetry.runtime_records import RUNTIME_RECORDS, SIGNALS, coverage_payload
+        out = {}
+        for rt in RUNTIME_RECORDS:
+            base = coverage_payload(rt, has_data=False)
+            out[rt] = {
+                "runtime_label": base["runtime_label"],
+                "records": {s: base["records"][s] for s in SIGNALS},
+                "headline": base["headline"],
+                "detail": base["detail"],
+                "suppress_zero": base["suppress_zero"],
+                "cost_is_estimate": base["cost_is_estimate"],
+                "status_when_empty": base["status"],
+            }
+        return out
+    except Exception as _e:
+        log.debug("runtimeRecords slice failed: %s", _e)
+        return {}
+
+
 def _build_runtime_summary(limit: int = 20000):
     """Per-runtime rollup so the cloud Models / Cost / Overview tabs can scope
     aggregates to the selected runtime for real (not just show a note).
@@ -20229,6 +20261,12 @@ def sync_system_snapshot(config: dict, state: dict, paths: dict) -> int:
         "diagnostics": _build_diagnostics(paths.get("workspace")),
         "modelAttribution": _build_model_attribution(),
         "runtimeSummary": _runtime_summary,
+        # What each runtime actually records (clawmetry/runtime_records.py).
+        # Rides the snapshot so the HOSTED dashboard can tell "this runtime
+        # was idle" apart from "this runtime keeps no cost record" — without
+        # it the cloud goes back to promising a number that will never
+        # arrive. Static, tiny (26 short entries), and content-free.
+        "runtimeRecords": _build_runtime_records(),
         "transcripts": _build_transcripts(
             extra_sids=[
                 s["sessionId"]

--- a/docs/ac_coverage_baseline.json
+++ b/docs/ac_coverage_baseline.json
@@ -8,7 +8,7 @@
     "after coverage improves, so the ratchet is tightened in the same PR.",
     "Regenerate with: python3 scripts/check_ac_coverage.py --update-baseline"
   ],
-  "covered_count": 10,
+  "covered_count": 11,
   "total_count": 77,
   "uncovered": [
     "AC-GOV-001.1",
@@ -49,7 +49,6 @@
     "AC-OBS-002.3",
     "AC-OBS-003.2",
     "AC-OBS-003.3",
-    "AC-OBS-CEA-001.2",
     "AC-OBS-CEA-001.3",
     "AC-OBS-CEA-002.1",
     "AC-OBS-GHA-001.1",

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1,6 +1,6 @@
 # Runtime / Agent Compatibility
 
-ClawMetry observes 22 AI-agent runtimes. Each runtime that
+ClawMetry observes 26 AI-agent runtimes. Each runtime that
 isn't OpenClaw ships a dedicated reader adapter (`clawmetry/adapters/`) that
 translates its native session format into ClawMetry's unified Session/Event
 shapes; the daemon then ingests them into the same local DuckDB store and cloud
@@ -42,6 +42,7 @@ See [`NUMBAT.md`](NUMBAT.md).
 | Gemini CLI | Beta adapter | One JSONL chat recording per session under `~/.gemini/tmp/<project-basename>/chats/session-<ts>-<id8>.jsonl` | Recording is always on (no setting to enable). Per-turn token split + model id + tool calls with results, and nested `chats/<parentSessionId>/` sub-agent transcripts. The project dir is the cwd's BASENAME; the sha256 is stored inside the file as `projectHash`. `GEMINI_CLI_HOME` names the dir *containing* `.gemini`. |
 | Cline | Beta adapter | SQLite index at `~/.cline/data/db/sessions.db` plus `~/.cline/data/sessions/<id>/<id>.messages.json` per session | Cost in USD is on disk, which is rare. The index records `pid`, `status` and sub-agent lineage, so liveness is reported rather than guessed. Rejected tool calls are surfaced as errors. Note the `data` leaf: `~/.cline` itself holds only hooks and worktrees. |
 | OpenHands | Beta adapter | One directory per conversation under `~/.openhands/conversations/<hex>/` — `base_state.json` plus one immutable JSON file per event | Tokens and per-call cost live in the sidecar, never on the events. The directory name is the conversation id with dashes stripped. `prompt_tokens` is cumulative across calls, and cost reads 0.0 both for a free local model and for a failed pricing lookup. Delegated sub-agents nest under `subagents/`. |
+| Devin | Beta adapter | One SQLite store for every session (`$XDG_DATA_HOME/devin/cli/sessions.db`) holding a message forest plus the ACP tool-call records | Sessions and tool calls. Fork and revert leave abandoned branches, which the adapter excludes so they are never billed. Whether usage and cost are recorded has not been verified against a real capture yet, so no token or cost number is claimed. Devin Cloud sessions are API-only and not ingested. |
 | ZeroClaw / TrustClaw / Nanobot | Not yet | unverified | Open an issue with a real session capture. |
 
 OpenClaw, NVIDIA NemoClaw and Goose are free in the OSS package — their

--- a/routes/usage.py
+++ b/routes/usage.py
@@ -225,6 +225,28 @@ def _ls_call(method_name, **kwargs):
         return None
 
 
+def _runtime_coverage(runtime, *, has_data):
+    """Coverage block for a runtime-scoped cost/usage payload.
+
+    A call-event-driven surface cannot tell "this runtime was idle" apart
+    from "this runtime never writes per-call cost", and both render as
+    $0.00. For a token-blind runtime that zero is a false statement about
+    the user's spend. ``clawmetry.runtime_records`` knows which is which;
+    this attaches the answer so the UI can say so.
+
+    Returns ``None`` for an unscoped (node-wide) request — a node mixes
+    runtimes, so there is no single honest verdict to attach.
+    """
+    rt = (runtime or "").strip().lower()
+    if not rt or rt == "all":
+        return None
+    try:
+        from clawmetry.runtime_records import coverage_payload
+        return coverage_payload(rt, has_data=bool(has_data))
+    except Exception:
+        return None
+
+
 def _try_local_store_usage(runtime: Optional[str] = None):
     """Fast path for /api/usage. Builds the daily token/cost chart by
     aggregating ``daily_aggregates`` (with a ``query_events`` fallback if
@@ -398,6 +420,12 @@ def _try_local_store_usage(runtime: Optional[str] = None):
         "warnings": [],
         "routing_savings_usd": round(float(routing_data.get("total_savings_usd") or 0.0), 6),
         "routing_substitutions": routing_data.get("by_pair") or [],
+        # Runtime-scoped honesty: says whether a $0 here means "idle" or
+        # "this runtime keeps no cost record". None when unscoped.
+        "coverage": _runtime_coverage(
+            runtime,
+            has_data=bool(month_tok or month_cost or today_tok or today_cost),
+        ),
     }
 
 
@@ -4542,6 +4570,14 @@ def api_efficiency():
                          "projected_monthly_cost_usd": 0.0, "actions": []}
         entry = dict(entry)
         entry["runtime"] = runtime
+        # ``insufficient_data`` alone conflates two opposite messages: a
+        # runtime that was idle, and a runtime that never writes the
+        # per-call cost this grade is computed from. The second one can
+        # never produce a grade no matter how long the user waits, so
+        # "not enough data yet" is a lie that costs them a support ticket.
+        entry["coverage"] = _runtime_coverage(
+            runtime, has_data=not entry.get("insufficient_data")
+        )
         return jsonify(entry)
     return jsonify(out)
 

--- a/tests/test_efficiency.py
+++ b/tests/test_efficiency.py
@@ -31,10 +31,12 @@ the "Cost and Efficiency Analytics" requirement in 8090 Software Factory):
   asserts ``cache_saved_monthly_usd`` (realised) separately from the
   ``actions[].savings_monthly_usd`` recommendations (potential).
 
-Deliberately NOT claimed here: AC-OBS-CEA-001.2 (an undeterminable cost must
-read as unavailable, never as zero) and AC-OBS-CEA-001.3 (one definition of a
-time scope across surfaces). Both are still uncovered -- see
-docs/ac_coverage_baseline.json.
+AC-OBS-CEA-001.2 (an undeterminable cost must read as unavailable, never as
+zero) is covered in tests/test_runtime_records.py, which is where the
+"does this runtime record cost at all" verdict lives.
+
+Deliberately NOT claimed here: AC-OBS-CEA-001.3 (one definition of a time
+scope across surfaces) -- still uncovered, see docs/ac_coverage_baseline.json.
 """
 from __future__ import annotations
 

--- a/tests/test_runtime_records.py
+++ b/tests/test_runtime_records.py
@@ -1,0 +1,237 @@
+"""Guards for clawmetry/runtime_records.py — the table that lets a cost
+surface say "not recorded by this runtime" instead of rendering $0.00.
+
+The table is only worth anything if it stays true. These guards are
+auto-discovering: they walk the catalogue and the doc rather than an
+allowlist, so a NEW runtime fails them until someone decides what it records,
+and an EDITED doc row fails them until the verdict is re-derived.
+
+Acceptance criteria proven here (docs/acceptance_criteria.json):
+
+* AC-OBS-CEA-001.2 -- when a cost value cannot be determined the system
+  identifies it as unavailable rather than reporting a zero:
+  ``test_token_blind_runtime_suppresses_its_zero``,
+  ``test_unverified_runtime_claims_nothing``,
+  ``test_efficiency_endpoint_says_not_recorded_for_a_token_blind_runtime``,
+  ``test_usage_endpoint_attaches_coverage_when_scoped``. The companion guard
+  that a runtime which CAN report cost keeps its honest zero is
+  ``test_idle_but_capable_runtime_keeps_its_zero`` -- "unavailable" must not
+  swallow a real $0.
+"""
+import re
+
+import pytest
+
+from clawmetry import runtime_records as rr
+from clawmetry.entitlements import ALL_RUNTIMES, RUNTIME_COUNT, RUNTIME_LABELS
+
+
+def _doc(path):
+    with open(path, encoding="utf-8") as fh:
+        return fh.read()
+
+
+def _table_row(text, label):
+    """The compatibility.md table row whose first cell is exactly ``label``."""
+    for line in text.splitlines():
+        if not line.startswith("|"):
+            continue
+        cells = [c.strip() for c in line.strip().strip("|").split("|")]
+        if cells and cells[0] == label:
+            return line
+    return None
+
+
+def test_every_catalogued_runtime_has_a_record():
+    """A new runtime cannot ship without someone deciding what it records.
+
+    Without this, a 27th runtime silently inherits the all-UNKNOWN fallback
+    and its Cost tab goes back to rendering an unexplained blank.
+    """
+    missing = sorted(set(ALL_RUNTIMES) - set(rr.RUNTIME_RECORDS))
+    assert not missing, f"runtimes with no runtime_records entry: {missing}"
+
+
+def test_no_records_for_runtimes_that_are_not_catalogued():
+    extra = sorted(set(rr.RUNTIME_RECORDS) - set(ALL_RUNTIMES))
+    assert not extra, f"runtime_records entries for unknown runtimes: {extra}"
+
+
+@pytest.mark.parametrize("runtime", sorted(rr.RUNTIME_RECORDS))
+def test_states_are_valid(runtime):
+    entry = rr.RUNTIME_RECORDS[runtime]
+    for signal in rr.SIGNALS:
+        assert entry[signal] in rr._STATES, (
+            f"{runtime}.{signal} = {entry[signal]!r} is not a known state"
+        )
+
+
+@pytest.mark.parametrize("runtime", sorted(rr.RUNTIME_RECORDS))
+def test_derived_cost_requires_tokens_on_disk(runtime):
+    """Cost is derived by pricing tokens. Claiming DERIVED cost without
+    tokens on disk would mean claiming a number with nothing behind it."""
+    entry = rr.RUNTIME_RECORDS[runtime]
+    if entry["cost"] == rr.DERIVED:
+        assert entry["tokens"] == rr.ON_DISK, (
+            f"{runtime} claims derived cost but records no tokens"
+        )
+
+
+@pytest.mark.parametrize("runtime", sorted(rr.RUNTIME_RECORDS))
+def test_unavailable_cost_is_not_secretly_derivable(runtime):
+    """If tokens are on disk, cost is derivable — so calling cost
+    UNAVAILABLE would suppress a number we could honestly show."""
+    entry = rr.RUNTIME_RECORDS[runtime]
+    if entry["cost"] == rr.UNAVAILABLE:
+        assert entry["tokens"] != rr.ON_DISK, (
+            f"{runtime} has tokens on disk, so its cost is derivable, not unavailable"
+        )
+
+
+@pytest.mark.parametrize("runtime", sorted(rr.RUNTIME_RECORDS))
+def test_verdict_is_grounded_in_the_docs(runtime):
+    """Each verdict cites a sentence from that runtime's documented row.
+
+    Edit the doc and this fails, which is the point: the table cannot drift
+    away from the compatibility matrix we actually maintain.
+    """
+    entry = rr.RUNTIME_RECORDS[runtime]
+    text = _doc(entry["doc_file"])
+    evidence = entry["evidence"]
+    assert evidence, f"{runtime} cites no evidence"
+    if entry["doc_file"].endswith("compatibility.md"):
+        label = entry["doc_label"] or RUNTIME_LABELS[runtime]
+        row = _table_row(text, label)
+        assert row is not None, (
+            f"{runtime}: no row titled {label!r} in docs/compatibility.md"
+        )
+        assert evidence in row, (
+            f"{runtime}: cited evidence {evidence!r} is no longer in its "
+            f"docs/compatibility.md row — re-derive the verdict"
+        )
+    else:
+        assert evidence in text, (
+            f"{runtime}: cited evidence {evidence!r} is no longer in "
+            f"{entry['doc_file']}"
+        )
+
+
+@pytest.mark.parametrize("runtime", sorted(rr.RUNTIME_RECORDS))
+def test_every_runtime_explains_itself(runtime):
+    """A "not recorded" badge with no reason is barely better than a zero."""
+    note = rr.RUNTIME_RECORDS[runtime]["note"]
+    assert note and len(note) > 40, f"{runtime} has no operator-facing note"
+
+
+def test_compatibility_doc_states_the_real_runtime_count():
+    text = _doc("docs/compatibility.md")
+    m = re.search(r"ClawMetry observes (\d+) AI-agent runtimes", text)
+    assert m, "compatibility.md no longer states a runtime count"
+    assert int(m.group(1)) == RUNTIME_COUNT, (
+        f"compatibility.md says {m.group(1)} runtimes; the catalogue has "
+        f"{RUNTIME_COUNT}"
+    )
+
+
+# ── the payload contract every surface depends on ────────────────────────
+
+def test_token_blind_runtime_suppresses_its_zero():
+    p = rr.coverage_payload("cursor")
+    assert p["status"] == "not_recorded"
+    assert p["suppress_zero"] is True
+    assert p["headline"] == "Not recorded by Cursor"
+    assert p["detail"]
+    assert "cost" in p["unrecorded"]
+
+
+def test_idle_but_capable_runtime_keeps_its_zero():
+    """OpenClaw records cost fine. An empty window means zero spend, and a
+    zero is the true answer — it must NOT be suppressed."""
+    p = rr.coverage_payload("openclaw")
+    assert p["status"] == "no_activity"
+    assert p["suppress_zero"] is False
+
+
+def test_data_present_always_wins():
+    p = rr.coverage_payload("cursor", has_data=True)
+    assert p["status"] == "ok"
+    assert p["suppress_zero"] is False
+
+
+def test_unverified_runtime_claims_nothing():
+    p = rr.coverage_payload("devin")
+    assert p["status"] == "unverified"
+    assert p["suppress_zero"] is True
+    assert "Not verified" in p["headline"]
+
+
+def test_derived_cost_is_labelled_as_an_estimate():
+    assert rr.coverage_payload("claude_code", has_data=True)["cost_is_estimate"] is True
+    assert rr.coverage_payload("opencode", has_data=True)["cost_is_estimate"] is False
+
+
+def test_unknown_runtime_does_not_raise():
+    p = rr.coverage_payload("no_such_runtime_at_all")
+    assert p["status"] == "unverified"
+    assert p["records"]["cost"] == rr.UNKNOWN
+
+
+def test_is_recorded_reads_both_on_disk_and_derived():
+    assert rr.is_recorded("opencode", "cost") is True     # runtime's own number
+    assert rr.is_recorded("claude_code", "cost") is True   # priced by us
+    assert rr.is_recorded("cursor", "cost") is False
+    assert rr.is_recorded("devin", "cost") is False
+
+
+# ── endpoint wiring: the surfaces that used to render the zero ───────────
+
+@pytest.fixture()
+def usage_app(monkeypatch):
+    """Flask app with routes.usage mounted and its store read stubbed to an
+    EMPTY rollup — the exact condition that used to paint $0.00 and "grade
+    appears after about a day" for a runtime that will never report cost."""
+    from flask import Flask
+
+    import routes.usage as usage_mod
+
+    monkeypatch.setattr(usage_mod, "_ls_call", lambda *a, **k: [])
+    app = Flask(__name__)
+    app.register_blueprint(usage_mod.bp_usage)
+    return app
+
+
+def test_efficiency_endpoint_says_not_recorded_for_a_token_blind_runtime(usage_app):
+    body = usage_app.test_client().get("/api/efficiency?runtime=cursor").get_json()
+    assert body["insufficient_data"] is True
+    cov = body["coverage"]
+    assert cov["status"] == "not_recorded"
+    assert cov["suppress_zero"] is True
+    assert cov["headline"] == "Not recorded by Cursor"
+    assert cov["detail"]
+
+
+def test_efficiency_endpoint_keeps_the_honest_zero_for_a_capable_runtime(usage_app):
+    """OpenClaw records cost. An empty window is a real, reportable $0 and
+    must NOT be dressed up as "this runtime does not support it"."""
+    body = usage_app.test_client().get("/api/efficiency?runtime=openclaw").get_json()
+    cov = body["coverage"]
+    assert cov["status"] == "no_activity"
+    assert cov["suppress_zero"] is False
+
+
+def test_efficiency_node_wide_attaches_no_verdict(usage_app):
+    """A node mixes runtimes, so there is no single honest verdict."""
+    body = usage_app.test_client().get("/api/efficiency").get_json()
+    assert body.get("coverage") is None
+
+
+def test_usage_endpoint_attaches_coverage_when_scoped():
+    """/api/usage's fast path carries the same verdict, so the Cost tab and
+    the Efficiency card cannot disagree about the same runtime."""
+    import routes.usage as usage_mod
+
+    cov = usage_mod._runtime_coverage("cursor", has_data=False)
+    assert cov["status"] == "not_recorded"
+    assert usage_mod._runtime_coverage("cursor", has_data=True)["status"] == "ok"
+    assert usage_mod._runtime_coverage("", has_data=False) is None
+    assert usage_mod._runtime_coverage("all", has_data=False) is None


### PR DESCRIPTION
## The bug

The Cost tab and the Efficiency grade are call-event driven — they sum per-call token/cost rows. A runtime that never writes per-call cost to disk rendered as **\$0.00**, or as *"Collecting efficiency data. Your grade appears after about a day of activity."*

Both are false, and both are the opposite of the true statement:

- "Cursor spent \$0.00 this month" is wrong about the user's spend.
- "your grade appears after about a day" promises a number that will **never** arrive — the input it is computed from does not exist.

A buyer reads either as *ClawMetry is broken*, not as *this runtime doesn't keep that record*.

## Why the surfaces couldn't tell

Nothing in the system knew which runtimes record what. `insufficient_data` conflated **idle** with **token-blind**.

## The fix

`clawmetry/runtime_records.py` — for each of the 26 catalogued runtimes, whether `tokens` / `cost` / `model` are:

| state | meaning |
|---|---|
| `on_disk` | the runtime writes it |
| `derived` | we compute it from what it does write (cost from tokens × published rates) |
| `unavailable` | absent entirely — this is the state that must never render as 0 |
| `unknown` | not yet verified — claim nothing |

Ground truth is `docs/compatibility.md`, the per-runtime matrix already maintained from real installs. **Every entry cites the exact sentence from its own row**, and the guards fail if that sentence leaves the doc — so the table can't drift, and a 27th runtime can't be catalogued without someone deciding what it records.

`/api/usage?runtime=` and `/api/efficiency?runtime=` now attach a `coverage` verdict:

- `not_recorded` → show the reason
- `unverified` → claim nothing
- `no_activity` → it records fine and was idle; **the zero is true and stays**

That last case is the one worth guarding: "unavailable" must not swallow a real \$0. An idle OpenClaw still reports zero, pinned by `test_idle_but_capable_runtime_keeps_its_zero`.

## Cloud parity

The verdicts ride the snapshot as `runtimeRecords`, so the hosted dashboard can reach the same conclusion with no local handler. The JS falls back to the old wording when `coverage` is absent, so an older daemon is never worse than today. Cloud interceptor change follows separately.

## Acceptance criteria

Covers **AC-OBS-CEA-001.2** (*when a cost value cannot be determined, identify it as unavailable rather than report a zero*), listed as uncovered since it was written. Ratchet tightened 10/77 → 11/77.

## Also

- adds the missing **Devin** row to `docs/compatibility.md`
- corrects its runtime count 22 → 26, now guarded

## Tests

144 in `tests/test_runtime_records.py` (auto-discovering: parametrized over the live catalogue, not an allowlist). `make lint` targets green; `ruff` clean on the new module.