### PR TITLE
Harden CI: pass setup-openclaw inputs through env instead of into the script

### DIFF
--- a/.github/actions/setup-openclaw/action.yml
+++ b/.github/actions/setup-openclaw/action.yml
@@ -51,18 +51,24 @@ runs:
           ~/.npm-openclaw-global
         key: openclaw-${{ runner.os }}-${{ inputs.version }}-v1
 
+    # `version` is supplied by the calling workflow, so it reaches the shell
+    # through the environment and is referenced as a quoted variable rather
+    # than being expanded into the script text by the expression evaluator.
     - name: Install OpenClaw (npm -g)
       shell: bash
+      env:
+        OPENCLAW_VERSION: ${{ inputs.version }}
+        OPENCLAW_CACHE_HIT: ${{ steps.cache.outputs.cache-hit }}
       run: |
         set -e
         PREFIX="$HOME/.npm-openclaw-global"
         mkdir -p "$PREFIX"
         npm config set prefix "$PREFIX"
         echo "$PREFIX/bin" >> "$GITHUB_PATH"
-        if [ "${{ steps.cache.outputs.cache-hit }}" = "true" ] && [ -x "$PREFIX/bin/openclaw" ]; then
+        if [ "$OPENCLAW_CACHE_HIT" = "true" ] && [ -x "$PREFIX/bin/openclaw" ]; then
           echo "openclaw cache hit, skipping install"
         else
-          npm install -g --no-audit --no-fund "openclaw@${{ inputs.version }}"
+          npm install -g --no-audit --no-fund "openclaw@$OPENCLAW_VERSION"
         fi
 
     - name: Verify openclaw on PATH
@@ -78,9 +84,25 @@ runs:
 
     - name: Export OPENCLAW_GATEWAY_TOKEN for downstream steps
       shell: bash
+      env:
+        OPENCLAW_GATEWAY_TOKEN_INPUT: ${{ inputs.gateway-token }}
       run: |
+        set -e
         # Downstream workflow steps read this to authenticate dashboard
         # requests against the running gateway. Empty token = dashboard
         # falls back to anon mode (which is why "the screenshots are
         # always broken" today: no token, no authed screens).
-        echo "OPENCLAW_GATEWAY_TOKEN=${{ inputs.gateway-token }}" >> "$GITHUB_ENV"
+        #
+        # The value comes from the caller, so it is passed through the
+        # environment instead of being expanded into this script. $GITHUB_ENV
+        # is line-oriented: a newline in the value would define extra
+        # variables for every later step in the job, so reject one loudly
+        # rather than write it. The input is documented as a single token.
+        case "$OPENCLAW_GATEWAY_TOKEN_INPUT" in
+          *$'\n'*|*$'\r'*)
+            echo "::error::setup-openclaw: gateway-token must be a single line"
+            exit 1
+            ;;
+        esac
+        printf 'OPENCLAW_GATEWAY_TOKEN=%s\n' \
+          "$OPENCLAW_GATEWAY_TOKEN_INPUT" >> "$GITHUB_ENV"


### PR DESCRIPTION
Continues the CI hardening series. One concern, one file: `.github/actions/setup-openclaw/action.yml`.

This is the last place in the repo where a caller-supplied `inputs.*` value was expanded into a `run:` block. After the recent pinning and token-scope PRs, `.github/` now has zero `inputs.*` interpolations inside `run:`.

## What changed

The shared `setup-openclaw` composite action expanded three values directly into its `run:` blocks, so each became part of the script text before bash ever saw it:

| Value | Where it landed |
|---|---|
| `inputs.version` | the `npm install -g` argument |
| `inputs.gateway-token` | the line appended to `$GITHUB_ENV` |
| `steps.cache.outputs.cache-hit` | a `[ ... = "true" ]` test |

All three now reach the shell through `env:` and are referenced as quoted shell variables — the documented safe pattern, and the same one PRs #5246, #5249, #5251 and #5295 applied to the workflows.

The token step additionally rejects a multi-line value with a clear `::error::` instead of writing it. `$GITHUB_ENV` is line-oriented, so a newline in that value would define extra environment variables for every later step in the job. The input is documented as a single token, so failing loudly is the honest behaviour.

## Why this action in particular

It is shared, not local: six workflows call it — `ci`, `e2e-nightly`, `openclaw-boot`, `pr-screenshots`, `oss-golden-path`, `moat-keystone-drive-nightly` — so one fix covers all six call sites. `pr-screenshots` is the one that passes a secret-backed value (`CLAWMETRY_VISUAL_DIFF_TOKEN`) as `gateway-token`.

## Verification

- Every workflow and action file re-parsed: `python3 -c "import yaml,glob; [yaml.safe_load(open(f)) for f in glob.glob('.github/workflows/*.yml')]"`, plus the same over `*.yaml` and `.github/actions/**`. All parse.
- Repo-wide re-scan of `run:` blocks for `inputs.*` interpolation: **0 remaining** (was 2, both in this file).
- Both rewritten steps simulated in bash. A normal token (`ci-openclaw-token`) and one containing spaces, quotes and backticks are both written to `$GITHUB_ENV` verbatim and unexpanded; a value containing a newline exits 1 with the error rather than writing a second variable. A version string containing shell metacharacters stays a single inert `npm` argument.

## No behaviour change for callers

All six callers keep passing exactly the same values, and the action's `version` output and exported `OPENCLAW_GATEWAY_TOKEN` are unchanged for every value any of them passes today.

## Not in this PR

Two lower-priority classes remain in `.github/`, each its own batch:

- `${{ github.event_name }}` in two workflows — a GitHub-controlled enum, not caller-influenced.
- `${{ steps.*.outputs.* }}` in `run:` blocks across ~7 workflows — values produced by earlier steps in the same job rather than by a caller.

## Scope

`.github/` only, which is exempt from the product-record CI gate.

No-PRD: CI/workflow hardening only, no product surface touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KukCwqqjmm2pkomzHtu2Wm)_