### PR TITLE
[RELEASE] Your team can be watched without installing anything on anyone's laptop (carries #5210)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 ## Unreleased
 
+### Release: your team can be watched without installing anything on anyone's laptop (carries #5210) (2026-08-26)
+- **Who this reaches:** anyone whose company will not let a new program be installed on every developer's computer. Until now that was the end of the conversation. It no longer is.
+- **What changes for you:** if your team already uses Claude Code or Codex, those tools can send what they are doing straight to a ClawMetry your company already runs. Nobody installs anything. Somebody sets one setting, once, and the machines start reporting.
+- **You can finally ask "what did this team spend on this project".** Every report that arrives carries who was working, which company they belong to, and which session it came from. If you also tell your tools which team and which project a machine belongs to, the answer is grouped that way: platform team, payments project, this person, last thirty days.
+- **The numbers stop resetting.** Reports used to be held in memory only, so restarting the service threw away everything it had ever received. They are now written down and are still there afterwards.
+- **The times are the real times.** A batch of reports that arrives now, describing work from six hours ago, is recorded as six hours ago. It used to be stamped with the moment it arrived, which quietly moved yesterday's spending onto today.
+- **A hiccup on the network cannot inflate your bill.** These reports are designed to be sent again if the first attempt is not acknowledged, and a repeat used to be counted as a second charge. A repeat now changes nothing, on the stored figures and on the live ones.
+- **Stuck agents are still spotted.** When one of these tools asks permission to run something, or reports how it went, that now feeds the same checks that notice an agent looping or failing the same thing over and over. A permission you refused is not counted as something the agent did.
+- **What this does not do, said plainly.** It works with the tools that already speak this language, which today are Claude Code and Codex. Everything else still needs the usual install. And what arrives this way is not encrypted by the tool that sends it, so if that matters to you, run ClawMetry inside your own network, where none of it leaves.
+
+
 ### Release: your agent is watched for more than loops, and the list is sorted by what it costs you (carries #5168) (2026-08-25)
 - **Who this reaches:** everyone. The detection that used to notice a stuck agent now also notices one behaving unlike itself, and the list you look at is ordered by money rather than by whichever check spoke last.
 - **Four new things get noticed.** Until now the only questions asked were about repetition: is it looping, is it stalling, is the same tool failing, did it plough on after an error. Four more are asked now. Did it change an unusual number of files, or run something destructive like a recursive delete at your home folder. Did it open a password or key file, a `.env`, a certificate, a stored token. Did it contact somewhere it has never contacted before. Did it ask for admin rights or turn off a system protection.

--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -1413,7 +1413,7 @@ _DDL = [
     #
     # record_id is deterministic (see dashboard._otlp_record_id), so an OTLP
     # exporter retrying a batch REPLACEs its rows instead of double-counting
-    # the spend. That matters more here than anyone else in the store: OTLP
+    # the spend. That matters more here than anywhere else in the store: OTLP
     # delivery is at-least-once by specification.
     #
     # NOTE ON DATA HANDLING: rows on this path arrive in PLAINTEXT over HTTP.


### PR DESCRIPTION
Releases #5210 (WO-7, daemon-free OTLP intake), merged as 1576a011d.

An organisation that will not put a background process on 500 developer laptops can now onboard by changing one config value. The receiver at `/v1/logs` existed but was a prototype: it stamped receipt time on every record, extracted no identity, and wrote only to an in-memory cache that a restart erased.

**What shipped**

| Fix | Effect |
|---|---|
| Honour the record's own timestamp | A batch describing work from six hours ago is stored six hours ago, instead of being dated "now" whenever delivery was buffered or retried |
| Extract identity | user, email, organisation, session, plus team and repo from `OTEL_RESOURCE_ATTRIBUTES` |
| Persist to DuckDB | New `otlp_records` table, written through the daemon proxy so a request handler never takes the writer lock |
| Map tool records | `tool_decision` and `tool_result` become tool events the trajectory detectors read |
| Bake in `opentelemetry-proto` | The enterprise ingest image can no longer answer 501 to the default exporter protocol |

**Also fixed, found while doing the above:** a retried batch used to double the spend (record ids are now content-derived, and the live tiles get the same guarantee); a machine running both the daemon and the exporter counted every session twice (the daemon's richer transcript read wins); and a refused permission prompt was being recorded as a tool the agent ran.

**CI:** a new `otlp-receiver` job, the only one that installs the otel extra. Every OTLP protobuf test in the repo was `importorskip`'d in CI, so this path had zero coverage and two tests had been failing unseen. 100 tests run there now, and the job asserts the decoder is present so it cannot skip and report green.

**Honesty boundaries, documented and tested:** this path covers the runtimes that emit OpenTelemetry natively (Claude Code, Codex), not all of them; and records arrive unencrypted, so the daemon's end-to-end encryption does not extend here. A test checks both statements are still in the docs.

**Product record** (same one #5210 cited; this PR ships that work):

- Requirement: https://factory.8090.ai/project/b415065f-ab2f-4f53-8864-0c009fd098cb/requirements/d518c6c3-eb50-4b0f-9ed0-59440380b7bf (REQ-OBS-006, AC-OBS-006.1 through .8)
- Blueprint: https://factory.8090.ai/project/b415065f-ab2f-4f53-8864-0c009fd098cb/blueprints/e42834c9-33d0-4ee8-b1f3-423970a6527a (ADR-WO7-001/002/003)

This PR also restores one word in a `local_store.py` comment that an automated edit changed on the feature branch after CI went green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012uGvkvdXhove8dmNhCU1r8
