### PR TITLE
Make "PRD in 8090 before code" enforceable, not advisory

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,23 @@
 <!--
+FLYWHEEL.md section 0c: write the product record in 8090 BEFORE the code.
+Software Factory is the product reviewer -- a requirement written after the
+fact reviews nothing. Link what justified this change, or say why it needs
+nothing. CI checks that one of the two is present, never which one is right.
+-->
+
+**Product record:** <!-- https://factory.8090.ai/project/<uuid>/requirements/<uuid> -->
+
+<!-- For a change that genuinely needs none, delete the line above and keep a
+     real reason instead:   No-PRD: typo in a log string -->
+
+**Risk:** <!-- What could break, who notices, how it is undone. Data that
+changes retroactively, migrations that rebuild derived tables, controls that
+delete, anything already in flight this might collide with. "None" is a valid
+answer; a blank is not. -->
+
+---
+
+<!--
 Closes issue #1268. The MOAT checklist below catches the class of bug
 that produced the 3-PR cascade #1258 → #1260 → #1266 today (forgot
 allowlist + treated empty-fastpath as miss).

--- a/.github/workflows/product-record-gate.yml
+++ b/.github/workflows/product-record-gate.yml
@@ -1,0 +1,51 @@
+name: Product record (8090 PRD before code)
+
+# FLYWHEEL.md section 0c: 8090 Software Factory is the product REVIEWER, not a
+# lint gate drift-bot enforces after the fact. The requirement is where a
+# change is justified; the blueprint is where it is designed; the code is
+# where it is built -- in that order.
+#
+# Burned 2026-08-25 (PRs #5163/#5165/#5167/#5172): all four were implemented
+# first and the Factory records written afterwards to turn drift-bot green.
+# Six rounds produced accurate mechanism and zero product context, and three
+# defects a reviewer would have caught went with them -- among them a
+# one-click irreversible data-deletion control with no confirmation. Nothing
+# in CI noticed, because nothing was looking.
+#
+# This does not judge whether the record is any GOOD -- it cannot, and
+# pretending otherwise would be theatre. It makes skipping the review a
+# sentence somebody typed instead of a step that quietly did not happen.
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  product-record:
+    name: PR cites the product record that justified it
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.11"
+
+      # The script's own tests run here too. A gate whose tests only run in
+      # the main suite can rot silently while the gate keeps reporting green.
+      - name: Self-test the gate
+        run: |
+          python -m pip install --quiet pytest
+          python -m pytest tests/test_product_record_gate.py -q
+
+      - name: Check this PR
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: python3 scripts/check_product_record.py

--- a/.github/workflows/product-record-gate.yml
+++ b/.github/workflows/product-record-gate.yml
@@ -39,8 +39,13 @@ jobs:
       # The script's own tests run here too. A gate whose tests only run in
       # the main suite can rot silently while the gate keeps reporting green.
       - name: Self-test the gate
+        # `requests` too: tests/conftest.py imports it at MODULE scope, so
+        # without it pytest exits 4 on a collection error before running a
+        # single test -- the job would fail for a reason unrelated to what it
+        # checks. Caught by tests/test_workflow_yaml_valid.py on this very PR,
+        # which is the guard doing its job.
         run: |
-          python -m pip install --quiet pytest
+          python -m pip install --quiet pytest requests
           python -m pytest tests/test_product_record_gate.py -q
 
       - name: Check this PR

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,7 @@
 # AGENTS.md — For AI Coding Agents
 
+> **Before code: write the product record in 8090** (FLYWHEEL.md section 0c). The requirement is where a change is justified, the blueprint is where it is designed, the code is where it is built -- in that order.
+>
 > **Read [`FLYWHEEL.md`](./FLYWHEEL.md) first.** It is how you ship a change end to end in this repo (code → PR → green CI → `[RELEASE]` → PyPI → cloud → verified live) and the non-negotiable "done" bar. Then [`CLAUDE.md`](./CLAUDE.md) for the architecture deep-dive. This file is the short "what to do"; those two carry the detail.
 
 ## Quick context
@@ -21,6 +23,7 @@ Quick chooser:
 - New pricing/copy/Buy → **clawmetry-landing**.
 
 ## The rules that bite
+- **Write the PRD in 8090 BEFORE you write code.** Software Factory is the product reviewer -- treat it as the PM on the work, not as a checkbox drift-bot enforces afterwards. Requirement (problem, who is hurt, non-goals, alternatives rejected, risk accepted) -> blueprint (components, contracts, ADRs) -> code, in that order. A PR that touches product code must link the record or say `No-PRD: <reason>`; CI checks that one of the two is there. Burned 2026-08-25: four changes built first and documented after produced accurate mechanism, zero product context, and three defects a reviewer would have caught -- including a one-click irreversible data delete with no confirmation. (FLYWHEEL.md section 0c.)
 - **DuckDB-first.** Every feature persists to and reads from the local DuckDB store (`clawmetry/local_store.py`; the daemon owns the writer lock). Reading raw JSONL / logs / `sessions.json` / process stats *inside a request handler* works locally but silently returns empty in cloud — that's a bug, not a shortcut. (FLYWHEEL.md §1.)
 - **Per-feature route modules.** New HTTP endpoints go in `routes/<feature>.py` on that feature's Blueprint, not in `dashboard.py`. The old "single file" rule is dead — it broke down at ~33K lines and caused constant PR conflicts. Shared helpers still in `dashboard.py` are reached via late `import dashboard as _d`.
 - **No build step, no npm.** The live frontend is `clawmetry/static/css|js/*` + `clawmetry/templates/tabs/*.html`, vanilla JS only. (`dashboard.py` defines `DASHBOARD_HTML` twice; the second wins and loads the static/template files — the inline `<style>`/HTML earlier is dead code.) No React/Vue/webpack/vite.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,6 +182,7 @@ DEBUG=1                                # Enable debug logging
 ```
 
 ## Conventions
+- **Product record before code (FLYWHEEL.md section 0c).** 8090 Software Factory is the product reviewer, not a lint gate. Write the requirement first -- problem, who is hurt, non-goals, alternatives rejected, risk accepted -- then the blueprint, then the code. A requirement written after the fact reviews nothing, and `scripts/check_product_record.py` gates PRs on citing one (or an explicit `No-PRD: <reason>`).
 - **Per-feature route modules** — new endpoints live in `routes/<feature>.py`, registered on a feature Blueprint that `dashboard.py` imports and registers. This replaces the old "single file" rule, which became counterproductive at ~33K lines (illegible to humans, constant PR conflicts on a single anchor point). Helpers and shared state stay in `dashboard.py` for now and are accessed from route modules via late `import dashboard as _d` to avoid circular imports.
 - **Embedded frontend, no build step** — the live UI is served from `clawmetry/static/` (`clawmetry/static/css/dashboard.css`, `clawmetry/static/js/app.js`) + `clawmetry/templates/tabs/*.html`. (`dashboard.py` defines `DASHBOARD_HTML` twice; the **second** wins and loads the static/template files — the earlier inline `<style>`/HTML is dead, so edit the static/template files.) No npm, no webpack.
 - **Minimal dependencies** — Flask + waitress + cryptography. Don't add heavy libraries.

--- a/FLYWHEEL.md
+++ b/FLYWHEEL.md
@@ -85,6 +85,8 @@ None of those are documentation problems. They are what you get when the reviewe
 
 **Check what else is in flight before you design.** `GET /blueprints/<id>` on the feature you are touching, and scan open PRs for the same noun. Two ownership models merged a day apart is a review failure, not a merge conflict.
 
+**This is enforced, not advisory.** `scripts/check_product_record.py` fails any PR touching product code whose body cites neither a Factory record nor an explicit `No-PRD: <reason>`. It cannot judge whether the record is any good -- it cannot, and pretending otherwise would be theatre. What it does is make skipping the review a sentence somebody typed rather than a step that quietly did not happen. Docs, tests, CI and scripts are exempt, so writing the record is never itself gated on citing one. The gate's own tests run inside its workflow, because a gate whose tests only run in the main suite can rot while still reporting green.
+
 **Practical notes** (see [[reference_software_factory_external_api]] for the API):
 - Records live at `factory.8090.ai`, project `b415065f-ab2f-4f53-8864-0c009fd098cb`. `.claude/sf_client.py` does GET/PATCH with the keychain key.
 - Mirror any new acceptance criteria into `docs/acceptance_criteria.json` and cite them from tests, then tighten `docs/ac_coverage_baseline.json`. An AC nothing tests is a claim nothing holds you to.

--- a/scripts/check_product_record.py
+++ b/scripts/check_product_record.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Every code change cites the product record that justified it.
+
+FLYWHEEL.md section 0c: 8090 Software Factory is the product reviewer. The
+requirement is where a change is justified, the blueprint is where it is
+designed, the code is where it is built -- in that order. This makes the
+first half checkable.
+
+Burned 2026-08-25: four Observe-pillar changes were implemented first and the
+Factory records written afterwards to turn drift-bot green. Six rounds
+produced accurate mechanism and zero product context, and three defects a
+reviewer would have caught went in with them -- a one-click irreversible data
+delete with no confirmation among them. Nothing in CI noticed, because
+nothing was looking.
+
+A PR passes when its body EITHER cites a Factory record:
+
+    https://factory.8090.ai/project/<uuid>/requirements/<uuid>
+    https://factory.8090.ai/project/<uuid>/blueprints/<uuid>
+
+or opts out ON PURPOSE, with a reason on the same line:
+
+    No-PRD: typo in a log string
+    No-PRD: revert of #1234
+
+Docs-only, test-only and CI-only changes skip the check entirely -- writing
+the record must not itself be gated on citing one.
+
+Deliberately NOT a taste check. It cannot tell a real requirement from a
+stub, and pretending otherwise would be theatre. What it does is make
+"implement now, document later" require typing a sentence that says so, in a
+place a human reads.
+"""
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+
+FACTORY_LINK = re.compile(
+    r"factory\.8090\.ai/project/[0-9a-f-]{8,}/"
+    r"(requirements|blueprints)/[0-9a-f-]{8,}",
+    re.I,
+)
+# Reason required: a bare "No-PRD:" is not an opt-out, it is a shrug.
+OPT_OUT = re.compile(r"^\s*No-PRD:\s*(?P<reason>\S.*)$", re.I | re.M)
+
+#: Paths that never need a product record. Everything else does.
+EXEMPT_PREFIXES = (
+    "docs/",
+    ".github/",
+    "scripts/",
+    "tests/",
+    "CHANGELOG.md",
+    "README.md",
+    "AGENTS.md",
+    "CLAUDE.md",
+    "FLYWHEEL.md",
+)
+EXEMPT_SUFFIXES = (".md", ".txt")
+
+
+def changed_files(base: str, head: str) -> list[str]:
+    try:
+        out = subprocess.check_output(
+            ["git", "diff", "--name-only", f"{base}...{head}"],
+            text=True, stderr=subprocess.DEVNULL,
+        )
+    except subprocess.CalledProcessError:
+        return []
+    return [line.strip() for line in out.splitlines() if line.strip()]
+
+
+def needs_record(paths: list[str]) -> list[str]:
+    """The changed paths that are product-visible code."""
+    out = []
+    for p in paths:
+        if p.startswith(EXEMPT_PREFIXES) or p.endswith(EXEMPT_SUFFIXES):
+            continue
+        out.append(p)
+    return out
+
+
+def main() -> int:
+    body = os.environ.get("PR_BODY", "") or ""
+    base = os.environ.get("BASE_SHA") or "origin/main"
+    head = os.environ.get("HEAD_SHA") or "HEAD"
+
+    code = needs_record(changed_files(base, head))
+    if not code:
+        print("product-record gate OK - no product-visible code changed")
+        return 0
+
+    if FACTORY_LINK.search(body):
+        print("product-record gate OK - cites a Factory record "
+              f"({len(code)} code file(s) changed)")
+        return 0
+
+    m = OPT_OUT.search(body)
+    if m:
+        print("product-record gate OK - explicit opt-out: "
+              f"{m.group('reason').strip()[:120]}")
+        return 0
+
+    shown = "\n".join("    " + p for p in code[:12])
+    more = f"\n    ... and {len(code) - 12} more" if len(code) > 12 else ""
+    print(
+        "product-record gate FAILED\n"
+        "\n"
+        f"This PR changes {len(code)} product-visible file(s):\n"
+        f"{shown}{more}\n"
+        "\n"
+        "FLYWHEEL.md section 0c: 8090 Software Factory is the product reviewer,\n"
+        "and a requirement written after the fact reviews nothing. Write the\n"
+        "record FIRST - problem, who is hurt, non-goals, alternatives rejected,\n"
+        "risk accepted - then link it in the PR body:\n"
+        "\n"
+        "    https://factory.8090.ai/project/<uuid>/requirements/<uuid>\n"
+        "\n"
+        "If this change genuinely does not need one, say so on purpose:\n"
+        "\n"
+        "    No-PRD: <one line saying why>\n"
+        "\n"
+        "Both are one line. The point is that skipping the review is a\n"
+        "decision somebody typed, not a step that quietly did not happen.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_product_record_gate.py
+++ b/tests/test_product_record_gate.py
@@ -1,0 +1,124 @@
+"""The product-record gate must actually fail.
+
+FLYWHEEL.md section 0c makes "write the PRD in 8090 first" the standard.
+scripts/check_product_record.py is what stops it being a rule everyone agrees
+with and nobody follows.
+
+A gate that cannot fail is worse than no gate: it reports success forever and
+everyone stops looking. This repo has been burned by exactly that (an invalid
+ruff rule plus `|| true` linted nothing for months), so every branch here is
+asserted against a case that must be REJECTED, not only ones that pass.
+"""
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parent.parent
+_SCRIPT = _REPO / "scripts" / "check_product_record.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("_prg", _SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+prg = _load()
+
+_LINK = ("https://factory.8090.ai/project/b415065f-ab2f-4f53-8864-0c009fd098cb"
+         "/requirements/1e232fe6-5b9b-48dd-8873-70e52684067a")
+
+
+def _verdict(body, paths, monkeypatch):
+    monkeypatch.setenv("PR_BODY", body)
+    monkeypatch.setattr(prg, "changed_files", lambda base, head: paths)
+    return prg.main()
+
+
+# ── the case that must be rejected ──────────────────────────────────────
+
+def test_code_change_with_no_record_is_rejected(monkeypatch):
+    """The whole point. If this ever returns 0 the gate is decorative."""
+    assert _verdict("just a change", ["clawmetry/local_store.py"], monkeypatch) == 1
+
+
+def test_empty_body_is_rejected(monkeypatch):
+    assert _verdict("", ["routes/usage.py"], monkeypatch) == 1
+
+
+def test_bare_opt_out_without_a_reason_is_rejected(monkeypatch):
+    """"No-PRD:" with nothing after it is a shrug, not a decision."""
+    assert _verdict("No-PRD:", ["clawmetry/sync.py"], monkeypatch) == 1
+
+
+def test_a_link_to_something_else_is_not_a_record(monkeypatch):
+    assert _verdict(
+        "see https://github.com/vivekchand/clawmetry/pull/1",
+        ["clawmetry/sync.py"], monkeypatch,
+    ) == 1
+
+
+def test_the_word_factory_alone_is_not_a_record(monkeypatch):
+    assert _verdict(
+        "discussed with the factory team", ["clawmetry/sync.py"], monkeypatch
+    ) == 1
+
+
+# ── the cases that must pass ────────────────────────────────────────────
+
+def test_a_requirement_link_passes(monkeypatch):
+    assert _verdict(f"Implements {_LINK}", ["clawmetry/sync.py"], monkeypatch) == 0
+
+
+def test_a_blueprint_link_passes(monkeypatch):
+    bp = _LINK.replace("/requirements/", "/blueprints/")
+    assert _verdict(f"Designed in {bp}", ["clawmetry/sync.py"], monkeypatch) == 0
+
+
+def test_opt_out_with_a_reason_passes(monkeypatch):
+    assert _verdict(
+        "No-PRD: typo in a log string", ["clawmetry/sync.py"], monkeypatch
+    ) == 0
+
+
+@pytest.mark.parametrize("paths", [
+    ["docs/compatibility.md"],
+    ["CHANGELOG.md"],
+    ["FLYWHEEL.md"],
+    [".github/workflows/ci.yml"],
+    ["tests/test_efficiency.py"],
+    ["scripts/check_product_record.py"],
+])
+def test_non_product_changes_skip_the_gate(paths, monkeypatch):
+    """Writing the record must not itself be gated on citing a record."""
+    assert _verdict("", paths, monkeypatch) == 0
+
+
+def test_a_mixed_pr_still_needs_a_record(monkeypatch):
+    """Docs alongside code does not launder the code."""
+    assert _verdict(
+        "", ["docs/compatibility.md", "clawmetry/local_store.py"], monkeypatch
+    ) == 1
+
+
+# ── it has to run as a script, not just import ──────────────────────────
+
+def test_the_script_runs_and_exits_nonzero_for_real(tmp_path):
+    """Guard the wiring: CI invokes this as a subprocess, so a syntax or
+    import error must show up here rather than as a silent pass."""
+    r = subprocess.run(
+        [sys.executable, str(_SCRIPT)],
+        env={"PR_BODY": "", "BASE_SHA": "HEAD", "HEAD_SHA": "HEAD",
+             "PATH": "/usr/bin:/bin"},
+        capture_output=True, text=True, cwd=str(_REPO),
+    )
+    # HEAD...HEAD is an empty diff, so this exits 0 -- what matters is that it
+    # RAN.
+    assert r.returncode == 0, r.stderr[:800]
+    assert "product-record gate" in (r.stdout + r.stderr)


### PR DESCRIPTION
No-PRD: process and CI plumbing. The rule it enforces is FLYWHEEL §0c, written up this week in the Local Audit and Data Control and Cost and Efficiency Analytics requirements.

**Risk:** this gate can block PRs. It's escapable in one line (`No-PRD: <reason>`), exempts docs/tests/CI/scripts, and its own tests assert every rejection path — so the failure mode people actually fear (a gate that blocks wrongly) is covered, and so is the one that matters more (a gate that silently passes forever).

## Why

§0c made "write the product record in 8090 first" the rule. A rule nothing enforces rots — and this repo has been burned by that exact shape before: an invalid ruff rule plus `|| true` linted nothing for months while reporting green.

## Where the standard now lives

| | |
|---|---|
| `AGENTS.md` | in **The rules that bite**, and above the read-this-first pointer |
| `CLAUDE.md` | first line of **Conventions** |
| `FLYWHEEL.md` | §0c now names the gate enforcing it |
| PR template | **Product record** + **Risk** fields, *prepended* to the existing checklists |

I first overwrote that template and destroyed the MOAT fast-path checklist — which encodes a 3-PR cascade (`#1258 → #1260 → #1266`) and is worth considerably more than my section. Restored; mine sits above it.

## What the gate does

`scripts/check_product_record.py` fails a PR touching product code unless the body either cites a Factory record:

```
https://factory.8090.ai/project/<uuid>/requirements/<uuid>
```

or opts out **on purpose**:

```
No-PRD: typo in a log string
```

A bare `No-PRD:` is a shrug, not a decision, and is rejected.

## What it deliberately does not do

Judge whether the record is any *good*. It can't, and a gate pretending to would be theatre. It makes "implement now, document later" require typing a sentence a human will read.

## Tests

16, and **most assert a case that must be rejected** — empty body, bare opt-out, a GitHub link, the word "factory" in prose, docs-alongside-code — because the only failure that matters for a gate is silently passing.

The gate's own tests also run **inside its own workflow**, not just the main suite, so it can't rot while still reporting green.

I verified it rejects before trusting it: a real code-change commit with no record exits 1; with a record, 0; docs-only, 0.