### PR TITLE
Stop a corrupt DuckDB index from writing a 3.3GB log, and let the dashboard start under launchd

### DIFF
--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -1571,6 +1571,12 @@ def _ensure_local_dashboard(port: int = 8900, wait_secs: float = 12.0) -> bool:
             # stable across venv rebuilds (#4297).
             _launchd_cmd = [sys.executable, "-m", "clawmetry", "--port", str(port)]
             _args_xml = "\n".join(f"        <string>{a}</string>" for a in _launchd_cmd)
+            # launchd starts agents with cwd="/" and does not always export
+            # HOME. dashboard.py's workspace auto-detect ends in os.getcwd(),
+            # so cwd="/" made WORKSPACE="/" and the fleet DB resolve to
+            # "/.clawmetry-fleet.db" -- unwritable, so the dashboard exited(1)
+            # on every boot and the user saw no dashboard at all. Pin both.
+            _home_dir = str(_P.home())
             plist = f"""<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -1580,6 +1586,11 @@ def _ensure_local_dashboard(port: int = 8900, wait_secs: float = 12.0) -> bool:
     <array>
 {_args_xml}
     </array>
+    <key>WorkingDirectory</key>  <string>{_home_dir}</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>          <string>{_home_dir}</string>
+    </dict>
     <key>RunAtLoad</key>         <true/>
     <key>KeepAlive</key>         <true/>
     <key>StandardOutPath</key>   <string>{log_path}</string>

--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -160,6 +160,61 @@ ROLLUP_BACKFILL_CHUNK = int(os.environ.get("CLAWMETRY_ROLLUP_BACKFILL_CHUNK", "5
 # makes any replay a no-op.
 FLUSH_MAX_ATTEMPTS = int(os.environ.get("CLAWMETRY_LOCAL_FLUSH_MAX_ATTEMPTS", "3"))
 FLUSH_RETRY_BASE_SECS = float(os.environ.get("CLAWMETRY_LOCAL_FLUSH_RETRY_BASE_SECS", "0.05"))
+
+# Burned 2026-08-24: a corrupt DuckDB index made every flush raise, and the
+# retry path logged ``%s`` of the exception. A DuckDB constraint error embeds
+# the ENTIRE failing chunk in its message (30 columns x 258 rows), so each
+# failure wrote tens of KB, three attempts per tick, forever. sync.log reached
+# **3.3 GB** in 12 hours on a founder machine before anyone noticed. Log lines
+# must be bounded no matter what an exception chooses to put in its message.
+_EXC_LOG_LIMIT = 400
+
+
+def _brief_exc(exc: BaseException, limit: int = _EXC_LOG_LIMIT) -> str:
+    """One bounded line for ``exc``, safe to log on a hot retry path."""
+    try:
+        text = " ".join(str(exc).split())
+    except Exception:
+        return exc.__class__.__name__
+    if len(text) <= limit:
+        return text
+    return f"{text[:limit]}... [+{len(text) - limit} chars truncated]"
+
+
+def _is_fatal_db_state(exc: BaseException) -> bool:
+    """True when DuckDB has invalidated the connection.
+
+    Once DuckDB reports "database has been invalidated", every subsequent
+    statement on that handle fails the same way -- retrying is pure noise, and
+    the daemon burned 12 hours in that loop. The caller stops retrying and
+    reports the (one-line) recovery instead.
+    """
+    try:
+        return "has been invalidated" in str(exc)
+    except Exception:
+        return False
+
+
+# Log the invalidated-database recovery once per process, not once per tick.
+_fatal_db_reported = False
+
+
+def _report_fatal_db_once(exc: BaseException) -> None:
+    global _fatal_db_reported
+    if _fatal_db_reported:
+        return
+    _fatal_db_reported = True
+    log.error(
+        "local store: DuckDB has invalidated this connection and every write "
+        "will now fail (%s). This is almost always a corrupt index, not lost "
+        "data -- the table rows are intact. Recover with: stop the daemon "
+        "(launchctl bootout / systemctl stop), then in a standalone python: "
+        "con = duckdb.connect(<db>); con.execute('CHECKPOINT'); DROP INDEX "
+        "each name from duckdb_indexes(); con.execute('CHECKPOINT'); then "
+        "start the daemon -- migrations recreate the indexes clean.",
+        _brief_exc(exc),
+    )
+
 LOCAL_MAX_BYTES = int(
     float(os.environ.get("CLAWMETRY_LOCAL_MAX_GB", "5.0")) * 1024 * 1024 * 1024
 )
@@ -5893,13 +5948,18 @@ class LocalStore:
                 break
             except Exception as exc:  # noqa: BLE001 — surface any DuckDB error
                 last_exc = exc
+                if _is_fatal_db_state(exc):
+                    # The handle is dead; the next two attempts would fail
+                    # identically and each would log the whole failing chunk.
+                    _report_fatal_db_once(exc)
+                    break
                 if attempt + 1 < FLUSH_MAX_ATTEMPTS:
                     # Exponential backoff: 0.05s, 0.10s, 0.20s, ... capped at 1s.
                     delay = min(FLUSH_RETRY_BASE_SECS * (2 ** attempt), 1.0)
                     log.warning(
                         "local store: flush attempt %d/%d failed (%s); "
                         "retrying in %.2fs (ring keeps batch)",
-                        attempt + 1, FLUSH_MAX_ATTEMPTS, exc, delay,
+                        attempt + 1, FLUSH_MAX_ATTEMPTS, _brief_exc(exc), delay,
                     )
                     time.sleep(delay)
         if last_exc is not None:
@@ -5910,7 +5970,7 @@ class LocalStore:
             log.error(
                 "local store: flush failed after %d attempts; %d events stay "
                 "queued for next tick (err=%s)",
-                FLUSH_MAX_ATTEMPTS, len(batch), last_exc,
+                FLUSH_MAX_ATTEMPTS, len(batch), _brief_exc(last_exc),
             )
             raise last_exc
         with self._ring_lock:

--- a/dashboard.py
+++ b/dashboard.py
@@ -563,7 +563,18 @@ def _fleet_db_path():
     if FLEET_DB_PATH:
         return FLEET_DB_PATH
     if WORKSPACE:
-        return os.path.join(WORKSPACE, ".clawmetry-fleet.db")
+        _ws_db = os.path.join(WORKSPACE, ".clawmetry-fleet.db")
+        # Only honour the workspace-relative path when we can actually write
+        # there. Under launchd the process starts with cwd="/", and the
+        # workspace auto-detect below falls back to os.getcwd(), so WORKSPACE
+        # becomes "/" on any machine with no detectable OpenClaw workspace.
+        # That resolved to "/.clawmetry-fleet.db" -- unwritable on macOS -- and
+        # the dashboard exited(1) on every launchd boot instead of falling
+        # through to the ~/.clawmetry path this function documents as
+        # authoritative. A dev-mode workspace stays honoured; only an
+        # unwritable one is skipped.
+        if os.access(os.path.dirname(_ws_db) or ".", os.W_OK):
+            return _ws_db
     # Always use ~/.clawmetry/fleet.db -- create the dir if the installer
     # has not run yet or this is a fresh pip install without curl | bash.
     preferred_dir = os.path.expanduser("~/.clawmetry")
@@ -3436,7 +3447,11 @@ def detect_config(args=None):
                 WORKSPACE = c
                 break
         if not WORKSPACE:
-            WORKSPACE = os.getcwd()
+            # "/" is not a workspace. launchd starts agents with cwd="/", so
+            # this last-resort guess silently poisoned every workspace-relative
+            # state path (see _fleet_db_path) on an auto-started install.
+            _cwd = os.getcwd()
+            WORKSPACE = _cwd if _cwd not in ("/", "") else os.path.expanduser("~")
 
     MEMORY_DIR = os.path.join(WORKSPACE, "memory")
 
@@ -9495,7 +9510,18 @@ def _fleet_db_path():
     if FLEET_DB_PATH:
         return FLEET_DB_PATH
     if WORKSPACE:
-        return os.path.join(WORKSPACE, ".clawmetry-fleet.db")
+        _ws_db = os.path.join(WORKSPACE, ".clawmetry-fleet.db")
+        # Only honour the workspace-relative path when we can actually write
+        # there. Under launchd the process starts with cwd="/", and the
+        # workspace auto-detect below falls back to os.getcwd(), so WORKSPACE
+        # becomes "/" on any machine with no detectable OpenClaw workspace.
+        # That resolved to "/.clawmetry-fleet.db" -- unwritable on macOS -- and
+        # the dashboard exited(1) on every launchd boot instead of falling
+        # through to the ~/.clawmetry path this function documents as
+        # authoritative. A dev-mode workspace stays honoured; only an
+        # unwritable one is skipped.
+        if os.access(os.path.dirname(_ws_db) or ".", os.W_OK):
+            return _ws_db
     # Always use ~/.clawmetry/fleet.db -- create the dir if the installer
     # has not run yet or this is a fresh pip install without curl | bash.
     preferred_dir = os.path.expanduser("~/.clawmetry")
@@ -12274,7 +12300,11 @@ def detect_config(args=None):
                 WORKSPACE = c
                 break
         if not WORKSPACE:
-            WORKSPACE = os.getcwd()
+            # "/" is not a workspace. launchd starts agents with cwd="/", so
+            # this last-resort guess silently poisoned every workspace-relative
+            # state path (see _fleet_db_path) on an auto-started install.
+            _cwd = os.getcwd()
+            WORKSPACE = _cwd if _cwd not in ("/", "") else os.path.expanduser("~")
 
     MEMORY_DIR = os.path.join(WORKSPACE, "memory")
 

--- a/tests/test_duckdb_fatal_log_flood.py
+++ b/tests/test_duckdb_fatal_log_flood.py
@@ -1,0 +1,83 @@
+"""Guards for the 2026-08-24 founder-machine incident.
+
+A corrupt DuckDB index made every ``events`` flush raise. Two separate bugs
+turned that into a 12.5-hour outage nobody was told about:
+
+1. The retry path logged ``%s`` of the DuckDB exception. A DuckDB constraint
+   error embeds the ENTIRE failing chunk in its message (30 columns x 258
+   rows), so each failure wrote tens of KB -- three attempts per tick, every
+   tick. ``sync.log`` reached **3.3 GB**.
+2. Nothing recognised "database has been invalidated". Once DuckDB kills a
+   connection every later statement fails identically, so the daemon retried
+   a dead handle forever instead of reporting the (known, no-data-loss)
+   recovery once.
+
+These tests pin the bounded-logging and fatal-detection behaviour.
+"""
+
+from __future__ import annotations
+
+import clawmetry.local_store as ls
+
+
+# ── 1. exception text is bounded no matter what the driver puts in it ─────
+
+def test_brief_exc_truncates_a_chunk_dump():
+    # Shape of the real thing: a short headline then a huge chunk dump.
+    huge = "Invalid Input Error: Failed to delete all rows from index. " + (
+        "- FLAT VARCHAR: 258 = [ a10e57e08ab846e4, ] " * 2000
+    )
+    assert len(huge) > 50_000
+    out = ls._brief_exc(Exception(huge))
+    assert len(out) < ls._EXC_LOG_LIMIT + 100
+    assert "truncated" in out
+    # The diagnostic headline must survive the truncation.
+    assert "Failed to delete all rows from index" in out
+
+
+def test_brief_exc_leaves_a_short_message_alone():
+    assert ls._brief_exc(Exception("boom")) == "boom"
+
+
+def test_brief_exc_never_raises_on_a_hostile_exception():
+    class _Nasty(Exception):
+        def __str__(self):
+            raise RuntimeError("cannot stringify")
+
+    # A logging helper that throws takes down the line it was protecting.
+    assert ls._brief_exc(_Nasty()) == "_Nasty"
+
+
+def test_brief_exc_collapses_newlines_to_one_line():
+    out = ls._brief_exc(Exception("line one\nline two\n\tline three"))
+    assert "\n" not in out and "\t" not in out
+
+
+# ── 2. an invalidated connection is recognised, not retried ───────────────
+
+def test_is_fatal_db_state_matches_the_real_duckdb_message():
+    real = (
+        "FATAL Error: Failed: database has been invalidated because of a "
+        "previous fatal error. The database must be restarted prior to being "
+        'used again.\nOriginal error: "Invalid Input Error: Failed to delete '
+        'all rows from index. Only deleted 0 out of 258 rows.'
+    )
+    assert ls._is_fatal_db_state(Exception(real)) is True
+
+
+def test_is_fatal_db_state_ignores_an_ordinary_error():
+    assert ls._is_fatal_db_state(Exception("constraint violated")) is False
+    assert ls._is_fatal_db_state(Exception("boom")) is False
+
+
+def test_fatal_db_is_reported_once_per_process(monkeypatch, caplog):
+    """The whole point: one actionable line, not one per tick for 12 hours."""
+    monkeypatch.setattr(ls, "_fatal_db_reported", False, raising=False)
+    exc = Exception("database has been invalidated because of a previous fatal error")
+    with caplog.at_level("ERROR", logger="clawmetry.local_store"):
+        for _ in range(50):
+            ls._report_fatal_db_once(exc)
+    errors = [r for r in caplog.records if r.levelname == "ERROR"]
+    assert len(errors) == 1
+    # It must tell the operator how to recover, or it is just a nicer log flood.
+    assert "DROP INDEX" in errors[0].getMessage()

--- a/tests/test_launchd_cwd_kills_dashboard.py
+++ b/tests/test_launchd_cwd_kills_dashboard.py
@@ -1,0 +1,72 @@
+"""Guard for the launchd ``cwd="/"`` bug that kept the dashboard down.
+
+Found 2026-08-24 on a founder machine: ``com.clawmetry.dashboard`` had been
+exiting 1 on every boot with
+
+    [clawmetry] ERROR: Could not initialise fleet database at
+    '/.clawmetry-fleet.db' -- unable to open database file
+
+launchd starts agents with ``cwd="/"``. ``dashboard.py``'s workspace
+auto-detect ends in ``WORKSPACE = os.getcwd()``, so on any machine with no
+detectable OpenClaw workspace WORKSPACE became ``"/"``. ``_fleet_db_path``
+then returned ``os.path.join("/", ".clawmetry-fleet.db")`` -- unwritable on
+macOS -- and the process died before it ever served a request.
+
+Two independent guards, because either one alone would have prevented the
+outage: "/" is not a workspace, and a workspace we cannot write to must never
+win over the ~/.clawmetry path the function documents as authoritative.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+dashboard = pytest.importorskip("dashboard")
+
+
+@pytest.fixture(autouse=True)
+def _restore_globals(monkeypatch):
+    monkeypatch.setattr(dashboard, "FLEET_DB_PATH", None, raising=False)
+    yield
+
+
+def test_unwritable_workspace_does_not_win(monkeypatch):
+    """The launchd failure mode, exactly: WORKSPACE="/"."""
+    monkeypatch.setattr(dashboard, "WORKSPACE", "/", raising=False)
+    path = dashboard._fleet_db_path()
+    assert path != "/.clawmetry-fleet.db"
+    # It must fall through to a location we can actually create.
+    parent = os.path.dirname(path)
+    assert os.access(parent, os.W_OK), f"fell through to unwritable {path!r}"
+
+
+def test_writable_workspace_is_still_honoured(tmp_path, monkeypatch):
+    """Dev mode must keep working -- the fix is narrow, not a behaviour change."""
+    monkeypatch.setattr(dashboard, "WORKSPACE", str(tmp_path), raising=False)
+    assert dashboard._fleet_db_path() == str(tmp_path / ".clawmetry-fleet.db")
+
+
+def test_explicit_fleet_db_path_still_overrides(tmp_path, monkeypatch):
+    monkeypatch.setattr(dashboard, "WORKSPACE", "/", raising=False)
+    monkeypatch.setattr(
+        dashboard, "FLEET_DB_PATH", str(tmp_path / "custom.db"), raising=False
+    )
+    assert dashboard._fleet_db_path() == str(tmp_path / "custom.db")
+
+
+def test_root_is_never_accepted_as_a_workspace_fallback():
+    """The generated launchd plist must pin a real cwd/HOME.
+
+    Belt and braces with the code guard above: the plist template is what
+    stops the process from ever seeing cwd="/" in the first place.
+    """
+    import inspect
+
+    from clawmetry import cli
+
+    src = inspect.getsource(cli)
+    assert "<key>WorkingDirectory</key>" in src, (
+        "dashboard plist must pin WorkingDirectory or launchd gives it cwd=/"
+    )


### PR DESCRIPTION
Two real outages found on a founder machine while auditing the Govern pillar. Both were silent.

## 1. `sync.log` reached 3.3 GB in 12.5 hours

A corrupt DuckDB index made every `events` flush raise. The retry path logged `%s` of the exception — and a DuckDB constraint error embeds the **entire failing chunk** in its message (30 columns × 258 rows). Tens of KB per failure, three attempts per tick, every tick: **80,215 fatal blocks**.

Nothing recognised `"database has been invalidated"` either. Once DuckDB kills a connection every later statement fails identically, so the daemon retried a dead handle for 12.5 hours while ingest was fully stalled and nobody was told.

- Log lines are now bounded regardless of what a driver puts in an exception (`_brief_exc`)
- An invalidated handle stops the retry loop instead of feeding it
- The operator gets **one** actionable line carrying the no-data-loss recovery, not a flood

## 2. The dashboard could not start under launchd at all

launchd starts agents with `cwd="/"`. `dashboard.py`'s workspace auto-detect ends in `WORKSPACE = os.getcwd()`, so on any machine with no detectable OpenClaw workspace `WORKSPACE` became `"/"`. `_fleet_db_path` then returned `/.clawmetry-fleet.db` — unwritable on macOS — and the process exited(1) on every boot, `KeepAlive` respawning it into the same wall.

Worth noting the workspace branch is unconditional, so the `~/.clawmetry` path that same function documents as *"authoritative"* was unreachable in practice.

- An unwritable workspace now falls through to `~/.clawmetry`
- `"/"` is refused as a workspace
- The generated plist pins `WorkingDirectory` + `HOME` so the process never sees `cwd="/"`

## Verification

Recovered the live machine with this diagnosis: dropped + recreated all 65 indexes, daemon back to **0 fatals**, log 3.37 GB → 2 KB, dashboard serving `/api/overview` with `_source: local_store` and 61 active sessions.

11 new tests; the dev-mode workspace override still wins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QzdyAoBb4Rb8AZj9Pgq3Ny