### PR TITLE
Harden CI: bind untrusted event data to env vars in run: blocks

### DIFF
--- a/.github/workflows/harness-observability-audit.yml
+++ b/.github/workflows/harness-observability-audit.yml
@@ -67,12 +67,18 @@ jobs:
         run: bash scripts/harness/sync.sh
 
       - name: Audit observability coverage + file gap issues
+        # Dispatch inputs are untrusted text. Bind them to env vars and read
+        # them as quoted shell variables so the runner never expands them as
+        # code. Never interpolate ${{ github.event.* }} into a `run:` block.
+        env:
+          RUNTIME: ${{ github.event.inputs.runtime }}
+          FILE_ISSUES: ${{ github.event.inputs.file_issues }}
         run: |
-          ARGS=""
-          [ -n "${{ github.event.inputs.runtime }}" ] && ARGS="--runtime ${{ github.event.inputs.runtime }}"
+          ARGS=()
+          [ -n "$RUNTIME" ] && ARGS=(--runtime "$RUNTIME")
           # default to filing issues on schedule; honor the dispatch toggle
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ github.event.inputs.file_issues }}" = "false" ]; then
-            echo "dry-run (no issues)"; python3 scripts/harness/audit.py $ARGS
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "$FILE_ISSUES" = "false" ]; then
+            echo "dry-run (no issues)"; python3 scripts/harness/audit.py "${ARGS[@]}"
           else
-            python3 scripts/harness/audit.py --file-issues $ARGS
+            python3 scripts/harness/audit.py --file-issues "${ARGS[@]}"
           fi

--- a/.github/workflows/i18n-autotranslate.yml
+++ b/.github/workflows/i18n-autotranslate.yml
@@ -53,12 +53,18 @@ jobs:
 
       - name: Translate deltas (via Claude Code CLI, no API key)
         if: env.SKIP != '1'
+        # The dispatch input is untrusted text. Bind it to an env var and read
+        # it as a quoted shell variable — YAML quotes do NOT protect here,
+        # because ${{ }} is substituted textually before bash parses the line.
+        env:
+          ONLY: ${{ github.event.inputs.only }}
+          SINCE: ${{ github.event.before || 'HEAD~1' }}
         run: |
           python3 scripts/i18n_autotranslate.py \
             --engine claude-cli \
             --locales-dir clawmetry/static/locales \
-            --since "${{ github.event.before || 'HEAD~1' }}" \
-            --only "${{ github.event.inputs.only }}"
+            --since "$SINCE" \
+            --only "$ONLY"
 
       - name: Open sync PR
         if: env.SKIP != '1'

--- a/.github/workflows/i18n-docs-autotranslate.yml
+++ b/.github/workflows/i18n-docs-autotranslate.yml
@@ -47,12 +47,17 @@ jobs:
 
       - name: Translate README into all locales
         if: env.SKIP != '1'
+        # The dispatch input is untrusted text. Bind it to an env var and read
+        # it as a quoted shell variable — YAML quotes do NOT protect here,
+        # because ${{ }} is substituted textually before bash parses the line.
+        env:
+          ONLY: ${{ github.event.inputs.only }}
         run: |
           python3 scripts/i18n_translate_docs.py \
             --readme README.md \
             --locales-dir clawmetry/static/locales \
             --out-dir docs/i18n \
-            --only "${{ github.event.inputs.only }}"
+            --only "$ONLY"
 
       - name: Open sync PR
         if: env.SKIP != '1'

--- a/.github/workflows/pr-screenshots.yml
+++ b/.github/workflows/pr-screenshots.yml
@@ -329,9 +329,11 @@ jobs:
         if: ${{ always() && !github.event.pull_request.head.repo.fork }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Bind event data to an env var rather than interpolating it into the
+          # script, so no `run:` block in this repo expands ${{ github.event.* }}.
+          PR: ${{ github.event.pull_request.number }}
         run: |
           set -e
-          PR=${{ github.event.pull_request.number }}
           MARKER="<!-- visual-diff-bot -->"
           BODY="$(printf '%s\n\n%s' "$MARKER" "$(cat /tmp/visual-diff-body.md)")"
           existing_id=$(gh api -X GET "repos/${{ github.repository }}/issues/${PR}/comments" --paginate \


### PR DESCRIPTION
## What

Four workflow steps interpolated `${{ github.event.* }}` straight into a `run:` script. This PR binds each value to a step-level `env:` var and reads it as a quoted shell variable.

| Workflow | Value(s) bound |
|---|---|
| `harness-observability-audit.yml` | `inputs.runtime`, `inputs.file_issues` |
| `i18n-autotranslate.yml` | `inputs.only` (and `event.before` alongside it) |
| `i18n-docs-autotranslate.yml` | `inputs.only` |
| `pr-screenshots.yml` | `pull_request.number` |

## Why

GitHub substitutes `${{ }}` expressions **textually, before bash parses the line**. The surrounding YAML quotes therefore give no protection — the value lands in the script as source text rather than as data. Binding it to `env:` and referencing `"$VAR"` is the standard fix: the runner hands the value to the process as an argument, and bash never parses it.

This is the Scorecard *DangerousWorkflow* / zizmor *template-injection* class. After this PR, no `run:` block in the repo interpolates `github.event.*` — the one remaining site, `release-on-merge.yml`, is fixed in #5246.

Severity is not uniform across the four, and the diff says so plainly:

- The three `inputs.*` sites are the substantive ones. They are reachable via `workflow_dispatch`, so they need repo write access to reach — but both i18n workflows hold `contents: write` + `pull-requests: write` and the audit workflow files issues, so the blast radius past that point is real.
- `pull_request.number` is a GitHub-generated integer and was never a practical risk. It is included so the rule holds repo-wide with no "known exception" a future reader has to re-derive.

## Secondary fix

`harness-observability-audit.yml` also moves `ARGS` from an unquoted string to a bash array. Previously `$ARGS` was expanded unquoted, so a runtime name containing whitespace was word-split into separate argv entries. It now reaches `audit.py` as a single argument.

## Verification

- All 34 workflows parse: `python3 -c "import yaml,glob; [yaml.safe_load(open(f)) for f in glob.glob('.github/workflows/*.yml')]"` → OK
- `python3 scripts/check_action_refs.py` → OK, 17 refs
- The rewritten audit block was executed against a stub `audit.py` under `bash -e`. argv matches the previous script on every path:

  | Case | argv |
  |---|---|
  | schedule, blank input | `['--file-issues']` |
  | dispatch, `runtime=openclaw` | `['--file-issues', '--runtime', 'openclaw']` |
  | dispatch, `file_issues=false` | `['--runtime', 'openclaw']` (after `dry-run (no issues)`) |
  | runtime containing `;` and a command | passed through as one inert argv entry |

- No `permissions:` blocks are touched, so no release/publish path changes scope.
- Every file is under `.github/`, which `scripts/check_product_record.py` exempts — no Factory record needed.

No-PRD: CI-only workflow hardening under .github/, exempt from the product-record gate.

---
_Generated by [Claude Code](https://claude.ai/code/session_019xPcYnVqKnR6hrVrdsFXdt)_