### PR TITLE
e2e: fix stale tracking refs and C6 gate status message

### DIFF
--- a/.github/workflows/apply-required-checks.yml
+++ b/.github/workflows/apply-required-checks.yml
@@ -18,7 +18,7 @@ name: Apply required E2E status checks (C6 -- one-shot)
 #     With only GITHUB_TOKEN (ghs_): read-only verify path in the script
 #     (exits 0 if C6 configured, exits 1 if not -- no admin rights needed).
 #     With E2E_ADMIN_PAT: full apply + verify.
-#     On failure, posts a notification comment on tracking issue #4552.
+#     On failure, posts a notification comment on tracking issue #5266.
 #
 # TOKEN PATHS (priority order):
 #   1. inputs.pat_token  -- PAT typed into the Run workflow dialog
@@ -37,7 +37,7 @@ name: Apply required E2E status checks (C6 -- one-shot)
 #   clawmetry-landing.
 #
 # Idempotent: running multiple times is safe.
-# Tracking: vivekchand/clawmetry#4552
+# Tracking: vivekchand/clawmetry#5266 (E2E epic, C6)
 
 on:
   workflow_dispatch:
@@ -129,7 +129,7 @@ jobs:
         run: python3 scripts/apply_required_status_checks.py
 
       # When the C6 read-only verify exits 1 (checks not yet configured on main),
-      # post or update a comment on the E2E Robustness tracking issue #4552 so the
+      # post or update a comment on the E2E Robustness tracking issue #5266 so the
       # repo admin receives a GitHub notification.
       #
       # Only fires on push-to-main (the automated verify path), NOT on manual
@@ -164,19 +164,25 @@ jobs:
           Actions > 'Apply required E2E status checks (C6 -- one-shot)' > Run workflow
           confirm=APPLY, pat_token=paste-token-here
 
+          ### Also: merge these 3 CI-green pending PRs
+
+          - **C3** landing golden path required check: [clawmetry-landing#678](https://github.com/vivekchand/clawmetry-landing/pull/678)
+          - **C4** cross-repo handoff AES-GCM fidelity: [clawmetry#5269](https://github.com/vivekchand/clawmetry/pull/5269)
+          - **C5** cloud node tab screenshots: [clawmetry-cloud#2143](https://github.com/vivekchand/clawmetry-cloud/pull/2143)
+
           Once any option above is done, the next push to main self-heals to green."
 
           # Upsert: update existing comment if present, otherwise create new.
           existing_id=$(gh api -X GET \
-            "repos/${REPO}/issues/4552/comments" \
+            "repos/${REPO}/issues/5266/comments" \
             --jq 'map(select(.body | startswith("<!-- c6-notify-bot -->"))) | .[0].id // empty' \
             2>/dev/null || echo "")
           if [ -n "${existing_id}" ]; then
             gh api -X PATCH "repos/${REPO}/issues/comments/${existing_id}" \
               -f body="${BODY}" > /dev/null
-            echo "Updated existing C6 notification on #4552 (comment ${existing_id})"
+            echo "Updated existing C6 notification on #5266 (comment ${existing_id})"
           else
-            gh api -X POST "repos/${REPO}/issues/4552/comments" \
+            gh api -X POST "repos/${REPO}/issues/5266/comments" \
               -f body="${BODY}" > /dev/null
-            echo "Posted new C6 notification on #4552"
+            echo "Posted new C6 notification on #5266"
           fi

--- a/.github/workflows/c6-pr-gate.yml
+++ b/.github/workflows/c6-pr-gate.yml
@@ -3,7 +3,7 @@ name: C6 Required-status-checks gate (PR audit)
 # Runs on every pull request to surface whether C6 (required-status-checks)
 # is configured on main. Fails visibly on every PR until the admin closes C6.
 #
-# The daily c6-health.yml posts to issue #4029 but the admin may not check
+# The daily c6-health.yml posts to issue #5266 but the admin may not check
 # that issue between merges. This check appears directly in the PR status
 # list alongside OSS golden path, E2E Browser Tests, etc. -- impossible to
 # miss when reviewing a PR.
@@ -44,7 +44,7 @@ name: C6 Required-status-checks gate (PR audit)
 #     Edit main > Require status checks > add:
 #       E2E Gate (required)
 #
-# Tracking: vivekchand/clawmetry#4029 (C6)
+# Tracking: vivekchand/clawmetry#5266 (E2E epic, C6)
 
 on:
   pull_request:
@@ -121,7 +121,15 @@ jobs:
           [Apply required E2E status checks (C6)](https://github.com/vivekchand/clawmetry/actions/workflows/apply-required-checks.yml)
           -- confirm=APPLY, pat_token=paste-token-here
 
-          _C6 is the sole remaining criterion of the E2E Robustness epic. All other 6 criteria (C1 OSS golden path, C2 Cloud golden path, C3 Landing, C4 Cross-repo handoff, C5 Visual diff all tabs, C7 Quarantine) are green. Tracking: [#4029](https://github.com/vivekchand/clawmetry/issues/4029)_"
+          ### Also: merge these 3 pending PRs to clear C3/C4/C5
+
+          Three criteria are AMBER with CI-green PRs waiting for merge:
+
+          - **C3** (landing golden path required check): [clawmetry-landing#678](https://github.com/vivekchand/clawmetry-landing/pull/678)
+          - **C4** (cross-repo handoff AES-GCM fidelity): [clawmetry#5269](https://github.com/vivekchand/clawmetry/pull/5269)
+          - **C5** (cloud node tab screenshots): [clawmetry-cloud#2143](https://github.com/vivekchand/clawmetry-cloud/pull/2143)
+
+          _E2E epic tracking: [#5266](https://github.com/vivekchand/clawmetry/issues/5266). Current state: C1 OSS golden path GREEN, C2 cloud GREEN, C7 quarantine GREEN. AMBER: C3 (merge landing#678), C4 (merge #5269), C5 cloud (merge cloud#2143), C6 (this Settings fix)._"
 
           existing_id=$(gh api -X GET \
             "repos/${REPO}/issues/${PR}/comments" \

--- a/scripts/close-c6.sh
+++ b/scripts/close-c6.sh
@@ -25,7 +25,7 @@
 # After running: every PR in those 3 repos must pass the E2E suite to merge.
 # This closes criterion C6 of the E2E Robustness epic.
 #
-# Tracking: vivekchand/clawmetry#4029
+# Tracking: vivekchand/clawmetry#5266 (E2E epic, C6)
 
 set -euo pipefail
 


### PR DESCRIPTION
## Summary

The C6 PR gate comment told @vivekchand "C6 is the sole remaining criterion, all other 6 criteria are green" on every PR. This is inaccurate: C3 (landing required check), C4 (cross-repo handoff AES-GCM fidelity), and C5 cloud (cloud node tab screenshots) are still AMBER with CI-green PRs waiting for human merge.

Three tracking issue references were also stale:
- `c6-pr-gate.yml` and `close-c6.sh` referenced old epic #4029
- `apply-required-checks.yml` notification posted to issue #4552
- Current E2E robustness epic is #5266

## Changes

- **`c6-pr-gate.yml`**: Replace "C6 is the sole remaining criterion, all others green" footer with accurate per-criterion state. Add direct links to the 3 pending CI-green PRs that need merging (#678 landing, #5269 clawmetry, #2143 cloud). Fix tracking ref #4029 -> #5266.
- **`apply-required-checks.yml`**: Fix `issues/4552/comments` -> `issues/5266/comments` in the push-to-main notification step. Update header tracking comment. Add pending PR list to notification body.
- **`scripts/close-c6.sh`**: Fix tracking comment ref #4029 -> #5266.

## Why this matters

Every PR in clawmetry triggers c6-pr-gate.yml and gets a @vivekchand comment. That comment was actively misleading the admin into thinking the only outstanding action was the Settings UI fix, when 3 PRs also needed merging. With this fix the comment gives an accurate picture: merge 3 PRs + add required checks in Settings.

## Acceptance test

1. Merge this PR
2. Open any PR on clawmetry
3. The C6 gate comment (if C6 still not configured) now lists: C3 AMBER (merge landing#678), C4 AMBER (merge #5269), C5 cloud AMBER (merge cloud#2143), C6 (Settings fix)
4. The apply-required-checks.yml push-to-main notification now posts to #5266 instead of the dead #4552

No-PRD: stale-copy/wrong-issue-ref fix; no behavior change.

Tracking: vivekchand/clawmetry#5266 (E2E epic, C6)

---
_Generated by [Claude Code](https://claude.ai/code/session_016uVrwKAqJca3xy7LGQ12Cn)_