### PR TITLE
Harden CI: pin supply-chain.yml actions to commit SHAs

### DIFF
--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -32,8 +32,8 @@ jobs:
     name: No third-party asset loads
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-python@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.11"
       - name: Scan served pages for absolute http(s) asset references
@@ -43,8 +43,8 @@ jobs:
     name: Vendored assets match npm
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-python@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.11"
       - name: Verify sha256 pins and byte-compare against the npm registry
@@ -54,8 +54,8 @@ jobs:
     name: Vendored fonts not stale
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-python@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.11"
       # requests is needed because tests/conftest.py imports it at module
@@ -79,8 +79,8 @@ jobs:
     name: Python dependency audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-python@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.11"
       - run: python3 -m pip install --quiet pip-audit cyclonedx-bom
@@ -95,7 +95,7 @@ jobs:
           python3 -m pip install --quiet -r requirements.txt
           cyclonedx-py environment --output-format JSON > clawmetry-sbom.json
       - name: Publish SBOM as a build artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: clawmetry-sbom
           path: clawmetry-sbom.json
@@ -105,8 +105,8 @@ jobs:
     name: Action references resolve
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-python@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.11"
       # An unresolvable action fails its job at "Set up job" before any step
@@ -132,7 +132,7 @@ jobs:
       contents: read
       actions: read
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       # Pinned to the v2.4.4 commit, not a floating tag. Two reasons:
@@ -151,7 +151,7 @@ jobs:
           # Publishes to the public OpenSSF API so the README badge resolves.
           # Results are already public for a public repo.
           publish_results: true
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: scorecard-results
           path: scorecard-results.sarif


### PR DESCRIPTION
## What

Pins the 13 resolvable action references in `.github/workflows/supply-chain.yml` to full commit SHAs, with the human-readable version kept in a trailing comment.

| Action | Pinned to |
|---|---|
| `actions/checkout` (6 refs) | `3d3c42e5aac5ba805825da76410c181273ba90b1` # v7.0.1 |
| `actions/setup-python` (5 refs) | `5fda3b95a4ea91299a34e894583c3862153e4b97` # v7.0.0 |
| `actions/upload-artifact` (2 refs) | `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a` # v7.0.1 |

## Why

A floating tag is resolved at run time, so whoever can move the tag decides what executes in CI. A digest cannot be moved. This is the OpenSSF Scorecard `PinnedDependencies` probe, and it is particularly apt in this file — `supply-chain.yml` is the workflow that *runs* Scorecard, so an unpinned reference here was the workflow failing the check it exists to run. `ossf/scorecard-action` in this same job was already pinned for exactly that reason.

The trailing `# vX.Y.Z` comment is the form Dependabot reads, so version bumps keep flowing normally.

## Scope

One concern, one workflow file. 13 insertions, 13 deletions, nothing else.

`github/codeql-action/upload-sarif@v3` (line 160) is **deliberately left on its tag**: Dependabot PR #5158 is currently bumping `github/codeql-action` from 3 to 4, and pinning a v3 digest here would conflict with that bump. It is the only remaining unpinned reference in this file and is best pinned once that bump lands.

`ci.yml` is not touched — it is covered by the open PR #5275.

## Verification

- Every workflow file parses after the edit, not just the edited one:
  `python3 -c "import yaml,glob; [yaml.safe_load(open(f)) for f in glob.glob('.github/workflows/*.yml')]"` → 34/34 OK
- Parsed-YAML comparison against `main` with `uses:` values masked is **identical**, confirming only the action references changed.
- No `permissions:` block is added or modified anywhere, so no job's token scope changes.
- The digests are the same ones already exercised by the `ci.yml` pinning branch, whose "Action references resolve" check passed green.

## Risk

Low. Behaviour-neutral by construction — same actions, same versions, addressed by digest instead of tag. This repo's own "Action references resolve" job validates every reference on this PR.

Path is under `.github/`, which is exempt from the product-record gate.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LHL2XjNoJMscqDHfYNmVWs)_