### PR TITLE
Harden CI: pin ci.yml actions to commit SHAs

### DIFF
--- a/.github/actions/setup-openclaw/action.yml
+++ b/.github/actions/setup-openclaw/action.yml
@@ -37,7 +37,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup Node
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: ${{ inputs.node-version }}
 
@@ -45,7 +45,7 @@ runs:
     # Keyed on (OS, requested version) so a version bump invalidates cleanly.
     - name: Cache global openclaw install
       id: cache
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: |
           ~/.npm-openclaw-global

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,8 @@ jobs:
     name: Syntax & Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-python@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.9"
       - name: Check Python syntax (all .py files, Python 3.9 compatible)
@@ -218,7 +218,7 @@ jobs:
       # dashboard JS bundle died, stranding every user on the boot
       # overlay. `node --check` catches this in <1s. Required gate.
       - name: Setup Node (for JS syntax check)
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "20"
       - name: Check JS syntax (all clawmetry/static/js/*.js)
@@ -255,8 +255,8 @@ jobs:
             python-version: "3.9"
 
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-python@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -319,8 +319,8 @@ jobs:
     needs: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-python@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.11"
           cache: pip
@@ -383,8 +383,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-python@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.11"
           cache: pip
@@ -409,8 +409,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-python@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.11"
           cache: pip
@@ -441,8 +441,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-python@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.11"
           cache: pip
@@ -468,8 +468,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 6
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-python@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.11"
           cache: pip
@@ -528,8 +528,8 @@ jobs:
     timeout-minutes: 5
 
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-python@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.11"
           cache: pip
@@ -621,8 +621,8 @@ jobs:
       CLAWMETRY_HARD_BLOCK: '0'
 
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-python@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.11"
       - name: Install dependencies
@@ -631,7 +631,7 @@ jobs:
         # health check silently times out.
         run: pip install flask pytest pytest-playwright requests duckdb
       - name: Cache Playwright browsers
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/ms-playwright
           key: playwright-chromium-${{ runner.os }}-${{ hashFiles('setup.py', 'requirements.txt') }}
@@ -689,7 +689,7 @@ jobs:
 
       - name: Upload JUnit test report
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: junit-e2e-critical-${{ github.run_id }}
           path: /tmp/junit-e2e-critical.xml
@@ -717,8 +717,8 @@ jobs:
           - os: ubuntu-latest
             python-version: "3.9"
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-python@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install from source
@@ -766,8 +766,8 @@ jobs:
     needs: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-python@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.11"
       - name: Build wheel
@@ -858,8 +858,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-python@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.11"
           cache: pip
@@ -912,7 +912,7 @@ jobs:
           GITHUB_SHA: ${{ github.sha }}
         run: |
           clawmetry eval --suite tests/data/golden_ci.yaml --no-persist --json > eval-result.json || true
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: failure() && steps.gate.outputs.skip != '1' && steps.keycheck.outputs.skip != '1'
         with:
           name: clawmetry-ci-eval-result
@@ -948,8 +948,8 @@ jobs:
     # setup pattern is documented.
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-python@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.11"
       - name: Setup OpenClaw
@@ -973,7 +973,7 @@ jobs:
         run: python3 -m pytest tests/test_moat_live_openclaw_e2e.py tests/test_e2e_real_openclaw_pipeline.py -v --tb=short
       - name: Upload gateway logs on failure
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: moat-live-e2e-logs
           path: |


### PR DESCRIPTION
Addresses the Scorecard **PinnedDependencies** findings for `ci.yml`, the repo's most-run workflow.

## What this does

Every third-party action referenced by `.github/workflows/ci.yml` — and by the `setup-openclaw` composite action that `ci.yml` calls — now resolves to a full 40-character commit SHA, with the semver it came from in a trailing comment:

| Action | Pinned to | Version |
|---|---|---|
| `actions/checkout` | `3d3c42e5aac5ba805825da76410c181273ba90b1` | v7.0.1 (×13) |
| `actions/setup-python` | `5fda3b95a4ea91299a34e894583c3862153e4b97` | v7.0.0 (×13) |
| `actions/upload-artifact` | `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a` | v7.0.1 (×3) |
| `actions/setup-node` | `820762786026740c76f36085b0efc47a31fe5020` | v7.0.0 |
| `actions/cache` | `55cc8345863c7cc4c66a329aec7e433d2d1c52a9` | v6.1.0 |
| `actions/setup-node` (composite) | `49933ea5288caeca8642d1e84afbd3f7d6820020` | v4.4.0 |
| `actions/cache` (composite) | `0057852bfaa89a56745cba8c7296529d2fc39830` | v4.3.0 |

## Why

A version tag is mutable. `actions/checkout@v7` is whatever `v7` points at the next time a runner resolves it, so an upstream maintainer — or anyone who takes over that account — can change the code running in our CI without any commit landing in this repo. A commit SHA cannot be moved, so what runs in CI is fixed by this repository's own history.

## Scope

**Pins only, no version changes.** Each action was pinned to wherever its *current* major tag points today. The two actions inside the composite stay on their v4 majors rather than being pulled up to v7 — this PR is a supply-chain fix, not an upgrade, and mixing the two would make it harder to bisect if CI moved.

`.github/dependabot.yml` already covers the `github-actions` ecosystem, so Dependabot continues to propose upgrades and will bump the SHA and the version comment together.

## Verification

- All 35 workflow and composite-action files parse: `python3 -c "import yaml,glob; [yaml.safe_load(open(f)) for f in glob.glob('.github/workflows/*.yml')]"` — OK.
- The diff is 33 insertions / 33 deletions and **every changed line is a `uses:` line**; no structural, permission, or job changes.
- No `permissions:` block is touched — `ci.yml` keeps the scopes set in #5250/#5253.
- Local composite reference `uses: ./.github/actions/setup-openclaw` is left alone (repo-relative, already immutable).

## Notes

- Batched to one workflow file plus the composite it depends on, per the "one concern, reviewable size" rule. The remaining ~117 unpinned references across 31 other workflow files are follow-up batches.
- Touches only `.github/`, so the product-record gate does not apply.

No-PRD: CI/supply-chain hardening confined to `.github/`; no product surface changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mi9G4cAAvFDao8bREQCNjX)_