### PR TITLE
Harden CI: quote untrusted PR title, add least-privilege token scopes

### DIFF
--- a/.github/workflows/api-latency-smoke.yml
+++ b/.github/workflows/api-latency-smoke.yml
@@ -16,6 +16,11 @@ concurrency:
   group: api-latency-smoke-${{ github.ref }}
   cancel-in-progress: true
 
+# Least privilege: these jobs only read the repo. Any job needing more
+# must elevate with its own job-level `permissions:` block.
+permissions:
+  contents: read
+
 jobs:
   smoke:
     name: ${{ matrix.source == 'pypi' && 'PyPI nightly' || 'PR build' }}

--- a/.github/workflows/browserstack.yml
+++ b/.github/workflows/browserstack.yml
@@ -8,6 +8,11 @@ on:
     branches: [main]
     types: [labeled]  # Trigger by adding label 'browserstack'
 
+# Least privilege: these jobs only read the repo. Any job needing more
+# must elevate with its own job-level `permissions:` block.
+permissions:
+  contents: read
+
 jobs:
   cross-browser:
     name: Cross-Browser Tests

--- a/.github/workflows/cross-repo-handoff.yml
+++ b/.github/workflows/cross-repo-handoff.yml
@@ -13,6 +13,11 @@ concurrency:
   group: cross-repo-handoff-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+# Least privilege: these jobs only read the repo. Any job needing more
+# must elevate with its own job-level `permissions:` block.
+permissions:
+  contents: read
+
 jobs:
   cross-repo-handoff:
     name: Cross-repo handoff (C4)

--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -16,6 +16,11 @@ on:
     - cron: "17 3 * * *"
   workflow_dispatch:
 
+# Least privilege: these jobs only read the repo. Any job needing more
+# must elevate with its own job-level `permissions:` block.
+permissions:
+  contents: read
+
 jobs:
   e2e-nightly:
     name: E2E Browser Tests (full suite)

--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -6,6 +6,11 @@ on:
     paths: [install.sh, install.ps1, install.cmd]
   workflow_dispatch:
 
+# Least privilege: these jobs only read the repo. Any job needing more
+# must elevate with its own job-level `permissions:` block.
+permissions:
+  contents: read
+
 jobs:
   test-linux:
     runs-on: ubuntu-latest

--- a/.github/workflows/openclaw-boot.yml
+++ b/.github/workflows/openclaw-boot.yml
@@ -31,6 +31,11 @@ concurrency:
   group: openclaw-boot-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+# Least privilege: these jobs only read the repo. Any job needing more
+# must elevate with its own job-level `permissions:` block.
+permissions:
+  contents: read
+
 jobs:
   boot:
     name: Install + boot + health-check

--- a/.github/workflows/oss-golden-path.yml
+++ b/.github/workflows/oss-golden-path.yml
@@ -24,6 +24,11 @@ concurrency:
   group: oss-golden-path-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+# Least privilege: these jobs only read the repo. Any job needing more
+# must elevate with its own job-level `permissions:` block.
+permissions:
+  contents: read
+
 jobs:
   oss-golden-path:
     name: OSS golden path (wheel + OpenClaw + 9 tabs)

--- a/.github/workflows/quarantine-sweep.yml
+++ b/.github/workflows/quarantine-sweep.yml
@@ -20,6 +20,11 @@ on:
     - cron: "23 2 * * *"
   workflow_dispatch:
 
+# Least privilege: these jobs only read the repo. Any job needing more
+# must elevate with its own job-level `permissions:` block.
+permissions:
+  contents: read
+
 jobs:
   quarantine-sweep:
     name: Quarantine sweep (daily)

--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -392,13 +392,17 @@ jobs:
         # explicitly first — the workflow dispatch below needs the ref.
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Untrusted: a PR title is attacker-controlled text. Bind it to an
+          # env var and use "$PR_TITLE" so the shell never parses it as code.
+          # Never interpolate ${{ github.event.* }} directly into `run:`.
+          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
           NEW_TAG="v${{ steps.bump.outputs.new }}"
           git tag "$NEW_TAG" || echo "Tag already exists locally"
           git push origin "refs/tags/$NEW_TAG" || echo "Tag already on origin, skipping"
           gh release create "$NEW_TAG" \
             --title "$NEW_TAG" \
-            --notes "Released via PR: ${{ github.event.pull_request.title }}" \
+            --notes "Released via PR: $PR_TITLE" \
             --draft || echo "Release already exists, skipping"
 
       # GitHub deliberately suppresses `on: push: tags:` cascade triggers

--- a/.github/workflows/sync-test.yml
+++ b/.github/workflows/sync-test.yml
@@ -21,6 +21,11 @@ concurrency:
   group: sync-test-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+# Least privilege: these jobs only read the repo. Any job needing more
+# must elevate with its own job-level `permissions:` block.
+permissions:
+  contents: read
+
 jobs:
   sync-test:
     strategy:


### PR DESCRIPTION
Clears two OSSF Scorecard findings on this repo.

**DangerousWorkflow (critical)** — `release-on-merge.yml` interpolated the PR title directly into a `run:` block through `${{ github.event.pull_request.title }}`, so the shell parsed attacker-controlled text as code. It is now bound to a `PR_TITLE` env var and referenced as `"$PR_TITLE"`, which reaches the shell as data.

**TokenPermissions (high)** — 9 of the 24 flagged workflows had no top-level `permissions:`, so `GITHUB_TOKEN` inherited the repo default. Each of these nine only reads the repo, so they take `contents: read`.

Checked before applying: `cross-repo-handoff` authenticates with `CLOUD_REPO_PAT`, which workflow permissions do not govern, so it is unaffected.

Deliberately **not** in this PR: the six workflows that need write scopes (`publish`, `release-on-merge`, `desktop-artifacts`, `auto-deploy-cloud`, `ci`, `moat-keystone-drive-nightly`). A blanket `contents: read` there would break the release pipeline quietly, so they get a follow-up that elevates per job.

Every workflow file was parsed with `yaml.safe_load` after editing. Touches only `.github/`, which the product-record gate exempts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QToVh7B1GoMJpa9p5tz5pn