### PR TITLE
Harden CI: least-privilege token scopes for the last 3 workflows

### DIFF
--- a/.github/workflows/api-latency-smoke.yml
+++ b/.github/workflows/api-latency-smoke.yml
@@ -14,17 +14,13 @@ on:
 
 # Least privilege: this workflow only builds a wheel and probes a local
 # dashboard. It never writes to the repository or any GitHub API surface.
+# Any job needing more must elevate with its own job-level `permissions:`.
 permissions:
   contents: read
 
 concurrency:
   group: api-latency-smoke-${{ github.ref }}
   cancel-in-progress: true
-
-# Least privilege: these jobs only read the repo. Any job needing more
-# must elevate with its own job-level `permissions:` block.
-permissions:
-  contents: read
 
 jobs:
   smoke:

--- a/.github/workflows/auto-deploy-cloud.yml
+++ b/.github/workflows/auto-deploy-cloud.yml
@@ -20,6 +20,15 @@ on:
     types: [completed]
   workflow_dispatch:
 
+# Every cross-repo action below (checkout of clawmetry-cloud, branch push, PR
+# create/close/merge) authenticates as `secrets.CLOUD_REPO_PAT`, which this
+# block does not govern — a PAT carries its own scopes. The only thing that
+# rides on GITHUB_TOKEN is the checkout of THIS repo, which needs `contents:
+# read` and nothing more. Deliberately kept read-only so a future step cannot
+# quietly acquire write on clawmetry via the ambient token.
+permissions:
+  contents: read
+
 jobs:
   pin-version:
     name: Rebuild cloud with latest OSS

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,13 @@ on:
     branches: [main, master]
   pull_request:
 
+# Every job here only reads the repository: checkout, install, run tests,
+# upload an artifact. Nothing calls the GitHub API with GITHUB_TOKEN, pushes
+# a commit, tags, comments on a PR or touches a Release, so the whole
+# workflow runs on the read-only default and no job needs an elevated block.
+permissions:
+  contents: read
+
 concurrency:
   group: ci-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/desktop-artifacts.yml
+++ b/.github/workflows/desktop-artifacts.yml
@@ -18,6 +18,15 @@ on:
       - 'v*.*.*'
   workflow_dispatch: {}
 
+# Least-privilege floor for the three BUILD jobs (macos / linux inherit this;
+# windows re-declares it alongside id-token). The `release` job, and only that
+# job, elevates to `contents: write` so softprops/action-gh-release can attach
+# installers to the tag's Release and publish it. Keep the elevation on that
+# job — a workflow-wide `contents: write` would hand every build job, and each
+# third-party action it runs, the ability to write to the repository.
+permissions:
+  contents: read
+
 jobs:
   macos:
     name: macOS .app + .dmg (signed + notarized when secrets are set)

--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -5,6 +5,15 @@ on:
     types: [closed]
     branches: [main]
 
+# Read-only floor. This workflow's single job re-declares its own scopes
+# below, and a job-level block REPLACES the top level rather than merging
+# with it, so this value never actually applies to `release` — it is here so
+# the default for any job added later is read-only, and so the workflow
+# stops reading as "inherits whatever the repository default happens to be".
+# The publish/tag/PR scopes stay on the job that needs them, not up here.
+permissions:
+  contents: read
+
 jobs:
   release:
     name: Bump version & publish to PyPI

--- a/tests/test_workflow_yaml_valid.py
+++ b/tests/test_workflow_yaml_valid.py
@@ -79,6 +79,58 @@ def test_workflow_parses_as_yaml(path: str) -> None:
     )
 
 
+class _DuplicateKeyLoader(yaml.SafeLoader):
+    """A SafeLoader that refuses a mapping with a repeated key.
+
+    PyYAML's own resolution is last-one-wins, silently: ``yaml.safe_load`` on a
+    file with two top-level ``permissions:`` blocks returns a perfectly good
+    dict and raises nothing. GitHub Actions does the opposite -- it rejects the
+    file outright and fails the run at startup -- so a duplicate key is exactly
+    the class of break ``test_workflow_parses_as_yaml`` cannot see.
+    """
+
+
+def _no_duplicate_keys(loader, node, deep=False):
+    seen = set()
+    for key_node, _ in node.value:
+        key = loader.construct_object(key_node, deep=deep)
+        if key in seen:
+            raise yaml.YAMLError(
+                f"duplicate key {key!r} at line {key_node.start_mark.line + 1}"
+            )
+        seen.add(key)
+    return yaml.SafeLoader.construct_mapping(loader, node, deep=deep)
+
+
+_DuplicateKeyLoader.add_constructor(
+    yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, _no_duplicate_keys
+)
+
+
+@pytest.mark.parametrize("path", _workflow_files(), ids=os.path.basename)
+def test_workflow_has_no_duplicate_keys(path: str) -> None:
+    """No mapping may repeat a key. GitHub rejects the file if one does.
+
+    Burned by the token-permissions hardening pass: two separate PRs each
+    added a top-level ``permissions: contents: read`` block to
+    api-latency-smoke.yml. Both were individually correct, neither conflicted
+    in git, and the pre-merge check was ``yaml.safe_load`` -- which happily
+    kept the second and returned a valid dict. The workflow was dead on main
+    from the moment the second one merged, its runs listed under the file path
+    with zero jobs, and the API-latency safety net was off.
+    """
+    with open(path, encoding="utf-8") as fh:
+        source = fh.read()
+    try:
+        yaml.load(source, _DuplicateKeyLoader)
+    except yaml.YAMLError as exc:  # pragma: no cover - message is the point
+        pytest.fail(
+            f"{os.path.basename(path)} repeats a mapping key ({exc}). PyYAML "
+            "keeps the last one without complaining, but GitHub rejects the "
+            "workflow and fails every run at startup before any step executes."
+        )
+
+
 @pytest.mark.parametrize("path", _workflow_files(), ids=os.path.basename)
 def test_workflow_has_required_top_level_keys(path: str) -> None:
     """A parseable file can still be a non-workflow. Check the shape."""


### PR DESCRIPTION
Closes out the TokenPermissions batch: after this, **every workflow in `.github/workflows/` declares exactly one top-level `permissions:` block** — 34/34, verified on the current head with a loader that rejects duplicate keys.

These were left for last because all of them touch a release or deploy path, where a blanket `contents: read` breaks the pipeline silently. Each job was read individually and the scope justified below rather than applied uniformly.

## `ci.yml` — `contents: read`, no job elevation

All 13 jobs do the same shape of work: checkout, install, run tests, upload an artifact. Nothing in the file calls the GitHub API with `GITHUB_TOKEN`, pushes a commit, creates a tag, comments on a PR, or touches a Release. The only `uses:` beyond checkout/setup are `actions/cache`, `actions/upload-artifact` and the local `./.github/actions/setup-openclaw`; `upload-artifact` uses the runtime token, not `GITHUB_TOKEN`. The read-only floor therefore covers the whole workflow and no job needs an elevated block.

## `auto-deploy-cloud.yml` — `contents: read`

Worth stating explicitly because the job name suggests otherwise: this workflow checks out `clawmetry-cloud`, pushes a branch, and creates, closes and merges a PR there — but every one of those steps authenticates as `secrets.CLOUD_REPO_PAT`, both as the `token:` on the second checkout and as `GH_TOKEN` on the `gh` steps. **A workflow `permissions:` block does not govern a PAT**, so none of that cross-repo work is affected by this change.

The only thing riding on `GITHUB_TOKEN` is the checkout of this repo, which needs `contents: read` and nothing else. Keeping the floor read-only means a future step added here cannot quietly pick up write access to `clawmetry` through the ambient token — it would have to ask for the PAT, which is visible in review.

## `desktop-artifacts.yml` — `contents: read` floor, `release` stays `contents: write`

| job | effective scopes | why |
|---|---|---|
| `macos` | `contents: read` | inherits; checkout + build + upload-artifact |
| `linux` | `contents: read` | inherits; checkout + build + upload-artifact |
| `windows` | `id-token: write`, `contents: read` | unchanged — already declared for `azure/login` OIDC |
| `release` | `contents: write` | unchanged — `softprops/action-gh-release` attaches installers to the tag's Release and publishes it |

The elevation deliberately stays on the `release` job. A workflow-wide `contents: write` would hand it to all three build jobs and to every third-party action they run, which on the signing paths is the largest surface in this repo.

Note the ordering hazard this file already handles correctly: a job-level `permissions:` block *replaces* the top level rather than merging with it, so the `windows` job's existing block had to already carry `contents: read` for its checkout to keep working. It does (with a comment saying exactly that), so the new top-level block does not regress it.

## `release-on-merge.yml` — `contents: read` floor, job scopes untouched

#5250 was expected to cover this file but landed without a top-level block, leaving it the last workflow in the repo with none — caught by re-running the check across all 34 workflows after merging `main` into this branch, not assumed from #5250's description.

The change is **functionally inert by design**. The workflow has exactly one job; that job declares its own `contents: write` / `pull-requests: write` / `actions: write`; and since a job-level block replaces the top level, the new value can never apply to `release`. Its purpose is that a job added here later defaults to read-only rather than inheriting the repository default, and that the file stops reading as unscoped. The publish, tag and PR-merge scopes stay on the job that needs them.

## `api-latency-smoke.yml` — repairing a workflow the batch had broken

Carried in `36e773d`. Two earlier hardening commits each added a top-level `permissions: contents: read` to this file — `210696e` below `concurrency:`, `85873f0` (#5250) above it. Neither conflicted in git and both were individually correct, but **YAML forbids a repeated mapping key**, so GitHub rejected the workflow and failed every run at startup with zero jobs. The check had been dead on `main` since #5250 landed.

The fix keeps the block above `concurrency:` and folds the other comment's point into it. Effective scope is unchanged: `contents: read`, one job, no job-level override.

### Why the existing guard missed it, and the correction

This is worth flagging because it undercuts how the earlier revisions of this PR described their own verification. `yaml.safe_load` resolves a duplicate key **last-one-wins and raises nothing** — so `test_workflow_parses_as_yaml`, and the "all 34 workflows parse" check cited in this PR's earlier description, both passed happily on a file GitHub refuses to run. Parsing cleanly was never evidence of a single `permissions:` block; it just could not see the second one.

`36e773d` adds `tests/test_workflow_has_no_duplicate_keys` next to the existing guard, using a `SafeLoader` subclass whose mapping constructor rejects a repeat, auto-discovered over every workflow. Re-inserting the duplicate fails the new test while the old parse test still passes — which is precisely the blind spot being closed.

## Verification

Re-run on the current head (`36e773d`), which includes `main` (bringing #5250/#5251/#5252):

- All 34 workflow files parse **and none repeats a mapping key**, checked with a duplicate-rejecting loader rather than plain `safe_load`.
- Every workflow declares a top-level `permissions:` block; each of the four files this PR touches has exactly one.
- Effective per-job permissions resolved and inspected for all four files; the tables above are that output, not an assumption. `release-on-merge`'s job scopes confirmed unchanged.
- `api-latency-smoke` resolves to `contents: read` with its single `smoke` job.
- 184 workflow tests pass.
- `scripts/check_action_refs.py` — 17 action references, OK.

No functional change beyond reviving `api-latency-smoke.yml`: additive `permissions:` blocks and one de-duplication, no step, trigger or job logic touched.

No-PRD: CI-only change confined to `.github/` and `tests/`, exempt from the product-record gate.