### PR TITLE
fix(goose): resolve the session store per platform, not XDG-only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -349,6 +349,8 @@ jobs:
             tests/test_phase4_adapter_move.py \
             tests/test_openclaw_detection_real.py \
             tests/test_hooks_claude_code.py \
+            tests/test_goose_adapter.py \
+            tests/test_goose_platform_paths.py \
             -q
 
   # ── Entitlement API test suite (~2700+ hermetic tests) ─────────────────────────────────────────────

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ test: test-api test-e2e test-e2e-duckdb test-workflow test-compat
 # (per-session SQLite). Hermetic, ~1s — no live server, no gateway, no
 # network. Mirror in .github/workflows/ci.yml (moat-tests job).
 test-compat:
-	python3 -m pytest tests/test_picoclaw_adapter.py tests/test_nanoclaw_adapter.py tests/test_runtime_detection_snapshot.py tests/test_family_runtime_ingest.py tests/test_codex_adapter.py tests/test_cursor_adapter.py tests/test_claude_code_adapter.py tests/test_aider_adapter.py tests/test_goose_adapter.py tests/test_opencode_adapter.py tests/test_qwen_code_adapter.py -v
+	python3 -m pytest tests/test_picoclaw_adapter.py tests/test_nanoclaw_adapter.py tests/test_runtime_detection_snapshot.py tests/test_family_runtime_ingest.py tests/test_codex_adapter.py tests/test_cursor_adapter.py tests/test_claude_code_adapter.py tests/test_aider_adapter.py tests/test_goose_adapter.py tests/test_goose_platform_paths.py tests/test_opencode_adapter.py tests/test_qwen_code_adapter.py -v
 
 test-fast:
 	CLAWMETRY_URL=http://localhost:8900 CLAWMETRY_TOKEN=dev-token python3 -m pytest tests/test_api.py -v

--- a/clawmetry/adapters/goose.py
+++ b/clawmetry/adapters/goose.py
@@ -9,10 +9,24 @@ what a fresh ``goose`` install writes.
 
 On-disk layout
 --------------
-``$XDG_DATA_HOME/goose/sessions/sessions.db`` (default on macOS/Linux
-``~/.local/share/goose/sessions/sessions.db``). VERIFIED against a real
-Goose 1.35.0 install by running ``goose run`` against local Ollama and
-reading the DB it wrote (``schema_version`` = 13). Two relevant tables:
+``<goose data dir>/sessions/sessions.db``, where the data dir is whatever
+Goose's own ``Paths::data_dir()`` resolves to. See ``_candidate_db_paths()``
+for the derivation; the short version is:
+
+* ``$GOOSE_PATH_ROOT/data`` when that env var is set to an ABSOLUTE path.
+* Windows: ``%APPDATA%\\Block\\goose\\data``.
+* macOS **and** Linux: ``${XDG_DATA_HOME:-~/.local/share}/goose``. macOS is
+  NOT ``~/Library/Application Support`` here: Goose calls etcetera's
+  ``choose_app_strategy``, which is the *CLI* convention (Xdg everywhere but
+  Windows), not the platform-native one. Goose's own
+  ``documentation/docs/guides/logs.md`` agrees, listing Session Records under
+  "Unix-like (macOS, Linux)".
+* macOS legacy installs may still hold data at ``~/Library/Application
+  Support/Block/goose/`` — probed last, honoured only if present.
+
+VERIFIED against a real Goose 1.35.0 install (macOS, no XDG_DATA_HOME) by
+running ``goose run`` against local Ollama and reading the DB it wrote
+(``schema_version`` = 13). Two relevant tables:
 
 ``sessions`` (one row per conversation)::
 
@@ -89,6 +103,7 @@ import json
 import logging
 import os
 import sqlite3
+import sys
 from datetime import datetime, timezone
 from typing import Any
 
@@ -103,16 +118,107 @@ _AGENT = "goose"
 # -- discovery ---------------------------------------------------------------
 
 
-def _default_db_path() -> str:
-    """Resolve Goose's sessions.db, honouring XDG_DATA_HOME like Goose does.
+def _goose_path_root() -> str:
+    """``$GOOSE_PATH_ROOT`` if it is set AND absolute, else "".
 
-    Goose uses the platform data dir: ``$XDG_DATA_HOME/goose`` (falling back
-    to ``~/.local/share/goose``) on macOS/Linux. The sessions store lives at
-    ``<data>/sessions/sessions.db``.
+    Mirrors Goose's own ``Paths::validated_path_root`` — Goose *ignores* a
+    relative value rather than resolving it, so we must too or we would look
+    somewhere Goose never writes.
     """
-    xdg = os.environ.get("XDG_DATA_HOME")
-    base = xdg if xdg else os.path.expanduser("~/.local/share")
-    return os.path.join(base, "goose", "sessions", "sessions.db")
+    raw = (os.environ.get("GOOSE_PATH_ROOT") or "").strip()
+    if not raw:
+        return ""
+    root = os.path.expanduser(raw)
+    return root if os.path.isabs(root) else ""
+
+
+def _candidate_db_paths() -> list:
+    """Every place Goose may hold ``sessions.db``, in Goose's own precedence.
+
+    Resolved from ``crates/goose/src/config/paths.rs`` (read at goose 1.35.0),
+    which is ``GOOSE_PATH_ROOT`` first and otherwise etcetera's
+    ``choose_app_strategy``. That helper is **not** the platform-native
+    strategy: etcetera selects ``Windows`` on Windows and **``Xdg`` everywhere
+    else, macOS included** (``create_strategies!(Apple, Xdg)`` — verified in
+    etcetera 0.8/0.10/0.11, and 0.11 is what Goose pins). So:
+
+    * ``$GOOSE_PATH_ROOT/data/sessions/sessions.db`` — absolute paths only.
+    * Windows: ``%APPDATA%\\Block\\goose\\data\\sessions\\sessions.db``
+      (etcetera's Windows app strategy is ``<RoamingAppData>/<author>/<app>/data``).
+    * macOS **and** Linux: ``${XDG_DATA_HOME:-~/.local/share}/goose/sessions/sessions.db``.
+      Confirmed against a live goose 1.35.0 on macOS with no XDG_DATA_HOME set,
+      and against the repo's own ``documentation/docs/guides/logs.md``, which
+      lists Session Records as ``~/.local/share/goose/sessions/sessions.db``
+      for "Unix-like (macOS, Linux)".
+    * macOS legacy: ``~/Library/Application Support/Block/goose/sessions/sessions.db``.
+      Goose's ``paths.rs`` keeps the "Block" naming expressly for "existing
+      user config/data directories (e.g. ~/Library/Application Support/Block/
+      goose/)", and the repo's environment-variables guide still names it as
+      the macOS default, so an older install may really have data there. It is
+      probed LAST and only honoured if the file exists — we never report it as
+      the place Goose will write.
+
+    ``CLAWMETRY_GOOSE_DB`` overrides everything (same escape hatch shape as
+    ``CLAWMETRY_DEVIN_DB``), for installs that relocate the store.
+    """
+    home = os.path.expanduser("~")
+    out = []
+
+    override = (os.environ.get("CLAWMETRY_GOOSE_DB") or "").strip()
+    if override:
+        out.append(os.path.expanduser(override))
+
+    root = _goose_path_root()
+    if root:
+        out.append(os.path.join(root, "data", "sessions", "sessions.db"))
+
+    if sys.platform.startswith("win"):
+        appdata = (os.environ.get("APPDATA") or "").strip() or os.path.join(
+            home, "AppData", "Roaming")
+        out.append(os.path.join(appdata, "Block", "goose", "data",
+                                "sessions", "sessions.db"))
+    else:
+        xdg = (os.environ.get("XDG_DATA_HOME") or "").strip() or os.path.join(
+            home, ".local", "share")
+        out.append(os.path.join(xdg, "goose", "sessions", "sessions.db"))
+        if sys.platform == "darwin":
+            out.append(os.path.join(home, "Library", "Application Support",
+                                    "Block", "goose", "sessions", "sessions.db"))
+
+    seen = set()
+    uniq = []
+    for p in out:
+        if p and p not in seen:
+            seen.add(p)
+            uniq.append(p)
+    return uniq
+
+
+def data_dir_candidates() -> list:
+    """Goose data dirs (the parent of ``sessions/``) for each candidate store.
+
+    Public because the sync daemon's detection/recency tables read it rather
+    than re-deriving the layout — one stale copy of a path list is how a
+    runtime silently reads as "not installed" on a platform nobody tested.
+    """
+    return [os.path.dirname(os.path.dirname(p)) for p in _candidate_db_paths()]
+
+
+def _default_db_path() -> str:
+    """The Goose sessions.db to read: the first candidate that exists.
+
+    When none exists we return the FIRST candidate — where Goose would write
+    on this machine — so ``detect()`` reports an honest ``dbPath`` instead of
+    a legacy fallback the user has never had.
+    """
+    cands = _candidate_db_paths()
+    for p in cands:
+        try:
+            if os.path.isfile(p):
+                return p
+        except OSError:
+            continue
+    return cands[0]
 
 
 # -- helpers -----------------------------------------------------------------

--- a/clawmetry/runtime_probe.py
+++ b/clawmetry/runtime_probe.py
@@ -54,7 +54,12 @@ class RuntimeProbe:
                 if root and os.path.exists(os.path.expanduser(root)):
                     return True
             for p in self.paths:
-                expanded = os.path.expanduser(p)
+                # expandvars FIRST so "$XDG_DATA_HOME/..." resolves; an unset
+                # var stays literal and simply globs to nothing, which is the
+                # honest answer rather than a bare-root false positive.
+                expanded = os.path.expanduser(os.path.expandvars(p))
+                if "$" in expanded:
+                    continue
                 if _glob.glob(expanded):
                     return True
         except Exception:
@@ -75,7 +80,22 @@ RUNTIME_PROBES: tuple = (
         "~/.config/Cursor/User/globalStorage/state.vscdb",
     )),
     RuntimeProbe("aider", "Aider", ("~/.aider*",), env="AIDER_HISTORY_DIRS"),
-    RuntimeProbe("goose", "Goose", ("~/.local/share/goose/sessions",)),
+    # Goose resolves its data dir with etcetera's choose_app_strategy, which
+    # is XDG on macOS as well as Linux (NOT ~/Library/Application Support)
+    # and RoamingAppData on Windows; GOOSE_PATH_ROOT relocates all of it.
+    # The last entry is the legacy macOS location Goose's own paths.rs still
+    # names for pre-existing installs. The env-var forms are globbed rather
+    # than declared via ``env=``, because "$GOOSE_PATH_ROOT exists" is not
+    # evidence of a Goose install — "$GOOSE_PATH_ROOT/data/sessions exists"
+    # is. Kept in step with clawmetry/adapters/goose.py::_candidate_db_paths().
+    RuntimeProbe("goose", "Goose", (
+        "$GOOSE_PATH_ROOT/data/sessions",
+        "$XDG_DATA_HOME/goose/sessions",
+        "~/.local/share/goose/sessions",
+        "$APPDATA/Block/goose/data/sessions",
+        "~/AppData/Roaming/Block/goose/data/sessions",
+        "~/Library/Application Support/Block/goose/sessions",
+    )),
     RuntimeProbe("opencode", "opencode", ("~/.local/share/opencode",)),
     RuntimeProbe("qwen_code", "Qwen Code", ("~/.qwen/projects",)),
     RuntimeProbe("hermes", "Hermes", ("~/.hermes",), env="HERMES_HOME"),

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -7273,6 +7273,23 @@ def _xdg_data_home() -> str:
     return os.environ.get("XDG_DATA_HOME") or os.path.expanduser("~/.local/share")
 
 
+def _goose_data_dirs() -> list:
+    """Goose's data dir candidates, from the adapter that actually reads them.
+
+    Goose does NOT anchor at ``~/.local/share`` on every platform: Windows
+    lives under ``%APPDATA%\\Block\\goose\\data`` and ``GOOSE_PATH_ROOT``
+    relocates everything. Importing the adapter's resolver keeps detection and
+    ingestion from drifting apart — a hardcoded copy here is exactly how a
+    Windows install reads as "Goose not present" while the adapter is happily
+    ingesting it. Falls back to the POSIX default if the adapter is missing.
+    """
+    try:
+        from clawmetry.adapters.goose import data_dir_candidates
+        return list(data_dir_candidates())
+    except Exception:
+        return [os.path.join(os.path.expanduser("~"), ".local", "share", "goose")]
+
+
 def _runtime_data_paths(rid: str) -> list:
     """Native on-disk data location(s) for a runtime, used to compute recency.
     Mirrors the per-adapter stores (the same dirs the lite/pro detectors read).
@@ -7292,7 +7309,7 @@ def _runtime_data_paths(rid: str) -> list:
         "codex": [os.path.join(home, ".codex", "sessions")],
         "qwen_code": [os.path.join(home, ".qwen")],
         "opencode": [os.path.join(home, ".local", "share", "opencode", "opencode.db")],
-        "goose": [os.path.join(home, ".local", "share", "goose")],
+        "goose": _goose_data_dirs(),
         "hermes": [os.path.join(home, ".hermes", "state.db")],
         "aider": [os.path.join(home, ".aider")],
         "picoclaw": [os.path.join(home, ".picoclaw")],
@@ -7440,7 +7457,7 @@ def _detect_runtimes_lite() -> list:
     # Presence-only (non-JSONL formats — count unknown) → report with 0 sessions.
     _present = {
         "cursor": [os.path.join(home, "Library", "Application Support", "Cursor", "User", "globalStorage", "state.vscdb")],
-        "goose": [os.path.join(home, ".local", "share", "goose")],
+        "goose": _goose_data_dirs(),
         "opencode": [os.path.join(home, ".local", "share", "opencode")],
         "hermes": [os.path.join(home, ".hermes", "state.db")],
         "picoclaw": [os.path.join(home, ".picoclaw")],

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -26,7 +26,7 @@ See [`NUMBAT.md`](NUMBAT.md).
 | Codex       | Beta adapter   | "rollout" JSONL `~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl` | Transcripts, model, tool calls, token usage (from `token_count` events). |
 | Cursor      | Beta adapter   | SQLite `state.vscdb` (`cursorDiskKV` / `ItemTable`, global + per-workspace) | Chat/composer transcripts, model. No billed cost on disk (server-side). |
 | Aider       | Beta adapter   | Markdown `.aider.chat.history.md` per project dir (+ `.aider.input.history`) | Transcripts, model, token counts. Per-project history (set `AIDER_HISTORY_DIRS`). |
-| Goose       | Beta adapter (**free**) | SQLite `~/.local/share/goose/sessions/sessions.db` (`sessions` + `messages`) | Transcripts, model, tool calls, real token totals. Adapter ships in the OSS package (`clawmetry/adapters/goose.py`) — no plan required. |
+| Goose       | Beta adapter (**free**) | SQLite `<goose data dir>/sessions/sessions.db` — `${XDG_DATA_HOME:-~/.local/share}/goose` on macOS **and** Linux, `%APPDATA%\Block\goose\data` on Windows, or `$GOOSE_PATH_ROOT/data` when that is set (`sessions` + `messages` tables) | Transcripts, model, tool calls, real token totals. Adapter ships in the OSS package (`clawmetry/adapters/goose.py`) — no plan required. |
 | opencode    | Beta adapter   | SQLite `~/.local/share/opencode/opencode.db` (`session`/`message`/`part`) | Transcripts, model, tool calls, real tokens + cost. |
 | Qwen Code   | Beta adapter   | JSONL `~/.qwen/projects/<hash>/chats/<id>.jsonl` (Gemini-CLI lineage) | Transcripts, model, tool calls + thinking, real token usage. |
 | Pi          | Beta adapter   | JSONL `~/.pi/agent/sessions/` | Transcripts, model, tool calls, real tokens + cost. |

--- a/tests/test_goose_platform_paths.py
+++ b/tests/test_goose_platform_paths.py
@@ -1,0 +1,253 @@
+"""Where Goose actually keeps sessions.db, per platform.
+
+Raised by review on aaif-goose/goose#11554: the tutorial (and the adapter it
+describes) claimed a single XDG location, which is wrong on Windows and blind
+to ``GOOSE_PATH_ROOT``. The truth, read out of Goose's own
+``crates/goose/src/config/paths.rs``:
+
+* ``GOOSE_PATH_ROOT`` wins when set to an ABSOLUTE path -> ``<root>/data``.
+* otherwise etcetera's ``choose_app_strategy``, which is the CLI convention:
+  ``Windows`` on Windows, ``Xdg`` **everywhere else, macOS included**
+  (``create_strategies!(Apple, Xdg)``).
+
+So macOS is XDG, not ``~/Library/Application Support`` — the reviewer's
+correction was aimed at the right line but named the platform-native path.
+The legacy ``Block/goose`` location that Goose's own paths.rs still mentions
+for pre-existing installs is honoured only when a DB is really sitting there.
+
+Every test pins ``sys.platform`` and the home env vars so the whole matrix
+runs on any CI OS.
+"""
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+
+import pytest
+
+from clawmetry.adapters import goose as G
+from clawmetry.adapters.goose import GooseAdapter
+
+_FIX_DIR = os.path.join(os.path.dirname(__file__), "fixtures", "runtimes", "goose")
+_GEN_PATH = os.path.join(_FIX_DIR, "_make_fixture.py")
+
+_GOOSE_ENV = ("GOOSE_PATH_ROOT", "CLAWMETRY_GOOSE_DB", "XDG_DATA_HOME", "APPDATA")
+
+
+def _make_db(path: str) -> str:
+    spec = importlib.util.spec_from_file_location("_goose_fixture_gen", _GEN_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod.make_fixture(path)
+
+
+@pytest.fixture
+def home(tmp_path, monkeypatch):
+    """A clean HOME with no Goose env vars leaking in from the real machine."""
+    h = tmp_path / "home"
+    h.mkdir()
+    for var in _GOOSE_ENV:
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("HOME", str(h))
+    monkeypatch.setenv("USERPROFILE", str(h))  # expanduser() on Windows
+    return h
+
+
+def _as(monkeypatch, platform: str):
+    monkeypatch.setattr(sys, "platform", platform)
+
+
+# ── platform defaults ──────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("platform", ["linux", "darwin"])
+def test_posix_default_is_xdg(home, monkeypatch, platform):
+    """macOS gets the SAME XDG path as Linux — this is the review's line."""
+    _as(monkeypatch, platform)
+    assert G._candidate_db_paths()[0] == os.path.join(
+        str(home), ".local", "share", "goose", "sessions", "sessions.db")
+    assert G._default_db_path() == G._candidate_db_paths()[0]
+
+
+@pytest.mark.parametrize("platform", ["linux", "darwin"])
+def test_posix_honours_xdg_data_home(home, monkeypatch, platform):
+    _as(monkeypatch, platform)
+    monkeypatch.setenv("XDG_DATA_HOME", str(home / "xdg"))
+    assert G._candidate_db_paths()[0] == os.path.join(
+        str(home), "xdg", "goose", "sessions", "sessions.db")
+
+
+def test_windows_default_is_roaming_appdata(home, monkeypatch):
+    """etcetera's Windows app strategy: <RoamingAppData>/<author>/<app>/data."""
+    _as(monkeypatch, "win32")
+    monkeypatch.setenv("APPDATA", str(home / "AppData" / "Roaming"))
+    assert G._candidate_db_paths()[0] == os.path.join(
+        str(home), "AppData", "Roaming", "Block", "goose", "data",
+        "sessions", "sessions.db")
+
+
+def test_windows_falls_back_when_appdata_unset(home, monkeypatch):
+    _as(monkeypatch, "win32")
+    assert G._candidate_db_paths()[0] == os.path.join(
+        str(home), "AppData", "Roaming", "Block", "goose", "data",
+        "sessions", "sessions.db")
+
+
+def test_windows_never_offers_a_posix_path(home, monkeypatch):
+    _as(monkeypatch, "win32")
+    assert not [p for p in G._candidate_db_paths() if ".local" in p]
+
+
+def test_posix_never_offers_the_windows_path(home, monkeypatch):
+    _as(monkeypatch, "linux")
+    assert not [p for p in G._candidate_db_paths() if "Block" in p]
+
+
+# ── GOOSE_PATH_ROOT ────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("platform", ["linux", "darwin", "win32"])
+def test_goose_path_root_wins_on_every_platform(home, monkeypatch, platform, tmp_path):
+    _as(monkeypatch, platform)
+    root = tmp_path / "goose-root"
+    monkeypatch.setenv("GOOSE_PATH_ROOT", str(root))
+    assert G._candidate_db_paths()[0] == os.path.join(
+        str(root), "data", "sessions", "sessions.db")
+
+
+def test_relative_goose_path_root_is_ignored_like_goose_does(home, monkeypatch):
+    """Goose's validated_path_root() drops non-absolute values; so must we."""
+    _as(monkeypatch, "linux")
+    monkeypatch.setenv("GOOSE_PATH_ROOT", "relative/root")
+    assert G._candidate_db_paths()[0] == os.path.join(
+        str(home), ".local", "share", "goose", "sessions", "sessions.db")
+
+
+def test_goose_path_root_store_is_actually_read(home, monkeypatch, tmp_path):
+    _as(monkeypatch, "darwin")
+    root = tmp_path / "root"
+    monkeypatch.setenv("GOOSE_PATH_ROOT", str(root))
+    _make_db(str(root / "data" / "sessions" / "sessions.db"))
+    assert GooseAdapter().detect().detected is True
+
+
+# ── macOS legacy location ──────────────────────────────────────────────────
+
+
+def _legacy(home):
+    return os.path.join(str(home), "Library", "Application Support", "Block",
+                        "goose", "sessions", "sessions.db")
+
+
+def test_macos_legacy_store_is_found_when_it_exists(home, monkeypatch):
+    _as(monkeypatch, "darwin")
+    _make_db(_legacy(home))
+    assert G._default_db_path() == _legacy(home)
+    assert GooseAdapter().detect().detected is True
+
+
+def test_macos_legacy_never_reported_when_nothing_is_on_disk(home, monkeypatch):
+    """An empty machine must be told where Goose WILL write, not a ghost."""
+    _as(monkeypatch, "darwin")
+    assert "Library" not in G._default_db_path()
+
+
+def test_xdg_store_beats_legacy_when_both_exist(home, monkeypatch):
+    _as(monkeypatch, "darwin")
+    xdg_db = os.path.join(str(home), ".local", "share", "goose", "sessions",
+                          "sessions.db")
+    _make_db(xdg_db)
+    _make_db(_legacy(home))
+    assert G._default_db_path() == xdg_db
+
+
+def test_linux_does_not_probe_the_macos_legacy_path(home, monkeypatch):
+    _as(monkeypatch, "linux")
+    assert _legacy(home) not in G._candidate_db_paths()
+
+
+# ── explicit override ──────────────────────────────────────────────────────
+
+
+def test_clawmetry_goose_db_override_wins(home, monkeypatch, tmp_path):
+    _as(monkeypatch, "linux")
+    db = _make_db(str(tmp_path / "elsewhere" / "sessions.db"))
+    monkeypatch.setenv("CLAWMETRY_GOOSE_DB", db)
+    assert G._default_db_path() == db
+    assert GooseAdapter().detect().detected is True
+
+
+def test_explicit_db_path_argument_still_wins_over_env(home, monkeypatch, tmp_path):
+    _as(monkeypatch, "linux")
+    monkeypatch.setenv("CLAWMETRY_GOOSE_DB", str(tmp_path / "nope.db"))
+    db = _make_db(str(tmp_path / "explicit" / "sessions.db"))
+    assert GooseAdapter(db_path=db).detect().detected is True
+
+
+# ── never-raises + no duplicates ───────────────────────────────────────────
+
+
+@pytest.mark.parametrize("platform", ["linux", "darwin", "win32"])
+def test_candidates_are_unique_and_nonempty(home, monkeypatch, platform):
+    _as(monkeypatch, platform)
+    cands = G._candidate_db_paths()
+    assert cands and len(cands) == len(set(cands))
+
+
+def test_detect_never_raises_on_a_bogus_root(home, monkeypatch, tmp_path):
+    _as(monkeypatch, "linux")
+    monkeypatch.setenv("GOOSE_PATH_ROOT", str(tmp_path / "does" / "not" / "exist"))
+    assert GooseAdapter().detect().detected is False
+
+
+def test_detect_never_raises_when_the_store_is_a_directory(home, monkeypatch, tmp_path):
+    _as(monkeypatch, "linux")
+    root = tmp_path / "root"
+    os.makedirs(str(root / "data" / "sessions" / "sessions.db"))
+    monkeypatch.setenv("GOOSE_PATH_ROOT", str(root))
+    assert GooseAdapter().detect().detected is False
+
+
+def test_detect_never_raises_on_a_corrupt_store(home, monkeypatch):
+    _as(monkeypatch, "linux")
+    db = os.path.join(str(home), ".local", "share", "goose", "sessions",
+                      "sessions.db")
+    os.makedirs(os.path.dirname(db))
+    with open(db, "wb") as fh:
+        fh.write(b"not a sqlite database at all")
+    assert G._default_db_path() == db
+    assert GooseAdapter().detect().detected is False
+
+
+# ── one source of truth ────────────────────────────────────────────────────
+
+
+def test_data_dir_candidates_mirror_the_db_candidates(home, monkeypatch):
+    _as(monkeypatch, "darwin")
+    assert G.data_dir_candidates() == [
+        os.path.dirname(os.path.dirname(p)) for p in G._candidate_db_paths()]
+
+
+def test_sync_detection_reads_the_adapter_not_a_copy(home, monkeypatch):
+    """The daemon's recency/nudge tables must not hardcode a stale path."""
+    _as(monkeypatch, "win32")
+    monkeypatch.setenv("APPDATA", str(home / "AppData" / "Roaming"))
+    from clawmetry import sync
+    assert sync._goose_data_dirs() == G.data_dir_candidates()
+    assert sync._runtime_data_paths("goose") == G.data_dir_candidates()
+
+
+def test_runtime_probe_covers_every_platform_layout(home, monkeypatch):
+    from clawmetry.runtime_probe import RUNTIME_PROBES
+    probe = next(p for p in RUNTIME_PROBES if p.id == "goose")
+    joined = " ".join(probe.paths)
+    assert ".local/share/goose" in joined
+    assert "AppData/Roaming/Block/goose/data" in joined
+    assert "Library/Application Support/Block/goose" in joined
+    assert "$GOOSE_PATH_ROOT/data/sessions" in probe.paths
+    assert "$XDG_DATA_HOME/goose/sessions" in probe.paths
+    assert probe.found() is False
+    os.makedirs(os.path.join(str(home), "AppData", "Roaming", "Block", "goose",
+                             "data", "sessions"))
+    assert probe.found() is True


### PR DESCRIPTION
No-PRD: defect fix, no product surface. External review on aaif-goose/goose#11554 showed our goose store resolver was XDG-only, so Windows and GOOSE_PATH_ROOT installs read as "goose not present". This restores the documented behaviour on two platforms; it adds no capability and changes no product decision.

Review on the goose docs PR ([aaif-goose/goose#11554](https://github.com/aaif-goose/goose/pull/11554#discussion_r3853042366)) flagged that our tutorial tells macOS users their sessions are auto-detected at `~/.local/share/goose/...` and that this is not where goose writes. The reviewer had the right line and the wrong platform, but there were two real holes underneath it.

## What goose actually does

`crates/goose/src/config/paths.rs`, read at goose 1.35.0:

| Condition | Data dir |
| --- | --- |
| `GOOSE_PATH_ROOT` set to an **absolute** path | `<root>/data` |
| Windows | `%APPDATA%\Block\goose\data` |
| macOS **and** Linux | `${XDG_DATA_HOME:-~/.local/share}/goose` |

`choose_app_strategy` is the *CLI* convention, not the platform-native one — etcetera expands `create_strategies!(Apple, Xdg)` on macOS, so the app strategy there is Xdg (checked in etcetera 0.8, 0.10 and 0.11; goose pins 0.11). Confirmed empirically against a live goose 1.35.0 on this Mac with no `XDG_DATA_HOME` set, and against goose's own `documentation/docs/guides/logs.md`, which lists Session Records under "Unix-like (macOS, Linux)". goose's `environment-variables.md` disagrees with both — that is a bug in their docs, offered as a separate PR in the review reply.

## So what was broken

macOS was already right. These were not:

- **Windows** — the adapter looked under `~/.local/share` and found nothing. `runtime_probe` had the same blind spot, so onboarding also said "goose not found".
- **`GOOSE_PATH_ROOT`** — unhandled on every platform.

## Changes

- `clawmetry/adapters/goose.py` — `_candidate_db_paths()` resolves the store in goose's own precedence, mirroring `validated_path_root()` (a relative `GOOSE_PATH_ROOT` is *ignored*, as goose ignores it) and adding a `CLAWMETRY_GOOSE_DB` escape hatch. `_default_db_path()` returns the first candidate that **exists**, else the first candidate — so `detect()` reports where goose *will* write, never a legacy path the user has never had. The legacy macOS `Block/goose` location that `paths.rs` still names for pre-existing installs is probed last and honoured only when a DB is really there.
- `clawmetry/sync.py` — the daemon's recency and nudge tables import `data_dir_candidates()` instead of keeping a third copy of the layout.
- `clawmetry/runtime_probe.py` — probe paths now expand `$VAR` (an unset var globs to nothing rather than matching a bare root), so the goose probe covers `GOOSE_PATH_ROOT`, a relocated `XDG_DATA_HOME`, `APPDATA` and the legacy path. This is generic; only goose uses it today.
- `docs/compatibility.md` — the goose row now names all three layouts.
- `tests/test_goose_platform_paths.py` — 28 tests, each pinning `sys.platform` and the home env vars so the matrix runs on any CI OS.

Companion: clawmetry-pro `fix/goose-platform-session-path` drops its own copy of the resolver and imports this one, so a licensed node and a free node cannot disagree about where goose lives.

## Verification

Against the real goose store on this machine: 7 sessions, transcripts, tool_call/tool_result events.

Against planted fixtures, adapter + `sync._runtime_data_paths` + `runtime_probe` all agreeing:

```
PASS  macOS default (XDG)              detected=True sessions=4 probe=True syncdir=True
PASS  Linux default (XDG)              detected=True sessions=4 probe=True syncdir=True
PASS  macOS legacy Block/goose         detected=True sessions=4 probe=True syncdir=True
PASS  Windows RoamingAppData           detected=True sessions=4 probe=True syncdir=True
PASS  XDG_DATA_HOME relocated          detected=True sessions=4 probe=True syncdir=True
PASS  GOOSE_PATH_ROOT                  detected=True sessions=4 probe=True syncdir=True
PASS  no goose installed (macOS)       detected=False probe=False
PASS  no goose installed (win)         detected=False probe=False
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013qCBASpwE9vrSHDockpAji
