### PR TITLE
Harden CI: pin the remaining third-party actions to commit SHAs

### DIFF
--- a/.github/workflows/browserstack.yml
+++ b/.github/workflows/browserstack.yml
@@ -20,9 +20,9 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-python@v7
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.11"
 
@@ -41,13 +41,13 @@ jobs:
           done
 
       - name: Set up BrowserStack env
-        uses: browserstack/github-actions/setup-env@master
+        uses: browserstack/github-actions/setup-env@1ab56d9521ce20f4651bb5d9f3ef39c5ba54805a # master @ 2026-08-28
         with:
           username: ${{ secrets.BROWSERSTACK_USERNAME }}
           access-key: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
 
       - name: Start BrowserStack Local Tunnel
-        uses: browserstack/github-actions/setup-local@master
+        uses: browserstack/github-actions/setup-local@1ab56d9521ce20f4651bb5d9f3ef39c5ba54805a # master @ 2026-08-28
         with:
           local-testing: start
           local-identifier: clawmetry-${{ github.run_id }}
@@ -64,7 +64,7 @@ jobs:
 
       - name: Stop BrowserStack Local Tunnel
         if: always()
-        uses: browserstack/github-actions/setup-local@master
+        uses: browserstack/github-actions/setup-local@1ab56d9521ce20f4651bb5d9f3ef39c5ba54805a # master @ 2026-08-28
         with:
           local-testing: stop
           local-identifier: clawmetry-${{ github.run_id }}

--- a/.github/workflows/i18n-autotranslate.yml
+++ b/.github/workflows/i18n-autotranslate.yml
@@ -31,7 +31,7 @@ jobs:
       # Claude Code subscription token (from `claude setup-token`), NOT an Anthropic API key.
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 2  # need the previous en.json to detect CHANGED keys
 
@@ -42,7 +42,7 @@ jobs:
             echo "SKIP=1" >> "$GITHUB_ENV"
           fi
 
-      - uses: actions/setup-python@v7
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         if: env.SKIP != '1'
         with:
           python-version: '3.11'
@@ -68,7 +68,7 @@ jobs:
 
       - name: Open sync PR
         if: env.SKIP != '1'
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           branch: chore/i18n-autotranslate
           delete-branch: true

--- a/.github/workflows/i18n-docs-autotranslate.yml
+++ b/.github/workflows/i18n-docs-autotranslate.yml
@@ -27,7 +27,7 @@ jobs:
     env:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Guard - require Claude Code token
         run: |
@@ -36,7 +36,7 @@ jobs:
             echo "SKIP=1" >> "$GITHUB_ENV"
           fi
 
-      - uses: actions/setup-python@v7
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         if: env.SKIP != '1'
         with:
           python-version: '3.11'
@@ -61,7 +61,7 @@ jobs:
 
       - name: Open sync PR
         if: env.SKIP != '1'
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           branch: chore/i18n-docs-autotranslate
           delete-branch: true

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -157,6 +157,6 @@ jobs:
           path: scorecard-results.sarif
           retention-days: 30
       # Surfaces findings in the GitHub Security tab rather than only in logs.
-      - uses: github/codeql-action/upload-sarif@v3
+      - uses: github/codeql-action/upload-sarif@6f5948dfacef28e207b48d0905cf90c03365536d # v3.37.9
         with:
           sarif_file: scorecard-results.sarif


### PR DESCRIPTION
## What

The last `PinnedDependencies` batch that is not an `actions/`-org action. Six references across four files, each a 1:1 replacement of a mutable ref with the full commit SHA it resolves to today, plus a version comment.

| action | was | pinned to |
|---|---|---|
| `browserstack/github-actions/setup-env` | `@master` | `1ab56d9521ce20f4651bb5d9f3ef39c5ba54805a # master @ 2026-08-28` |
| `browserstack/github-actions/setup-local` (×2) | `@master` | `1ab56d9521ce20f4651bb5d9f3ef39c5ba54805a # master @ 2026-08-28` |
| `peter-evans/create-pull-request` (×2) | `@v8` | `5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1` |
| `github/codeql-action/upload-sarif` | `@v3` | `6f5948dfacef28e207b48d0905cf90c03365536d # v3.37.9` |

Files: `browserstack.yml`, `i18n-autotranslate.yml`, `i18n-docs-autotranslate.yml`, `supply-chain.yml`.

The four `actions/checkout@v7` / `actions/setup-python@v7` refs sitting in the same files are pinned in the same pass, to the SHAs this repository already uses in `ci.yml`, `supply-chain.yml` and the release workflows. That keeps one SHA per action across all 34 workflows, so the next bump stays a single sweep.

## Why this set, and why now

#5283 called these out as the batch that wanted its own look rather than a sweep, because unlike the earlier batches these are not first-party actions and three of them did not even resolve through a tag.

A branch ref is the weakest thing a workflow can depend on. `@master` is whatever BrowserStack pushed most recently — the code executed by the next run can change with nothing landing in this repository and nothing to review. `@v8` and `@v3` are floating major tags, repointable the same way, just more slowly. That is the Scorecard `PinnedDependencies` class, and it matters more here than for a first-party action because these are third-party repositories with their own release practices.

Two of the six are also unusually well-placed to do damage if the upstream ref moved: `peter-evans/create-pull-request` runs with the token that opens pull requests against this repository, and the BrowserStack steps receive `BROWSERSTACK_USERNAME` / `BROWSERSTACK_ACCESS_KEY`.

## Why these SHAs

Each was resolved directly from the upstream repository and then verified by fetching the commit:

- `peter-evans/create-pull-request` — `refs/tags/v8` is a lightweight tag pointing at the same commit as `v8.1.1`, so `@v8` resolves there today. Pinned to that commit and labelled with the concrete version.
- `github/codeql-action` — `refs/tags/v3` peels to the `v3.37.9` commit (`Merge pull request #4109 from github/backport-v3.37.9`). The v3 line is kept deliberately; #5158 proposes the 3→4 bump and that is its call to make, not this PR's.
- `browserstack/github-actions` — pinned to the current tip of `master` rather than to `v1.0.4`, because `master` is ahead of the last tag and moving to the tag would be a version rollback of unknown size, not a pin. Preserving today's behaviour is the point; the comment records what the SHA is so the next reader is not left guessing.

## Risk

`uses:` values only. No `permissions:` block, step, trigger, matrix, runner or `run:` body is touched, and no action's version changes — only how it is addressed.

Verification:
- all 34 files under `.github/workflows/` re-parsed with `yaml.safe_load` after the edit;
- each changed file loaded as a structure and compared against its `HEAD` version with `uses:` values masked — the diff is empty, confirming the change is pins and nothing else;
- each new SHA fetched from its upstream repository, confirming it is a real commit, with the commit subject matching the claimed version;
- `git diff --stat` is 12 insertions / 12 deletions across 4 files.

The `Action references resolve` job in `supply-chain.yml` re-checks all 23 references against the GitHub API on this PR, which is the authoritative check for this change.

## Where this leaves the repo

Every action reference in this repository that is not owned by the `actions/` org is now pinned to a commit SHA. `TokenPermissions` is clean — all 34 workflows declare a top-level `permissions:` block — and no `run:` block interpolates `${{ github.event.* }}`.

Remaining `PinnedDependencies` work is first-party only, and splits by version line rather than by family: fourteen workflows still on `actions/*@v7`, plus `actions/setup-python@v6` in `overhead-bench.yml` / `windows-enterprise-tls.yml`, `actions/cache@v6` in `oss-golden-path.yml` and `actions/upload-artifact@v4` in `overhead-bench.yml`.

## Product record

CI-only: every changed path is under `.github/`, which is exempt from the product-record gate.

No-PRD: CI/workflow-only change, all paths under `.github/` (gate-exempt).

---
_Generated by [Claude Code](https://claude.ai/code/session_01LMbwMnwYkoSjZ62Zo7J9ec)_