### PR TITLE
Give every agent an identity you can attach an owner, a policy or an audit actor to

### DIFF
--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -3409,6 +3409,164 @@ class LocalStore:
             }
         return out
 
+    # Stable prefix for a derived agent principal id. Short, greppable, and
+    # obviously not a session id when it shows up in an audit row.
+    _PRINCIPAL_PREFIX = "ap_"
+
+    @staticmethod
+    def principal_id(node_id: str, runtime: str, agent_id: str) -> str:
+        """Deterministic id for the agent identified by this triple.
+
+        Pure and stable: the same agent yields the same id on every node, in
+        every process, across restarts, with no lookup and nothing to persist.
+        That is what lets an audit row, a policy and an inventory row all name
+        the same principal without a shared table to join through.
+
+        Derived rather than minted on purpose. ClawMetry watches agents nobody
+        instrumented -- there is no enrolment step we could hang a generated id
+        off, so identity has to fall out of what we already observe.
+        """
+        import hashlib as _hl
+
+        parts = (
+            str(node_id or "").strip().lower(),
+            str(runtime or "").strip().lower(),
+            str(agent_id or "main").strip().lower(),
+        )
+        digest = _hl.sha256("\x1f".join(parts).encode("utf-8")).hexdigest()
+        return f"{LocalStore._PRINCIPAL_PREFIX}{digest[:16]}"
+
+    def query_agent_principals(
+        self,
+        *,
+        node_id: str | None = None,
+        runtime: str | None = None,
+        limit: int = 500,
+    ) -> list[dict[str, Any]]:
+        """One row per distinct AGENT, not per runtime.
+
+        The Agent Inventory rolls up one row per runtime, so ownership attaches
+        to "claude_code on this box" rather than to an agent. A policy cannot
+        say *this agent may not do that* without a principal, RBAC has no
+        subject, and the audit chain has no actor beyond a session id. This is
+        that missing primitive.
+
+        Derived from ``sessions``, which already carries every field the
+        identity needs -- so this adds no ingestion and works retroactively on
+        history already in the store. Runtime comes from the session-id prefix
+        (the same rule as ``sync._runtime_of_session`` / the frontend's
+        ``_cmRuntimeOf``), falling back to ``agent_type`` for rows whose id
+        carries no prefix.
+
+        Governance fields (owner / notes) are overlaid from ``agent_meta``,
+        keyed by principal id. That table's key is a free-form VARCHAR, so
+        principal-level ownership needs no migration and reuses the existing
+        ``set_agent_meta`` write path. A runtime-level label and an agent-level
+        label therefore coexist without colliding.
+
+        Each row::
+
+            {principal_id, node_id, runtime, agent_id, sessions, first_seen,
+             last_seen, total_tokens, cost_usd, owner, notes, owner_source}
+
+        ``owner_source`` is ``"agent"`` when this principal has its own label,
+        ``"runtime"`` when it inherits the runtime's, and ``""`` when nobody
+        has claimed it -- so the UI can show inherited ownership honestly
+        instead of implying someone named this agent specifically.
+
+        Never raises: any failure yields ``[]``.
+        """
+        try:
+            sql = """
+                SELECT
+                    COALESCE(node_id, '')                       AS node_id,
+                    CASE
+                        WHEN strpos(session_id, ':') > 1
+                        THEN lower(split_part(session_id, ':', 1))
+                        ELSE ''
+                    END                                          AS sid_prefix,
+                    lower(COALESCE(agent_type, ''))              AS agent_type,
+                    COALESCE(NULLIF(TRIM(agent_id), ''), 'main') AS agent_id,
+                    COUNT(DISTINCT session_id)                   AS sessions,
+                    MIN(started_at)                              AS first_seen,
+                    MAX(last_active_at)                          AS last_seen,
+                    COALESCE(SUM(total_tokens), 0)               AS total_tokens,
+                    COALESCE(SUM(cost_usd), 0.0)                 AS cost_usd
+                FROM sessions
+                WHERE session_id IS NOT NULL
+                GROUP BY 1, 2, 3, 4
+            """
+            rows = self._fetch(sql, [])
+        except Exception:
+            return []
+
+        # Resolve the prefix to a real runtime name. Unknown prefixes are not
+        # runtimes (a session id may contain a colon for other reasons), so
+        # they fall back to agent_type and finally to the openclaw default
+        # bucket -- the same precedence the rest of the codebase uses.
+        try:
+            from clawmetry import entitlements as _ent
+            known = set(_ent.ALL_RUNTIMES)
+        except Exception:
+            known = set()
+
+        try:
+            meta = self.query_agent_meta() or {}
+        except Exception:
+            meta = {}
+
+        want_node = (node_id or "").strip().lower() or None
+        want_rt = (runtime or "").strip().lower() or None
+
+        out: list[dict[str, Any]] = []
+        for r in rows:
+            (r_node, sid_prefix, agent_type, r_agent, sessions,
+             first_seen, last_seen, tokens, cost) = r
+            rt = ""
+            if sid_prefix and (not known or sid_prefix in known):
+                rt = sid_prefix
+            elif agent_type and (not known or agent_type in known):
+                rt = agent_type
+            if not rt:
+                rt = "openclaw"
+
+            if want_node is not None and str(r_node).lower() != want_node:
+                continue
+            if want_rt is not None and rt != want_rt:
+                continue
+
+            pid = self.principal_id(r_node, rt, r_agent)
+            own = meta.get(pid) or {}
+            source = "agent" if own else ""
+            if not own:
+                # Fall back to the runtime-level label the Agent Inventory
+                # already writes, so an agent inherits its runtime's owner
+                # rather than rendering as unowned.
+                own = meta.get(rt) or {}
+                source = "runtime" if own else ""
+
+            out.append({
+                "principal_id": pid,
+                "node_id": str(r_node or ""),
+                "runtime": rt,
+                "agent_id": str(r_agent or "main"),
+                "sessions": int(sessions or 0),
+                "first_seen": first_seen,
+                "last_seen": last_seen,
+                "total_tokens": int(tokens or 0),
+                "cost_usd": float(cost or 0.0),
+                "owner": own.get("owner") or "",
+                "notes": own.get("notes") or "",
+                "owner_source": source,
+            })
+
+        out.sort(key=lambda d: (d.get("last_seen") or "", d["sessions"]), reverse=True)
+        try:
+            n = max(1, min(2000, int(limit)))
+        except (TypeError, ValueError):
+            n = 500
+        return out[:n]
+
     def ingest_cron(self, cron: dict[str, Any]) -> None:
         """Upsert one cron-job row. Required: cron_id.
 

--- a/dashboard.py
+++ b/dashboard.py
@@ -125,6 +125,7 @@ from routes.autonomy import bp_autonomy
 from routes.selfconfig import bp_selfconfig
 from routes.agents import bp_agents
 from routes.inventory import bp_inventory
+from routes.govern import bp_govern
 from routes.assets import bp_assets
 from routes.reasoning import bp_reasoning
 from routes.plugins import bp_plugins
@@ -12422,6 +12423,7 @@ def detect_config(args=None):
     app.register_blueprint(bp_selfconfig)
     app.register_blueprint(bp_agents)
     app.register_blueprint(bp_inventory)
+    app.register_blueprint(bp_govern)
     if not _pro_loaded:
         app.register_blueprint(bp_assets)
     app.register_blueprint(bp_reasoning)

--- a/routes/govern.py
+++ b/routes/govern.py
@@ -1,0 +1,164 @@
+"""routes/govern.py — agent identity: a principal you can attach things to.
+
+The Agent Inventory (``routes/inventory.py``) rolls up one row per *runtime*,
+so ownership attaches to "claude_code on this box" rather than to an agent. That
+is the gap under three separate capabilities:
+
+* a policy cannot say *this agent may not do that* without a principal,
+* RBAC has no subject to bind a role to,
+* the audit chain has no actor beyond a session id.
+
+One primitive unblocks all three, so it lands before any of them.
+
+  GET  /api/govern/principals                   — the roster, one row per agent
+  GET  /api/govern/principals/<principal_id>    — one principal
+  POST /api/govern/principals/<principal_id>/owner
+                                                — claim it for a person or team
+
+Identity is **derived, not minted**: ``principal_id`` is a stable hash of
+(node_id, runtime, agent_id), all of which ``sessions`` already carries. There
+is no enrolment step to hang a generated id off -- ClawMetry watches agents
+nobody instrumented -- so identity has to fall out of what we already observe.
+It is therefore stable across restarts, reproducible in any process without a
+lookup, and works retroactively on history already in the store.
+
+Ownership writes reuse ``set_agent_meta`` keyed by the principal id. That
+table's key is a free-form VARCHAR, so agent-level and runtime-level labels
+coexist without a migration and without colliding. An agent with no label of
+its own inherits its runtime's, reported honestly as ``owner_source:
+"runtime"`` rather than pretending someone named this agent.
+
+CLOUD CONTRACT: every handler never-raises and returns an honest empty shape
+with HTTP 200 on the store-less cloud container, matching
+``routes/inventory.py`` so a cold fall-through paints an empty state rather
+than an error.
+"""
+from __future__ import annotations
+
+import logging
+
+from flask import Blueprint, jsonify, request
+
+from clawmetry.config import is_local_store_read_enabled
+
+logger = logging.getLogger("clawmetry.routes.govern")
+
+bp_govern = Blueprint("govern", __name__)
+
+# Read methods must open the store read-only in the single-process fallback.
+_READ_METHODS = frozenset({"query_agent_principals", "query_agent_meta"})
+
+
+def _store_call(method_name: str, **kwargs):
+    """Daemon-proxy first, direct open as a single-process fallback.
+
+    Same shape as ``routes/assets.py._try_store_call``: the daemon owns the
+    DuckDB writer lock, so the dashboard process must never open it writable.
+    Returns ``None`` when both paths fail.
+    """
+    try:
+        from routes.local_query import local_store_via_daemon
+
+        result = local_store_via_daemon(method_name, **kwargs)
+        if result is not None:
+            return result
+    except Exception:
+        pass
+    try:
+        from clawmetry import local_store
+
+        store = local_store.get_store(read_only=method_name in _READ_METHODS)
+        return getattr(store, method_name)(**kwargs)
+    except Exception:
+        return None
+
+
+def _zero():
+    return {"principals": [], "total": 0}
+
+
+@bp_govern.route("/api/govern/principals", methods=["GET"])
+def api_govern_principals():
+    """The agent roster, one row per agent rather than per runtime.
+
+    Optional ``node_id`` / ``runtime`` filters, and ``limit`` (1-2000).
+    Never raises; an empty roster is an honest 200, not a 500.
+    """
+    if not is_local_store_read_enabled():
+        return jsonify(_zero())
+
+    node_id = (request.args.get("node_id") or "").strip() or None
+    runtime = (request.args.get("runtime") or "").strip().lower() or None
+    if runtime == "all":
+        runtime = None
+    try:
+        limit = max(1, min(2000, int(request.args.get("limit", 500))))
+    except (TypeError, ValueError):
+        limit = 500
+
+    rows = _store_call(
+        "query_agent_principals", node_id=node_id, runtime=runtime, limit=limit
+    )
+    rows = rows or []
+    return jsonify({"principals": rows, "total": len(rows)})
+
+
+@bp_govern.route("/api/govern/principals/<principal_id>", methods=["GET"])
+def api_govern_principal(principal_id: str):
+    """One principal by id, or 404.
+
+    Filtered from the same derived roster rather than re-deriving it, so the
+    detail view can never disagree with the list view.
+    """
+    if not is_local_store_read_enabled():
+        return jsonify({"error": "not_found"}), 404
+    pid = (principal_id or "").strip()
+    if not pid:
+        return jsonify({"error": "not_found"}), 404
+    rows = _store_call("query_agent_principals", limit=2000) or []
+    for r in rows:
+        if r.get("principal_id") == pid:
+            return jsonify(r)
+    return jsonify({"error": "not_found"}), 404
+
+
+@bp_govern.route("/api/govern/principals/<principal_id>/owner", methods=["POST"])
+def api_govern_set_owner(principal_id: str):
+    """Claim a principal for a person or team.
+
+    Local-only: the write goes through the daemon proxy to the writer-locked
+    DuckDB, and the cloud relay is read-only so it cold-falls-through.
+
+    The id must name a principal we have actually observed. Accepting an
+    arbitrary key would let this endpoint write unbounded rows into
+    ``agent_meta`` and would let an owner be attached to an agent that does
+    not exist -- an inventory nobody can trust is worse than none.
+
+    ``owner``/``notes`` follow set_agent_meta's partial-update contract:
+    ``None`` means "leave this field alone", an empty string clears it.
+    """
+    if not is_local_store_read_enabled():
+        return jsonify({"ok": False, "error": "local store disabled"}), 200
+    pid = (principal_id or "").strip()
+    if not pid:
+        return jsonify({"ok": False, "error": "missing principal_id"}), 400
+
+    known = _store_call("query_agent_principals", limit=2000) or []
+    if not any(r.get("principal_id") == pid for r in known):
+        return jsonify({"ok": False, "error": "unknown principal"}), 404
+
+    body = request.get_json(silent=True) or {}
+    owner = body.get("owner")
+    notes = body.get("notes")
+    if owner is not None:
+        owner = str(owner).strip()
+    if notes is not None:
+        notes = str(notes)
+    if owner is None and notes is None:
+        return jsonify({"ok": False, "error": "nothing to set"}), 400
+
+    try:
+        _store_call("set_agent_meta", agent_key=pid, owner=owner, notes=notes)
+    except Exception:
+        return jsonify({"ok": False, "error": "write failed"}), 200
+    return jsonify({"ok": True, "principalId": pid, "owner": owner})

--- a/routes/local_query.py
+++ b/routes/local_query.py
@@ -857,6 +857,11 @@ _DAEMON_METHODS = frozenset({
     # returns None and the proxy 400s (memory feedback_cli_methods_need_daemon_allowlist).
     "query_agent_meta",
     "set_agent_meta",
+    # Agent identity: one principal per AGENT (node + runtime + agent_id),
+    # derived from sessions and overlaid with the agent_meta labels above.
+    # Read-only; the daemon owns the writer, and ownership writes reuse
+    # set_agent_meta (already allowlisted) keyed by principal id.
+    "query_agent_principals",
     # Issue #2860: session full-text search. Read-only; routed through the
     # daemon proxy so the dashboard process never opens DuckDB writable.
     "query_search",

--- a/tests/test_agent_principals.py
+++ b/tests/test_agent_principals.py
@@ -1,0 +1,194 @@
+"""Agent identity: a principal you can attach a policy, a role, or an owner to.
+
+The Agent Inventory rolls up one row per *runtime*, so ownership attached to
+"claude_code on this box" rather than to an agent. Without a principal a policy
+cannot say *this agent may not do that*, RBAC has no subject, and the audit
+chain has no actor beyond a session id.
+
+These tests pin the primitive: identity is DERIVED (stable, reproducible, no
+enrolment step, works on history already in the store), it is per-agent rather
+than per-runtime, and ownership overlays honestly.
+"""
+
+from __future__ import annotations
+
+import importlib
+import uuid
+
+import pytest
+
+
+@pytest.fixture
+def store(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "5")
+    import clawmetry.local_store as ls
+
+    importlib.reload(ls)
+    s = ls.LocalStore()
+    s.start()
+    yield s
+    s.stop(flush=True)
+
+
+def _sess(store, session_id, *, node_id="node-a", agent_id="main", **kw):
+    row = {
+        "session_id": session_id,
+        "node_id": node_id,
+        "agent_id": agent_id,
+        "started_at": kw.pop("started_at", "2026-08-01T00:00:00Z"),
+        "last_active_at": kw.pop("last_active_at", "2026-08-02T00:00:00Z"),
+        "total_tokens": kw.pop("total_tokens", 10),
+        "cost_usd": kw.pop("cost_usd", 0.5),
+    }
+    row.update(kw)
+    store.ingest_session(row)
+
+
+# ── the id itself ─────────────────────────────────────────────────────────
+
+def test_principal_id_is_deterministic(store):
+    a = store.principal_id("node-a", "claude_code", "main")
+    b = store.principal_id("node-a", "claude_code", "main")
+    assert a == b
+    assert a.startswith("ap_")
+
+
+def test_principal_id_is_case_and_whitespace_insensitive(store):
+    """The same agent must not get two identities because a caller shouted."""
+    assert store.principal_id("Node-A", "Claude_Code", " Main ") == store.principal_id(
+        "node-a", "claude_code", "main"
+    )
+
+
+def test_principal_id_separates_every_axis(store):
+    base = store.principal_id("node-a", "claude_code", "main")
+    assert store.principal_id("node-b", "claude_code", "main") != base
+    assert store.principal_id("node-a", "codex", "main") != base
+    assert store.principal_id("node-a", "claude_code", "worker") != base
+
+
+def test_principal_id_is_not_forgeable_by_field_smashing(store):
+    """A separator, not concatenation: ('ab','c') must not collide with
+    ('a','bc'). Without the delimiter two different agents share one identity,
+    which is the whole point of having one."""
+    assert store.principal_id("ab", "c", "main") != store.principal_id("a", "bc", "main")
+
+
+def test_principal_id_defaults_blank_agent_to_main(store):
+    assert store.principal_id("n", "r", "") == store.principal_id("n", "r", "main")
+
+
+# ── the roster is per-AGENT, which is the entire gap ──────────────────────
+
+def test_two_agents_on_one_runtime_are_two_principals(store):
+    _sess(store, "claude_code:s1", agent_id="main")
+    _sess(store, "claude_code:s2", agent_id="reviewer")
+    rows = store.query_agent_principals()
+    ids = {r["principal_id"] for r in rows}
+    assert len(ids) == 2, rows
+    assert {r["agent_id"] for r in rows} == {"main", "reviewer"}
+    # ...and both are correctly attributed to the same runtime.
+    assert {r["runtime"] for r in rows} == {"claude_code"}
+
+
+def test_same_agent_id_on_different_runtimes_stays_distinct(store):
+    _sess(store, "claude_code:s1", agent_id="main")
+    _sess(store, "codex:s2", agent_id="main")
+    rows = store.query_agent_principals()
+    assert len({r["principal_id"] for r in rows}) == 2
+    assert {r["runtime"] for r in rows} == {"claude_code", "codex"}
+
+
+def test_runtime_comes_from_the_session_prefix_not_agent_type(store):
+    """Same rule as sync._runtime_of_session / the frontend's _cmRuntimeOf."""
+    _sess(store, "codex:s1", agent_type="openclaw")
+    rows = store.query_agent_principals()
+    assert rows and rows[0]["runtime"] == "codex"
+
+
+def test_unprefixed_session_falls_back_to_the_openclaw_bucket(store):
+    _sess(store, "plain-session-id")
+    rows = store.query_agent_principals()
+    assert rows and rows[0]["runtime"] == "openclaw"
+
+
+def test_sessions_are_counted_and_aggregated_per_principal(store):
+    _sess(store, "claude_code:s1", total_tokens=10, cost_usd=1.0)
+    _sess(store, "claude_code:s2", total_tokens=5, cost_usd=0.25)
+    rows = store.query_agent_principals()
+    assert len(rows) == 1
+    assert rows[0]["sessions"] == 2
+    assert rows[0]["total_tokens"] == 15
+    assert rows[0]["cost_usd"] == pytest.approx(1.25)
+
+
+def test_filters_narrow_the_roster(store):
+    _sess(store, "claude_code:s1", node_id="node-a")
+    _sess(store, "codex:s2", node_id="node-b")
+    assert len(store.query_agent_principals(runtime="codex")) == 1
+    assert len(store.query_agent_principals(node_id="node-a")) == 1
+    assert len(store.query_agent_principals()) == 2
+
+
+def test_empty_store_returns_empty_not_an_error(store):
+    assert store.query_agent_principals() == []
+
+
+# ── ownership overlays honestly ───────────────────────────────────────────
+
+def test_owner_attaches_to_the_agent_not_the_runtime(store):
+    _sess(store, "claude_code:s1", agent_id="main")
+    _sess(store, "claude_code:s2", agent_id="reviewer")
+    rows = {r["agent_id"]: r for r in store.query_agent_principals()}
+    store.set_agent_meta(rows["reviewer"]["principal_id"], owner="platform-team")
+
+    after = {r["agent_id"]: r for r in store.query_agent_principals()}
+    assert after["reviewer"]["owner"] == "platform-team"
+    assert after["reviewer"]["owner_source"] == "agent"
+    # The sibling agent on the SAME runtime must not inherit it.
+    assert after["main"]["owner"] == ""
+
+
+def test_unclaimed_agent_inherits_its_runtime_owner_but_says_so(store):
+    """Inheritance is useful; pretending a human named this agent is not."""
+    _sess(store, "claude_code:s1")
+    store.set_agent_meta("claude_code", owner="sre")
+    row = store.query_agent_principals()[0]
+    assert row["owner"] == "sre"
+    assert row["owner_source"] == "runtime"
+
+
+def test_unowned_agent_reports_no_owner_source(store):
+    _sess(store, "claude_code:s1")
+    row = store.query_agent_principals()[0]
+    assert row["owner"] == ""
+    assert row["owner_source"] == ""
+
+
+def test_agent_label_wins_over_the_runtime_label(store):
+    _sess(store, "claude_code:s1")
+    store.set_agent_meta("claude_code", owner="sre")
+    pid = store.query_agent_principals()[0]["principal_id"]
+    store.set_agent_meta(pid, owner="ml-team")
+    row = store.query_agent_principals()[0]
+    assert row["owner"] == "ml-team"
+    assert row["owner_source"] == "agent"
+
+
+def test_identity_is_stable_across_a_store_restart(store, tmp_path, monkeypatch):
+    """Derived, not minted: nothing is persisted that a restart could lose."""
+    _sess(store, "claude_code:s1")
+    before = store.query_agent_principals()[0]["principal_id"]
+    store.stop(flush=True)
+
+    import clawmetry.local_store as ls
+
+    reopened = ls.LocalStore()
+    reopened.start()
+    try:
+        after = reopened.query_agent_principals()[0]["principal_id"]
+    finally:
+        reopened.stop(flush=True)
+    assert before == after

--- a/tests/test_govern_principals_api.py
+++ b/tests/test_govern_principals_api.py
@@ -1,0 +1,209 @@
+"""API surface for agent identity (``routes/govern.py``).
+
+Pins the contracts that matter for a governance primitive:
+
+* the store-less cloud container gets an honest empty 200, never a 500
+  (the same cold-fall-through contract ``routes/inventory.py`` carries);
+* ownership can only be attached to a principal we have actually observed --
+  an inventory that accepts arbitrary keys is an inventory nobody can trust;
+* the detail view is filtered from the same derived roster as the list view,
+  so the two can never disagree.
+"""
+
+from __future__ import annotations
+
+import pytest
+from flask import Flask
+
+from routes.govern import bp_govern
+
+
+def _app():
+    app = Flask(__name__)
+    app.register_blueprint(bp_govern)
+    return app
+
+
+@pytest.fixture
+def client(monkeypatch):
+    import routes.govern as g
+
+    monkeypatch.setattr(g, "is_local_store_read_enabled", lambda: True)
+    return _app().test_client()
+
+
+_ROWS = [
+    {
+        "principal_id": "ap_1111111111111111",
+        "node_id": "node-a",
+        "runtime": "claude_code",
+        "agent_id": "main",
+        "sessions": 3,
+        "owner": "",
+        "owner_source": "",
+    },
+    {
+        "principal_id": "ap_2222222222222222",
+        "node_id": "node-a",
+        "runtime": "codex",
+        "agent_id": "reviewer",
+        "sessions": 1,
+        "owner": "sre",
+        "owner_source": "runtime",
+    },
+]
+
+
+def _stub_store(monkeypatch, rows=None, capture=None):
+    import routes.govern as g
+
+    def _call(method, **kw):
+        if capture is not None:
+            capture.append((method, kw))
+        if method == "query_agent_principals":
+            return list(_ROWS if rows is None else rows)
+        return None
+
+    monkeypatch.setattr(g, "_store_call", _call)
+
+
+# ── cloud cold fall-through ───────────────────────────────────────────────
+
+def test_store_less_cloud_gets_an_honest_empty_200(monkeypatch):
+    import routes.govern as g
+
+    monkeypatch.setattr(g, "is_local_store_read_enabled", lambda: False)
+    r = _app().test_client().get("/api/govern/principals")
+    assert r.status_code == 200
+    assert r.get_json() == {"principals": [], "total": 0}
+
+
+def test_a_dead_store_is_an_empty_roster_not_a_500(client, monkeypatch):
+    import routes.govern as g
+
+    monkeypatch.setattr(g, "_store_call", lambda *a, **k: None)
+    r = client.get("/api/govern/principals")
+    assert r.status_code == 200
+    assert r.get_json()["total"] == 0
+
+
+# ── list ──────────────────────────────────────────────────────────────────
+
+def test_list_returns_the_roster(client, monkeypatch):
+    _stub_store(monkeypatch)
+    body = client.get("/api/govern/principals").get_json()
+    assert body["total"] == 2
+    assert {p["agent_id"] for p in body["principals"]} == {"main", "reviewer"}
+
+
+def test_filters_are_forwarded_to_the_store(client, monkeypatch):
+    seen = []
+    _stub_store(monkeypatch, capture=seen)
+    client.get("/api/govern/principals?runtime=codex&node_id=node-a&limit=7")
+    method, kw = seen[0]
+    assert method == "query_agent_principals"
+    assert kw["runtime"] == "codex"
+    assert kw["node_id"] == "node-a"
+    assert kw["limit"] == 7
+
+
+def test_runtime_all_means_no_runtime_filter(client, monkeypatch):
+    seen = []
+    _stub_store(monkeypatch, capture=seen)
+    client.get("/api/govern/principals?runtime=all")
+    assert seen[0][1]["runtime"] is None
+
+
+def test_a_garbage_limit_does_not_500(client, monkeypatch):
+    _stub_store(monkeypatch)
+    assert client.get("/api/govern/principals?limit=banana").status_code == 200
+
+
+def test_limit_is_clamped(client, monkeypatch):
+    seen = []
+    _stub_store(monkeypatch, capture=seen)
+    client.get("/api/govern/principals?limit=999999")
+    assert seen[0][1]["limit"] == 2000
+
+
+# ── detail ────────────────────────────────────────────────────────────────
+
+def test_detail_returns_one_principal(client, monkeypatch):
+    _stub_store(monkeypatch)
+    body = client.get("/api/govern/principals/ap_2222222222222222").get_json()
+    assert body["agent_id"] == "reviewer"
+    assert body["owner_source"] == "runtime"
+
+
+def test_detail_404s_for_an_unknown_id(client, monkeypatch):
+    _stub_store(monkeypatch)
+    assert client.get("/api/govern/principals/ap_nope").status_code == 404
+
+
+# ── ownership ─────────────────────────────────────────────────────────────
+
+def test_owner_write_targets_the_principal_id(client, monkeypatch):
+    seen = []
+    _stub_store(monkeypatch, capture=seen)
+    r = client.post(
+        "/api/govern/principals/ap_1111111111111111/owner",
+        json={"owner": "platform-team"},
+    )
+    assert r.status_code == 200 and r.get_json()["ok"] is True
+    writes = [(m, kw) for m, kw in seen if m == "set_agent_meta"]
+    assert writes and writes[0][1]["agent_key"] == "ap_1111111111111111"
+    assert writes[0][1]["owner"] == "platform-team"
+
+
+def test_owner_write_is_refused_for_an_unobserved_principal(client, monkeypatch):
+    """Accepting any key would write unbounded rows into agent_meta and let an
+    owner be attached to an agent that does not exist."""
+    seen = []
+    _stub_store(monkeypatch, capture=seen)
+    r = client.post(
+        "/api/govern/principals/ap_not_a_real_agent/owner", json={"owner": "x"}
+    )
+    assert r.status_code == 404
+    assert not [m for m, _ in seen if m == "set_agent_meta"]
+
+
+def test_an_empty_body_is_rejected_rather_than_clearing_the_owner(client, monkeypatch):
+    """None means "leave this field alone"; a bodyless POST must not be read as
+    "clear it"."""
+    seen = []
+    _stub_store(monkeypatch, capture=seen)
+    r = client.post("/api/govern/principals/ap_1111111111111111/owner", json={})
+    assert r.status_code == 400
+    assert not [m for m, _ in seen if m == "set_agent_meta"]
+
+
+def test_owner_can_be_cleared_explicitly(client, monkeypatch):
+    seen = []
+    _stub_store(monkeypatch, capture=seen)
+    r = client.post(
+        "/api/govern/principals/ap_1111111111111111/owner", json={"owner": ""}
+    )
+    assert r.status_code == 200
+    writes = [kw for m, kw in seen if m == "set_agent_meta"]
+    assert writes and writes[0]["owner"] == ""
+
+
+def test_notes_only_update_leaves_owner_untouched(client, monkeypatch):
+    seen = []
+    _stub_store(monkeypatch, capture=seen)
+    client.post(
+        "/api/govern/principals/ap_1111111111111111/owner", json={"notes": "on call"}
+    )
+    writes = [kw for m, kw in seen if m == "set_agent_meta"]
+    assert writes and writes[0]["owner"] is None and writes[0]["notes"] == "on call"
+
+
+def test_owner_write_is_a_noop_when_the_store_is_disabled(monkeypatch):
+    import routes.govern as g
+
+    monkeypatch.setattr(g, "is_local_store_read_enabled", lambda: False)
+    r = _app().test_client().post(
+        "/api/govern/principals/ap_1/owner", json={"owner": "x"}
+    )
+    assert r.status_code == 200
+    assert r.get_json()["ok"] is False


### PR DESCRIPTION
Artifact step 01: *"Agent identity — everything else waits on this."*

The Agent Inventory rolls up **one row per runtime**, so ownership attaches to "claude_code on this box" rather than to an agent. That single missing primitive sits under three separate capabilities:

- a policy cannot say *this agent may not do that* without a principal
- RBAC has no subject to bind a role to
- the audit chain has no actor beyond a session id

Build the primitive once and all three become possible. This is the primitive, nothing more — no UI, no RBAC, no policy binding.

## Identity is derived, not minted

`principal_id` is a stable hash of `(node_id, runtime, agent_id)` — every field of which `sessions` **already carries**.

ClawMetry watches agents nobody instrumented, so there is no enrolment step to hang a generated id off; identity has to fall out of what we already observe. The consequences are the useful part:

- stable across restarts
- reproducible in any process, with no lookup and nothing to persist
- works **retroactively** on history already in the store

The hash joins its fields with a separator, so `("ab","c")` cannot collide with `("a","bc")`. Without that, two different agents quietly share one identity — which defeats the point of having one.

## Ownership overlays honestly

Reuses `set_agent_meta` keyed by the principal id. That table's key is a free-form VARCHAR, so agent-level and runtime-level labels coexist with **no migration** and no collision.

An agent with no label of its own inherits its runtime's, reported as `owner_source: "runtime"` rather than pretending a human named this specific agent. Inheritance is useful; implying an ownership decision nobody made is not.

## API

```
GET  /api/govern/principals
GET  /api/govern/principals/<id>
POST /api/govern/principals/<id>/owner
```

The write only accepts a principal we have **actually observed**. Taking arbitrary keys would write unbounded rows into `agent_meta` and let an owner be attached to an agent that does not exist — an inventory nobody can trust is worse than no inventory.

Reads go through the daemon proxy (allowlisted) so the dashboard process never opens the writer-locked DuckDB. Every handler never-raises with an honest empty 200 on the store-less cloud container, matching the cold-fall-through contract `routes/inventory.py` already carries.

## Verification

32 tests, plus end-to-end through the real Flask app: three sessions across two runtimes resolve to three principals, `claude_code/main` and `claude_code/reviewer` are correctly **distinct**, and claiming one leaves its sibling on the same runtime unowned.

```
ap_ddca16ac1e3a610d  claude_code  agent=main      owner='platform-team' src='agent'
ap_ec781e604f992fb9  claude_code  agent=reviewer  owner=''             src=''
ap_96fbb7fb646064ad  codex        agent=main      owner=''             src=''
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QzdyAoBb4Rb8AZj9Pgq3Ny