### PR TITLE
Harden CI: pin the remaining first-party actions to commit SHAs

### DIFF
--- a/.github/workflows/api-latency-smoke.yml
+++ b/.github/workflows/api-latency-smoke.yml
@@ -38,8 +38,8 @@ jobs:
       OPENCLAW_GATEWAY_TOKEN: ci-smoke-token
       CLAWMETRY_LOCAL_STORE_PATH: ${{ github.workspace }}/.smoke/clawmetry.duckdb
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-python@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.11"
 

--- a/.github/workflows/auto-deploy-cloud.yml
+++ b/.github/workflows/auto-deploy-cloud.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout OSS repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Get OSS version
         id: oss_version
@@ -80,7 +80,7 @@ jobs:
           echo "::warning::clawmetry==$V not on PyPI after wait; continuing (cloud CI will gate the merge)"
 
       - name: Checkout cloud repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: vivekchand/clawmetry-cloud
           token: ${{ secrets.CLOUD_REPO_PAT }}

--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -31,8 +31,8 @@ jobs:
     continue-on-error: true
 
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-python@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.11"
       - name: Install dependencies

--- a/.github/workflows/moat-keystone-drive-nightly.yml
+++ b/.github/workflows/moat-keystone-drive-nightly.yml
@@ -45,8 +45,8 @@ jobs:
       issues: write
 
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-python@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.11"
           cache: pip

--- a/.github/workflows/openclaw-boot.yml
+++ b/.github/workflows/openclaw-boot.yml
@@ -43,7 +43,7 @@ jobs:
     timeout-minutes: 5
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup OpenClaw
         id: openclaw
@@ -136,7 +136,7 @@ jobs:
 
       - name: Upload gateway logs on failure
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: openclaw-gateway-logs
           path: /tmp/openclaw-logs/

--- a/.github/workflows/oss-golden-path.yml
+++ b/.github/workflows/oss-golden-path.yml
@@ -42,16 +42,16 @@ jobs:
       CLAWMETRY_HARD_BLOCK: '0'
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-python@v7
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.11"
 
       # Cache the ~100 MB Playwright chromium binary so the download step
       # takes seconds rather than minutes on warm runners.
       - name: Cache Playwright browsers
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/ms-playwright
           key: playwright-chromium-${{ runner.os }}-${{ hashFiles('setup.py', 'requirements.txt') }}
@@ -300,7 +300,7 @@ jobs:
 
       - name: Upload JUnit test reports
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: junit-c1c5-${{ github.run_id }}
           path: /tmp/junit-*.xml
@@ -309,7 +309,7 @@ jobs:
 
       - name: Upload logs on failure
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: c1-c5-golden-path-logs
           path: |

--- a/.github/workflows/overhead-bench.yml
+++ b/.github/workflows/overhead-bench.yml
@@ -39,8 +39,8 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.11"
 
@@ -102,7 +102,7 @@ jobs:
           for name, cond in hg["conditions"].items():
               print(f"  hook {name:<12} +{cond['added_over_floor_p50_us'] / 1000:.0f} ms over floor")
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: overhead-${{ matrix.os }}
           path: overhead-*.json

--- a/.github/workflows/pr-screenshots.yml
+++ b/.github/workflows/pr-screenshots.yml
@@ -67,24 +67,24 @@ jobs:
     steps:
       # -- 1. Check out PR head ------------------------------------------------
       - name: Checkout PR head
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           path: head
 
       # -- 2. Check out PR base for "before" screenshots ----------------------
       - name: Checkout PR base
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.base.sha }}
           path: base
 
       # -- 3. Toolchains -------------------------------------------------------
-      - uses: actions/setup-python@v7
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.11"
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "20"
 
@@ -352,7 +352,7 @@ jobs:
       # -- 12. Belt + suspenders: upload PNGs as artefact ----------------------
       - name: Upload screenshots artefact
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: visual-diff-pr-${{ github.event.pull_request.number }}
           path: screenshots/

--- a/.github/workflows/sync-test.yml
+++ b/.github/workflows/sync-test.yml
@@ -37,9 +37,9 @@ jobs:
     name: Sync ${{ matrix.os }} / Python ${{ matrix.python }}
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-python@v7
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ matrix.python }}
 

--- a/.github/workflows/windows-enterprise-tls.yml
+++ b/.github/workflows/windows-enterprise-tls.yml
@@ -32,9 +32,9 @@ jobs:
     runs-on: windows-latest
     timeout-minutes: 25
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '3.13'
 

--- a/.github/workflows/zero-click-auth-e2e.yml
+++ b/.github/workflows/zero-click-auth-e2e.yml
@@ -44,13 +44,13 @@ jobs:
       CLAWMETRY_HARD_BLOCK: '0'
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-python@v7
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.11"
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "20"
 


### PR DESCRIPTION
## What

Pins the last 30 unpinned `actions/*` references across 11 workflows to full commit SHAs. This closes out the OpenSSF Scorecard **PinnedDependencies** work for every workflow that is not already covered by an open hardening PR.

A floating tag like `actions/checkout@v7` is a mutable pointer — whoever controls the tag controls what runs in CI. A commit SHA is immutable, so the workflow keeps running the reviewed code until someone deliberately bumps it.

## No version changes

Every SHA was resolved from the tag the workflow already floats on, so nothing is upgraded or downgraded:

| Reference | Pinned to | Tag |
|---|---|---|
| `actions/checkout@v7` | `3d3c42e5aac5ba805825da76410c181273ba90b1` | v7.0.1 |
| `actions/setup-python@v7` | `5fda3b95a4ea91299a34e894583c3862153e4b97` | v7.0.0 |
| `actions/setup-python@v6` | `ece7cb06caefa5fff74198d8649806c4678c61a1` | v6.3.0 |
| `actions/setup-node@v7` | `820762786026740c76f36085b0efc47a31fe5020` | v7.0.0 |
| `actions/upload-artifact@v7` | `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a` | v7.0.1 |
| `actions/upload-artifact@v4` | `ea165f8d65b6e75b540449e92b4886f43607fa02` | v4.6.2 |
| `actions/cache@v6` | `55cc8345863c7cc4c66a329aec7e433d2d1c52a9` | v6.1.0 |

Five of these seven SHAs are already pinned elsewhere in this repo, so the values are consistent with what has already been reviewed and merged.

## Files

`api-latency-smoke`, `auto-deploy-cloud`, `e2e-nightly`, `moat-keystone-drive-nightly`, `openclaw-boot`, `oss-golden-path`, `overhead-bench`, `pr-screenshots`, `sync-test`, `windows-enterprise-tls`, `zero-click-auth-e2e`.

## Scope / safety

- Diff is **30 insertions / 30 deletions, every one on a `uses:` line**. Verified mechanically.
- **No `permissions:` block is touched.** `auto-deploy-cloud` and `moat-keystone-drive-nightly` need write scopes and keep exactly the scopes they have today — this PR is pinning only, one concern.
- All 34 workflow files re-parsed with `yaml.safe_load` after the edit.
- `python3 scripts/check_action_refs.py` passes.

## Coordination

No overlap with the two open hardening PRs. #5283 and #5285 claim 13 workflow files between them; this PR takes the 11 they do not touch. Once all three land, every `uses:` reference in `.github/workflows/` is SHA-pinned.

`.github/` is exempt from the product-record gate, so no Factory record is cited.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XYG7PAMbVohpq1cGBcCUhc)_