### PR TITLE
Harden deps: put the repo's npm trees under Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,3 +19,48 @@ updates:
     open-pull-requests-limit: 5
     labels:
       - "dependencies"
+
+  # npm — the React SPA. This is the repo's largest JS dependency tree and
+  # the only one with a committed lockfile that ships into clawmetry/static/.
+  # Minor/patch updates are grouped so a routine week is one PR, not twenty.
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+    groups:
+      frontend-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # npm — Playwright E2E harness. Runs in CI on every PR, so its
+  # dependencies are part of the CI supply chain.
+  - package-ecosystem: "npm"
+    directory: "/tests/e2e"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+    groups:
+      e2e-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # npm — the ClawHub/OpenClaw plugin, which is published to npm
+  # (openclaw.release.publishToNpm). No lockfile, so Dependabot updates the
+  # manifest ranges.
+  - package-ecosystem: "npm"
+    directory: "/clawhub-plugin"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"


### PR DESCRIPTION
## What

`.github/dependabot.yml` declared two ecosystems — `pip` and `github-actions` — and no `npm`, even though the repo commits three JavaScript manifests. This adds them.

| directory | manifest | lockfile | limit | grouping |
|---|---|---|---|---|
| `/frontend` | `package.json` | ✅ `package-lock.json` | 5 | minor + patch |
| `/tests/e2e` | `package.json` | ✅ `package-lock.json` | 3 | minor + patch |
| `/clawhub-plugin` | `package.json` | — | 3 | — |

Root `package.json` is deliberately left out: it declares no dependencies, only two `bash` deploy scripts, so an entry there would generate nothing.

## Why

Dependabot **security** updates run off the dependency graph and do not need a config entry — that is why `/frontend` security PRs already show up. Dependabot **version** updates do need one. Without an `npm` entry, the JS trees only ever moved when something was already a published advisory; routine upgrades that close a vulnerability *before* it is advisory-tagged never landed, and the lockfile drifted between security bumps.

`/tests/e2e` matters for the same reason as any CI dependency: it installs and executes on every pull request, so it is part of the CI supply chain. `/clawhub-plugin` is published to npm (`openclaw.release.publishToNpm`), so its manifest ranges are what downstream installs resolve against.

## Noise control

The two lockfile trees group `minor` and `patch` into a single weekly PR each. `major` bumps stay individual, since those are the ones that need a human to read a changelog. Per-directory `open-pull-requests-limit` caps the rest. Security updates are unaffected by these limits and continue to open immediately.

## Validation

- `yaml.safe_load` on `.github/dependabot.yml` — parses.
- Asserted every `(package-ecosystem, directory)` pair is unique, every block has the required keys, and every `schedule.interval` is a valid value.
- Asserted a real `package.json` exists at each of the three declared npm directories.
- Re-parsed all 34 files in `.github/workflows/` — all parse. (Nothing in this diff touches a workflow; run anyway per the repo's own rule.)

## Scope

One file, additive only. No existing block is modified. No workflow, no runtime code, no `permissions:` change — this is independent of #5250 and #5251 and does not touch the same files.

`No-PRD: CI/dependency configuration only — .github/** is exempt from the product-record gate.`

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ea5PWYDYgYpGTSy89Q7kxc)_