### PR TITLE
Harden CI: pin conformance/install/handoff workflow actions to commit SHAs

### DIFF
--- a/.github/workflows/conformance-heartbeat.yml
+++ b/.github/workflows/conformance-heartbeat.yml
@@ -95,7 +95,7 @@ jobs:
           - os: ubuntu-latest
             python-version: "3.9"
     steps:
-      - uses: actions/setup-python@v7
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -143,7 +143,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-      - uses: actions/setup-python@v7
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.11"
       - name: Install from PyPI and smoke the CLI
@@ -168,7 +168,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Run install script
         run: bash install.sh
       - name: Verify binary
@@ -184,8 +184,8 @@ jobs:
     runs-on: windows-latest
     timeout-minutes: 25
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-python@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
       - name: Run PowerShell install
@@ -204,8 +204,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-python@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.11"
       - name: Report the matrix

--- a/.github/workflows/cross-repo-handoff.yml
+++ b/.github/workflows/cross-repo-handoff.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout clawmetry (OSS)
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           path: oss
 
@@ -52,7 +52,7 @@ jobs:
       # PRs skip gracefully; the test falls back to its inline stub in that case.
       - name: Checkout clawmetry-landing
         if: steps.access.outputs.available == 'true'
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: vivekchand/clawmetry-landing
           token: ${{ secrets.CLOUD_REPO_PAT }}
@@ -61,7 +61,7 @@ jobs:
       # Cloud repo provides run_cloud.py stub + DaemonSim wire-format simulator.
       - name: Checkout clawmetry-cloud
         if: steps.access.outputs.available == 'true'
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: vivekchand/clawmetry-cloud
           token: ${{ secrets.CLOUD_REPO_PAT }}
@@ -88,7 +88,7 @@ jobs:
           print("patched _throttle_patched: added node_id kwarg")
           EOF
 
-      - uses: actions/setup-python@v7
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.11"
 
@@ -152,7 +152,7 @@ jobs:
 
       - name: Upload JUnit results
         if: always() && steps.access.outputs.available == 'true'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: junit-c4-${{ github.run_id }}
           path: /tmp/junit-c4-${{ github.run_id }}.xml
@@ -169,7 +169,7 @@ jobs:
 
       - name: Upload logs on failure
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: c4-handoff-logs
           path: |

--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -15,7 +15,7 @@ jobs:
   test-linux:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Run install script
         run: bash install.sh
       - name: Verify clawmetry binary
@@ -34,7 +34,7 @@ jobs:
   test-macos:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Run install script
         run: bash install.sh
       - name: Add bin to PATH
@@ -53,9 +53,9 @@ jobs:
     runs-on: windows-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.12'
       - name: Run PowerShell install
@@ -110,9 +110,9 @@ jobs:
     runs-on: windows-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.12'
       - name: Run CMD install
@@ -148,6 +148,6 @@ jobs:
   shellcheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: ShellCheck
         run: shellcheck install.sh


### PR DESCRIPTION
## What

Pins all 20 action references in three workflow files to full commit SHAs, with the human-readable version kept in a trailing comment.

| File | Refs pinned |
|---|---|
| `.github/workflows/conformance-heartbeat.yml` | 7 |
| `.github/workflows/install-test.yml` | 7 |
| `.github/workflows/cross-repo-handoff.yml` | 6 |

| Action | Pinned to |
|---|---|
| `actions/checkout` (11 refs) | `3d3c42e5aac5ba805825da76410c181273ba90b1` # v7.0.1 |
| `actions/setup-python` (7 refs) | `5fda3b95a4ea91299a34e894583c3862153e4b97` # v7.0.0 |
| `actions/upload-artifact` (2 refs) | `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a` # v7.0.1 |

These are the same three digests already merged into `ci.yml` by #5275, so this adds no new trust decisions — it extends one already made.

## Why

A floating tag is resolved at run time, so whoever can move the tag decides what runs in CI. A digest cannot be moved. This is the OpenSSF Scorecard `PinnedDependencies` probe.

The trailing `# vX.Y.Z` comment is the form Dependabot reads, so version bumps keep flowing normally.

## Scope

One concern, three files, 20 insertions and 20 deletions — nothing else. No `permissions:` blocks, job definitions or step logic are touched.

These three files were chosen because every action in them is first-party (`actions/*`) and already at the major version that the currently-open Dependabot bumps target, so pinning them now cannot conflict with those PRs. Files still holding `actions/upload-artifact@v4`, `actions/download-artifact@v4`, `azure/login@v2` or `softprops/action-gh-release@v2` are deliberately left for after #5154, #5155, #5156 and #5157 land — pinning an old major there would collide with the bump. `supply-chain.yml` is not touched; it is covered by the open PR #5276.

## Verification

- Every workflow file in the repo parses after the edit, not just the three edited:
  `python3 -c "import yaml,glob; [yaml.safe_load(open(f)) for f in glob.glob('.github/workflows/*.yml')]"` → OK
- `python3 scripts/check_action_refs.py` → `Found 22 distinct action reference(s) across the workflows. OK`
- Re-scanned the three files for any remaining tag-form reference → none.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pw5EDmCUvFQMXbdGXehQm9)_