### PR TITLE
Hosted retention panel goes read-only instead of stating the plan as the machine's setting

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -10918,6 +10918,27 @@ function _renderRetention(state) {
   var label = document.getElementById('retention-label');
   var input = document.getElementById('retention-days-input');
   if (!label || !input) return;
+  // On the hosted dashboard there is no node to read or write. The server
+  // answers from the plan alone, which is true for the account but blind to
+  // a SHORTER period the operator set on the machine itself — and the write
+  // has no path to that machine at all. Showing the plan number next to an
+  // editable box would state it as the machine's setting and offer a control
+  // that cannot work, so the panel goes read-only and says where the real
+  // answer lives.
+  if (window.CLOUD_MODE) {
+    var _rw = document.getElementById('retention-controls');
+    if (_rw) _rw.style.display = 'none';
+    var _days = state && state.cap_days;
+    label.textContent = _days
+      ? ('Your plan keeps event history for ' + _days + ' day'
+         + (_days === 1 ? '' : 's') + '. A machine can be set to keep less '
+         + 'than that, from the Security tab on the machine itself.')
+      : ('Your plan keeps event history indefinitely. A machine can be set '
+         + 'to keep less, from the Security tab on the machine itself.');
+    var _st = document.getElementById('retention-status');
+    if (_st) { _st.textContent = ''; _st.style.color = ''; }
+    return;
+  }
   label.textContent = (state && state.explanation) || '';
   if (state && state.configured_days) {
     input.value = state.configured_days;

--- a/clawmetry/templates/tabs/security.html
+++ b/clawmetry/templates/tabs/security.html
@@ -102,7 +102,7 @@
         <div style="font-size:13px;font-weight:700;color:var(--text-primary);" data-i18n="security.retention_title">Data retention</div>
         <div id="retention-label" style="font-size:11px;color:var(--text-muted);margin-top:2px;" data-i18n="security.retention_checking">Checking how long this machine keeps activity history...</div>
       </div>
-      <div style="display:flex;align-items:center;gap:6px;flex-shrink:0;">
+      <div id="retention-controls" style="display:flex;align-items:center;gap:6px;flex-shrink:0;">
         <label for="retention-days-input" style="font-size:11px;color:var(--text-muted);" data-i18n="security.retention_keep_for">Keep for</label>
         <input id="retention-days-input" type="number" min="1" step="1" style="
           width:74px;padding:4px 6px;font-size:12px;border-radius:6px;

--- a/tests/test_retention_setting.py
+++ b/tests/test_retention_setting.py
@@ -221,3 +221,49 @@ def test_the_daemon_prune_loop_reads_this_resolver():
     src = inspect.getsource(sync)
     assert "retention as _ret" in src
     assert "_ret.resolve(store=store)" in src
+
+
+# ── the hosted dashboard must not offer a control it cannot honour ──────
+
+def _app_js():
+    from pathlib import Path
+    return (Path(__file__).resolve().parent.parent
+            / "clawmetry" / "static" / "js" / "app.js").read_text(encoding="utf-8")
+
+
+def _security_html():
+    from pathlib import Path
+    return (Path(__file__).resolve().parent.parent
+            / "clawmetry" / "templates" / "tabs" / "security.html"
+            ).read_text(encoding="utf-8")
+
+
+def test_hosted_panel_hides_the_control_it_cannot_honour():
+    """On cloud there is no node to write to, so the input and its buttons
+    must not render. Offering a Save that always fails is worse than not
+    offering one."""
+    html = _security_html()
+    assert 'id="retention-controls"' in html, (
+        "the editable controls need their own id so the hosted view can hide them"
+    )
+    js = _app_js()
+    i = js.index("function _renderRetention(")
+    body = js[i:i + 2000]
+    assert "window.CLOUD_MODE" in body
+    assert "retention-controls" in body
+
+
+def test_hosted_panel_does_not_state_the_plan_number_as_the_machines_setting():
+    """The hosted answer comes from the entitlement alone and cannot see a
+    shorter period set on the machine. It must be worded as the plan's
+    period, not as what this machine actually does."""
+    js = _app_js()
+    i = js.index("function _renderRetention(")
+    body = js[i:i + 2000]
+    assert "Your plan keeps event history" in body
+    assert "on the machine itself" in body
+    # and it must read cap_days (the plan ceiling), never effective_days,
+    # which on cloud is the same number wearing a claim it cannot support.
+    cloud_branch = body[body.index("window.CLOUD_MODE"):body.index("label.textContent = (state")]
+    assert "cap_days" in cloud_branch
+    assert "effective_days" not in cloud_branch


### PR DESCRIPTION
Follow-up to [#5167](https://github.com/vivekchand/clawmetry/pull/5167), found while pinning the cloud to the release that carries it.

## The problem the pin would have shipped

Retention is a **per-node** setting: the value lives in that machine's local store, and the daemon there is what prunes to it. The hosted dashboard has neither. So two things break the moment cloud serves this panel.

**The number.** On cloud the resolver answers from the entitlement alone, giving the plan ceiling. That's true for the account but **blind to a shorter period the operator set on the machine itself** — and the panel rendered it as *"Event history older than N days is deleted on this node"*, a claim it cannot support.

**The control.** The write has no path to the node, so Save could only ever fail.

## The fix

On `CLOUD_MODE` the panel goes read-only and says what it actually knows:

> Your plan keeps event history for 30 days. A machine can be set to keep less than that, from the Security tab on the machine itself.

The input and its buttons are hidden. A control that always errors is worse than no control.

It reads `cap_days`, never `effective_days` — on cloud they're the same number, but only one of them is a claim we can stand behind. A test pins that, because reaching for the more convenient field is exactly how this regresses.

## Companion

[clawmetry-cloud#2111](https://github.com/vivekchand/clawmetry-cloud/pull/2111) classifies `GET /api/security/retention` as `oss-passthrough` and `POST` as `cloud-disabled`, for the same reason. That PR's route audit is what surfaced this.

## Tests

28 in `tests/test_retention_setting.py` (2 new). Source-inspection guards for the JS branch, since the repo has no JS test runner — same approach as the cloud-side interceptor guard.

Pre-existing and untouched: `test_i18n_no_raw_codes.py` has two failures on main (45 missing keys across other tabs, plus an emoji entity in `banners.html`). This branch's keys are all present.