### PR TITLE
WO-7: harden the OTLP receiver into a daemon-free intake path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -441,6 +441,57 @@ jobs:
       - name: Run compression/cache-safety eval suite
         run: python3 -m pytest tests/test_compression_safety_eval.py -q
 
+  # ── OTLP receiver (daemon-free intake path, WO-7) ────────────────────────────
+  # The ONLY job that installs opentelemetry-proto. Without it every OTLP
+  # protobuf test in this repo is importorskip'd, so the receiver an
+  # enterprise points 500 machines at had zero CI coverage — the failure mode
+  # is a green board over an untested path, not a red one. Two tests in
+  # test_spans_otlp_edge_cases.py had in fact been failing the whole time and
+  # nobody could see it, because the file skipped itself.
+  #
+  # The enterprise ingest image bakes the same dependency in (see Dockerfile),
+  # so this job runs the receiver in the configuration a customer actually
+  # deploys. HARD-FAIL: no continue-on-error.
+  otlp-receiver:
+    name: OTLP receiver (with otel extra)
+    needs: lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 6
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.11"
+          cache: pip
+      - name: Install dependencies (including the otel extra)
+        run: |
+          pip install flask waitress cryptography duckdb pytest requests psutil
+          pip install "opentelemetry-proto>=1.20.0" "protobuf>=4.21.0"
+      - name: Assert the protobuf decoder is actually available
+        run: |
+          python3 -c "
+          import dashboard
+          assert dashboard._HAS_OTEL_PROTO, (
+              'otel extra did not import — the suite below would silently skip')
+          print('OTLP protobuf decoder present')
+          "
+      - name: Run the OTLP receiver suite
+        run: |
+          python3 -m pytest \
+            tests/test_otlp_daemon_free_intake.py \
+            tests/test_otlp_logs.py \
+            tests/test_otlp_metrics_edge_cases.py \
+            tests/test_otlp_traces_cost.py \
+            tests/test_otlp_json_no_protobuf.py \
+            tests/test_otlp_compat_port.py \
+            tests/test_otlp_dos_auth.py \
+            tests/test_otlp_rollup_cpu_budget.py \
+            tests/test_spans_otlp_edge_cases.py \
+            -q
+          # NOT listed: tests/test_e2e_otlp_ingest.py — it drives a LIVE
+          # dashboard over HTTP (BASE_URL), which this job does not boot. It
+          # runs in the api-tests job, which does.
+
   # ── MOAT keystone (DuckDB-first invariant, 13-endpoint bar) ──────────────────────────────
   # Implements `docs/MOAT_BAR.md` Section 5 acceptance criterion #1:
   # `keystone_e2e.py --no-drive` exits 0 on every PR. The keystone is the

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,16 @@ WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
+# OTLP protobuf support, baked in rather than left to the [otel] extra.
+# This image is what deploy/self-hosted/docker-compose.yml builds, and the
+# daemon-free intake path (an org points OTEL_EXPORTER_OTLP_ENDPOINT here
+# instead of installing anything per machine) depends on it: OTLP/JSON
+# decodes with the stdlib, but the default exporter protocol is
+# http/protobuf, and without these the receiver answers 501 to every POST.
+# An enterprise receiver that has to be told to `pip install clawmetry[otel]`
+# before it accepts data is not a receiver.
+RUN pip install --no-cache-dir "opentelemetry-proto>=1.20.0" "protobuf>=4.21.0"
+
 # Copy application code and necessary files for setup
 COPY dashboard.py .
 COPY history.py .

--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -1397,6 +1397,63 @@ _DDL = [
     """,
     "CREATE INDEX IF NOT EXISTS idx_session_phase_phase ON session_phase(phase, phase_since DESC)",
     "CREATE INDEX IF NOT EXISTS idx_session_phase_runtime ON session_phase(runtime, observed_at DESC)",
+    # ── Daemon-free OTLP intake (WO-7) ────────────────────────────────────
+    # The receiver at /v1/logs used to fold every record into the in-memory
+    # metrics cache, so an org that onboarded by pointing OTEL_* at ClawMetry
+    # lost everything on restart and could not roll anything up by team, repo
+    # or person. This table is the durable half of that path: one row per
+    # ingested OTLP log record, with the identity the runtime already sends
+    # (user.id / user.email / organization.id / session.id) plus the rollup
+    # dimensions an org sets via OTEL_RESOURCE_ATTRIBUTES (team, repo).
+    #
+    # NOT the events table. Events are the agent's behaviour stream (and the
+    # tool records below DO land there, so the trajectory detectors see this
+    # path); this table is the money-and-identity ledger the org buyer asks
+    # for. Keeping it separate means no migration on a hot shared schema.
+    #
+    # record_id is deterministic (see dashboard._otlp_record_id), so an OTLP
+    # exporter retrying a batch REPLACEs its rows instead of double-counting
+    # the spend. That matters more here than anyone else in the store: OTLP
+    # delivery is at-least-once by specification.
+    #
+    # NOTE ON DATA HANDLING: rows on this path arrive in PLAINTEXT over HTTP.
+    # The runtime encrypts nothing, so the daemon's E2E snapshot guarantee
+    # does not extend here. docs/enterprise.md says so out loud; keep it that
+    # way rather than letting the encryption claim drift over this table.
+    """
+    CREATE TABLE IF NOT EXISTS otlp_records (
+        record_id     VARCHAR PRIMARY KEY,
+        ts            DOUBLE  NOT NULL,
+        received_at   DOUBLE  NOT NULL,
+        event_name    VARCHAR,
+        session_id    VARCHAR,
+        user_id       VARCHAR,
+        user_email    VARCHAR,
+        org_id        VARCHAR,
+        team          VARCHAR,
+        repo          VARCHAR,
+        node_id       VARCHAR,
+        agent_type    VARCHAR,
+        service_name  VARCHAR,
+        model         VARCHAR,
+        provider      VARCHAR,
+        cost_usd      DOUBLE,
+        tokens_input  INTEGER,
+        tokens_output INTEGER,
+        token_count   INTEGER,
+        duration_ms   DOUBLE,
+        tool_name     VARCHAR,
+        decision      VARCHAR,
+        success       BOOLEAN,
+        attributes    BLOB
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_otlp_records_ts       ON otlp_records(ts)",
+    "CREATE INDEX IF NOT EXISTS idx_otlp_records_org_ts   ON otlp_records(org_id, ts)",
+    "CREATE INDEX IF NOT EXISTS idx_otlp_records_team_ts  ON otlp_records(team, ts)",
+    "CREATE INDEX IF NOT EXISTS idx_otlp_records_repo_ts  ON otlp_records(repo, ts)",
+    "CREATE INDEX IF NOT EXISTS idx_otlp_records_user_ts  ON otlp_records(user_email, ts)",
+    "CREATE INDEX IF NOT EXISTS idx_otlp_records_sess_ts  ON otlp_records(session_id, ts)",
 ]
 
 
@@ -5608,6 +5665,302 @@ class LocalStore:
         call ``local_store.get_store().put_span(...)`` per the issue spec
         without us painting the rest of the module a different colour."""
         self.ingest_span(span)
+
+    # ── Daemon-free OTLP intake (WO-7) ─────────────────────────────────────
+
+    _OTLP_RECORD_COLS = (
+        "record_id", "ts", "received_at", "event_name", "session_id",
+        "user_id", "user_email", "org_id", "team", "repo", "node_id",
+        "agent_type", "service_name", "model", "provider", "cost_usd",
+        "tokens_input", "tokens_output", "token_count", "duration_ms",
+        "tool_name", "decision", "success", "attributes",
+    )
+
+    def put_otlp_batch(
+        self,
+        records: list[dict[str, Any]] | None = None,
+        events: list[dict[str, Any]] | None = None,
+    ) -> dict[str, int]:
+        """Persist ONE OTLP export batch: identity/spend rows into
+        ``otlp_records`` and behaviour rows into ``events``.
+
+        Both halves in one call on purpose. In the dashboard process
+        ``get_store()`` returns a ``_ProxyStore`` that forwards to the daemon
+        over HTTP, so a per-record call would cost one round trip per record —
+        an OTLP exporter ships batches of hundreds. One hop per batch keeps the
+        receiver inside the CPU budget (FLYWHEEL 1e).
+
+        Args are keyword-friendly and the proxy forwards ``**kwargs`` only, so
+        call this as ``put_otlp_batch(records=[...], events=[...])``. A
+        positional call through the proxy silently writes nothing — the same
+        foot-gun ``put_span`` hit.
+
+        ``record_id`` is the primary key and callers derive it deterministically
+        from the record's own content, so a retried OTLP batch REPLACEs its rows
+        rather than double-counting spend. Event rows dedup on ``id`` through
+        the normal INSERT-OR-IGNORE ingest path.
+
+        Returns ``{"records": n, "events": n, "events_skipped_daemon_owned":
+        n}`` — what was accepted, and what was dropped because a daemon
+        already owns that session (see below).
+        Never raises on a single bad row; a malformed record is skipped and the
+        rest of the batch lands.
+        """
+        if self._read_only:
+            raise RuntimeError("local_store: put_otlp_batch() on read-only store")
+        rows: dict[str, list[Any]] = {}
+        for rec in records or []:
+            if not isinstance(rec, dict):
+                continue
+            rid = rec.get("record_id")
+            if not rid:
+                continue
+            try:
+                ts = float(rec.get("ts") or 0.0)
+            except (TypeError, ValueError):
+                continue
+            if ts <= 0:
+                continue
+
+            def _s(key: str) -> str | None:
+                v = rec.get(key)
+                if v in (None, ""):
+                    return None
+                return str(v)
+
+            def _f(key: str) -> float | None:
+                v = rec.get(key)
+                if v in (None, ""):
+                    return None
+                try:
+                    return float(v)
+                except (TypeError, ValueError):
+                    return None
+
+            def _i(key: str) -> int | None:
+                v = _f(key)
+                return None if v is None else int(v)
+
+            success = rec.get("success")
+            if success is not None:
+                success = bool(success)
+            try:
+                received = float(rec.get("received_at") or 0.0) or time.time()
+            except (TypeError, ValueError):
+                received = time.time()
+            # Last write wins within the batch — an exporter that repeats a
+            # record inside one payload should not insert it twice.
+            rows[str(rid)] = [
+                str(rid), ts, received,
+                _s("event_name"), _s("session_id"), _s("user_id"),
+                _s("user_email"), _s("org_id"), _s("team"), _s("repo"),
+                _s("node_id"), _s("agent_type"), _s("service_name"),
+                _s("model"), _s("provider"),
+                _f("cost_usd"), _i("tokens_input"), _i("tokens_output"),
+                _i("token_count"), _f("duration_ms"),
+                _s("tool_name"), _s("decision"), success,
+                _to_blob(rec.get("attributes")),
+            ]
+
+        written = 0
+        if rows:
+            placeholders = ", ".join(["?"] * len(self._OTLP_RECORD_COLS))
+            sql = (
+                "INSERT OR REPLACE INTO otlp_records ("
+                + ", ".join(self._OTLP_RECORD_COLS)
+                + f") VALUES ({placeholders})"
+            )
+            with self._write_lock:
+                for params in rows.values():
+                    try:
+                        self._conn.execute(sql, params)
+                        written += 1
+                    except Exception:
+                        log.warning("otlp_records: row rejected", exc_info=True)
+
+        # Sessions whose behaviour stream a DAEMON already owns. On a machine
+        # that runs the daemon AND has the org's OTEL config pushed to it, the
+        # same session arrives twice: once read from the transcript on disk,
+        # once pushed by the runtime. Writing both would double the session's
+        # spend and show every tool call twice — and a cost figure that
+        # doubles because two collectors both worked is worse than a missing
+        # one. The transcript read is strictly richer (real tool arguments,
+        # assistant text), so the daemon wins and the OTLP events are dropped.
+        # The identity/spend LEDGER above is unaffected: it is a separate
+        # table with its own dedup key, and the org rollups still see every
+        # record.
+        #
+        # Known gap, stated rather than hidden: if the OTLP record arrives
+        # BEFORE the daemon has ingested that session's transcript, this check
+        # sees no daemon rows yet and lets the events through. The window is
+        # the first ingest tick of a brand-new session.
+        owned_by_daemon: set[str] = set()
+        want_sessions = sorted({
+            str(ev.get("session_id")) for ev in (events or [])
+            if isinstance(ev, dict) and ev.get("session_id")
+        })
+        if want_sessions:
+            try:
+                placeholders = ", ".join(["?"] * len(want_sessions))
+                rows = self._fetch(
+                    "SELECT DISTINCT session_id FROM events "
+                    f"WHERE session_id IN ({placeholders}) "
+                    "AND id NOT LIKE 'otlp:%'",
+                    list(want_sessions),
+                )
+                owned_by_daemon = {str(r[0]) for r in rows if r and r[0]}
+            except Exception:
+                log.warning("otlp events: ownership probe failed", exc_info=True)
+
+        ev_written = 0
+        ev_skipped = 0
+        for ev in events or []:
+            if not isinstance(ev, dict):
+                continue
+            if str(ev.get("session_id") or "") in owned_by_daemon:
+                ev_skipped += 1
+                continue
+            try:
+                self.ingest(ev)
+                ev_written += 1
+            except Exception:
+                log.warning("otlp events: row rejected", exc_info=True)
+        # The receiver is a request handler, not the daemon's ingest loop, so
+        # there is no flusher tick coming to drain the ring on its own
+        # schedule. Flush now: "data survives a restart" is this path's
+        # acceptance criterion, and a batch sitting in the ring does not.
+        if ev_written:
+            try:
+                self._flush_now()
+            except Exception:
+                log.warning("otlp events: flush failed", exc_info=True)
+        return {
+            "records": written,
+            "events": ev_written,
+            "events_skipped_daemon_owned": ev_skipped,
+        }
+
+    def query_otlp_records(
+        self,
+        *,
+        session_id: str | None = None,
+        org_id: str | None = None,
+        team: str | None = None,
+        repo: str | None = None,
+        user_email: str | None = None,
+        event_name: str | None = None,
+        since: float | None = None,
+        until: float | None = None,
+        limit: int = 500,
+    ) -> list[dict[str, Any]]:
+        """Read OTLP intake rows, newest first. Filters compose with AND."""
+        clauses: list[str] = []
+        params: list[Any] = []
+        for col, val in (
+            ("session_id", session_id), ("org_id", org_id), ("team", team),
+            ("repo", repo), ("user_email", user_email),
+            ("event_name", event_name),
+        ):
+            if val:
+                clauses.append(f"{col} = ?")
+                params.append(str(val))
+        if since is not None:
+            clauses.append("ts >= ?")
+            params.append(float(since))
+        if until is not None:
+            clauses.append("ts <= ?")
+            params.append(float(until))
+        where = f"WHERE {' AND '.join(clauses)}" if clauses else ""
+        cols = list(self._OTLP_RECORD_COLS)
+        sql = (
+            f"SELECT {', '.join(cols)} FROM otlp_records {where} "
+            "ORDER BY ts DESC LIMIT ?"
+        )
+        params.append(int(limit))
+        out: list[dict[str, Any]] = []
+        for r in self._fetch(sql, params):
+            d = dict(zip(cols, r))
+            raw = d.get("attributes")
+            if raw is not None:
+                try:
+                    raw = _ccr.maybe_decompress(raw)
+                    text = (
+                        raw.decode("utf-8")
+                        if isinstance(raw, (bytes, bytearray)) else raw
+                    )
+                    try:
+                        d["attributes"] = json.loads(text)
+                    except (ValueError, TypeError):
+                        d["attributes"] = text
+                except UnicodeDecodeError:
+                    d["attributes"] = None
+            out.append(d)
+        return out
+
+    _OTLP_ROLLUP_DIMENSIONS = frozenset(
+        {"team", "repo", "org_id", "user_email", "user_id",
+         "model", "agent_type", "session_id"}
+    )
+
+    def query_otlp_rollup(
+        self,
+        *,
+        dimension: str = "team",
+        since: float | None = None,
+        until: float | None = None,
+        limit: int = 200,
+    ) -> list[dict[str, Any]]:
+        """Spend/token rollup over the daemon-free intake path.
+
+        ``dimension`` is one of ``_OTLP_ROLLUP_DIMENSIONS`` — the whole point of
+        the identity extraction, and the acceptance criterion for WO-7: a
+        by-team or by-repo answer from the ingested rows alone, no join against
+        anything the daemon would have had to write.
+
+        The dimension is validated against a frozenset before it reaches the
+        SQL string; it is a column name, so it cannot be parameterised.
+        """
+        dim = str(dimension or "team")
+        if dim not in self._OTLP_ROLLUP_DIMENSIONS:
+            raise ValueError(f"unsupported rollup dimension: {dimension!r}")
+        clauses = [f"{dim} IS NOT NULL", f"{dim} <> ''"]
+        params: list[Any] = []
+        if since is not None:
+            clauses.append("ts >= ?")
+            params.append(float(since))
+        if until is not None:
+            clauses.append("ts <= ?")
+            params.append(float(until))
+        sql = f"""
+            SELECT {dim} AS key,
+                   COUNT(*)                     AS records,
+                   COUNT(DISTINCT session_id)   AS sessions,
+                   COALESCE(SUM(cost_usd), 0)   AS cost_usd,
+                   COALESCE(SUM(token_count), 0) AS tokens,
+                   COALESCE(SUM(tokens_input), 0) AS tokens_input,
+                   COALESCE(SUM(tokens_output), 0) AS tokens_output,
+                   MIN(ts)                      AS first_ts,
+                   MAX(ts)                      AS last_ts
+            FROM otlp_records
+            WHERE {' AND '.join(clauses)}
+            GROUP BY {dim}
+            ORDER BY cost_usd DESC, records DESC
+            LIMIT ?
+        """
+        params.append(int(limit))
+        cols = ("key", "records", "sessions", "cost_usd", "tokens",
+                "tokens_input", "tokens_output", "first_ts", "last_ts")
+        return [dict(zip(cols, r)) for r in self._fetch(sql, params)]
+
+    def count_otlp_records(self) -> int:
+        """Row count for the daemon-free intake table. Used by
+        ``/api/otel-status`` to show that data actually persisted (as opposed
+        to living in the in-memory cache that a restart clears)."""
+        try:
+            rows = self._fetch("SELECT COUNT(*) FROM otlp_records", [])
+            return int(rows[0][0]) if rows else 0
+        except Exception:
+            return 0
 
     def query_spans(
         self,

--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -5952,15 +5952,21 @@ class LocalStore:
                 "tokens_input", "tokens_output", "first_ts", "last_ts")
         return [dict(zip(cols, r)) for r in self._fetch(sql, params)]
 
-    def count_otlp_records(self) -> int:
+    def count_otlp_records(self) -> int | None:
         """Row count for the daemon-free intake table. Used by
-        ``/api/otel-status`` to show that data actually persisted (as opposed
-        to living in the in-memory cache that a restart clears)."""
+        ``/api/otel-status`` to show that data actually persisted, as opposed
+        to living in the in-memory cache that a restart clears.
+
+        Returns ``None`` when the count could not be taken. Swallowing that as
+        ``0`` would render "we could not ask" as "nothing is stored", which is
+        the reading that sends someone to debug an ingest that is fine.
+        """
         try:
             rows = self._fetch("SELECT COUNT(*) FROM otlp_records", [])
             return int(rows[0][0]) if rows else 0
         except Exception:
-            return 0
+            log.warning("count_otlp_records failed", exc_info=True)
+            return None
 
     def query_spans(
         self,

--- a/clawmetry/otlp_json.py
+++ b/clawmetry/otlp_json.py
@@ -280,10 +280,17 @@ class _Span:
 
 
 class _LogRecord:
-    __slots__ = ("time_unix_nano", "event_name", "severity_text", "body", "attributes")
+    __slots__ = ("time_unix_nano", "observed_time_unix_nano", "event_name",
+                 "severity_text", "body", "attributes")
 
     def __init__(self, raw: dict):
         self.time_unix_nano = _as_int(_get(raw, "timeUnixNano", "time_unix_nano"))
+        # WO-7: the record's own clock is what the intake path stores, and an
+        # exporter that sets only observedTimeUnixNano (legal per the OTLP/JSON
+        # spec) used to fall through to receipt time here — misdating every
+        # batched or retried delivery as "now".
+        self.observed_time_unix_nano = _as_int(
+            _get(raw, "observedTimeUnixNano", "observed_time_unix_nano"))
         self.event_name = str(_get(raw, "eventName", "event_name", default="") or "")
         self.severity_text = str(_get(raw, "severityText", "severity_text", default="") or "")
         body = raw.get("body")

--- a/dashboard.py
+++ b/dashboard.py
@@ -18,6 +18,7 @@ from clawmetry.gateway_protocol import (
     GATEWAY_MAX_PROTOCOL as _GW_MAX_PROTO,
     GATEWAY_MIN_PROTOCOL as _GW_MIN_PROTO,
 )
+import hashlib
 import hmac
 import os
 import sys
@@ -3118,7 +3119,11 @@ def _process_otlp_traces(pb_data, content_encoding=None, content_type=None):
 
 
 def _process_otlp_logs(pb_data, content_encoding=None, content_type=None):
-    """Decode OTLP logs protobuf and ingest agent EVENT records (#2596).
+    """DEAD COPY — shadowed. dashboard.py defines this twice and the SECOND
+    definition wins (search for "Daemon-free OTLP intake"). Edits here change
+    nothing at runtime; make them in the live copy.
+
+    Decode OTLP logs protobuf and ingest agent EVENT records (#2596).
 
     Claude Code (and other runtimes) export their per-turn event stream as OTel
     *logs* — ``event_name`` like ``claude_code.api_request`` / ``tool_decision``
@@ -11934,18 +11939,200 @@ def _process_otlp_traces(pb_data, content_encoding=None, content_type=None):
                             pass
 
 
-def _process_otlp_logs(pb_data, content_encoding=None, content_type=None):
-    """Decode OTLP logs protobuf and ingest agent EVENT records (#2596).
+# ── Daemon-free OTLP intake (WO-7) ───────────────────────────────────────────
+#
+# Everything below serves one deployment shape: an org that does NOT install a
+# per-machine daemon and instead sets OTEL_EXPORTER_OTLP_ENDPOINT (one config
+# value, pushed by MDM) at a ClawMetry the org already runs. That is the only
+# path a 500-developer security review approves in an afternoon.
+#
+# HONESTY BOUNDARIES on this path, which the docs repeat and nothing here may
+# quietly widen:
+#   * Only runtimes that emit OTel natively arrive here — Claude Code and
+#     Codex today. This is NOT a 26-runtime intake path.
+#   * Records arrive in PLAINTEXT. The runtime encrypts nothing, so the
+#     daemon's end-to-end encryption guarantee does not cover this path; the
+#     honest answer for a customer who needs it is the self-hosted VPC
+#     receiver, where the plaintext never leaves their network.
 
-    Claude Code (and other runtimes) export their per-turn event stream as OTel
-    *logs* — ``event_name`` like ``claude_code.api_request`` / ``tool_decision``
-    with cost/token/model attributes — not just metrics/traces, so an OTel-
-    configured install gives signal we previously dropped. We map any log record
-    carrying cost or token attributes into the same metrics cache categories as
-    /v1/metrics (cost / tokens / runs), so the cost + usage tiles light up.
-    Best-effort: a bad record never breaks the batch.
+# Log-record event names, matched on the suffix after the runtime prefix
+# ("claude_code.tool_decision" -> "tool_decision").
+_OTLP_TOOL_CALL_EVENTS = frozenset(
+    {"tool_decision", "tool_use", "tool_call"}
+)
+_OTLP_TOOL_RESULT_EVENTS = frozenset(
+    {"tool_result", "tool_use_result"}
+)
+
+
+# Record ids the live metrics cache has already counted. OTLP delivery is
+# at-least-once, so a retried batch used to add its cost to the tiles a second
+# time — the DuckDB ledger dedups on the primary key, but the tile a person
+# actually looks at showed double. Bounded: this is a cache guard, not a
+# ledger, and it must never grow without limit on a busy receiver. Old ids
+# fall out; a retry that arrives after ~20k records is vanishingly rare and
+# costs one duplicated tile entry, not a duplicated stored row.
+_OTLP_SEEN_MAX = 20000
+_otlp_seen_ids = set()
+_otlp_seen_order = deque()
+_otlp_seen_lock = threading.Lock()
+
+
+def _otlp_seen(record_id):
+    """True if this record already reached the metrics cache. Records it
+    otherwise. Thread-safe: waitress serves OTLP posts on many threads."""
+    if not record_id:
+        return False
+    with _otlp_seen_lock:
+        if record_id in _otlp_seen_ids:
+            return True
+        _otlp_seen_ids.add(record_id)
+        _otlp_seen_order.append(record_id)
+        while len(_otlp_seen_order) > _OTLP_SEEN_MAX:
+            _otlp_seen_ids.discard(_otlp_seen_order.popleft())
+    return False
+
+
+def _otlp_event_suffix(event_name):
+    """``claude_code.tool_decision`` -> ``tool_decision``. Lower-cased."""
+    name = (event_name or "").strip().lower()
+    return name.rsplit(".", 1)[-1] if "." in name else name
+
+
+def _otlp_record_ts(rec, received_at):
+    """Seconds for ONE OTLP log record, from the record's own clock.
+
+    The prototype stamped ``time.time()`` on every record, so a batched or
+    backfilled delivery — the normal case for OTLP, whose exporters buffer and
+    retry — was misdated as "now". Any daily or per-sprint rollup built on that
+    is wrong, and wrong in a way nobody notices until they compare it to a bill.
+
+    Precedence is the OTel spec's: ``time_unix_nano`` (when the event happened)
+    beats ``observed_time_unix_nano`` (when the collector saw it), and receipt
+    time is the last resort for an exporter that sends neither.
     """
+    for field in ("time_unix_nano", "observed_time_unix_nano"):
+        try:
+            nanos = int(getattr(rec, field, 0) or 0)
+        except (TypeError, ValueError):
+            continue
+        if nanos > 0:
+            return nanos / 1e9
+    return received_at
+
+
+def _otlp_repo_key(value):
+    """Normalise a repository attribute into a groupable key.
+
+    An org sends its repo as whatever its tooling has: an https clone URL, an
+    ssh remote, or a checkout path. Rolling up cost by repo means those three
+    have to land on one key, so we take the last path segment without ``.git``
+    (``git@github.com:acme/api.git`` and ``/Users/x/src/api`` both -> ``api``).
+    The raw value stays in the attributes blob, so nothing is lost.
+    """
+    raw = str(value or "").strip()
+    if not raw:
+        return None
+    raw = raw.rstrip("/")
+    if raw.endswith(".git"):
+        raw = raw[:-4]
+    for sep in ("/", "\\", ":"):
+        if sep in raw:
+            raw = raw.rsplit(sep, 1)[-1]
+    return raw or None
+
+
+def _otlp_record_id(service_name, session_id, event_name, rec, attrs):
+    """Deterministic id for one log record, so a retried batch REPLACEs
+    instead of double-counting.
+
+    OTLP delivery is at-least-once by specification: an exporter that does not
+    see our 200 resends the whole batch. Without a stable key the second
+    delivery is a second $4.10, and spend that inflates on a network blip is
+    worse than no spend number at all. The record carries no id of its own, so
+    we hash what identifies it: emitter, session, event name, its own
+    nanosecond timestamp, body, and every attribute.
+    """
+    # Two decoders reach here: the protobuf message (``HasField``) and the
+    # OTLP/JSON shim (a plain object with a ``body`` attribute and no
+    # ``HasField``). Read the body without assuming either.
+    body = ""
+    try:
+        raw_body = getattr(rec, "body", None)
+        has_field = getattr(rec, "HasField", None)
+        if callable(has_field):
+            raw_body = rec.body if has_field("body") else None
+        if raw_body is not None:
+            try:
+                body = _otel_attr_value(raw_body)
+            except Exception:
+                body = str(raw_body)
+    except Exception:
+        body = ""
+    parts = [
+        str(service_name or ""), str(session_id or ""), str(event_name or ""),
+        str(getattr(rec, "time_unix_nano", 0) or 0),
+        str(getattr(rec, "observed_time_unix_nano", 0) or 0),
+        str(body),
+    ]
+    try:
+        for k in sorted(attrs):
+            parts.append("%s=%s" % (k, attrs[k]))
+    except Exception:
+        pass
+    joined = "\x1f".join(parts).encode("utf-8", "replace")
+    return hashlib.sha256(joined).hexdigest()[:32]
+
+
+def _process_otlp_logs(pb_data, content_encoding=None, content_type=None):
+    """Decode OTLP logs protobuf and ingest agent EVENT records (#2596, WO-7).
+
+    Claude Code and Codex export their per-turn event stream as OTel *logs* —
+    ``event_name`` like ``claude_code.api_request`` / ``tool_decision`` with
+    cost/token/model attributes. This handler is the daemon-free intake path:
+    an org points OTEL_EXPORTER_OTLP_ENDPOINT here and gets observability with
+    nothing installed per machine.
+
+    Three destinations, in order of durability:
+
+    1. **DuckDB ``otlp_records``** — the durable ledger. One row per record
+       with the identity the runtime already sends (``user.id``,
+       ``user.email``, ``organization.id``, ``session.id``) plus the rollup
+       dimensions an org adds through ``OTEL_RESOURCE_ATTRIBUTES``
+       (``team.id``, repository). Without these there is no per-team or
+       per-repo answer, which is the whole reason an org buys this.
+    2. **DuckDB ``events``** — ``tool_decision`` / ``tool_result`` records
+       become ``tool_call`` / ``tool_result`` events, so the trajectory
+       detectors (stuck_loop, no_progress, repeated_tool_failure) work on this
+       path exactly as they do on the daemon path.
+    3. **The in-memory metrics cache** — unchanged, because it is what the
+       live tiles read on the same request. It is a cache, not storage: before
+       WO-7 it was the ONLY destination, so a restart erased the deployment's
+       entire history.
+
+    Writes go through ``local_store.get_store()``, which in this process is a
+    ``_ProxyStore`` forwarding to the daemon that owns the writer lock — the
+    request handler never takes it. Best-effort throughout: a bad record never
+    breaks the batch, and a failed DuckDB write never breaks the tiles.
+    """
+    received_at = time.time()
     req = _otlp_request(pb_data, "logs", content_encoding, content_type)
+
+    # Resolve the store lazily (same contract as the traces path): tests that
+    # monkeypatch the singleton, and installs without DuckDB, both keep working.
+    _store = None
+    try:
+        from clawmetry import local_store as _ls
+        _store = _ls.get_store()
+    except Exception:
+        _store = None
+
+    # Accumulated across the WHOLE export batch and written in one call. An
+    # exporter ships hundreds of records per POST and get_store() here is an
+    # HTTP proxy to the daemon, so per-record writes would be per-record round
+    # trips (FLYWHEEL 1e, the daemon's CPU budget).
+    out_records = []
+    out_events = []
 
     def _f(attrs, *keys):
         for k in keys:
@@ -11959,48 +12146,277 @@ def _process_otlp_logs(pb_data, content_encoding=None, content_type=None):
             for attr in resource_logs.resource.attributes:
                 resource_attrs[attr.key] = _otel_attr_value(attr.value)
 
+        service_name = resource_attrs.get("service.name") or ""
+        agent_type = (
+            _otlp_service_name_to_agent_type(service_name) or "openclaw"
+        )
+        node_id = (
+            resource_attrs.get("node.id")
+            or resource_attrs.get("host.name")
+            or resource_attrs.get("host.id")
+            or "otlp"
+        )
+
         for scope_logs in resource_logs.scope_logs:
             for rec in scope_logs.log_records:
                 attrs = {}
                 for attr in rec.attributes:
                     attrs[attr.key] = _otel_attr_value(attr.value)
-                ts = time.time()
-                model = _f(attrs, "model") or resource_attrs.get("model", "")
-                channel = _f(attrs, "channel") or resource_attrs.get("channel", "")
-                provider = _f(attrs, "provider") or resource_attrs.get("provider", "")
+
+                def _pick(*keys):
+                    """Record attributes win over resource attributes — the
+                    precedence the OTel spec uses."""
+                    v = _f(attrs, *keys)
+                    if v is not None:
+                        return v
+                    return _f(resource_attrs, *keys)
+
+                # ── Fix 1: the record's own timestamp, not receipt time ──
+                ts = _otlp_record_ts(rec, received_at)
+
+                # ── Fix 2: identity ──────────────────────────────────────
+                # Claude Code sets user.id / user.email / organization.id /
+                # session.id on every record; team and repository come from
+                # the org's own OTEL_RESOURCE_ATTRIBUTES.
+                session_id = _pick(
+                    "session.id", "session_id", "gen_ai.conversation.id",
+                    "conversation.id",
+                )
+                user_id = _pick(
+                    "user.id", "user.account_uuid", "enduser.id", "user_id",
+                )
+                user_email = _pick("user.email", "enduser.email", "user_email")
+                org_id = _pick(
+                    "organization.id", "organization.uuid", "org.id",
+                    "organization_id", "tenant.id",
+                )
+                team = _pick(
+                    "team.id", "team", "department", "cost_center",
+                    "cost.center", "squad", "group.id",
+                )
+                repo_raw = _pick(
+                    "vcs.repository.url.full", "vcs.repository.url",
+                    "repository", "repo", "git.repository", "git.repo",
+                    "code.repository", "project.name", "workspace",
+                )
+                repo = _otlp_repo_key(repo_raw)
+
+                model = _pick("model", "gen_ai.request.model",
+                              "gen_ai.response.model") or ""
+                channel = _pick("channel") or ""
+                provider = _pick("provider", "gen_ai.provider.name",
+                                 "gen_ai.system") or ""
+
+                event_name = (getattr(rec, "event_name", "") or "").strip()
+                if not event_name:
+                    event_name = str(_f(attrs, "event.name") or "")
+                suffix = _otlp_event_suffix(event_name)
+
+                record_id = _otlp_record_id(
+                    service_name, session_id, event_name, rec, attrs
+                )
+                # The tiles must not count a retried batch twice. The DuckDB
+                # write below is idempotent on record_id; this is the same
+                # guarantee for the in-memory cache the live tiles read.
+                fresh = not _otlp_seen(record_id)
 
                 cost = _f(attrs, "cost_usd", "cost.usd", "cost")
+                cost_val = None
                 if cost is not None:
                     try:
-                        _add_metric("cost", {
-                            "timestamp": ts, "usd": float(cost),
-                            "model": model, "channel": channel, "provider": provider,
-                        })
+                        cost_val = float(cost)
                     except (TypeError, ValueError):
-                        pass
+                        cost_val = None
+                if cost_val is not None and fresh:
+                    _add_metric("cost", {
+                        "timestamp": ts, "usd": cost_val,
+                        "model": model, "channel": channel, "provider": provider,
+                    })
 
-                itok = _f(attrs, "input_tokens", "tokens.input", "prompt_tokens")
-                otok = _f(attrs, "output_tokens", "tokens.output", "completion_tokens")
+                itok = _f(attrs, "input_tokens", "tokens.input", "prompt_tokens",
+                          "gen_ai.usage.input_tokens")
+                otok = _f(attrs, "output_tokens", "tokens.output",
+                          "completion_tokens", "gen_ai.usage.output_tokens")
+                tin = tout = None
                 if itok is not None or otok is not None:
                     try:
-                        i, o = int(itok or 0), int(otok or 0)
-                        _add_metric("tokens", {
-                            "timestamp": ts, "input": i, "output": o, "total": i + o,
-                            "model": model, "channel": channel, "provider": provider,
-                        })
+                        tin, tout = int(itok or 0), int(otok or 0)
                     except (TypeError, ValueError):
-                        pass
+                        tin = tout = None
+                if tin is not None and fresh:
+                    _add_metric("tokens", {
+                        "timestamp": ts, "input": tin, "output": tout,
+                        "total": tin + tout,
+                        "model": model, "channel": channel, "provider": provider,
+                    })
 
                 dur = _f(attrs, "duration_ms", "duration.ms")
-                ev = (getattr(rec, "event_name", "") or "").lower()
-                if dur is not None and any(k in ev for k in ("request", "run", "completion")):
+                dur_val = None
+                if dur is not None:
                     try:
-                        _add_metric("runs", {
-                            "timestamp": ts, "duration_ms": float(dur),
-                            "model": model, "channel": channel,
-                        })
+                        dur_val = float(dur)
                     except (TypeError, ValueError):
-                        pass
+                        dur_val = None
+                if dur_val is not None and fresh and any(
+                    k in suffix for k in ("request", "run", "completion")
+                ):
+                    _add_metric("runs", {
+                        "timestamp": ts, "duration_ms": dur_val,
+                        "model": model, "channel": channel,
+                    })
+
+                # ── Fix 4: tool records become tool events ───────────────
+                tool_name = _f(
+                    attrs, "tool_name", "tool.name", "name",
+                    "gen_ai.tool.name",
+                )
+                decision = _f(attrs, "decision", "tool.decision")
+                success_attr = _f(attrs, "success", "tool.success")
+                success = None
+                if success_attr is not None:
+                    success = str(success_attr).strip().lower() not in (
+                        "false", "0", "no", "failure", "error",
+                    )
+
+                # ── Fix 3: persist, rather than only caching in memory ───
+                out_records.append({
+                    "record_id": record_id,
+                    "ts": ts,
+                    "received_at": received_at,
+                    "event_name": event_name or suffix or "log",
+                    "session_id": session_id,
+                    "user_id": user_id,
+                    "user_email": user_email,
+                    "org_id": org_id,
+                    "team": team,
+                    "repo": repo,
+                    "node_id": node_id,
+                    "agent_type": agent_type,
+                    "service_name": service_name,
+                    "model": model or None,
+                    "provider": provider or None,
+                    "cost_usd": cost_val,
+                    "tokens_input": tin,
+                    "tokens_output": tout,
+                    "token_count": (
+                        (tin or 0) + (tout or 0) if tin is not None else None
+                    ),
+                    "duration_ms": dur_val,
+                    "tool_name": tool_name,
+                    "decision": decision,
+                    "success": success,
+                    "attributes": {
+                        "resource": resource_attrs,
+                        "record": attrs,
+                        "repo_raw": repo_raw,
+                    },
+                })
+
+                if not session_id:
+                    # Every downstream reader keys on session_id; a record
+                    # without one can still be rolled up by team/user above,
+                    # but it cannot join a trajectory.
+                    continue
+
+                ev_common = {
+                    "node_id": node_id,
+                    "agent_type": agent_type,
+                    "agent_id": "main",
+                    "session_id": str(session_id),
+                    "workspace_id": repo,
+                    "ts": datetime.fromtimestamp(ts, timezone.utc).isoformat(),
+                    "runtime_kind": agent_type,
+                }
+
+                if suffix in _OTLP_TOOL_CALL_EVENTS and tool_name:
+                    # A rejected permission prompt is not a tool CALL — the
+                    # tool never ran. Recording it as one would tell the
+                    # no-progress detector the agent acted when it was
+                    # actually blocked waiting for a human.
+                    if str(decision or "").strip().lower() in (
+                        "reject", "rejected", "deny", "denied",
+                    ):
+                        continue
+                    args = _f(attrs, "tool_parameters", "tool.parameters",
+                              "arguments", "input")
+                    if isinstance(args, str):
+                        try:
+                            args = json.loads(args)
+                        except (ValueError, TypeError):
+                            pass
+                    if args in (None, ""):
+                        # This path usually carries no arguments, and the
+                        # stuck_loop detector trips on K consecutive
+                        # IDENTICAL (tool, args) calls. Hashing "no args" to
+                        # one constant would make five Reads of five
+                        # different files look like a loop, so we say what is
+                        # true instead: the arguments are unknown here, and
+                        # unknown is not evidence of identical. The cycle
+                        # branch (tool NAMES only) still works untouched.
+                        args = {"_otlp_args_unknown": record_id}
+                    ev = dict(ev_common)
+                    ev["id"] = "otlp:" + record_id
+                    ev["event_type"] = "tool_call"
+                    ev["data"] = {
+                        "tool": str(tool_name),
+                        "args": args,
+                        "decision": decision,
+                        "source": _f(attrs, "source", "tool.source"),
+                        "_otlp": True,
+                    }
+                    out_events.append(ev)
+                elif suffix in _OTLP_TOOL_RESULT_EVENTS and tool_name:
+                    err_text = _f(attrs, "error", "error.message") or ""
+                    ev = dict(ev_common)
+                    ev["id"] = "otlp:" + record_id
+                    ev["event_type"] = "tool_result"
+                    ev["data"] = {
+                        "tool": str(tool_name),
+                        "is_error": (success is False) or bool(err_text),
+                        "error": err_text,
+                        "duration_ms": dur_val,
+                        "_otlp": True,
+                    }
+                    out_events.append(ev)
+                elif cost_val is not None or tin is not None:
+                    # The money records (api_request). Landing them in events
+                    # is what makes the usage + cost surfaces survive a
+                    # restart on a daemon-free deployment.
+                    ev = dict(ev_common)
+                    ev["id"] = "otlp:" + record_id
+                    ev["event_type"] = "llm_call"
+                    ev["cost_usd"] = cost_val
+                    ev["token_count"] = (
+                        (tin or 0) + (tout or 0) if tin is not None else None
+                    )
+                    ev["model"] = model or None
+                    ev["data"] = {
+                        "model": model,
+                        "provider": provider,
+                        "input_tokens": tin,
+                        "output_tokens": tout,
+                        "cost_usd": cost_val,
+                        "duration_ms": dur_val,
+                        "_otlp": True,
+                    }
+                    out_events.append(ev)
+
+    if _store is not None and (out_records or out_events):
+        try:
+            # Keyword args are REQUIRED: the dashboard's _ProxyStore forwards
+            # **kwargs only, so a positional call silently writes nothing
+            # whenever the daemon owns the writer lock — i.e. every real
+            # install. put_otlp_batch is allowlisted in
+            # routes/local_query._DAEMON_METHODS so the daemon runs the write.
+            _store.put_otlp_batch(records=out_records, events=out_events)
+        except Exception as e:
+            try:
+                import logging as _lg
+                _lg.getLogger("clawmetry.dashboard").warning(
+                    "local_store.put_otlp_batch failed: %s", e
+                )
+            except Exception:
+                pass
 
 
 def _get_otel_usage_data():

--- a/deploy/self-hosted/README.md
+++ b/deploy/self-hosted/README.md
@@ -80,7 +80,7 @@ from the ingested rows alone. The image already contains the protobuf decoder
 this needs.
 
 Two things to know before you plan around it. **It covers Claude Code and
-Codex** — the runtimes that emit OpenTelemetry natively; the rest need the
+Codex**, the runtimes that emit OpenTelemetry natively; the rest need the
 daemon that reads their transcripts. And **records arrive in plaintext**: the
 runtime encrypts nothing before it sends, so the `CLAWMETRY_SELF_HOSTED_E2E`
 option below does not apply to this path. Inside a VPC deployment the

--- a/deploy/self-hosted/README.md
+++ b/deploy/self-hosted/README.md
@@ -55,6 +55,38 @@ The self-hosted server records every node's heartbeats, sessions, and events
 node roster, daemon versions, liveness) plus fleet APIs:
 `/api/selfhosted/nodes`, `/api/selfhosted/status`, `/api/export/events`.
 
+## Onboarding without a per-machine daemon
+
+If a fleet-wide daemon install is not going to clear your security review,
+this deployment also accepts data straight from the runtime. Developers
+install nothing; you push one config value:
+
+```bash
+CLAWMETRY_TELEMETRY=1
+OTEL_EXPORTER_OTLP_ENDPOINT=https://clawmetry.internal.example
+OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+OTEL_EXPORTER_OTLP_HEADERS="Authorization=Bearer <your gateway token>"
+OTEL_RESOURCE_ATTRIBUTES="team.id=platform,repository=payments-api"
+```
+
+The `Authorization` header is required from anywhere but the loopback
+interface (`/v1/*` is gated like `/api/*`), and a refused exporter drops its
+batch silently, so get it right before rolling this out to a fleet.
+
+Records land on `/v1/logs` and persist to DuckDB with the identity the runtime
+sends (user, email, organization, session) plus your own team/repo attributes,
+so `GET /api/otel/rollup?dimension=team` answers "what did this team spend"
+from the ingested rows alone. The image already contains the protobuf decoder
+this needs.
+
+Two things to know before you plan around it. **It covers Claude Code and
+Codex** — the runtimes that emit OpenTelemetry natively; the rest need the
+daemon that reads their transcripts. And **records arrive in plaintext**: the
+runtime encrypts nothing before it sends, so the `CLAWMETRY_SELF_HOSTED_E2E`
+option below does not apply to this path. Inside a VPC deployment the
+plaintext never leaves your network, which is exactly why this shape and
+self-hosting go together.
+
 ## E2E encryption trade-off
 
 By default the server answers `/auth` with `"e2e": false`, so nodes send

--- a/docs/acceptance_criteria.json
+++ b/docs/acceptance_criteria.json
@@ -312,6 +312,54 @@
       "text": "Where a session is waiting on a person, the system shall report whether that ask can be answered through ClawMetry, so that a surface never offers an action it cannot perform."
     },
     {
+      "id": "AC-OBS-006.1",
+      "doc": "Local Agent Observability",
+      "doc_id": "d518c6c3-eb50-4b0f-9ed0-59440380b7bf",
+      "text": "The system shall record each received telemetry record at the time the record itself reports, and shall use the time of receipt only when the record carries no time of its own."
+    },
+    {
+      "id": "AC-OBS-006.2",
+      "doc": "Local Agent Observability",
+      "doc_id": "d518c6c3-eb50-4b0f-9ed0-59440380b7bf",
+      "text": "The system shall retain the identity carried on a received record -- the person, their organisation, and the session -- together with any team or repository the sender declared."
+    },
+    {
+      "id": "AC-OBS-006.3",
+      "doc": "Local Agent Observability",
+      "doc_id": "d518c6c3-eb50-4b0f-9ed0-59440380b7bf",
+      "text": "Received telemetry shall be readable after a restart of the service that received it."
+    },
+    {
+      "id": "AC-OBS-006.4",
+      "doc": "Local Agent Observability",
+      "doc_id": "d518c6c3-eb50-4b0f-9ed0-59440380b7bf",
+      "text": "The system shall report spend and token totals grouped by team, by repository, or by person, from received records alone. Every such answer shall state that the grouping is self-reported by the sender."
+    },
+    {
+      "id": "AC-OBS-006.5",
+      "doc": "Local Agent Observability",
+      "doc_id": "d518c6c3-eb50-4b0f-9ed0-59440380b7bf",
+      "text": "Re-delivery of a batch already received shall not change any reported total, in stored records or in the live view."
+    },
+    {
+      "id": "AC-OBS-006.6",
+      "doc": "Local Agent Observability",
+      "doc_id": "d518c6c3-eb50-4b0f-9ed0-59440380b7bf",
+      "text": "Where the same session is observed both from the machine and from received telemetry, the system shall report it once, and shall prefer the machine's own observation."
+    },
+    {
+      "id": "AC-OBS-006.7",
+      "doc": "Local Agent Observability",
+      "doc_id": "d518c6c3-eb50-4b0f-9ed0-59440380b7bf",
+      "text": "Tool decisions and tool results arriving as telemetry shall be usable by the trajectory detectors, so that a stuck or repeatedly failing agent is visible on a machine with nothing installed on it. A permission the user REFUSED shall not be reported as a tool the agent ran."
+    },
+    {
+      "id": "AC-OBS-006.8",
+      "doc": "Local Agent Observability",
+      "doc_id": "d518c6c3-eb50-4b0f-9ed0-59440380b7bf",
+      "text": "Where this path is described to a customer, the description shall state which runtimes it covers and that records arrive unencrypted."
+    },
+    {
       "id": "AC-OBS-CEA-001.1",
       "doc": "Cost and Efficiency Analytics",
       "doc_id": "43d6b27c-0e37-45dc-9fdd-df4200844c29",

--- a/docs/enterprise.md
+++ b/docs/enterprise.md
@@ -119,6 +119,14 @@ the runtime already sends (`user.id`, `user.email`, `organization.id`,
 and `tool_result` records also become tool events, so the trajectory detectors
 (stuck loops, no progress, repeated tool failures) work on this path.
 
+The team and repository on this path are **self-reported**: they are whatever
+the org stamped on its own telemetry, carried through with the record, and
+every rollup response says so (`attribution: self-reported`). That is a
+different question from agent principals, which derive owner and team from
+what ClawMetry observes and name the rung an inherited value came from. A
+daemon-free machine has no principals to derive from, which is exactly why
+this path carries the org's own labels instead of inventing an answer.
+
 Read it back with `GET /api/otel/rollup?dimension=team|repo|user_email&days=30`,
 or `GET /api/otel-status`, whose `persisted` field is the DuckDB row count —
 `counts` above it is an in-memory cache that a restart clears.

--- a/docs/enterprise.md
+++ b/docs/enterprise.md
@@ -128,19 +128,19 @@ daemon-free machine has no principals to derive from, which is exactly why
 this path carries the org's own labels instead of inventing an answer.
 
 Read it back with `GET /api/otel/rollup?dimension=team|repo|user_email&days=30`,
-or `GET /api/otel-status`, whose `persisted` field is the DuckDB row count —
+or `GET /api/otel-status`, whose `persisted` field is the DuckDB row count.
 `counts` above it is an in-memory cache that a restart clears.
 
 **Two limits, stated here because this path is sold on them:**
 
-* **It covers the runtimes that emit OTel natively — Claude Code and Codex.**
+* **It covers the runtimes that emit OTel natively: Claude Code and Codex.**
   It is not a 26-runtime intake path, and no page should imply it is. The
   other runtimes need the daemon, which is what actually reads their
   transcripts.
 * **Records arrive in plaintext.** The runtime encrypts nothing before it
-  sends, so the end-to-end encryption described under *Data flow* — which is a
-  property of the **daemon's** snapshot push, where the key never leaves the
-  node — does not extend to this path. For a customer who needs the data never
+  sends, so the end-to-end encryption described under *Data flow* (a property
+  of the **daemon's** snapshot push, where the key never leaves the node) does
+  not extend to this path. For a customer who needs the data never
   to cross their boundary in the clear, the honest answer is the self-hosted
   VPC deployment: the receiver runs inside their network, and the plaintext
   never leaves it. Do not let the encryption claim drift over this path.

--- a/docs/enterprise.md
+++ b/docs/enterprise.md
@@ -86,6 +86,63 @@ activity without replacing the ClawMetry dashboard:
   (`CLAWMETRY_OTLP_ENDPOINT`, see `docs/OTEL_PUSH_EXPORTER.md`) and the
   `GET /api/otel/export` pull endpoint.
 
+## Daemon-free intake (the OTLP receiver)
+
+The deployment above assumes a daemon on every machine. Many orgs will not
+approve that: a background process on 500 developer laptops that reads
+transcripts and can signal processes is a security review measured in
+quarters. The receiver is the alternative. Developers install nothing; one
+config value, pushed by MDM, points the runtime at a ClawMetry the org already
+runs:
+
+```bash
+export CLAWMETRY_TELEMETRY=1                 # Claude Code: turn on its exporter
+export OTEL_EXPORTER_OTLP_ENDPOINT=https://clawmetry.internal.example
+export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+export OTEL_EXPORTER_OTLP_HEADERS="Authorization=Bearer $CLAWMETRY_GATEWAY_TOKEN"
+# Optional, and what makes the rollups useful:
+export OTEL_RESOURCE_ATTRIBUTES="team.id=platform,repository=payments-api"
+```
+
+The header is not optional off the loopback interface. `/v1/*` is gated like
+`/api/*`: loopback is trusted, anything else needs the gateway token, and an
+exporter that is refused drops its batch quietly on the developer's machine
+rather than telling anyone. (`CLAWMETRY_OTLP_ALLOW_UNAUTH=1` on the server
+turns the gate off for a trusted network segment; the receiver then accepts
+cost and usage data from anyone who can route to it, so treat that as a
+deliberate decision, not a convenience.)
+
+Records land on `POST /v1/logs` (also `/v1/traces`, `/v1/metrics`) and are
+written to DuckDB: one row per record in `otlp_records` carrying the identity
+the runtime already sends (`user.id`, `user.email`, `organization.id`,
+`session.id`) plus whatever `OTEL_RESOURCE_ATTRIBUTES` adds. `tool_decision`
+and `tool_result` records also become tool events, so the trajectory detectors
+(stuck loops, no progress, repeated tool failures) work on this path.
+
+Read it back with `GET /api/otel/rollup?dimension=team|repo|user_email&days=30`,
+or `GET /api/otel-status`, whose `persisted` field is the DuckDB row count —
+`counts` above it is an in-memory cache that a restart clears.
+
+**Two limits, stated here because this path is sold on them:**
+
+* **It covers the runtimes that emit OTel natively — Claude Code and Codex.**
+  It is not a 26-runtime intake path, and no page should imply it is. The
+  other runtimes need the daemon, which is what actually reads their
+  transcripts.
+* **Records arrive in plaintext.** The runtime encrypts nothing before it
+  sends, so the end-to-end encryption described under *Data flow* — which is a
+  property of the **daemon's** snapshot push, where the key never leaves the
+  node — does not extend to this path. For a customer who needs the data never
+  to cross their boundary in the clear, the honest answer is the self-hosted
+  VPC deployment: the receiver runs inside their network, and the plaintext
+  never leaves it. Do not let the encryption claim drift over this path.
+
+Prerequisite: the ingest image ships `opentelemetry-proto`, because the default
+exporter protocol is `http/protobuf` and without it the receiver answers 501.
+The `Dockerfile` that `deploy/self-hosted/docker-compose.yml` builds installs
+it; a bare `pip install clawmetry` needs `pip install clawmetry[otel]` (OTLP/JSON
+alone decodes with the stdlib and needs no extra).
+
 ## Audit export
 
 ```bash

--- a/routes/local_query.py
+++ b/routes/local_query.py
@@ -755,6 +755,19 @@ _DAEMON_METHODS = frozenset({
     # set_agent_meta. The handler calls put_span(span=...) by keyword (the proxy
     # only forwards kwargs).
     "put_span",
+    # WO-7 daemon-free intake. The OTLP /v1/logs receiver runs in the
+    # DASHBOARD process, which does not own the DuckDB writer lock, so its
+    # batch write has to come through here or it silently no-ops on every
+    # real install (the same trap put_span hit above). Call it by KEYWORD:
+    # put_otlp_batch(records=[...], events=[...]) — the proxy forwards
+    # **kwargs only. One call per OTLP export batch, not per record.
+    "put_otlp_batch",
+    # Read side of the same table: per-team / per-repo / per-person rollups
+    # over the daemon-free path, and the persisted-row count /api/otel-status
+    # shows so an operator can tell durable storage from the in-memory cache.
+    "query_otlp_records",
+    "query_otlp_rollup",
+    "count_otlp_records",
     # Issue #1364 (Tier-1 2026-05-15): /api/fallbacks model/provider
     # transition aggregator. Replaces a JSONL walker that opened up to 100
     # transcript files per request — multi-second on a busy workspace.

--- a/routes/meta.py
+++ b/routes/meta.py
@@ -1367,7 +1367,6 @@ def api_otel_rollup():
     and a caller must be able to tell which one it asked, so every response
     says ``attribution: self-reported``.
     """
-    import dashboard as _d  # noqa: F401 — parity with the rest of bp_otel
     dimension = (request.args.get("dimension") or "team").strip()
     # Validate HERE, not in the store: _ls_call swallows the store's
     # ValueError and returns None, which would turn "you asked for a column

--- a/routes/meta.py
+++ b/routes/meta.py
@@ -1358,6 +1358,14 @@ def api_otel_rollup():
     ``?days=N`` bounds the window (default 30, max 365). Every figure is
     MEASURED: it sums what the runtime reported. Where a runtime reported no
     cost the sum is smaller, never estimated up to look complete.
+
+    The identity here is SELF-REPORTED — it is whatever the org stamped on its
+    own telemetry via ``OTEL_RESOURCE_ATTRIBUTES``, carried through with the
+    record. It is deliberately NOT ClawMetry's ownership answer: agent
+    principals (REQ-OBS-004) derive owner and team from what we observe, and
+    report which rung an inherited value came from. Two different questions,
+    and a caller must be able to tell which one it asked, so every response
+    says ``attribution: self-reported``.
     """
     import dashboard as _d  # noqa: F401 — parity with the rest of bp_otel
     dimension = (request.args.get("dimension") or "team").strip()
@@ -1399,6 +1407,9 @@ def api_otel_rollup():
         "rows": rows,
         "source": "otlp",
         "basis": "measured",
+        # What the org's own exporter config declared, not an attribution
+        # ClawMetry derived. See the docstring.
+        "attribution": "self-reported",
     })
 
 

--- a/routes/meta.py
+++ b/routes/meta.py
@@ -1324,8 +1324,82 @@ def api_otel_status():
             "exportLastFlushAt": export_stats.get("last_flush_at"),
             "exportSpansSent": export_stats.get("spans_sent", 0),
             "exportLastError": export_stats.get("last_error"),
+            # WO-7: ``counts`` above is the in-memory cache — it empties on
+            # restart, and reading it as "we have N records" is exactly the
+            # mistake this work order exists to correct. ``persisted`` is the
+            # DuckDB row count on the daemon-free intake path: the number that
+            # is still there tomorrow. ``None`` means we could not ask the
+            # store, which is not the same as zero.
+            "persisted": _otlp_persisted_count(),
         }
     )
+
+
+def _otlp_persisted_count():
+    """DuckDB row count for the daemon-free intake path, or None if unknown."""
+    try:
+        n = _ls_call("count_otlp_records")
+        return None if n is None else int(n)
+    except Exception:
+        return None
+
+
+@bp_otel.route("/api/otel/rollup")
+def api_otel_rollup():
+    """Spend + tokens on the daemon-free intake path, grouped by one identity
+    dimension: ``team``, ``repo``, ``org_id``, ``user_email``, ``user_id``,
+    ``model``, ``agent_type`` or ``session_id``.
+
+    This is the answer the org buyer actually asks for ("what did the platform
+    team spend on the payments repo last month"), and it comes from the
+    ingested rows alone — no daemon, no per-machine install, nothing joined in
+    from a filesystem the cloud container does not have.
+
+    ``?days=N`` bounds the window (default 30, max 365). Every figure is
+    MEASURED: it sums what the runtime reported. Where a runtime reported no
+    cost the sum is smaller, never estimated up to look complete.
+    """
+    import dashboard as _d  # noqa: F401 — parity with the rest of bp_otel
+    dimension = (request.args.get("dimension") or "team").strip()
+    # Validate HERE, not in the store: _ls_call swallows the store's
+    # ValueError and returns None, which would turn "you asked for a column
+    # that does not exist" into "the store is down".
+    try:
+        from clawmetry.local_store import LocalStore as _LS
+        allowed = set(_LS._OTLP_ROLLUP_DIMENSIONS)
+    except Exception:
+        allowed = {"team", "repo", "org_id", "user_email", "user_id",
+                   "model", "agent_type", "session_id"}
+    if dimension not in allowed:
+        return jsonify({
+            "error": f"unsupported dimension: {dimension!r}",
+            "allowed": sorted(allowed),
+        }), 400
+    try:
+        days = max(1, min(365, int(request.args.get("days") or 30)))
+    except (TypeError, ValueError):
+        days = 30
+    since = time.time() - days * 86400
+    rows = _ls_call(
+        "query_otlp_rollup", dimension=dimension, since=since, limit=200
+    )
+    if rows is None:
+        # The store could not be reached. Say so, rather than rendering an
+        # empty rollup that reads as "this team spent nothing".
+        return jsonify({
+            "dimension": dimension,
+            "rows": [],
+            "unavailable": True,
+            "error": "local store unavailable",
+        }), 503
+    return jsonify({
+        "dimension": dimension,
+        "days": days,
+        "since": since,
+        "rows": rows,
+        "source": "otlp",
+        "basis": "measured",
+    })
 
 
 # ── Version impact analysis ─────────────────────────────────────────────────────────────────────

--- a/routes/selfhosted_ingest.py
+++ b/routes/selfhosted_ingest.py
@@ -17,6 +17,14 @@ can point a fleet of nodes at a single-tenant server inside a customer VPC:
 * ``POST /api/approvals/request``, ``GET /api/approvals/<id>`` + admin decision
 * ``GET  /api/export/events``        — audit export (JSONL/CSV, time-ranged)
 * ``GET  /api/selfhosted/nodes``, ``GET /api/selfhosted/status``
+
+The other way into a VPC deployment does NOT come through this module: a
+runtime that speaks OpenTelemetry can post straight to the ``bp_otel``
+receiver (``/v1/logs``) with no daemon on the machine at all, and that path
+persists to DuckDB via ``dashboard._process_otlp_logs``. It is the same
+server and the same container; it just skips the node-daemon protocol below.
+See ``docs/enterprise.md`` — "Daemon-free intake" — including why the E2E
+option here does not cover it (the runtime sends plaintext).
 * ``GET  /selfhosted``               — fleet overview page (admin-gated HTML)
 
 Storage is a single SQLite database (stdlib, WAL) at

--- a/tests/test_otlp_daemon_free_intake.py
+++ b/tests/test_otlp_daemon_free_intake.py
@@ -700,3 +700,17 @@ def test_the_batch_write_never_nests_a_read_inside_the_write_lock(store):
     )
     assert not error, error
     assert store.query_otlp_records(session_id="sess-lock")
+
+
+def test_a_count_that_could_not_be_taken_is_not_reported_as_zero(store, monkeypatch):
+    """``persisted`` on /api/otel-status is the number that answers "did this
+    actually store anything". Returning 0 when the count FAILED renders "we
+    could not ask" as "nothing is stored", which sends someone to debug an
+    ingest that is fine. None is the honest answer, and the route passes it
+    through.
+    """
+    def _boom(*a, **k):
+        raise RuntimeError("store is wedged")
+
+    monkeypatch.setattr(type(store), "_fetch", _boom)
+    assert store.count_otlp_records() is None

--- a/tests/test_otlp_daemon_free_intake.py
+++ b/tests/test_otlp_daemon_free_intake.py
@@ -262,7 +262,7 @@ def test_repo_key_normalisation(raw, expected):
 def test_rows_survive_a_store_restart(store, monkeypatch, tmp_path):
     """The acceptance criterion the in-memory cache could never meet.
     AC-OBS-006.2
-    
+
     AC-OBS-006.3
     """
     _d._process_otlp_logs(_export([_api_request(int(time.time() * 1e9))]))
@@ -318,7 +318,7 @@ def test_trajectory_detectors_fire_on_the_otlp_path(store):
     """The point of mapping tool events: a session that fails the same tool
     over and over is visible on a deployment with no daemon on any machine.
     AC-OBS-006.7
-    
+
     AC-OBS-006.7
     """
     from clawmetry import detectors
@@ -599,7 +599,7 @@ def test_rollup_endpoint_says_the_grouping_is_self_reported(store):
     observes and name the rung an inherited value came from. This path carries
     what the sender declared about itself. A reader who cannot tell which
     question they asked has been misled, so the answer says which one it is.
-    
+
     AC-OBS-006.4
     """
     now = time.time()
@@ -640,7 +640,7 @@ def test_the_docs_state_the_two_limits_this_path_is_sold_on():
       guarantee does not stretch over this path
 
     A claim nothing checks is a claim that drifts. This is the check.
-    
+
     AC-OBS-006.8
     """
     root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))

--- a/tests/test_otlp_daemon_free_intake.py
+++ b/tests/test_otlp_daemon_free_intake.py
@@ -56,7 +56,19 @@ def _clear_seen_ids():
 def store(monkeypatch):
     """A private DuckDB writer for one test, wired in as the singleton the
     handler resolves. Never touches the developer's real store."""
+    import importlib
     import pathlib
+
+    # Re-resolve the module every time instead of trusting the import at the
+    # top of this file. Several suites (test_alert_rules_local_store.py among
+    # them) do ``sys.modules.pop("clawmetry.local_store"); importlib.reload``,
+    # which leaves this file holding a STALE module object. Patching
+    # ``get_store`` on the stale copy silently does nothing — the handler
+    # imports the live one, opens the real singleton, and the test fails with
+    # zero rows and no clue why. Rebind the global so the whole file agrees
+    # with the module the code under test will actually import.
+    global _ls
+    _ls = importlib.import_module("clawmetry.local_store")
 
     tmpdir = tempfile.mkdtemp(prefix="clawmetry-wo7-")
     path = os.path.join(tmpdir, "wo7.duckdb")
@@ -69,7 +81,12 @@ def store(monkeypatch):
     prev_db_path = _ls.DB_PATH
     _ls.DB_PATH = pathlib.Path(path)
     st = _ls.LocalStore()
-    monkeypatch.setattr(_ls, "_store_rw", st, raising=False)
+    # Deliberately NOT published to ``_ls._store_rw``. Other test modules tear
+    # down with ``local_store.get_store().stop()``, and a session-scoped
+    # finalizer running while our store sits in that global closes OUR
+    # connection mid-test — which surfaces here as "Connection already closed"
+    # from a write nobody in this file made. Patching the accessor is enough:
+    # the handler under test resolves its store through ``get_store()``.
     monkeypatch.setattr(_ls, "get_store", lambda read_only=False: st)
     try:
         yield st

--- a/tests/test_otlp_daemon_free_intake.py
+++ b/tests/test_otlp_daemon_free_intake.py
@@ -650,3 +650,53 @@ def test_the_docs_state_the_two_limits_this_path_is_sold_on():
             f"{rel} must name the runtimes this path actually covers")
         assert "plaintext" in text or "unencrypted" in text, (
             f"{rel} must say records arrive unencrypted on this path")
+
+
+def test_the_batch_write_never_nests_a_read_inside_the_write_lock(store):
+    """The trap this work order was warned about by name.
+
+    ``LocalStore._write_lock`` is a plain ``threading.Lock``, not an RLock, and
+    ``_fetch`` takes it. So a read placed inside the write-lock block does not
+    fail: it DEADLOCKS the daemon, and a deadlocked daemon stops ingesting
+    everything, not just this path. The batch writer therefore closes its write
+    block before it probes for daemon-owned sessions.
+
+    Asserted on a daemon thread with a join timeout, because the failure mode
+    is a hang: a test that reproduces the bug by hanging forever is not a test,
+    it is an outage in CI.
+    """
+    import threading
+
+    done = threading.Event()
+    error = []
+
+    def _run():
+        try:
+            store.put_otlp_batch(
+                records=[{
+                    "record_id": "lock-probe",
+                    "ts": time.time(),
+                    "session_id": "sess-lock",
+                    "cost_usd": 1.0,
+                }],
+                events=[{
+                    "id": "otlp:lock-probe",
+                    "node_id": "n",
+                    "session_id": "sess-lock",
+                    "event_type": "tool_call",
+                    "ts": "2026-08-25T10:00:00+00:00",
+                    "data": {"tool": "Bash", "args": {}},
+                }],
+            )
+        except Exception as exc:  # pragma: no cover - a real failure, not a hang
+            error.append(exc)
+        finally:
+            done.set()
+
+    t = threading.Thread(target=_run, daemon=True)
+    t.start()
+    assert done.wait(timeout=20), (
+        "put_otlp_batch did not return: a read is nested inside the write lock"
+    )
+    assert not error, error
+    assert store.query_otlp_records(session_id="sess-lock")

--- a/tests/test_otlp_daemon_free_intake.py
+++ b/tests/test_otlp_daemon_free_intake.py
@@ -1,0 +1,487 @@
+"""WO-7 — daemon-free OTLP intake.
+
+The receiver at ``/v1/logs`` is the path an org uses when it will NOT install a
+per-machine daemon: one config value (``OTEL_EXPORTER_OTLP_ENDPOINT``), pushed
+by MDM, reviewed once. Before this work order it was a prototype that stamped
+``time.time()`` on every record, extracted no identity, and wrote only to an
+in-memory cache that a restart erased.
+
+Each test here pins one of the five fixes, plus the honesty properties that
+make the numbers safe to bill against:
+
+1. the record's OWN timestamp is stored (batched / backfilled delivery)
+2. identity (user / email / org / session) and rollup dims (team / repo)
+3. rows land in DuckDB and survive a store restart
+4. tool_decision / tool_result become tool events the detectors can read
+5. the enterprise ingest image ships opentelemetry-proto (never a 501)
+
+plus: a retried OTLP batch does not double-count spend, a REJECTED permission
+prompt is not recorded as a tool call, and absent tool arguments are not
+hashed into a fake "identical calls" loop.
+"""
+import os
+import tempfile
+import time
+
+import pytest
+
+pytest.importorskip(
+    "opentelemetry.proto.collector.logs.v1.logs_service_pb2",
+    reason="opentelemetry-proto not installed (pip install clawmetry[otel])",
+)
+
+from opentelemetry.proto.collector.logs.v1 import logs_service_pb2  # noqa: E402
+from opentelemetry.proto.logs.v1 import logs_pb2  # noqa: E402
+from opentelemetry.proto.common.v1 import common_pb2  # noqa: E402
+
+import dashboard as _d  # noqa: E402
+from clawmetry import local_store as _ls  # noqa: E402
+
+
+# ── fixtures ────────────────────────────────────────────────────────────────
+
+@pytest.fixture(autouse=True)
+def _clear_seen_ids():
+    """The metrics-cache dedup set is module state that outlives one test.
+    Left dirty, a later test posting an identical payload would be silently
+    deduped and its assertion would fail for a reason nothing points at."""
+    _d._otlp_seen_ids.clear()
+    _d._otlp_seen_order.clear()
+    yield
+    _d._otlp_seen_ids.clear()
+    _d._otlp_seen_order.clear()
+
+
+@pytest.fixture()
+def store(monkeypatch):
+    """A private DuckDB writer for one test, wired in as the singleton the
+    handler resolves. Never touches the developer's real store."""
+    import pathlib
+
+    tmpdir = tempfile.mkdtemp(prefix="clawmetry-wo7-")
+    path = os.path.join(tmpdir, "wo7.duckdb")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", path)
+    _ls._reset_singleton_for_tests()
+    # DB_PATH is module state, resolved at import. Restore it on the way out:
+    # leaving it pointed at this test's scratch file makes the NEXT test file
+    # open a store it did not create, which is how one test's fixture becomes
+    # another test's mystery failure.
+    prev_db_path = _ls.DB_PATH
+    _ls.DB_PATH = pathlib.Path(path)
+    st = _ls.LocalStore()
+    monkeypatch.setattr(_ls, "_store_rw", st, raising=False)
+    monkeypatch.setattr(_ls, "get_store", lambda read_only=False: st)
+    try:
+        yield st
+    finally:
+        try:
+            st.stop(flush=True)
+        except Exception:
+            pass
+        _ls.DB_PATH = prev_db_path
+        _ls._reset_singleton_for_tests()
+
+
+def _kv(key, s=None, i=None, d=None, b=None):
+    v = common_pb2.AnyValue()
+    if s is not None:
+        v.string_value = s
+    elif i is not None:
+        v.int_value = i
+    elif d is not None:
+        v.double_value = d
+    elif b is not None:
+        v.bool_value = b
+    return common_pb2.KeyValue(key=key, value=v)
+
+
+# Identity exactly as Claude Code emits it, per record.
+def _identity(session_id="sess-wo7"):
+    return [
+        _kv("session.id", s=session_id),
+        _kv("user.id", s="u-42"),
+        _kv("user.email", s="dana@acme.example"),
+        _kv("organization.id", s="org-acme"),
+    ]
+
+
+# Team / repo as an org sets them via OTEL_RESOURCE_ATTRIBUTES.
+def _resource(repo="git@github.com:acme/payments-api.git", team="platform"):
+    return [
+        _kv("service.name", s="claude-code"),
+        _kv("team.id", s=team),
+        _kv("repository", s=repo),
+        _kv("host.name", s="mac-of-dana"),
+    ]
+
+
+def _export(records, resource_attrs=None):
+    scope = logs_pb2.ScopeLogs(log_records=records)
+    res = logs_pb2.ResourceLogs(scope_logs=[scope])
+    res.resource.attributes.extend(resource_attrs or _resource())
+    return logs_service_pb2.ExportLogsServiceRequest(
+        resource_logs=[res]
+    ).SerializeToString()
+
+
+def _api_request(when_ns, session_id="sess-wo7", cost=4.10):
+    rec = logs_pb2.LogRecord(time_unix_nano=when_ns)
+    rec.event_name = "claude_code.api_request"
+    rec.attributes.extend(_identity(session_id) + [
+        _kv("model", s="claude-opus-4-8"),
+        _kv("cost_usd", d=cost),
+        _kv("input_tokens", i=1500),
+        _kv("output_tokens", i=300),
+        _kv("duration_ms", d=820.0),
+    ])
+    return rec
+
+
+def _tool_decision(when_ns, tool, decision="accept", session_id="sess-wo7"):
+    rec = logs_pb2.LogRecord(time_unix_nano=when_ns)
+    rec.event_name = "claude_code.tool_decision"
+    rec.attributes.extend(_identity(session_id) + [
+        _kv("tool_name", s=tool),
+        _kv("decision", s=decision),
+        _kv("source", s="config"),
+    ])
+    return rec
+
+
+def _tool_result(when_ns, tool, success=True, error="", session_id="sess-wo7"):
+    rec = logs_pb2.LogRecord(time_unix_nano=when_ns)
+    rec.event_name = "claude_code.tool_result"
+    attrs = _identity(session_id) + [
+        _kv("tool_name", s=tool),
+        _kv("success", b=success),
+        _kv("duration_ms", d=120.0),
+    ]
+    if error:
+        attrs.append(_kv("error", s=error))
+    rec.attributes.extend(attrs)
+    return rec
+
+
+# ── Fix 1: honour the record's own timestamp ────────────────────────────────
+
+def test_batched_delivery_keeps_its_own_timestamps(store):
+    """A batch delivered now, describing work from six hours ago, must land
+    six hours ago. The prototype stamped time.time() on every record, so any
+    daily rollup over a retried or buffered export was silently wrong."""
+    six_hours_ago = time.time() - 6 * 3600
+    _d._process_otlp_logs(_export([_api_request(int(six_hours_ago * 1e9))]))
+
+    rows = store.query_otlp_records(session_id="sess-wo7")
+    assert len(rows) == 1
+    assert abs(rows[0]["ts"] - six_hours_ago) < 1.0, rows[0]["ts"]
+    # And receipt time is kept separately, not conflated with it.
+    assert rows[0]["received_at"] - rows[0]["ts"] > 5 * 3600
+
+
+def test_observed_time_is_used_when_the_record_has_no_event_time(store):
+    """Exporters may set only observedTimeUnixNano. Falling through to
+    receipt time there is the same misdating bug in a different coat."""
+    observed = time.time() - 3600
+    rec = _api_request(0)
+    rec.observed_time_unix_nano = int(observed * 1e9)
+    _d._process_otlp_logs(_export([rec]))
+
+    rows = store.query_otlp_records(session_id="sess-wo7")
+    assert abs(rows[0]["ts"] - observed) < 1.0
+
+
+def test_metrics_cache_gets_the_record_timestamp_too(store, monkeypatch):
+    """The live tiles read the in-memory cache; if only the DuckDB row is
+    correctly dated, today's tile still counts yesterday's spend."""
+    captured = []
+    monkeypatch.setattr(
+        _d, "_add_metric", lambda cat, e: captured.append((cat, e))
+    )
+    when = time.time() - 2 * 3600
+    _d._process_otlp_logs(_export([_api_request(int(when * 1e9))]))
+    cost = next(e for c, e in captured if c == "cost")
+    assert abs(cost["timestamp"] - when) < 1.0
+
+
+# ── Fix 2: identity extraction ──────────────────────────────────────────────
+
+def test_identity_is_extracted_from_the_record_and_the_resource(store):
+    _d._process_otlp_logs(_export([_api_request(int(time.time() * 1e9))]))
+    row = store.query_otlp_records(session_id="sess-wo7")[0]
+
+    assert row["user_id"] == "u-42"
+    assert row["user_email"] == "dana@acme.example"
+    assert row["org_id"] == "org-acme"
+    assert row["session_id"] == "sess-wo7"
+    assert row["team"] == "platform"
+    # An ssh remote, an https URL and a checkout path must land on one key,
+    # or a per-repo rollup fragments into three rows for one repo.
+    assert row["repo"] == "payments-api"
+    assert row["agent_type"] == "claude_code"
+    assert row["node_id"] == "mac-of-dana"
+    # The raw value is not thrown away.
+    assert row["attributes"]["repo_raw"].endswith("payments-api.git")
+
+
+@pytest.mark.parametrize("raw,expected", [
+    ("git@github.com:acme/payments-api.git", "payments-api"),
+    ("https://github.com/acme/payments-api", "payments-api"),
+    ("/Users/dana/src/payments-api", "payments-api"),
+    ("payments-api", "payments-api"),
+    ("", None),
+])
+def test_repo_key_normalisation(raw, expected):
+    assert _d._otlp_repo_key(raw) == expected
+
+
+# ── Fix 3: it survives a restart ────────────────────────────────────────────
+
+def test_rows_survive_a_store_restart(store, monkeypatch, tmp_path):
+    """The acceptance criterion the in-memory cache could never meet."""
+    _d._process_otlp_logs(_export([_api_request(int(time.time() * 1e9))]))
+    db_path = str(_ls.DB_PATH)
+    store.stop(flush=True)
+
+    reopened = _ls.LocalStore(read_only=True)
+    try:
+        rows = reopened.query_otlp_records(session_id="sess-wo7")
+        assert len(rows) == 1
+        assert rows[0]["cost_usd"] == pytest.approx(4.10)
+        assert os.path.exists(db_path)
+    finally:
+        reopened.stop(flush=False)
+
+
+def test_a_retried_batch_does_not_double_count_spend(store):
+    """OTLP delivery is at-least-once. An exporter that misses our 200 resends
+    the batch, and spend that doubles on a network blip is worse than none."""
+    payload = _export([_api_request(int(time.time() * 1e9))])
+    _d._process_otlp_logs(payload)
+    _d._process_otlp_logs(payload)
+    _d._process_otlp_logs(payload)
+
+    rows = store.query_otlp_records(session_id="sess-wo7")
+    assert len(rows) == 1
+    total = sum(r["cost_usd"] or 0 for r in rows)
+    assert total == pytest.approx(4.10)
+
+
+# ── Fix 4: tool events reach the detectors ──────────────────────────────────
+
+def test_tool_records_become_tool_events(store):
+    now = time.time()
+    recs = [
+        _tool_decision(int((now - 30) * 1e9), "Bash"),
+        _tool_result(int((now - 29) * 1e9), "Bash", success=False,
+                     error="command not found: pytest"),
+    ]
+    _d._process_otlp_logs(_export(recs))
+
+    events = store.query_events(session_id="sess-wo7", limit=50)
+    types = {e["event_type"] for e in events}
+    assert "tool_call" in types and "tool_result" in types, types
+    result = next(e for e in events if e["event_type"] == "tool_result")
+    assert result["data"]["tool"] == "Bash"
+    assert result["data"]["is_error"] is True
+
+
+def test_trajectory_detectors_fire_on_the_otlp_path(store):
+    """The point of mapping tool events: a session that fails the same tool
+    over and over is visible on a deployment with no daemon on any machine."""
+    from clawmetry import detectors
+
+    now = time.time()
+    recs = []
+    for i in range(8):
+        recs.append(_tool_decision(int((now - 60 + i * 2) * 1e9), "Bash"))
+        recs.append(
+            _tool_result(int((now - 59 + i * 2) * 1e9), "Bash", success=False,
+                         error="command not found: pytest")
+        )
+    _d._process_otlp_logs(_export(recs))
+
+    events = store.query_events(session_id="sess-wo7", limit=200)
+    incident = detectors.repeated_tool_failure(events, "sess-wo7", "claude_code")
+    assert incident is not None, "repeated tool failures went unseen"
+    assert incident["kind"] == "repeated_tool_failure"
+
+
+def test_unknown_tool_arguments_do_not_fabricate_a_loop(store):
+    """This path usually carries no tool arguments. Hashing "no args" to one
+    constant would make five Reads of five different files look like the agent
+    repeating itself — a false alarm on someone's real work."""
+    from clawmetry import detectors
+
+    now = time.time()
+    recs = [
+        _tool_decision(int((now - 30 + i) * 1e9), "Read") for i in range(10)
+    ]
+    _d._process_otlp_logs(_export(recs))
+
+    events = store.query_events(session_id="sess-wo7", limit=200)
+    steps = [e for e in events if e["event_type"] == "tool_call"]
+    assert len(steps) == 10
+    hashes = {
+        detectors._args_hash(e["data"].get("args")) for e in steps
+    }
+    assert len(hashes) == 10, "identical arg hashes would read as a loop"
+    assert detectors.stuck_loop(events, "sess-wo7", "claude_code") is None
+
+
+def test_a_rejected_permission_is_not_a_tool_call(store):
+    """The tool never ran. Counting it as a call tells the no-progress
+    detector the agent acted, when it was blocked waiting for a human."""
+    now = time.time()
+    _d._process_otlp_logs(_export([
+        _tool_decision(int(now * 1e9), "Bash", decision="reject"),
+    ]))
+    events = store.query_events(session_id="sess-wo7", limit=50)
+    assert [e for e in events if e["event_type"] == "tool_call"] == []
+    # The decision itself is still on the record, for the audit trail.
+    row = store.query_otlp_records(session_id="sess-wo7")[0]
+    assert row["decision"] == "reject"
+
+
+# ── The payoff: a rollup from the ingested rows alone ───────────────────────
+
+def test_rollup_by_team_and_repo(store):
+    now = time.time()
+    _d._process_otlp_logs(_export(
+        [_api_request(int(now * 1e9), session_id="s1", cost=4.0)],
+        resource_attrs=_resource(repo="acme/payments-api", team="platform"),
+    ))
+    _d._process_otlp_logs(_export(
+        [_api_request(int(now * 1e9), session_id="s2", cost=1.5)],
+        resource_attrs=_resource(repo="acme/web", team="growth"),
+    ))
+    _d._process_otlp_logs(_export(
+        [_api_request(int(now * 1e9), session_id="s3", cost=2.5)],
+        resource_attrs=_resource(repo="acme/payments-api", team="platform"),
+    ))
+
+    by_team = {r["key"]: r for r in store.query_otlp_rollup(dimension="team")}
+    assert by_team["platform"]["cost_usd"] == pytest.approx(6.5)
+    assert by_team["platform"]["sessions"] == 2
+    assert by_team["growth"]["cost_usd"] == pytest.approx(1.5)
+
+    by_repo = {r["key"]: r for r in store.query_otlp_rollup(dimension="repo")}
+    assert by_repo["payments-api"]["cost_usd"] == pytest.approx(6.5)
+    assert by_repo["web"]["tokens"] == 1800
+
+    by_person = {
+        r["key"]: r for r in store.query_otlp_rollup(dimension="user_email")
+    }
+    assert by_person["dana@acme.example"]["records"] == 3
+
+
+def test_rollup_rejects_an_unknown_dimension(store):
+    with pytest.raises(ValueError):
+        store.query_otlp_rollup(dimension="cost_usd; DROP TABLE events")
+
+
+# ── Fix 5: the enterprise image can never answer 501 ────────────────────────
+
+def test_enterprise_image_ships_the_otlp_protobuf_dependency():
+    """deploy/self-hosted/docker-compose.yml builds the root Dockerfile. A
+    receiver that answers 501 until someone remembers `pip install
+    clawmetry[otel]` is not a receiver an org can point 500 machines at."""
+    root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    dockerfile = open(os.path.join(root, "Dockerfile")).read()
+    assert "opentelemetry-proto" in dockerfile
+    assert "protobuf" in dockerfile
+
+    compose = open(
+        os.path.join(root, "deploy", "self-hosted", "docker-compose.yml")
+    ).read()
+    assert "context: ../.." in compose, "compose must build that Dockerfile"
+
+
+def test_receiver_is_reachable_without_a_daemon(store, monkeypatch):
+    """No store at all (a first boot before DuckDB is ready) must not 500 the
+    receiver — the exporter would retry forever and the org would see drops."""
+    monkeypatch.setattr(
+        _ls, "get_store", lambda read_only=False: (_ for _ in ()).throw(
+            RuntimeError("no store")
+        )
+    )
+    _d._process_otlp_logs(_export([_api_request(int(time.time() * 1e9))]))
+
+
+# ── Hybrid installs: the daemon wins, nothing is counted twice ──────────────
+
+def test_a_session_the_daemon_already_owns_is_not_duplicated(store):
+    """A machine can have BOTH the daemon and the org's OTEL config. The same
+    session then arrives twice — read from the transcript, and pushed by the
+    runtime. Spend that doubles because two collectors both did their job is
+    worse than spend that is missing."""
+    now = time.time()
+    # The daemon got there first: a transcript-derived event for this session.
+    store.ingest({
+        "id": "daemon-evt-1",
+        "node_id": "mac-of-dana",
+        "agent_type": "claude_code",
+        "session_id": "sess-wo7",
+        "event_type": "tool_call",
+        "ts": "2026-08-25T10:00:00+00:00",
+        "cost_usd": 4.10,
+        "data": {"tool": "Bash", "args": {"command": "pytest"}},
+    })
+    store._flush_now()
+
+    _d._process_otlp_logs(_export([
+        _api_request(int(now * 1e9)),
+        _tool_decision(int(now * 1e9), "Bash"),
+    ]))
+
+    events = store.query_events(session_id="sess-wo7", limit=50)
+    assert [e for e in events if str(e["id"]).startswith("otlp:")] == []
+    assert sum(e.get("cost_usd") or 0 for e in events) == pytest.approx(4.10)
+
+    # The identity ledger still records everything — the org rollup does not
+    # lose a machine just because that machine also runs a daemon.
+    rows = store.query_otlp_records(session_id="sess-wo7")
+    assert len(rows) == 2
+
+
+def test_a_daemon_free_session_still_gets_its_events(store):
+    """The control for the test above: with no daemon rows, the events land."""
+    now = time.time()
+    _d._process_otlp_logs(_export([
+        _api_request(int(now * 1e9)),
+        _tool_decision(int(now * 1e9), "Bash"),
+    ]))
+    events = store.query_events(session_id="sess-wo7", limit=50)
+    assert [e for e in events if str(e["id"]).startswith("otlp:")]
+    assert sum(e.get("cost_usd") or 0 for e in events) == pytest.approx(4.10)
+
+
+def test_a_retried_batch_does_not_double_the_live_tiles_either(store, monkeypatch):
+    """The DuckDB ledger dedups on the record id, but a person looks at the
+    tile, not the table. Both have to hold, or the receiver reports a spike
+    that is really the network retrying."""
+    captured = []
+    monkeypatch.setattr(
+        _d, "_add_metric", lambda cat, e: captured.append((cat, e))
+    )
+    payload = _export([_api_request(int(time.time() * 1e9))])
+    _d._process_otlp_logs(payload)
+    _d._process_otlp_logs(payload)
+
+    costs = [e for c, e in captured if c == "cost"]
+    assert len(costs) == 1, f"retry counted {len(costs)} times in the tiles"
+    assert costs[0]["usd"] == pytest.approx(4.10)
+
+
+def test_the_cache_dedup_set_stays_bounded(monkeypatch):
+    """A receiver that runs for a month must not grow a set forever."""
+    monkeypatch.setattr(_d, "_OTLP_SEEN_MAX", 10)
+    _d._otlp_seen_ids.clear()
+    _d._otlp_seen_order.clear()
+    for i in range(50):
+        assert _d._otlp_seen(f"rec-{i}") is False
+    assert len(_d._otlp_seen_ids) <= 10
+    assert len(_d._otlp_seen_order) <= 10
+    # The newest is still remembered; the oldest has aged out, which is the
+    # trade: a bounded guard, not a permanent ledger.
+    assert _d._otlp_seen("rec-49") is True
+    assert _d._otlp_seen("rec-0") is False

--- a/tests/test_otlp_daemon_free_intake.py
+++ b/tests/test_otlp_daemon_free_intake.py
@@ -714,3 +714,48 @@ def test_a_count_that_could_not_be_taken_is_not_reported_as_zero(store, monkeypa
 
     monkeypatch.setattr(type(store), "_fetch", _boom)
     assert store.count_otlp_records() is None
+
+
+# ── Not hardcoded to one emitter ────────────────────────────────────────────
+
+def test_a_second_emitter_is_not_mis_bucketed_as_claude_code(store):
+    """Every other fixture in this file says ``claude-code``, which is exactly
+    how a path ends up quietly hardcoded to one runtime.
+
+    This asserts a property of OUR mapping, not a claim about any other
+    runtime's schema: the emitter comes from the OTel-standard
+    ``service.name`` resource attribute, and the event kind from the suffix
+    after the last dot, so a different emitter lands under its OWN agent_type
+    with its tool records mapped the same way. A second runtime showing up
+    inside the first one's runtime filter is the bug this prevents.
+    """
+    now = time.time()
+    other = [
+        _kv("service.name", s="codex"),
+        _kv("team.id", s="platform"),
+        _kv("repository", s="acme/payments-api"),
+        _kv("host.name", s="build-box"),
+    ]
+    rec = _tool_decision(int(now * 1e9), "shell", session_id="other-sess")
+    rec.event_name = "codex.tool_decision"
+    money = _api_request(int(now * 1e9), session_id="other-sess", cost=0.75)
+    money.event_name = "codex.api_request"
+
+    _d._process_otlp_logs(_export([money, rec], resource_attrs=other))
+
+    rows = store.query_otlp_records(session_id="other-sess")
+    assert len(rows) == 2
+    assert {r["agent_type"] for r in rows} == {"codex"}
+    assert {r["service_name"] for r in rows} == {"codex"}
+    # Identity and rollup dimensions work the same for it.
+    assert rows[0]["team"] == "platform" and rows[0]["repo"] == "payments-api"
+
+    events = store.query_events(session_id="other-sess", limit=20)
+    kinds = {e["event_type"] for e in events}
+    assert "tool_call" in kinds, "a second emitter's tool records must map too"
+    assert {e["agent_type"] for e in events} == {"codex"}
+
+    # And it rolls up beside the first one rather than on top of it.
+    by_runtime = {r["key"]: r for r in store.query_otlp_rollup(
+        dimension="agent_type")}
+    assert by_runtime["codex"]["cost_usd"] == pytest.approx(0.75)

--- a/tests/test_otlp_daemon_free_intake.py
+++ b/tests/test_otlp_daemon_free_intake.py
@@ -184,7 +184,9 @@ def _tool_result(when_ns, tool, success=True, error="", session_id="sess-wo7"):
 def test_batched_delivery_keeps_its_own_timestamps(store):
     """A batch delivered now, describing work from six hours ago, must land
     six hours ago. The prototype stamped time.time() on every record, so any
-    daily rollup over a retried or buffered export was silently wrong."""
+    daily rollup over a retried or buffered export was silently wrong.
+    AC-OBS-006.1
+    """
     six_hours_ago = time.time() - 6 * 3600
     _d._process_otlp_logs(_export([_api_request(int(six_hours_ago * 1e9))]))
 
@@ -197,7 +199,9 @@ def test_batched_delivery_keeps_its_own_timestamps(store):
 
 def test_observed_time_is_used_when_the_record_has_no_event_time(store):
     """Exporters may set only observedTimeUnixNano. Falling through to
-    receipt time there is the same misdating bug in a different coat."""
+    receipt time there is the same misdating bug in a different coat.
+    AC-OBS-006.1
+    """
     observed = time.time() - 3600
     rec = _api_request(0)
     rec.observed_time_unix_nano = int(observed * 1e9)
@@ -209,7 +213,9 @@ def test_observed_time_is_used_when_the_record_has_no_event_time(store):
 
 def test_metrics_cache_gets_the_record_timestamp_too(store, monkeypatch):
     """The live tiles read the in-memory cache; if only the DuckDB row is
-    correctly dated, today's tile still counts yesterday's spend."""
+    correctly dated, today's tile still counts yesterday's spend.
+    AC-OBS-006.1
+    """
     captured = []
     monkeypatch.setattr(
         _d, "_add_metric", lambda cat, e: captured.append((cat, e))
@@ -254,7 +260,11 @@ def test_repo_key_normalisation(raw, expected):
 # ── Fix 3: it survives a restart ────────────────────────────────────────────
 
 def test_rows_survive_a_store_restart(store, monkeypatch, tmp_path):
-    """The acceptance criterion the in-memory cache could never meet."""
+    """The acceptance criterion the in-memory cache could never meet.
+    AC-OBS-006.2
+    
+    AC-OBS-006.3
+    """
     _d._process_otlp_logs(_export([_api_request(int(time.time() * 1e9))]))
     db_path = str(_ls.DB_PATH)
     store.stop(flush=True)
@@ -271,7 +281,9 @@ def test_rows_survive_a_store_restart(store, monkeypatch, tmp_path):
 
 def test_a_retried_batch_does_not_double_count_spend(store):
     """OTLP delivery is at-least-once. An exporter that misses our 200 resends
-    the batch, and spend that doubles on a network blip is worse than none."""
+    the batch, and spend that doubles on a network blip is worse than none.
+    AC-OBS-006.5
+    """
     payload = _export([_api_request(int(time.time() * 1e9))])
     _d._process_otlp_logs(payload)
     _d._process_otlp_logs(payload)
@@ -304,7 +316,11 @@ def test_tool_records_become_tool_events(store):
 
 def test_trajectory_detectors_fire_on_the_otlp_path(store):
     """The point of mapping tool events: a session that fails the same tool
-    over and over is visible on a deployment with no daemon on any machine."""
+    over and over is visible on a deployment with no daemon on any machine.
+    AC-OBS-006.7
+    
+    AC-OBS-006.7
+    """
     from clawmetry import detectors
 
     now = time.time()
@@ -347,7 +363,9 @@ def test_unknown_tool_arguments_do_not_fabricate_a_loop(store):
 
 def test_a_rejected_permission_is_not_a_tool_call(store):
     """The tool never ran. Counting it as a call tells the no-progress
-    detector the agent acted, when it was blocked waiting for a human."""
+    detector the agent acted, when it was blocked waiting for a human.
+    AC-OBS-006.7
+    """
     now = time.time()
     _d._process_otlp_logs(_export([
         _tool_decision(int(now * 1e9), "Bash", decision="reject"),
@@ -401,7 +419,9 @@ def test_rollup_rejects_an_unknown_dimension(store):
 def test_enterprise_image_ships_the_otlp_protobuf_dependency():
     """deploy/self-hosted/docker-compose.yml builds the root Dockerfile. A
     receiver that answers 501 until someone remembers `pip install
-    clawmetry[otel]` is not a receiver an org can point 500 machines at."""
+    clawmetry[otel]` is not a receiver an org can point 500 machines at.
+    AC-OBS-006.4
+    """
     root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     dockerfile = open(os.path.join(root, "Dockerfile")).read()
     assert "opentelemetry-proto" in dockerfile
@@ -430,7 +450,9 @@ def test_a_session_the_daemon_already_owns_is_not_duplicated(store):
     """A machine can have BOTH the daemon and the org's OTEL config. The same
     session then arrives twice — read from the transcript, and pushed by the
     runtime. Spend that doubles because two collectors both did their job is
-    worse than spend that is missing."""
+    worse than spend that is missing.
+    AC-OBS-006.6
+    """
     now = time.time()
     # The daemon got there first: a transcript-derived event for this session.
     store.ingest({
@@ -475,7 +497,9 @@ def test_a_daemon_free_session_still_gets_its_events(store):
 def test_a_retried_batch_does_not_double_the_live_tiles_either(store, monkeypatch):
     """The DuckDB ledger dedups on the record id, but a person looks at the
     tile, not the table. Both have to hold, or the receiver reports a spike
-    that is really the network retrying."""
+    that is really the network retrying.
+    AC-OBS-006.5
+    """
     captured = []
     monkeypatch.setattr(
         _d, "_add_metric", lambda cat, e: captured.append((cat, e))
@@ -563,3 +587,66 @@ def test_the_batch_write_forwards_through_the_daemon_proxy(monkeypatch):
     for method in ("put_otlp_batch", "query_otlp_rollup",
                    "query_otlp_records", "count_otlp_records"):
         assert method in lq._DAEMON_METHODS, f"{method} missing from the allowlist"
+
+
+# ── The two claims that only exist if a surface actually makes them ─────────
+
+def test_rollup_endpoint_says_the_grouping_is_self_reported(store):
+    """AC-OBS-006.4 asks for two things and the second is the easy one to
+    lose: the rollup must SAY the grouping is self-reported.
+
+    Agent principals (REQ-OBS-004) derive owner and team from what ClawMetry
+    observes and name the rung an inherited value came from. This path carries
+    what the sender declared about itself. A reader who cannot tell which
+    question they asked has been misled, so the answer says which one it is.
+    
+    AC-OBS-006.4
+    """
+    now = time.time()
+    _d._process_otlp_logs(_export(
+        [_api_request(int(now * 1e9), session_id="s1", cost=4.0)],
+        resource_attrs=_resource(repo="acme/payments-api", team="platform"),
+    ))
+
+    # A bare Flask app with just this blueprint: dashboard.app registers its
+    # blueprints inside detect_config(), which a unit test does not run.
+    import flask
+    import routes.meta as meta
+
+    app = flask.Flask(__name__)
+    app.register_blueprint(meta.bp_otel)
+    client = app.test_client()
+    r = client.get("/api/otel/rollup?dimension=team&days=30")
+    assert r.status_code == 200, r.get_data(as_text=True)[:300]
+    body = r.get_json()
+    assert body["attribution"] == "self-reported"
+    assert body["basis"] == "measured"
+    assert body["dimension"] == "team"
+    assert {row["key"] for row in body["rows"]} == {"platform"}
+
+    # A column that does not exist is a caller error, not a store outage —
+    # answering 503 there would send someone to look at the wrong thing.
+    bad = client.get("/api/otel/rollup?dimension=cost_usd%3B+DROP+TABLE+events")
+    assert bad.status_code == 400
+    assert "allowed" in bad.get_json()
+
+
+def test_the_docs_state_the_two_limits_this_path_is_sold_on():
+    """AC-OBS-006.8. Both limits are load-bearing for a customer decision and
+    both are the kind of sentence that quietly disappears in an edit:
+
+    * it covers the runtimes that emit OpenTelemetry natively, not all of them
+    * records arrive unencrypted, so the daemon's end-to-end encryption
+      guarantee does not stretch over this path
+
+    A claim nothing checks is a claim that drifts. This is the check.
+    
+    AC-OBS-006.8
+    """
+    root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    for rel in ("docs/enterprise.md", "deploy/self-hosted/README.md"):
+        text = open(os.path.join(root, rel)).read().lower()
+        assert "claude code" in text and "codex" in text, (
+            f"{rel} must name the runtimes this path actually covers")
+        assert "plaintext" in text or "unencrypted" in text, (
+            f"{rel} must say records arrive unencrypted on this path")

--- a/tests/test_otlp_daemon_free_intake.py
+++ b/tests/test_otlp_daemon_free_intake.py
@@ -502,3 +502,64 @@ def test_the_cache_dedup_set_stays_bounded(monkeypatch):
     # trade: a bounded guard, not a permanent ledger.
     assert _d._otlp_seen("rec-49") is True
     assert _d._otlp_seen("rec-0") is False
+
+
+# ── The write reaches the writer, or it reaches nothing ─────────────────────
+
+class _RecordingProxy:
+    """Stand-in for the dashboard-process ``_ProxyStore``: records every call
+    and no-ops, the way the real proxy forwards to the daemon."""
+
+    _read_only = True
+
+    def __init__(self):
+        self.calls = []
+
+    def __getattr__(self, name):
+        def _f(*a, **k):
+            self.calls.append((name, a, k))
+            return None
+        return _f
+
+
+def test_the_batch_write_forwards_through_the_daemon_proxy(monkeypatch):
+    """When a daemon owns the DuckDB writer — every real install — the
+    dashboard's ``get_store()`` returns a proxy that forwards **kwargs ONLY.
+    A positional call is not an error: it is dropped, and the receiver
+    silently stores nothing while answering 200 to every exporter. That is how
+    the OTLP span path broke in June, found only by looking at live data.
+
+    So the contract is pinned from both ends: the call is by keyword, and the
+    method is on the daemon allowlist. Either one missing is the same silent
+    no-op.
+    """
+    import importlib
+
+    import routes.local_query as lq
+
+    ls = importlib.import_module("clawmetry.local_store")
+    rec = _RecordingProxy()
+    monkeypatch.setattr(ls, "get_store", lambda *a, **k: rec)
+
+    _d._process_otlp_logs(_export([
+        _api_request(int(time.time() * 1e9)),
+        _tool_decision(int(time.time() * 1e9), "Bash"),
+    ]))
+
+    calls = [c for c in rec.calls if c[0] == "put_otlp_batch"]
+    assert calls, "put_otlp_batch was never called by the receiver"
+    _name, args, kwargs = calls[0]
+    assert not args, f"positional args are dropped by the proxy: {args!r}"
+    assert "records" in kwargs and "events" in kwargs
+    assert kwargs["records"], "no records handed to the writer"
+    assert kwargs["events"], "no events handed to the writer"
+
+    # One call for the whole export batch, not one per record: get_store() here
+    # is an HTTP hop to the daemon and an exporter ships hundreds at a time.
+    assert len(calls) == 1, f"{len(calls)} writes for one batch"
+
+    # A method absent from the allowlist is refused by the daemon and the
+    # caller reads the 400 as an empty result.
+    for method in ("put_otlp_batch", "query_otlp_rollup",
+                   "query_otlp_records", "count_otlp_records"):
+        assert method in lq._DAEMON_METHODS, f"{method} missing from the allowlist"

--- a/tests/test_spans_otlp_edge_cases.py
+++ b/tests/test_spans_otlp_edge_cases.py
@@ -85,6 +85,37 @@ def _hx(n: int) -> str:
     return f"{n:016x}"
 
 
+def _otlp_json_body(req) -> str:
+    """Serialise an OTLP request as spec-compliant OTLP/JSON.
+
+    ``json_format.MessageToJson`` is NOT OTLP/JSON: protobuf-JSON encodes every
+    ``bytes`` field as base64, but the OTLP/JSON spec overrides that for
+    ``traceId`` / ``spanId`` / ``parentSpanId``, which are lowercase HEX. Real
+    exporters send hex, and ``clawmetry.otlp_json`` decodes hex, so a test that
+    posts base64 is testing a wire format nothing speaks — and it only ran at
+    all when opentelemetry-proto happened to be installed, which CI never did.
+    """
+    import base64 as _b64
+    doc = _json.loads(_json_format.MessageToJson(req))
+
+    def _fix(node):
+        if isinstance(node, dict):
+            for k, v in list(node.items()):
+                if k in ("traceId", "spanId", "parentSpanId") and isinstance(v, str):
+                    try:
+                        node[k] = _b64.b64decode(v).hex()
+                    except Exception:
+                        pass
+                else:
+                    _fix(v)
+        elif isinstance(node, list):
+            for item in node:
+                _fix(item)
+
+    _fix(doc)
+    return _json.dumps(doc)
+
+
 def _build_req(specs, *, n_resource_spans=1, service_name="openclaw"):
     """Build the OTLP request PROTO object (not yet serialized) so callers can
     pick the wire encoding (binary / JSON / gzip). ``specs`` is a list of span
@@ -334,7 +365,7 @@ def test_otlp_json_accepted_and_parsed_identically(app):
                                      "gen_ai.request.model": "claude-3-5-haiku-20241022"},
                        "int_attrs": {"gen_ai.usage.input_tokens": 10,
                                      "gen_ai.usage.output_tokens": 5}}])
-    body = _json_format.MessageToJson(req)
+    body = _otlp_json_body(req)
     r = c.post("/v1/traces", data=body, content_type="application/json")
     assert r.status_code == 200, r.get_data(as_text=True)[:200]
     _drain(ls)
@@ -648,7 +679,7 @@ def test_openllmetry_openai_chat_shape_end_to_end(app):
     _iattr("llm.usage.prompt_tokens", 850)
     _iattr("llm.usage.completion_tokens", 120)
 
-    body = _json_format.MessageToJson(req)
+    body = _otlp_json_body(req)
     r = c.post("/v1/traces", data=body, content_type="application/json")
     assert r.status_code == 200, r.get_data(as_text=True)[:200]
     _drain(ls)


### PR DESCRIPTION
**Product record**

- Requirement: https://factory.8090.ai/project/b415065f-ab2f-4f53-8864-0c009fd098cb/requirements/d518c6c3-eb50-4b0f-9ed0-59440380b7bf (REQ-OBS-006 "Observe agents on a machine with nothing installed on it", v14, AC-OBS-006.1 through .8)
- Blueprint: https://factory.8090.ai/project/b415065f-ab2f-4f53-8864-0c009fd098cb/blueprints/e42834c9-33d0-4ee8-b1f3-423970a6527a ("Telemetry from a machine with nothing installed on it", v32, ADR-WO7-001/002/003)

Order, stated plainly: the work order that specified this (problem, scope, acceptance, non-goals, and the trap) was written before the code, but the Factory records were written after it. FLYWHEEL 0c asks for the reverse and is right to. What the review would have caught early, I caught late and fixed in the diff rather than leaving: this path stores a self-reported team one day after REQ-OBS-004 shipped derived ownership, which is close enough to read as a second ownership model. Every rollup response now says `attribution: self-reported`, and ADR-WO7-001 says why the two questions are different.

---

Implements **WO-7, Daemon-Free Intake**. An org that will not put a background process on 500 developer laptops can now onboard by changing one config value.

The receiver at `/v1/logs` already existed, but it was a prototype: it stamped `time.time()` on every record, extracted no identity, and wrote only to an in-memory cache that a restart erased.

## The five fixes

| # | Fix | Where |
|---|---|---|
| 1 | Honour the record's own timestamp (`time_unix_nano`, then `observed_time_unix_nano`, then receipt) | `dashboard._otlp_record_ts`, `clawmetry/otlp_json.py` |
| 2 | Extract identity (`user.id`, `user.email`, `organization.id`, `session.id`) plus team and repo from `OTEL_RESOURCE_ATTRIBUTES` | `dashboard._process_otlp_logs` |
| 3 | Persist to DuckDB instead of the in-memory cache | new `otlp_records` table plus `put_otlp_batch` |
| 4 | `tool_decision` and `tool_result` become tool events the detectors read | `dashboard._process_otlp_logs` |
| 5 | Ship `opentelemetry-proto` in the enterprise ingest image | `Dockerfile` |

Writes go through the daemon proxy (`put_otlp_batch` is allowlisted in `routes/local_query._DAEMON_METHODS`), one call per export batch rather than per record, so a request handler never takes the writer lock.

## Acceptance

- **A batch with six-hour-old timestamps lands six hours ago.** Verified against a running dashboard: stored `13:16`, delivered `19:16`.
- **Data survives a restart.** After SIGTERM and reboot the in-memory cache reads 0 cost entries and `/api/otel/rollup` still answers. That contrast is the fix.
- **A rollup by team or repo is possible from the ingested rows alone.** `GET /api/otel/rollup?dimension=team|repo|user_email&days=30`, with no join against anything a daemon would have had to write.
- **Writes go through the daemon; the writer lock is never grabbed from a handler.** Pinned by a test against a recording proxy, not left as a claim.

## Three problems the fixes made visible

- **A retried batch used to double the spend.** OTLP delivery is at-least-once. `record_id` is now derived from the record's own content so the ledger replaces, and a bounded seen-set gives the live tiles the same guarantee. A person looks at the tile, not the table.
- **A machine running both the daemon and the org's OTEL config saw each session twice.** The daemon's transcript read is strictly richer, so it wins and the OTLP events are dropped; the identity ledger still records every record. The one remaining gap (an OTLP record beating the first transcript ingest of a brand-new session) is written down in the code, not hidden.
- **A rejected permission prompt is not a tool call**, and absent tool arguments are not hashed to one constant. That would make five `Read`s of five different files read as a loop.

## CI

New `otlp-receiver` job, the only one that installs the otel extra. Every OTLP protobuf test in this repo was `importorskip`'d in CI, so this path had **zero** coverage, and two tests in `test_spans_otlp_edge_cases.py` had been failing the whole time where nobody could see them: they posted protobuf-JSON (base64 ids) at a decoder that implements OTLP/JSON (hex ids). The fixture now emits the real wire format.

`tests/test_otlp_daemon_free_intake.py` adds 26 tests, one per property above. AC-OBS-006.1 through .8 are mirrored into `docs/acceptance_criteria.json` and declared by the tests that hold them (traceability gate: 55/120 covered, ratchet holding).

## Non-goals, respected

- No claim that this covers 26 runtimes. It covers the runtimes that emit OTel natively, Claude Code and Codex, and `docs/enterprise.md` plus the deploy README say so where the path is sold. A test checks both documents still say it.
- No end-to-end-encryption claim on this path. The runtime encrypts nothing; the docs say the honest answer is the self-hosted VPC receiver, where the plaintext never leaves the customer's network.

Also documented: `/v1/*` is auth-gated off loopback, and a refused exporter drops its batch silently. Worth knowing before rolling this out to a fleet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012uGvkvdXhove8dmNhCU1r8
