### PR TITLE
Harden CI: least-privilege top-level token scopes (5 remaining workflows)

### DIFF
--- a/.github/workflows/api-latency-smoke.yml
+++ b/.github/workflows/api-latency-smoke.yml
@@ -12,6 +12,11 @@ on:
     - cron: "0 6 * * *"   # nightly PyPI-release run
   workflow_dispatch:
 
+# Least privilege: this workflow only builds a wheel and probes a local
+# dashboard. It never writes to the repository or any GitHub API surface.
+permissions:
+  contents: read
+
 concurrency:
   group: api-latency-smoke-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/c6-apply-ruleset.yml
+++ b/.github/workflows/c6-apply-ruleset.yml
@@ -36,6 +36,12 @@ on:
     branches: [main]
   workflow_dispatch:
 
+# Least-privilege default. The apply-ruleset job below declares its own
+# permissions block (contents: read + issues: write), which replaces this
+# default wholesale, so the tracking-issue comment still works.
+permissions:
+  contents: read
+
 jobs:
   apply-ruleset:
     name: Upsert E2E required-checks ruleset on main (C6)

--- a/.github/workflows/moat-keystone-drive-nightly.yml
+++ b/.github/workflows/moat-keystone-drive-nightly.yml
@@ -27,6 +27,12 @@ concurrency:
   group: moat-keystone-drive-nightly
   cancel-in-progress: false
 
+# Least-privilege default. The drive job below declares its own
+# permissions block (contents: read + issues: write), which replaces this
+# default wholesale, so the auto-filed P0 issue still works.
+permissions:
+  contents: read
+
 jobs:
   drive:
     name: Keystone Drive (real openclaw turn -> 13 probes)

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,13 @@ on:
         description: 'Version to publish (e.g. 0.10.0)'
         required: true
 
+# Least-privilege default. The publish job below declares its own
+# permissions block (contents: read + id-token: write + attestations:
+# write), which replaces this default wholesale -- provenance minting and
+# PyPI Trusted Publishing are unaffected.
+permissions:
+  contents: read
+
 jobs:
   publish:
     name: Build & Publish to PyPI

--- a/.github/workflows/windows-enterprise-tls.yml
+++ b/.github/workflows/windows-enterprise-tls.yml
@@ -23,6 +23,10 @@ on:
       - .github/workflows/windows-enterprise-tls.yml
   workflow_dispatch:
 
+# Least privilege: checkout + pytest + a local mitmproxy. No API writes.
+permissions:
+  contents: read
+
 jobs:
   e2e:
     runs-on: windows-latest


### PR DESCRIPTION
Adds a top-level `permissions: contents: read` to the five remaining workflows that had no top-level block, so `GITHUB_TOKEN` starts from a read-only default instead of the repository default (OpenSSF Scorecard **TokenPermissions**). Follows #5246, which covered nine other workflows; the file sets do not overlap.

## Why each of these five is safe

Three already declare a **complete job-level `permissions:` block**. A job-level block replaces the workflow default wholesale, so their write scopes are unchanged by this PR — the top-level block only sets the default for jobs that declare none, and each of these workflows has exactly one job, which declares its own:

| Workflow | Job-level scopes (unchanged) | Why those scopes |
|---|---|---|
| `publish.yml` | `contents: read`, `id-token: write`, `attestations: write` | OIDC token for build provenance / PyPI Trusted Publishing; attestation recorded against the repo |
| `c6-apply-ruleset.yml` | `contents: read`, `issues: write` | Posts the one-time C6 comment on the tracking issue |
| `moat-keystone-drive-nightly.yml` | `contents: read`, `issues: write` | Auto-files the P0 issue when the nightly drive fails |

The other two never touch a GitHub API write surface, so `contents: read` is their real requirement:

- `api-latency-smoke.yml` — builds a wheel, starts the daemon + dashboard locally, probes `localhost:8900`.
- `windows-enterprise-tls.yml` — checkout, pytest, a local mitmproxy, `clawmetry doctor`.

## Deliberately left out

`ci.yml`, `desktop-artifacts.yml` and `auto-deploy-cloud.yml` still have no top-level block. Unlike the five above, they contain jobs with **no** job-level `permissions:`, so a blanket top-level default would actually narrow those jobs (release-asset uploads, cross-repo automation). They need per-job elevation worked out first and will come as their own change. Note `auto-deploy-cloud.yml` authenticates to the cloud repo with `secrets.CLOUD_REPO_PAT`, which workflow permissions do not govern — that has to be reasoned about separately.

## Verification

- Every file under `.github/workflows/` re-parsed with `yaml.safe_load` after the edit — all parse.
- Effective permissions re-read from the parsed YAML to confirm each job-level block still wins:
  - `publish` → `{contents: read, id-token: write, attestations: write}`
  - `c6-apply-ruleset` → `{contents: read, issues: write}`
  - `moat-keystone-drive-nightly` → `{contents: read, issues: write}`

No-PRD: CI-only change confined to `.github/`, which is exempt from the product-record gate.

---
_Generated by [Claude Code](https://claude.ai/code/session_019ZX8T7NYi8j8jkuawEksC4)_