### PR TITLE
Stamp tool_call_count on family cloud session rows (hosted Autonomy unlock)

### DIFF
--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -14344,6 +14344,31 @@ def _session_compression_potential(events, model: str = "", min_chars: int = 400
     return out
 
 
+def _session_tool_call_count(events) -> int:
+    """Tool EXECUTIONS in this session, from the adapter events in hand.
+
+    Carried to the cloud on the session row so hosted Autonomy (deep
+    sessions = 10+ tool calls) can score without the events table, which
+    never syncs. Counts calls, not results, mirroring the Pro engine's
+    "tool executions" semantics; a result-shaped event (type contains
+    "result") is skipped even when it names a tool. Never raises.
+    """
+    n = 0
+    try:
+        for e in events:
+            et = (getattr(e, "type", "") or "").lower()
+            if "result" in et:
+                continue
+            calls = getattr(e, "tool_calls", None)
+            if isinstance(calls, (list, tuple)) and calls:
+                n += len(calls)
+            elif calls or getattr(e, "tool_name", ""):
+                n += 1
+    except Exception:
+        return n
+    return n
+
+
 def _session_idle_gaps(events, ttl_sec: int = 300) -> dict:
     """Count idle gaps that crossed the prompt-cache TTL. Anthropic's cache
     expires after ~5 minutes, so every consecutive-event gap longer than that
@@ -14842,6 +14867,12 @@ def sync_family_runtimes(config: dict, state: dict, paths: dict) -> int:
                     # Only the dedicated key: metadata["source"] is already used
                     # by other adapters for cwd paths and provider names.
                     "surface": metadata.get("surface") or "",
+                    # Tool executions on the row so hosted Autonomy (deep
+                    # sessions = 10+ tool calls) can score without the events
+                    # table, which never syncs. None (not 0) when no events
+                    # were readable, so blind never looks like zero.
+                    "tool_call_count": (
+                        _session_tool_call_count(_events) if _events else None),
                 })
                 # Events → transcript (rides the existing _build_transcripts path).
                 # Re-ingest the full event set for sessions that advanced (the

--- a/tests/test_family_runtime_ingest.py
+++ b/tests/test_family_runtime_ingest.py
@@ -294,3 +294,41 @@ def test_family_sessions_persist_cwd_from_metadata(sync_with_isolated_store):
     assert sync._session_cwd({"cwd": "/proj/demo"}) == "/proj/demo"             # pi
     assert sync._session_cwd({"metadata": {"workingDir": "/x"}}) == "/x"        # nested
     assert sync._session_cwd({"displayName": "n"}) is None
+
+
+def test_session_tool_call_count_counts_calls_not_results():
+    """tool_call_count rides the cloud session row so hosted Autonomy can
+    score deep sessions (10+ tool calls) without the events table, which
+    never syncs. Calls count; results do not; absent events stay None."""
+    from clawmetry.sync import _session_tool_call_count
+
+    class _E:
+        def __init__(self, type="", tool_name="", tool_calls=None):
+            self.type = type
+            self.tool_name = tool_name
+            self.tool_calls = tool_calls
+
+    events = [
+        _E(type="tool_call", tool_name="Bash"),
+        _E(type="TOOL_CALL", tool_calls=[{"name": "Read"}, {"name": "Grep"}]),
+        _E(type="tool_result", tool_name="Bash"),   # result: not an execution
+        _E(type="message"),                          # no tool at all
+    ]
+    assert _session_tool_call_count(events) == 3
+    assert _session_tool_call_count([]) == 0
+
+
+def test_family_cloud_row_carries_tool_call_count():
+    """Source guard: the family cloud session row names tool_call_count so a
+    refactor cannot silently drop the field the hosted Autonomy score reads.
+    (Pairs the present-thing grep with the ingest allowlist on the cloud.)"""
+    import inspect
+    import clawmetry.sync as _sync
+
+    src = inspect.getsource(_sync)
+    anchor = src.index('"surface": metadata.get("surface") or ""')
+    window = src[anchor:anchor + 600]
+    assert '"tool_call_count"' in window, (
+        "family cloud_session_rows no longer carries tool_call_count; "
+        "hosted Autonomy goes blind without it"
+    )


### PR DESCRIPTION
Events never sync to cloud, so hosted Autonomy was structurally blind (honestly labeled since cloud#2166, but blind). The family ingest already reads each session's events; this counts tool executions (calls, not results — mirrors the Pro engine's deep-session semantics) and carries `tool_call_count` on the cloud session row beside the cost-intel keys. `None`, never `0`, when events were unreadable.

Pairs with clawmetry-cloud#2170 (ingest allowlist + bundle lift) and clawmetry-pro 0.7.18 (engine reads row-level tool counts).

Tests in `tests/test_family_runtime_ingest.py` (already in the CI moat list): call-vs-result counting semantics + a source guard so a refactor can't silently drop the field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014cCdbTmcRyx4TqdCBDmoK7

## Product record

Justified and designed in the Insights Leader blueprint (updated 2026-08-28 with the People-lens restructure and the row-level Autonomy contract):
https://factory.8090.ai/project/b415065f-ab2f-4f53-8864-0c009fd098cb/blueprints/28e14f03-ff56-4be8-9db9-85e812006371
