### PR TITLE
Seal a shared session with the organisation key, or upload nothing at all

### DIFF
--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -8628,6 +8628,13 @@ def send_heartbeat(config: dict) -> bool:
             pending = (resp_json or {}).get("pending_queries") or []
             if pending:
                 _dispatch_pending_queries(config, pending)
+            # Sessions their owner asked to share with their organisation. We
+            # seal each with the ORGANISATION key and upload it once, so a
+            # colleague can read it without this machine being awake and
+            # without holding this machine's key.
+            shares = (resp_json or {}).get("share_requests") or []
+            if shares:
+                _seal_shared_traces(config, shares)
             return True
         except Exception as e:
             last_err = e
@@ -11185,6 +11192,66 @@ def _build_q1_cache_pushes(config: dict) -> list:
             log.debug("q1 cache push failed for shape=%s: %s", shape, _e)
 
     return pushes
+
+
+def _seal_shared_traces(config: dict, session_ids: list) -> None:
+    """Seal each requested session's trace with the ORGANISATION key and upload.
+
+    This is the only path by which one person's session becomes readable by
+    their colleagues, and the key choice is the whole design:
+
+    * With an organisation key, the trace is sealed so every member can open
+      it, and the cloud stores ciphertext it cannot read.
+    * WITHOUT one we upload NOTHING. Sealing with this machine's own key would
+      produce a blob no colleague could open, and the share would sit there
+      looking successful forever. A share that cannot be read is worse than a
+      share that plainly failed, so we log what is missing and leave the
+      session in `sealing` until a key exists.
+
+    Failures are per-session and never raise: one unreadable session must not
+    stop the heartbeat or the other shares.
+    """
+    try:
+        from clawmetry import org_key as _ok
+    except Exception:
+        return
+    api_key = config.get("api_key")
+    if not api_key:
+        return
+
+    org = _ok.get(config)
+    if not org:
+        log.warning(
+            "share: %d session(s) are marked shared but this machine has no "
+            "organisation key, so nothing can be sealed for colleagues. Run "
+            "`clawmetry team key create`, or accept your organisation's key "
+            "with `clawmetry team key set --file KEYFILE`.",
+            len(session_ids),
+        )
+        return
+    fp = _ok.fingerprint(org)
+
+    for sid in list(session_ids)[:5]:
+        sid = str(sid or "").strip()
+        if not sid:
+            continue
+        try:
+            from routes.local_query import _dispatch as _local_dispatch
+            body = _local_dispatch("transcript", {"session_id": sid,
+                                                  "limit": 5000})
+            rows = (body or {}).get("rows") or []
+            if not rows:
+                log.info("share: %s has no recorded events; nothing to seal", sid)
+                continue
+            blob = encrypt_payload({"rows": rows, "count": len(rows),
+                                    "session_id": sid}, org)
+            _post("/ingest/shared-trace",
+                  {"session_id": sid, "blob": blob, "key_fingerprint": fp},
+                  api_key)
+            log.info("share: sealed %s (%d events) for the organisation",
+                     sid, len(rows))
+        except Exception as exc:
+            log.warning("share: could not seal %s: %s", sid, exc)
 
 
 def _dispatch_pending_queries(config: dict, pending: list) -> None:

--- a/tests/test_seal_shared_trace.py
+++ b/tests/test_seal_shared_trace.py
@@ -1,0 +1,132 @@
+"""Sealing a session so a colleague can read it.
+
+This is the only path by which one person's session becomes readable by their
+colleagues, and the key choice IS the design:
+
+* with an organisation key, the trace is sealed so every member can open it,
+  and the cloud stores ciphertext it cannot read;
+* WITHOUT one, nothing is uploaded. Sealing with this machine's own key would
+  produce a blob no colleague could open, and the share would sit there looking
+  successful forever. A share that cannot be read is worse than one that
+  plainly failed.
+
+That second case is the one worth a test: it is silent, it looks like success
+from every angle the user can see, and it is exactly what a "just use whatever
+key we have" implementation would do.
+
+Cloud half: clawmetry-cloud#2127 (REQ-CLOUD-TS-003).
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+
+@pytest.fixture
+def sync_mod(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "e.duckdb"))
+    monkeypatch.delenv("CLAWMETRY_ORG_KEY", raising=False)
+    import clawmetry.sync as sync
+    importlib.reload(sync)
+    return sync
+
+
+@pytest.fixture
+def captured(sync_mod, monkeypatch):
+    """Record what the daemon would POST, and feed it one fake session."""
+    posts = []
+    monkeypatch.setattr(sync_mod, "_post",
+                        lambda path, body, key=None, **kw: posts.append((path, body)),
+                        raising=False)
+
+    def fake_dispatch(shape, args):
+        assert shape == "transcript"
+        return {"rows": [{"event_type": "message", "data": {"role": "user",
+                                                            "content": "hello"}}],
+                "count": 1}
+
+    import routes.local_query as lq
+    monkeypatch.setattr(lq, "_dispatch", fake_dispatch, raising=False)
+    return posts
+
+
+ORG = "b3BlbmNsYXctb3JnLWtleS0zMi1ieXRlcy1sb25nISE"  # 32 bytes, urlsafe b64
+
+
+def test_a_trace_is_sealed_with_the_ORGANISATION_key(sync_mod, captured):
+    from clawmetry import org_key
+
+    cfg = {"api_key": "cm_x", "encryption_key": "NODEKEY",
+           org_key.CONFIG_FIELD: ORG}
+    sync_mod._seal_shared_traces(cfg, ["claude_code:aaa"])
+
+    assert len(captured) == 1
+    path, body = captured[0]
+    assert path == "/ingest/shared-trace"
+    assert body["session_id"] == "claude_code:aaa"
+    assert body["key_fingerprint"] == org_key.fingerprint(ORG)
+    # It opens with the ORGANISATION key, which is what makes it readable by a
+    # colleague. If it opened with the node key, only this machine could.
+    opened = sync_mod.decrypt_payload(body["blob"], ORG)
+    assert opened["count"] == 1
+    assert opened["rows"][0]["data"]["content"] == "hello"
+
+
+def test_the_plaintext_never_appears_in_what_is_uploaded(sync_mod, captured):
+    from clawmetry import org_key
+    cfg = {"api_key": "cm_x", org_key.CONFIG_FIELD: ORG}
+    sync_mod._seal_shared_traces(cfg, ["claude_code:aaa"])
+    _path, body = captured[0]
+    import json as _j
+    assert "hello" not in _j.dumps(body)
+
+
+def test_without_an_organisation_key_NOTHING_is_uploaded(sync_mod, captured):
+    """The silent-failure case. Uploading a node-key blob would look like a
+    successful share to everyone involved and be unreadable by the colleague
+    it was shared with."""
+    cfg = {"api_key": "cm_x", "encryption_key": "NODEKEY"}
+    sync_mod._seal_shared_traces(cfg, ["claude_code:aaa"])
+    assert captured == []
+
+
+def test_a_session_with_no_events_is_skipped_rather_than_sealed_empty(
+        sync_mod, monkeypatch, captured):
+    from clawmetry import org_key
+    import routes.local_query as lq
+    monkeypatch.setattr(lq, "_dispatch",
+                        lambda shape, args: {"rows": [], "count": 0},
+                        raising=False)
+    sync_mod._seal_shared_traces({"api_key": "cm_x", org_key.CONFIG_FIELD: ORG},
+                                 ["claude_code:empty"])
+    assert captured == []
+
+
+def test_one_unreadable_session_does_not_stop_the_others(sync_mod, monkeypatch,
+                                                          captured):
+    """Per-session failures must never take down the heartbeat or the rest of
+    the batch."""
+    from clawmetry import org_key
+    import routes.local_query as lq
+    calls = {"n": 0}
+
+    def flaky(shape, args):
+        calls["n"] += 1
+        if args.get("session_id") == "bad":
+            raise RuntimeError("duckdb invalidated")
+        return {"rows": [{"event_type": "message", "data": {"content": "ok"}}],
+                "count": 1}
+
+    monkeypatch.setattr(lq, "_dispatch", flaky, raising=False)
+    sync_mod._seal_shared_traces({"api_key": "cm_x", org_key.CONFIG_FIELD: ORG},
+                                 ["bad", "good"])
+    assert [b["session_id"] for _p, b in captured] == ["good"]
+
+
+def test_a_burst_of_shares_cannot_eat_a_whole_check_in(sync_mod, captured):
+    from clawmetry import org_key
+    sync_mod._seal_shared_traces({"api_key": "cm_x", org_key.CONFIG_FIELD: ORG},
+                                 ["s%d" % i for i in range(40)])
+    assert len(captured) == 5


### PR DESCRIPTION
**Product record:** https://factory.8090.ai/project/b415065f-ab2f-4f53-8864-0c009fd098cb/requirements/b04736fc-e656-4640-94d0-9c413f59c894 (REQ-CLOUD-TS-003, Team Sessions and Shared Agent Context). Cloud half: vivekchand/clawmetry-cloud#2127.

**Risk:** runs only when the heartbeat response carries `share_requests`, which is empty for everyone who has not shared a session. Per-session failures are caught and logged. No existing path changes. Undone by reverting.

## What it does

The heartbeat response now carries `share_requests`: sessions whose owner asked to share them with their organisation. For each, the machine reads the trace from **its own DuckDB**, seals it with the **organisation key**, and uploads it once.

That single upload is what the relay cannot do. A colleague can then read the session **without this machine being awake** and **without holding this machine's key**, and the cloud stores ciphertext it cannot read.

## The case this is really about

**With no organisation key we upload nothing, and say why.**

Sealing with this machine's own key would produce a blob no colleague could open — while the share sat there looking successful from every angle the user can see: the button worked, the row says shared, the cloud has bytes. **A share that cannot be read is worse than one that plainly failed**, because nobody goes looking for it. The log names the two commands that fix it.

That is the behaviour a "just use whatever key we have" implementation would get wrong, so it has its own test.

## Tests

`tests/test_seal_shared_trace.py`, 6 cases:

- **sealed with the ORG key, not the node key** — asserted by decrypting with the org key and reading the events back, so a wrong-key implementation fails rather than merely looking different
- the plaintext never appears anywhere in what is uploaded
- **no organisation key means no upload**
- an empty session is skipped rather than sealed empty
- one unreadable session does not block the others
- 40 requests produce 5 uploads, so a burst cannot eat a whole check-in

`ruff`: 27 findings before, 27 after — no new lint debt.

Not claimed: end-to-end sharing needs the cloud half (#2127) merged and deployed too. Neither side does anything on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012SppEmAi5dccxvpsg3aAaZ