### PR TITLE
Harden CI: pin gate/guard/quarantine workflow actions to commit SHAs

### DIFF
--- a/.github/workflows/apply-required-checks.yml
+++ b/.github/workflows/apply-required-checks.yml
@@ -69,7 +69,7 @@ jobs:
     name: Apply required E2E status checks (C6)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Preview checks (dry run)
         if: github.event_name == 'workflow_dispatch' && github.event.inputs.confirm != 'APPLY'

--- a/.github/workflows/auth-bootstrap-guard.yml
+++ b/.github/workflows/auth-bootstrap-guard.yml
@@ -25,13 +25,13 @@ jobs:
       CLAWMETRY_HARD_BLOCK: '0'
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-python@v7
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.11"
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "20"
 

--- a/.github/workflows/auto-quarantine.yml
+++ b/.github/workflows/auto-quarantine.yml
@@ -36,11 +36,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: actions/setup-python@v7
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.11"
 

--- a/.github/workflows/c6-pr-gate.yml
+++ b/.github/workflows/c6-pr-gate.yml
@@ -64,7 +64,7 @@ jobs:
     timeout-minutes: 2
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # Read-only audit: verify clawmetry/main has the required E2E status
       # checks configured. The script detects the ghs_ GITHUB_TOKEN prefix,

--- a/.github/workflows/c6-schedule-heal.yml
+++ b/.github/workflows/c6-schedule-heal.yml
@@ -91,7 +91,7 @@ jobs:
     # was added. See PR #4553.
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Check for admin token
         id: pat-check

--- a/.github/workflows/e2e-gate.yml
+++ b/.github/workflows/e2e-gate.yml
@@ -51,7 +51,7 @@ jobs:
       # checkout while the logic was an inline heredoc, which needs nothing
       # from the working tree -- converting it to a script call silently broke
       # that assumption and the gate died with "No such file or directory".
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # The gate logic lives in scripts/e2e_gate.py so it can be unit-tested
       # (tests/test_e2e_gate.py) instead of only being exercised in anger on a

--- a/.github/workflows/harness-observability-audit.yml
+++ b/.github/workflows/harness-observability-audit.yml
@@ -46,13 +46,13 @@ jobs:
       HARNESS_DIR: ${{ github.workspace }}/.harness
     steps:
       - name: Checkout clawmetry (OSS)
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-python@v7
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.11"
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22"
 

--- a/.github/workflows/product-record-gate.yml
+++ b/.github/workflows/product-record-gate.yml
@@ -28,11 +28,11 @@ jobs:
     name: PR cites the product record that justified it
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v7
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.11"
 

--- a/.github/workflows/quarantine-sweep.yml
+++ b/.github/workflows/quarantine-sweep.yml
@@ -33,9 +33,9 @@ jobs:
     continue-on-error: true
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-python@v7
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.11"
 
@@ -127,7 +127,7 @@ jobs:
 
       - name: Upload sweep logs
         if: always() && steps.check.outputs.count != '0'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: quarantine-sweep-logs-${{ github.run_number }}
           path: |


### PR DESCRIPTION
## What

Continues the `PinnedDependencies` batches (after `ci.yml` #5275, `supply-chain.yml` #5276, the conformance/install/handoff set #5279, and the release pipeline #5281) with the nine PR-gate, guard and quarantine workflows. 17 refs, all 1:1 replacements of a floating major tag with the full commit SHA plus a version comment.

| action | pinned to |
|---|---|
| `actions/checkout@v7` | `3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1` |
| `actions/setup-python@v7` | `5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0` |
| `actions/setup-node@v7` | `820762786026740c76f36085b0efc47a31fe5020 # v7.0.0` |
| `actions/upload-artifact@v7` | `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1` |

Files: `apply-required-checks.yml`, `c6-pr-gate.yml`, `c6-schedule-heal.yml`, `e2e-gate.yml`, `product-record-gate.yml`, `auth-bootstrap-guard.yml`, `auto-quarantine.yml`, `quarantine-sweep.yml`, `harness-observability-audit.yml`.

## Why

A floating tag is mutable. Whoever controls the upstream repository can repoint `@v7` at a different commit, and the next run of these workflows fetches that commit with no change landing here and nothing to review. That is the Scorecard `PinnedDependencies` class.

These nine are worth doing as one batch because of what they are: they gate the merge queue, so they run against pull requests the repository does not control. A workflow that decides whether other changes may merge is a poor place to keep a mutable dependency.

## Why these four SHAs

They are not newly resolved — they are the values this repository already pins in `ci.yml`, `supply-chain.yml` and the release workflows from the four earlier batches, all of which are green on `main`. So this adds no upstream code that is not already running here; it makes these nine files agree with the ones already pinned, and keeps a single SHA per action across the repo so the next bump is one sweep.

## Risk

`uses:` values only. No `permissions:` block, step, trigger, matrix, runner or `run:` body is touched, and no action's version changes — only how it is addressed.

Verification:
- all 34 files under `.github/workflows/` re-parsed with `yaml.safe_load` after the edit;
- each changed file loaded as a structure and compared against its `HEAD` version with `uses:` values masked — the diff is empty, confirming the change is pins and nothing else;
- `git diff --stat` is 17 insertions / 17 deletions across 9 files.

## Not in this PR

Fifteen workflows still carry floating refs and belong in later batches, split by family. Three of them need a SHA that is not yet established anywhere in this repo and so want their own look rather than a sweep:

- `browserstack.yml` references `browserstack/github-actions/*@master` — a branch, not even a tag, so it is the weakest ref in the repo and deserves its own PR;
- `i18n-autotranslate.yml` / `i18n-docs-autotranslate.yml` use `peter-evans/create-pull-request@v8`, a third-party action that opens PRs;
- `overhead-bench.yml` / `windows-enterprise-tls.yml` pin `actions/setup-python@v6` and `supply-chain.yml` has one `github/codeql-action/upload-sarif@v3` left.

Also out of scope: `TokenPermissions` is now clean on this repo — all 34 workflows declare a top-level `permissions:` block — and no `run:` block interpolates `${{ github.event.* }}`.

## Product record

CI-only: every changed path is under `.github/`, which is exempt from the product-record gate.

No-PRD: CI/workflow-only change, all paths under `.github/` (gate-exempt).

---
_Generated by [Claude Code](https://claude.ai/code/session_015Uyc5F1U4k6AiufL2JEFz6)_