### PR TITLE
Move audit_logs and rbac from Enterprise to Pro, and drop the governance claim the OSS package cannot back

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ too. See [docs/SDK_TRACKING.md](docs/SDK_TRACKING.md).
 |---|---|---|
 | **Free** | OpenClaw + NVIDIA NemoClaw + Goose, full dashboard, local only | $0 |
 | **Starter** | Every other runtime above, fleet view, cloud sync | $9 per node / month |
-| **Pro** | Starter + governance: approvals, tool-risk policies, evals, anomaly detection, cost optimizer, OTel export | $19 per node / month |
+| **Pro** | Starter + control and evaluation: approvals, tool-risk policies, evals, anomaly detection, cost optimizer, OTel export, tamper-evident audit log | $19 per node / month |
 
 Annual plans, Enterprise and the current numbers live at
 **[clawmetry.com/pricing](https://clawmetry.com/pricing)**. Self-hosted license

--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -445,6 +445,25 @@ PRO_ONLY_FEATURES = frozenset(
         "anomaly_detection",
         "cost_optimizer",
         "compliance_pack",
+        # ── Governance, moved down from Enterprise 2026-08-25 ────────────
+        # Pro was sold as "the governance layer" while every governance
+        # primitive sat in Enterprise; a buyer who read that, clicked in and
+        # found cost-waste flags discounted the rest of the page. Auth0's
+        # shape is the precedent: RBAC and audit logs at the paid tier,
+        # Enterprise reserved for residency, private deploy and SLA.
+        #
+        # ``audit_logs`` is a real capability and moves with a working
+        # surface behind it: the append-only hash chain in clawmetry/audit.py,
+        # producers in sync.py / approvals.py / license.py, /api/audit-log +
+        # /api/security/audit, and the Security-tab activity feed.
+        #
+        # ``rbac`` does NOT yet have an implementation. It is tiered here so
+        # the tier map stops contradicting the pricing copy, but it must not
+        # be advertised on the pricing page until there is something to sell
+        # -- there is no principal to attach a role to yet (agent identity is
+        # the prerequisite). Ship the capability, then the claim.
+        "audit_logs",
+        "rbac",
     }
 )
 
@@ -454,8 +473,9 @@ ENTERPRISE_FEATURES = frozenset(
     {
         "siem_export",
         "sso",
-        "audit_logs",
-        "rbac",
+        # ``audit_logs`` and ``rbac`` moved to PRO_ONLY_FEATURES on
+        # 2026-08-25 -- see the note there. Enterprise keeps the genuinely
+        # enterprise-shaped keys: SSO, SIEM, air-gapped licensing, residency.
         "air_gapped_license",
         "custom_data_residency",
         # Org-wide Claude coverage: the day-level rollup for Claude surfaces

--- a/docs/ENTITLEMENTS.md
+++ b/docs/ENTITLEMENTS.md
@@ -100,8 +100,16 @@ below live here so the free UI can render locked rows with an accurate
 | Bucket | Constant | Features |
 |---|---|---|
 | Starter | `STARTER_FEATURES` | `multi_runtime`, `fleet`, `cloud_sync`, `all_channels`, `approval_queue`, `budget_limits`, `per_runtime_health_timeline` |
-| Pro-only | `PRO_ONLY_FEATURES` | `per_run_waste_flags`, `per_run_compare`, `error_triage`, `self_evolve`, `asset_registry`, `eval_suite`, `tool_policy`, `otel_export`, `custom_webhooks`, `custom_runtime_ingest`, `custom_alerts`, `alert_webhooks`, `anomaly_detection`, `cost_optimizer`, `compliance_pack` |
-| Enterprise | `ENTERPRISE_FEATURES` | `siem_export`, `sso`, `audit_logs`, `rbac`, `air_gapped_license`, `custom_data_residency` |
+| Pro-only | `PRO_ONLY_FEATURES` | `per_run_waste_flags`, `per_run_compare`, `error_triage`, `self_evolve`, `asset_registry`, `eval_suite`, `tool_policy`, `otel_export`, `custom_webhooks`, `custom_runtime_ingest`, `custom_alerts`, `alert_webhooks`, `anomaly_detection`, `cost_optimizer`, `compliance_pack`, `audit_logs`, `rbac` |
+| Enterprise | `ENTERPRISE_FEATURES` | `siem_export`, `sso`, `air_gapped_license`, `custom_data_residency`, `org_analytics` |
+
+`audit_logs` and `rbac` moved from Enterprise to Pro on 2026-08-25. Pro was
+sold as "the governance layer" while every governance primitive sat in
+Enterprise. `audit_logs` moved with a working surface behind it (append-only
+hash chain, real producers, `/api/audit-log`, the Security-tab feed). `rbac`
+has **no implementation yet** and is deliberately not advertised on the
+pricing page: there is no principal to attach a role to until agent identity
+ships. Ship the capability, then the claim.
 
 Display labels for every feature live in `entitlements.FEATURE_LABELS`.
 

--- a/setup.py
+++ b/setup.py
@@ -150,7 +150,7 @@ setup(
         "Topic :: System :: Monitoring",
     ],
     keywords=(
-        "clawmetry observability governance monitoring dashboard "
+        "clawmetry observability monitoring dashboard "
         "ai agent llm llm-observability opentelemetry cost-tracking "
         "claude-code codex cursor github-copilot gemini-cli cline openhands "
         "opencode aider goose qwen devin kimi grok n8n antigravity deepseek "

--- a/tests/test_audit_route_gate.py
+++ b/tests/test_audit_route_gate.py
@@ -103,9 +103,11 @@ def test_audit_log_returns_402_when_enforced(enforce, monkeypatch):
         # all" from "entitled but on a downgrade path".
         assert "tier" in body
         # required_tier lets the paywall render the right upgrade CTA.
-        # Audit logs are Enterprise-only, NOT Pro — so the CTA has to
-        # target Enterprise or users get sent to the wrong upgrade flow.
-        assert body["required_tier"] == enforce.TIER_ENTERPRISE
+        # audit_logs moved Enterprise -> Pro on 2026-08-25, so the CTA must
+        # target Pro. Sending a buyer to Enterprise for something their $19
+        # plan already unlocks is the same wrong-flow bug this line has
+        # always guarded, just in the other direction.
+        assert body["required_tier"] == enforce.TIER_CLOUD_PRO
         assert isinstance(body.get("hint"), str) and body["hint"]
         # No entries payload leaked through.
         assert "entries" not in body

--- a/tests/test_entitlement_min_tier.py
+++ b/tests/test_entitlement_min_tier.py
@@ -139,12 +139,13 @@ def test_min_tier_enterprise_only_feature_is_enterprise(ent):
     for feat in (
         "siem_export",
         "sso",
-        "audit_logs",
-        "rbac",
         "air_gapped_license",
         "custom_data_residency",
     ):
         assert ent.min_tier_for_feature(feat) == ent.TIER_ENTERPRISE, feat
+    # audit_logs + rbac moved Enterprise -> Pro on 2026-08-25.
+    for feat in ("audit_logs", "rbac"):
+        assert ent.min_tier_for_feature(feat) == ent.TIER_CLOUD_PRO, feat
 
 
 def test_min_tier_unknown_feature_is_none(ent):

--- a/tests/test_entitlement_tier_locks_path.py
+++ b/tests/test_entitlement_tier_locks_path.py
@@ -253,12 +253,16 @@ def test_adjacent_step_is_one_row(ent):
 
 def test_descending_path_loses_enterprise_at_top_step(ent):
     """The first rung of an enterprise -> oss descent is the one that
-    sheds the enterprise-only features (``sso`` + ``audit_logs``)."""
+    sheds the enterprise-only features (``sso`` + ``siem_export``).
+
+    ``audit_logs`` moved to Pro on 2026-08-25, so it is no longer shed at
+    this rung -- an Enterprise -> Pro downgrade keeps it."""
     path = ent.tier_locks_path(ent.TIER_ENTERPRISE, ent.TIER_OSS)
     first = path[0]
     assert first["next_tier"] == ent.TIER_ENTERPRISE
     assert "sso" in first["lost_features"]
-    assert "audit_logs" in first["lost_features"]
+    assert "siem_export" in first["lost_features"]
+    assert "audit_logs" not in first["lost_features"]
 
 
 def test_ascending_path_terminates_at_to_but_losses_are_empty(ent):

--- a/tests/test_entitlement_tier_path.py
+++ b/tests/test_entitlement_tier_path.py
@@ -218,9 +218,11 @@ def test_ascending_path_unlocks_enterprise_at_top(ent):
     path = ent.tier_path(ent.TIER_OSS, ent.TIER_ENTERPRISE)
     final = path[-1]
     assert final["to"] == ent.TIER_ENTERPRISE
-    # enterprise-only features land at the terminal rung
+    # enterprise-only features land at the terminal rung. audit_logs moved to
+    # Pro on 2026-08-25, so it is added EARLIER in the walk, not here.
     assert "sso" in final["added_features"]
-    assert "audit_logs" in final["added_features"]
+    assert "siem_export" in final["added_features"]
+    assert "audit_logs" not in final["added_features"]
 
 
 def test_descending_path_loses_paid_runtimes_at_floor(ent):

--- a/tests/test_entitlement_tier_unlocks_path.py
+++ b/tests/test_entitlement_tier_unlocks_path.py
@@ -233,9 +233,11 @@ def test_ascending_path_unlocks_enterprise_at_top(ent):
     path = ent.tier_unlocks_path(ent.TIER_OSS, ent.TIER_ENTERPRISE)
     final = path[-1]
     assert final["tier"] == ent.TIER_ENTERPRISE
-    # enterprise-only features land at the terminal rung
+    # enterprise-only features land at the terminal rung. audit_logs moved
+    # to Pro on 2026-08-25, so it now unlocks EARLIER in the walk, not here.
     assert "sso" in final["features"]
-    assert "audit_logs" in final["features"]
+    assert "siem_export" in final["features"]
+    assert "audit_logs" not in final["features"]
 
 
 def test_descending_path_terminates_at_to_but_unlocks_are_empty(ent):

--- a/tests/test_entitlements_catalogue.py
+++ b/tests/test_entitlements_catalogue.py
@@ -60,11 +60,19 @@ def test_pro_only_features_include_published_pro_set(ent):
 def test_enterprise_features_match_pricing(ent):
     """Enterprise card on /pricing promises these 6 keys — all must be honoured.
 
+    Asserted against the Enterprise tier's RESOLVED feature set, not the
+    ``ENTERPRISE_FEATURES`` bucket. The promise a customer read on the card is
+    "buy Enterprise and you get these", and that is a statement about the tier,
+    not about which constant a key happens to live in.
+
+    The distinction became load-bearing on 2026-08-25, when ``audit_logs`` and
+    ``rbac`` moved down to ``PRO_ONLY_FEATURES``. Enterprise resolves to
+    ``PAID_FEATURES | ENTERPRISE_FEATURES`` and ``PAID_FEATURES`` includes the
+    Pro-only set, so no Enterprise customer lost anything — but a guard written
+    against the bucket would have gone red and implied they had.
+
     Asserted as a subset, not equality, so the catalogue can grow without the
-    guard going red: the promise is "the card's 6 keys are included", and a 7th
-    Enterprise key breaks nothing a customer was told. Mirrors how
-    ``test_pro_only_features`` guards the Pro set. What the card must never do
-    is lose one of these — that assertion is unchanged.
+    guard going red. What the tier must never do is lose one of these.
     """
     promised = frozenset({
         "siem_export",
@@ -74,7 +82,11 @@ def test_enterprise_features_match_pricing(ent):
         "air_gapped_license",
         "custom_data_residency",
     })
-    assert promised.issubset(ent.ENTERPRISE_FEATURES)
+    enterprise_resolved = ent.FREE_FEATURES | ent._TIER_FEATURES[ent.TIER_ENTERPRISE]
+    assert promised.issubset(enterprise_resolved)
+    # And the two that moved are genuinely reachable one tier down now.
+    pro_resolved = ent.FREE_FEATURES | ent._TIER_FEATURES[ent.TIER_CLOUD_PRO]
+    assert {"audit_logs", "rbac"}.issubset(pro_resolved)
 
 
 def test_org_analytics_is_enterprise_only(ent):

--- a/tests/test_paywall_body.py
+++ b/tests/test_paywall_body.py
@@ -74,9 +74,14 @@ def test_body_required_tier_enterprise_feature(ent_grace):
     ``enterprise`` so the UI renders the Enterprise CTA, not the Pro one."""
     from clawmetry._paywall import upgrade_required_body
 
-    for key in ("audit_logs", "sso", "siem_export"):
+    # audit_logs + rbac moved to Pro on 2026-08-25; the keys left here are
+    # the genuinely enterprise-shaped ones.
+    for key in ("sso", "siem_export", "custom_data_residency"):
         body = upgrade_required_body(key)
         assert body["required_tier"] == ent_grace.TIER_ENTERPRISE, key
+    for key in ("audit_logs", "rbac"):
+        body = upgrade_required_body(key)
+        assert body["required_tier"] == ent_grace.TIER_CLOUD_PRO, key
 
 
 def test_body_required_tier_free_feature_is_none(ent_grace):
@@ -235,10 +240,13 @@ def test_stub_blueprint_402_carries_required_tier(
 
 
 def test_audit_stub_402_uses_paywall_shape(ent_grace, monkeypatch):
-    """``routes/audit.py`` gates on the Enterprise-only ``audit_logs``
-    feature; forcing the entitlement check to deny exercises the 402 path
-    and the shared body builder. ``required_tier`` must be
-    ``enterprise`` (not ``cloud_pro``) so the UI offers the right plan."""
+    """``routes/audit.py`` gates on ``audit_logs``; forcing the entitlement
+    check to deny exercises the 402 path and the shared body builder.
+
+    ``audit_logs`` moved Enterprise -> Pro on 2026-08-25, so ``required_tier``
+    must now be ``cloud_pro`` -- a Free install being told to buy Enterprise
+    for a feature Pro already unlocks is the exact mis-CTA this test exists
+    to catch, just in the other direction."""
     monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
     # Reload so is_enforced() picks up the env change.
     import clawmetry.entitlements as e
@@ -254,7 +262,7 @@ def test_audit_stub_402_uses_paywall_shape(ent_grace, monkeypatch):
         assert r.status_code == 402
         body = r.get_json()
         assert body["feature"] == "audit_logs"
-        assert body["required_tier"] == e.TIER_ENTERPRISE
+        assert body["required_tier"] == e.TIER_CLOUD_PRO
         assert body["tier"] in (e.TIER_OSS, e.TIER_CLOUD_FREE)
 
     e.invalidate()

--- a/tests/test_required_tier_canonical.py
+++ b/tests/test_required_tier_canonical.py
@@ -125,8 +125,11 @@ def test_gate_required_tier_enterprise_feature_resolves_to_enterprise(ent_grace)
     drives the right CTA (not the Pro one)."""
     from clawmetry._gate import _required_tier
 
-    for key in ("audit_logs", "sso", "siem_export"):
+    for key in ("sso", "siem_export", "custom_data_residency"):
         assert _required_tier(key) == ent_grace.TIER_ENTERPRISE, key
+    # Moved to Pro 2026-08-25 -- pinned here so the CTA follows the tier map.
+    for key in ("audit_logs", "rbac"):
+        assert _required_tier(key) == ent_grace.TIER_CLOUD_PRO, key
 
 
 def test_gate_required_tier_swallows_resolver_errors(monkeypatch):

--- a/tests/test_security_audit_route_gate.py
+++ b/tests/test_security_audit_route_gate.py
@@ -106,9 +106,11 @@ def test_security_audit_returns_402_when_enforced(enforce, monkeypatch):
         # all" from "entitled but on a downgrade path".
         assert "tier" in body
         # required_tier lets the paywall render the right upgrade CTA.
-        # Audit logs are Enterprise-only, NOT Pro — so the CTA has to
-        # target Enterprise or users get sent to the wrong upgrade flow.
-        assert body["required_tier"] == enforce.TIER_ENTERPRISE
+        # audit_logs moved Enterprise -> Pro on 2026-08-25, so the CTA must
+        # target Pro. Sending a buyer to Enterprise for something their $19
+        # plan already unlocks is the same wrong-flow bug this line has
+        # always guarded, just in the other direction.
+        assert body["required_tier"] == enforce.TIER_CLOUD_PRO
         assert isinstance(body.get("hint"), str) and body["hint"]
         # No entries payload leaked through.
         assert "entries" not in body


### PR DESCRIPTION
Pro is sold as "the governance layer" while every governance primitive sat in Enterprise. A buyer who reads that, clicks in, and finds cost-waste flags discounts the rest of the page. Auth0's shape is the precedent: RBAC and audit logs at the paid tier, Enterprise reserved for residency, private deploy and SLA.

## What moves

**`audit_logs` → Pro, with a working surface behind it.** The append-only hash chain in `clawmetry/audit.py`, producers in `sync.py` / `approvals.py` / `license.py`, both `/api/audit-log` and `/api/security/audit`, and the Security-tab activity feed. Pro gains a real capability, not a relabelled empty key.

**`rbac` → Pro, but deliberately NOT advertised.** It has no implementation. It is tiered here so the tier map stops contradicting the pricing copy, but it stays off the pricing page: there is no principal to attach a role to until agent identity ships. Ship the capability, then the claim. The README Pro row gains the audit log only.

## Nobody loses access

Enterprise resolves to `PAID_FEATURES | ENTERPRISE_FEATURES`, and `PAID_FEATURES` includes the Pro-only set — so an Enterprise customer still gets both keys.

`test_enterprise_features_match_pricing` now asserts that against the **resolved tier** rather than the `ENTERPRISE_FEATURES` bucket. The promise on the card is about the tier a customer bought, not about which constant a key lives in, and a guard written against the bucket would have gone red and implied a takeaway that never happened.

## Also

Drops `governance` from the setup.py PyPI keywords. The free package is observability; the word was attracting governance buyers to something that does not govern. `setup.py`'s `description=` was already honest.

46 affected test files, **1188 passing**.

## Follow-up NOT done here

`clawmetry-landing/pricing.html` is a separate repo and a public pricing change, so it is left for a deliberate decision. It currently:
- lists the tamper-evident audit log as a **Free** feature and as a check in **all four** comparison columns (this contradicted the code *before* this PR and still does after it)
- sells "RBAC + teams" on the Enterprise card for something that does not exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QzdyAoBb4Rb8AZj9Pgq3Ny