### PR TITLE
fix: update stale C6 tracking issue link in c6_required_checks_status.py

### DIFF
--- a/scripts/c6_required_checks_status.py
+++ b/scripts/c6_required_checks_status.py
@@ -180,7 +180,7 @@ def render_summary(all_ok: bool, rows: list[str]) -> str:
             "**Or store a PAT** as the `E2E_ADMIN_PAT` secret and this "
             "workflow heals it automatically.",
             "",
-            "Tracking: [#4552](https://github.com/vivekchand/clawmetry/issues/4552)",
+            "Tracking: [#5266](https://github.com/vivekchand/clawmetry/issues/5266)",
         ]
     return "\n".join(out)
 


### PR DESCRIPTION
## Summary

`scripts/c6_required_checks_status.py` pointed its "Tracking" link at #4552 (a closed predecessor issue). The active E2E Robustness tracker is #5266. This updates the link -- no behaviour change.

## Why

When the C6 schedule-heal workflow runs and reports a missing required check, the "Tracking" link in the step summary now directs to the live tracker where per-fire progress is recorded, rather than a closed duplicate.

## Test plan

- [x] No logic change -- diff is one URL string.
- [x] CI lint/workflow-YAML checks unchanged.

No-PRD: docs/link fix only.

Tracking: vivekchand/clawmetry#5266 (C6 criterion)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BKdwpSswMpcxrMRgQDR5d5)_