### PR TITLE
Harden CI: bind remaining untrusted inputs and secrets in run: blocks

### DIFF
--- a/.github/workflows/apply-required-checks.yml
+++ b/.github/workflows/apply-required-checks.yml
@@ -73,17 +73,25 @@ jobs:
 
       - name: Preview checks (dry run)
         if: github.event_name == 'workflow_dispatch' && github.event.inputs.confirm != 'APPLY'
+        # This step only needs to know WHETHER a token is available, never its
+        # value. Compare in the expression context and pass the booleans down,
+        # so neither the PAT input nor the secret is ever spliced into the
+        # script as source text. Never interpolate an input or a secret into a
+        # `run:` block.
+        env:
+          HAS_PAT_INPUT: ${{ inputs.pat_token != '' }}
+          HAS_PAT_SECRET: ${{ secrets.E2E_ADMIN_PAT != '' }}
         run: |
           echo "=== DRY RUN -- checks that will be added when confirm=APPLY ==="
           echo ""
-          if [ -z "${{ inputs.pat_token }}" ] && [ -z "${{ secrets.E2E_ADMIN_PAT }}" ]; then
+          if [ "$HAS_PAT_INPUT" != "true" ] && [ "$HAS_PAT_SECRET" != "true" ]; then
             echo "  No admin token available (neither pat_token input nor E2E_ADMIN_PAT secret)."
             echo "  Quickest path: paste a fine-grained PAT into the pat_token input and"
             echo "  re-run with confirm=APPLY.  No local setup required."
             echo ""
             echo "  PAT permissions needed: Administration (read+write) on:"
             echo "    clawmetry, clawmetry-cloud, clawmetry-landing"
-          elif [ -n "${{ inputs.pat_token }}" ]; then
+          elif [ "$HAS_PAT_INPUT" = "true" ]; then
             echo "  Using pat_token input -- will apply to all 3 repos:"
             echo "  clawmetry         : E2E Gate (required)"
             echo "  clawmetry-cloud   : Cloud golden-path browser E2E"
@@ -106,7 +114,11 @@ jobs:
 
       - name: Mask PAT token
         if: inputs.pat_token != ''
-        run: echo "::add-mask::${{ inputs.pat_token }}"
+        # ::add-mask:: needs the literal value, so it must reach the step --
+        # but via the environment, not spliced into the script as source text.
+        env:
+          PAT_TOKEN: ${{ inputs.pat_token }}
+        run: echo "::add-mask::${PAT_TOKEN}"
 
       - name: Apply required status checks
         id: c6_verify

--- a/.github/workflows/auto-quarantine.yml
+++ b/.github/workflows/auto-quarantine.yml
@@ -50,13 +50,18 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO_OWNER: vivekchand
           REPO_NAME: clawmetry
+          # Dispatch inputs are untrusted text. Bind them to env vars and read
+          # them as quoted shell variables so the runner never expands them as
+          # code. Never interpolate an input into a `run:` block.
+          DRY_RUN: ${{ inputs.dry_run }}
+          LOOKBACK: ${{ inputs.lookback }}
         run: |
-          ARGS=""
-          if [ "${{ inputs.dry_run }}" = "true" ] && [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            ARGS="--dry-run"
+          ARGS=()
+          if [ "$DRY_RUN" = "true" ] && [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            ARGS=(--dry-run)
           fi
-          if [ -n "${{ inputs.lookback }}" ]; then
-            ARGS="$ARGS --lookback ${{ inputs.lookback }}"
+          if [ -n "$LOOKBACK" ]; then
+            ARGS+=(--lookback "$LOOKBACK")
           fi
           # GitHub Actions uses set -eo pipefail by default. Without set +e,
           # bash exits the run block immediately when auto_quarantine.py exits
@@ -65,7 +70,7 @@ jobs:
           # Fix: disable exit-on-error for the python call, capture the exit
           # code in SCRIPT_EXIT, then re-enable.
           set +e
-          python3 scripts/auto_quarantine.py $ARGS
+          python3 scripts/auto_quarantine.py "${ARGS[@]}"
           SCRIPT_EXIT=$?
           set -e
           echo "exit_code=${SCRIPT_EXIT}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/pr-screenshots.yml
+++ b/.github/workflows/pr-screenshots.yml
@@ -253,8 +253,13 @@ jobs:
       # fork guardrail.
       - name: Set per-PR screenshots branch name
         if: always()
+        # Event data is untrusted text. Bind it to an env var and read it as a
+        # quoted shell variable so the runner never expands it as code.
+        # Never interpolate ${{ github.event.* }} into a `run:` block.
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          echo "PR_SCREENSHOTS_BRANCH=pr-screenshots-pr-${{ github.event.pull_request.number }}" >> "$GITHUB_ENV"
+          echo "PR_SCREENSHOTS_BRANCH=pr-screenshots-pr-${PR_NUMBER}" >> "$GITHUB_ENV"
 
       - name: Publish screenshots to per-PR branch
         if: ${{ always() && !github.event.pull_request.head.repo.fork }}


### PR DESCRIPTION
Follow-on to #5249, which converted four such sites. Three more remained where a `${{ ... }}` expression was interpolated straight into a `run:` script. GitHub substitutes those textually before bash parses the line, so the surrounding YAML quotes give no protection — the value lands in the script as source text rather than as data.

| Workflow | Values now bound to `env:` |
|---|---|
| `pr-screenshots.yml` | `pull_request.number` — the branch-name step. #5249 converted the sibling publish step but left this one. |
| `auto-quarantine.yml` | `inputs.dry_run`, `inputs.lookback` |
| `apply-required-checks.yml` | `inputs.pat_token`, `secrets.E2E_ADMIN_PAT` |

Each site binds the value to a step-level `env:` var and reads it as a quoted shell variable, matching the pattern #5249 established. `${{ github.event_name }}` is deliberately left interpolated — it is a fixed GitHub-controlled enum, the same call #5249 made.

`auto-quarantine.yml` also moves `ARGS` from an unquoted string to a bash array, so the lookback value reaches `auto_quarantine.py` as one argument and is no longer word-split.

## `apply-required-checks.yml` gets the stronger treatment

Its dry-run preview only needs to know **whether** a token is available, never its value. The comparison now happens in the expression context and only the booleans reach the shell:

```yaml
env:
  HAS_PAT_INPUT: ${{ inputs.pat_token != '' }}
  HAS_PAT_SECRET: ${{ secrets.E2E_ADMIN_PAT != '' }}
```

So the PAT input and the `E2E_ADMIN_PAT` secret no longer enter that script at all — not as source text, not as an environment value. The one step that genuinely needs the literal value, `::add-mask::`, takes it from the environment instead of having it spliced into the command line.

## Verification

- **argv equivalence, `auto-quarantine.yml`** — old vs new compared across all five `dry_run` / `event_name` / `lookback` combinations (`true·workflow_dispatch·30`, `false·workflow_dispatch·30`, `true·schedule·∅`, `false·schedule·∅`, `true·workflow_dispatch·∅`). Every case produces identical argv.
- **Branch equivalence, `apply-required-checks.yml`** — the three-way dry-run branch compared across all four token-presence combinations (neither / input only / secret only / both). Every case selects the same branch.
- **YAML** — all 34 files under `.github/workflows/` re-parsed with `yaml.safe_load` after the edit; all parse.
- A repository-wide re-scan for untrusted interpolation inside `run:` blocks now returns zero hits.

No-PRD: CI-only change confined to `.github/`, which is exempt from the product-record gate.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JKYBNwT3VTaa3G7PHbQZ9G)_