### PR TITLE
Harden CI: read the ref from the runner env instead of expanding it into run: blocks

### DIFF
--- a/.github/workflows/desktop-artifacts.yml
+++ b/.github/workflows/desktop-artifacts.yml
@@ -49,7 +49,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/v') && env.HAS_SIGN != 'true'
         shell: bash
         run: |
-          echo "::error::${{ github.ref_name }} would ship an UNSIGNED macOS build. Set MACOS_SIGN_IDENTITY + MACOS_CERT_P12_BASE64."
+          echo "::error::${GITHUB_REF_NAME} would ship an UNSIGNED macOS build. Set MACOS_SIGN_IDENTITY + MACOS_CERT_P12_BASE64."
           exit 1
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
@@ -276,7 +276,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/v') && env.HAS_AZ_SIGN != 'true' && env.HAS_WIN_CERT != 'true'
         shell: bash
         run: |
-          echo "::error::${{ github.ref_name }} would ship an UNSIGNED Windows build. Set AZURE_CLIENT_ID + AZ_SIGN_PROFILE (Artifact Signing) or WINDOWS_CERT_PFX_BASE64."
+          echo "::error::${GITHUB_REF_NAME} would ship an UNSIGNED Windows build. Set AZURE_CLIENT_ID + AZ_SIGN_PROFILE (Artifact Signing) or WINDOWS_CERT_PFX_BASE64."
           exit 1
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
@@ -293,8 +293,8 @@ jobs:
       - name: Stamp bundle version
         shell: pwsh
         run: |
-          $refName = "${{ github.ref_name }}"
-          if ("${{ github.ref_type }}" -eq "tag") {
+          $refName = $Env:GITHUB_REF_NAME
+          if ($Env:GITHUB_REF_TYPE -eq "tag") {
             $version = $refName.Substring(1)
           } else {
             $version = (Select-String -Path dashboard.py -Pattern '__version__ = "(.+?)"').Matches.Groups[1].Value


### PR DESCRIPTION
## What

A `${{ ... }}` expression inside a `run:` block is substituted into the script *before* the shell parses it, so whatever it holds becomes shell **source text** rather than a value. `desktop-artifacts.yml` had four such expansions of `github.ref_name` / `github.ref_type`, across three steps. All four now read the value from the runner environment instead.

| Job | Step | Was | Now |
|---|---|---|---|
| macOS | Require signing on release tags | `${{ github.ref_name }}` | `${GITHUB_REF_NAME}` |
| Windows | Require signing on release tags | `${{ github.ref_name }}` | `${GITHUB_REF_NAME}` |
| Windows | Stamp bundle version (pwsh) | `${{ github.ref_name }}` | `$Env:GITHUB_REF_NAME` |
| Windows | Stamp bundle version (pwsh) | `${{ github.ref_type }}` | `$Env:GITHUB_REF_TYPE` |

## Why this shape

This file had already established the right pattern — it just wasn't applied consistently. The **macOS and Linux** `Stamp bundle version` steps read `${GITHUB_REF_TYPE}` and `${GITHUB_REF_NAME}` straight from the runner environment, with no template expansion at all. The Windows job and the two signing gates were the outliers, so this PR converges them on the convention already in the file rather than introducing new `env:` bindings.

`GITHUB_REF_NAME` and `GITHUB_REF_TYPE` are default GitHub Actions environment variables, set on every runner including Windows. So no `env:` block is required, and the resolved values are identical to what the expansions produced.

The `if:` conditions at lines 49, 276 and 679 use `github.ref` in a **conditional**, not a `run:` block. Those are evaluated by the Actions expression engine and never reach a shell, so they are correct as-is and are untouched.

## Verification

- **zizmor 1.29.0** (the version this repo's tooling uses) over `.github/workflows/`, `main` vs branch, same binary and invocation:
  - High-severity `template-injection`: **4 → 0**
  - Every other rule count **unchanged**: `unpinned-uses` 30, `artipacked` 48 Medium / 13 Low, informational `template-injection` 29, `adhoc-packages` 5, `misfeature` 3, `dangerous-triggers` 2, `excessive-permissions` 2, `cache-poisoning` 1, Medium `template-injection` 1. Total 140 → 136.
- **actionlint 1.7.7** (which runs shellcheck over every `run:` block): exit 0 on both `main` and this branch.
- All **34** workflow files re-parsed with `yaml.safe_load` after the edit.
- `python3 scripts/check_action_refs.py` passes (23 distinct action references).

## Scope / safety

- Diff is **6 lines, every one inside a `run:` block**.
- **No `permissions:` block is touched.** `desktop-artifacts` is one of the workflows that needs write scopes to publish release assets, and it keeps exactly the scopes it has today — this PR is expression-binding only, one concern.
- No trigger, step, job or action version changed.

## Coordination

No overlap with open hardening PR #5294, which pins actions across 11 other workflow files and does not touch `desktop-artifacts.yml`. This file's `uses:` references are already SHA-pinned from an earlier batch.

## Not in this PR

Left for their own batches, one concern per PR:

- `unpinned-uses` (30) — covered by #5294, currently open and green.
- `artipacked` (61) — `actions/checkout` without `persist-credentials: false`.
- Informational `template-injection` (29) — these expand `steps.*.outputs.*`, an internally-derived value, and are a separate concern from ref-derived input.
- `excessive-permissions` (2), `dangerous-triggers` (2), `cache-poisoning` (1).

`.github/` is exempt from the product-record gate, so no Factory record is cited.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UYeD7Hs9edpH86kLibimqS)_