### PR TITLE
fix: fall back to sandbox exec for container gateway log (#5291)

### DIFF
--- a/clawmetry/adapters/openclaw.py
+++ b/clawmetry/adapters/openclaw.py
@@ -751,11 +751,18 @@ def _openshell_sandbox_logs(name: str, count: int = 20) -> list:
     Arms OCSF output first (idempotent settings set), then calls
     ``openshell logs <name> -n <count> --source all``.  For container-backed
     (non-terminal) sandboxes also merges the last ``count`` lines from the
-    OpenClaw gateway log at ``/tmp/gateway.log`` (override with
-    ``OPENSHELL_GATEWAY_LOG``), matching the harness's two-source merge in
-    ``showSandboxLogsWithDeps`` (#3571).  Returns a list of parsed OCSF event
-    dicts; silently drops non-JSON lines.  Never raises; returns ``[]`` when
-    openshell is absent or any call fails.
+    OpenClaw gateway log, matching the harness's two-source merge in
+    ``showSandboxLogsWithDeps`` (#3571).
+
+    Gateway log resolution order for non-terminal sandboxes:
+    1. ``OPENSHELL_GATEWAY_LOG`` env override (for testing / explicit override).
+    2. Host-side rotating log files found by ``_gateway_log_files()``.
+    3. ``openshell sandbox exec -n <name> -- tail -n <count> /tmp/gateway.log``
+       — the fallback for genuinely container-backed sandboxes where the
+       gateway writes its log inside the container, not on the host (#5291).
+
+    Returns a list of parsed OCSF event dicts; silently drops non-JSON lines.
+    Never raises; returns ``[]`` when openshell is absent or any call fails.
     """
     try:
         import shutil as _sh

--- a/clawmetry/adapters/openclaw.py
+++ b/clawmetry/adapters/openclaw.py
@@ -806,6 +806,26 @@ def _openshell_sandbox_logs(name: str, count: int = 20) -> list:
                             pass
                 except OSError:
                     pass
+            elif not _gw_log_override:
+                # No host-side log found and no explicit override: the gateway log
+                # lives inside the container.  Read it via `sandbox exec`, which is
+                # exactly what the harness does in showSandboxLogsWithDeps (#5291).
+                try:
+                    _exec_res = _sp.run(
+                        ["openshell", "sandbox", "exec", "-n", name, "--",
+                         "tail", "-n", str(count), "/tmp/gateway.log"],
+                        capture_output=True, text=True, timeout=10,
+                    )
+                    for _exec_line in (_exec_res.stdout or "").splitlines():
+                        _exec_line = _exec_line.strip()
+                        if not _exec_line:
+                            continue
+                        try:
+                            events.append(json.loads(_exec_line))
+                        except Exception:
+                            pass
+                except Exception:
+                    pass
         return events
     except Exception:
         return []

--- a/tests/test_obs_gap_nemoclaw_container_exec_5291.py
+++ b/tests/test_obs_gap_nemoclaw_container_exec_5291.py
@@ -1,0 +1,146 @@
+"""Tests for #5291 — NemoClaw: container-backed sandbox gateway log read via
+sandbox exec when no host-side log is available.
+
+For container-backed (non-terminal) sandboxes the gateway writes its log to
+/tmp/gateway.log *inside* the container.  Host-side globs (_gateway_log_files)
+return nothing, so _openshell_sandbox_logs must fall back to
+`openshell sandbox exec -n <name> -- tail -n N /tmp/gateway.log`, matching the
+harness's showSandboxLogsWithDeps approach.
+
+Fingerprint: hgap-f28fbe6633
+"""
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+
+import pytest
+
+from clawmetry.adapters.openclaw import _openshell_sandbox_logs
+
+
+def _fake_run_factory(*, ocsf_stdout="", runtime_kind="container", exec_stdout=""):
+    """Return a fake subprocess.run serving openshell mock responses."""
+    def fake_run(cmd, **kw):
+        words = [str(c) for c in cmd]
+        if "sandbox" in words and "get" in words:
+            return type("R", (), {"stdout": f"Runtime: {runtime_kind}\n"})()
+        if "sandbox" in words and "exec" in words:
+            return type("R", (), {"stdout": exec_stdout})()
+        if "logs" in words and "--source" in words:
+            return type("R", (), {"stdout": ocsf_stdout})()
+        return type("R", (), {"stdout": ""})()
+    return fake_run
+
+
+def test_container_no_host_log_uses_sandbox_exec(monkeypatch):
+    """Container sandbox + no host log → sandbox exec output ingested."""
+    monkeypatch.setattr(shutil, "which", lambda _: "/usr/bin/openshell")
+    monkeypatch.delenv("OPENSHELL_GATEWAY_LOG", raising=False)
+
+    from clawmetry.adapters import openclaw as _oc
+    monkeypatch.setattr(_oc, "_gateway_log_files", lambda: [])
+
+    gw_event = {"ts": 1700000010, "msg": "container-gateway startup"}
+    exec_out = json.dumps(gw_event) + "\n"
+
+    monkeypatch.setattr(subprocess, "run", _fake_run_factory(exec_stdout=exec_out))
+
+    result = _openshell_sandbox_logs("container-sandbox")
+    assert gw_event in result
+
+
+def test_container_exec_non_json_lines_dropped(monkeypatch):
+    """sandbox exec output with non-JSON lines is silently skipped."""
+    monkeypatch.setattr(shutil, "which", lambda _: "/usr/bin/openshell")
+    monkeypatch.delenv("OPENSHELL_GATEWAY_LOG", raising=False)
+
+    from clawmetry.adapters import openclaw as _oc
+    monkeypatch.setattr(_oc, "_gateway_log_files", lambda: [])
+
+    valid = {"ts": 1700000011, "msg": "ok"}
+    exec_out = "not-json\n[INFO] gateway\n" + json.dumps(valid) + "\n"
+
+    monkeypatch.setattr(subprocess, "run", _fake_run_factory(exec_stdout=exec_out))
+
+    result = _openshell_sandbox_logs("container-sandbox")
+    assert valid in result
+    assert len(result) == 1
+
+
+def test_host_log_present_sandbox_exec_not_called(monkeypatch, tmp_path):
+    """When a host-side log IS found, sandbox exec is never invoked."""
+    monkeypatch.setattr(shutil, "which", lambda _: "/usr/bin/openshell")
+    monkeypatch.delenv("OPENSHELL_GATEWAY_LOG", raising=False)
+
+    gw_log = tmp_path / "openclaw-2026-01-01.log"
+    host_event = {"ts": 1700000020, "msg": "host-gateway"}
+    gw_log.write_text(json.dumps(host_event) + "\n")
+
+    from clawmetry.adapters import openclaw as _oc
+    monkeypatch.setattr(_oc, "_gateway_log_files", lambda: [str(gw_log)])
+
+    exec_called = []
+
+    def fake_run(cmd, **kw):
+        words = [str(c) for c in cmd]
+        if "exec" in words:
+            exec_called.append(True)
+        if "sandbox" in words and "get" in words:
+            return type("R", (), {"stdout": "Runtime: container\n"})()
+        return type("R", (), {"stdout": ""})()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    result = _openshell_sandbox_logs("container-sandbox")
+    assert host_event in result
+    assert not exec_called, "sandbox exec must not be called when host log is present"
+
+
+def test_openshell_gateway_log_set_sandbox_exec_not_called(monkeypatch, tmp_path):
+    """OPENSHELL_GATEWAY_LOG override set (even if missing) → exec not called."""
+    monkeypatch.setattr(shutil, "which", lambda _: "/usr/bin/openshell")
+    monkeypatch.setenv("OPENSHELL_GATEWAY_LOG", "/nonexistent/gateway.log")
+
+    from clawmetry.adapters import openclaw as _oc
+    monkeypatch.setattr(_oc, "_gateway_log_files", lambda: [])
+
+    exec_called = []
+
+    def fake_run(cmd, **kw):
+        words = [str(c) for c in cmd]
+        if "exec" in words:
+            exec_called.append(True)
+        if "sandbox" in words and "get" in words:
+            return type("R", (), {"stdout": "Runtime: container\n"})()
+        return type("R", (), {"stdout": ""})()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    result = _openshell_sandbox_logs("container-sandbox")
+    assert not exec_called, "sandbox exec must not be called when OPENSHELL_GATEWAY_LOG is set"
+
+
+def test_terminal_sandbox_exec_not_called(monkeypatch):
+    """Terminal sandboxes never trigger sandbox exec (gateway block skipped)."""
+    monkeypatch.setattr(shutil, "which", lambda _: "/usr/bin/openshell")
+    monkeypatch.delenv("OPENSHELL_GATEWAY_LOG", raising=False)
+
+    from clawmetry.adapters import openclaw as _oc
+    monkeypatch.setattr(_oc, "_gateway_log_files", lambda: [])
+
+    exec_called = []
+
+    def fake_run(cmd, **kw):
+        words = [str(c) for c in cmd]
+        if "exec" in words:
+            exec_called.append(True)
+        if "sandbox" in words and "get" in words:
+            return type("R", (), {"stdout": "Runtime: terminal\n"})()
+        return type("R", (), {"stdout": ""})()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    _openshell_sandbox_logs("term-sandbox")
+    assert not exec_called


### PR DESCRIPTION
## Summary

For container-backed (non-terminal) NemoClaw sandboxes, `_openshell_sandbox_logs()` was silently missing gateway JSONL events because it only globs host-side log paths — but a containerised gateway writes to `/tmp/gateway.log` *inside* the container, unreachable from the host filesystem. This adds a fallback that runs `openshell sandbox exec -n <name> -- tail -n N /tmp/gateway.log` when no host-side log is found and no `OPENSHELL_GATEWAY_LOG` override is set, matching exactly what the harness does in `showSandboxLogsWithDeps`.

No-PRD: bug fix restoring data that should already be collected — automated harness-gap issue #5291, no new user-visible product behaviour introduced.

## Changes

- `clawmetry/adapters/openclaw.py` — add `elif not _gw_log_override:` branch after the host-side log block in `_openshell_sandbox_logs()`; runs `sandbox exec` to read the container-internal `/tmp/gateway.log` and parses its JSONL output into events
- `tests/test_obs_gap_nemoclaw_container_exec_5291.py` — 5 new tests covering: exec path invoked when no host log; non-JSON exec lines dropped; host log present → exec not called; `OPENSHELL_GATEWAY_LOG` set → exec not called (override respected); terminal sandbox → exec not called

## Test plan

- [x] `python3 -m pytest tests/test_obs_gap_nemoclaw_container_exec_5291.py -q` — 5 passed
- [x] `python3 -m pytest tests/test_obs_gap_nemoclaw_gateway_log_3571.py -q` — 7 passed (no regression)
- [x] `python3 -c 'import ast; ast.parse(open("clawmetry/adapters/openclaw.py").read())'` — clean

## Bot meta

<!-- bot-autofix -->
Draft PR opened autonomously based on the plan in #5291. Marked draft for human review — mark Ready for Review once happy.

Closes #5291