### PR TITLE
Harden CI: grant issues:write only to the job that opens issues

### DIFF
--- a/.github/workflows/conformance-heartbeat.yml
+++ b/.github/workflows/conformance-heartbeat.yml
@@ -40,9 +40,11 @@ concurrency:
   group: conformance-heartbeat-${{ github.event.schedule || inputs.scope }}
   cancel-in-progress: false
 
+# Six of the seven jobs below only read: they install the published wheel and
+# run it. Only `alarm` writes, and only to file the heartbeat issue, so
+# `issues: write` is granted on that job instead of to the whole workflow.
 permissions:
   contents: read
-  issues: write
 
 jobs:
   # ---------------------------------------------------------------------
@@ -230,6 +232,11 @@ jobs:
     needs: [pypi-install, pypi-install-3os, installers, installers-windows, matrix-report]
     if: always() && contains(needs.*.result, 'failure')
     runs-on: ubuntu-latest
+    # The only job that writes. `gh issue list` reads before it writes, so
+    # keep read alongside the write it actually needs.
+    permissions:
+      contents: read
+      issues: write
     steps:
       - name: File or update the alarm issue
         env:

--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -35,9 +35,11 @@ concurrency:
   group: release-canary
   cancel-in-progress: false
 
+# `wait-for-propagation` and `canary` only check out the repo and install from
+# PyPI. Only `alarm` writes, and only to open the P0 issue, so `issues: write`
+# is granted on that job instead of to the whole workflow.
 permissions:
   contents: read
-  issues: write
 
 jobs:
   wait-for-propagation:
@@ -150,6 +152,11 @@ jobs:
     needs: [wait-for-propagation, canary]
     if: always() && contains(needs.*.result, 'failure')
     runs-on: ubuntu-latest
+    # The only job that writes. `gh issue list` reads before it writes, so
+    # keep read alongside the write it actually needs.
+    permissions:
+      contents: read
+      issues: write
     steps:
       - name: Open a P0 issue with the decision and the link
         env:


### PR DESCRIPTION
## What

`conformance-heartbeat.yml` and `release-canary.yml` each declared `issues: write` at the **workflow** level, so every job in them ran with a token that could write issues — even though only one job in each ever does.

This moves the scope to where it is used:

| workflow | before | after |
|---|---|---|
| `conformance-heartbeat.yml` | top-level `contents: read` + `issues: write` (7 jobs) | top-level `contents: read`; `alarm` job adds `issues: write` |
| `release-canary.yml` | top-level `contents: read` + `issues: write` (3 jobs) | top-level `contents: read`; `alarm` job adds `issues: write` |

## Why each scope is what it is

- **Top level `contents: read`** — the reading jobs check out the repo (`installers`, `installers-windows`, `matrix-report`, `wait-for-propagation`, `canary`) or only install the published wheel from PyPI (`pypi-install`, `pypi-install-3os`, `scope`). None of them touches the issues API.
- **`alarm` job: `contents: read` + `issues: write`** — this is the only job that runs `gh issue`. It calls `gh issue list` before `gh issue create` / `gh issue comment`, so it keeps read alongside the write it needs. A job-level `permissions:` block sets every unlisted scope to `none`, so read is stated explicitly rather than inherited.

Neither workflow pushes tags, publishes, or deploys, and no write scope that was in use has been removed — `alarm` still files and updates its issue in both workflows.

## Verification

- Every workflow file still parses: `python3 -c "import yaml,glob; [yaml.safe_load(open(f)) for f in glob.glob('.github/workflows/*.yml')]"`.
- Structural check of the parsed YAML: in both files, the only job carrying `issues: write` is the only job whose steps run `gh issue`.
- `zizmor --persona regular .github/workflows/` — both `excessive-permissions` findings (High severity, High confidence) are gone; no new finding of any severity is introduced.

No-PRD: CI-only change confined to `.github/workflows/`, which is exempt from the product-record gate.

---
_Generated by [Claude Code](https://claude.ai/code/session_017snjUVn3xFAYfcH32Y6Xr2)_