### PR TITLE
Harden CI: stop ci.yml checkouts persisting the job credential

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.9"
@@ -270,6 +272,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ matrix.python-version }}
@@ -334,6 +338,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.11"
@@ -401,6 +407,8 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.11"
@@ -427,6 +435,8 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.11"
@@ -459,6 +469,8 @@ jobs:
     timeout-minutes: 3
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.11"
@@ -486,6 +498,8 @@ jobs:
     timeout-minutes: 6
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.11"
@@ -546,6 +560,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.11"
@@ -639,6 +655,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.11"
@@ -735,6 +753,8 @@ jobs:
             python-version: "3.9"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ matrix.python-version }}
@@ -784,6 +804,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.11"
@@ -876,6 +898,8 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.11"
@@ -966,6 +990,8 @@ jobs:
     continue-on-error: true
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.11"


### PR DESCRIPTION
`actions/checkout` leaves the token it used in `.git/config` unless told otherwise. Every later step in that job can then read it, and any step that archives the workspace carries it off the runner. All **13 checkouts in `ci.yml`** now pass `persist-credentials: false`.

This is the same change, and the same reasoning, that landed on `clawmetry-cloud` in #2168; the OSS copy was left behind. It clears all 13 of the `artipacked` findings zizmor reports against this file.

No-PRD: CI-only change, confined to `.github/workflows/ci.yml` (exempt path).

## Why it is safe here

No job in `ci.yml` makes an authenticated git call at all. Verified against the file:

- **zero `git` invocations** and **zero `gh` calls** anywhere in the workflow
- **no step reads `GITHUB_TOKEN`** — the only secrets referenced are `ANTHROPIC_API_KEY` / `CI_ANTHROPIC_API_KEY`, which the job token does not govern
- **no submodules and no LFS**, both of which would need the credential to remain in place
- the three `upload-artifact` steps publish single named files (a JUnit XML, an `eval-result.json`, a log directory) rather than the workspace, so the leftover credential had no path off the runner today

The workflow's own header already documents this contract — *"Nothing calls the GitHub API with GITHUB_TOKEN, pushes a commit, tags, comments on a PR or touches a Release"* — which is also why it already runs on a top-level `permissions: contents: read`. That block is unchanged by this PR.

So this removes a standing copy of the credential, not a live leak. Defence in depth: it means a future step added to any of these 13 jobs cannot pick the token up by accident.

## Verification

**zizmor 1.29.0 `--persona regular`, base vs branch:**

| rule | base | branch |
|---|---|---|
| `artipacked` | 61 | **48** |
| adhoc-packages | 5 | 5 |
| cache-poisoning | 1 | 1 |
| dangerous-triggers | 2 | 2 |
| misfeature | 3 | 3 |
| template-injection | 30 | 30 |
| superfluous-actions | 1 | 1 |
| use-trusted-publishing | 1 | 1 |

13 fixed, **0 `artipacked` remaining in `ci.yml`**, and every other rule count unchanged — no collateral.

- `actionlint` 1.7.7: **0 errors**
- `yaml.safe_load` over all **35** workflow + composite-action files: all parse
- **Structural diff:** with `persist-credentials` stripped back out, the parsed document is identical to `origin/main` — triggers, permissions, job names and per-job step counts all unchanged

YAML only: 26 added lines, no deletions. No step, trigger, permission or action version changed.

## Scope

Deliberately one file. The remaining 48 `artipacked` findings span 31 other workflows, several of which *do* push commits, tag, or deploy — those need their own per-job verification and will come as separate changes rather than riding along here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JL9v1bMrpZRDMNVCjuBiq9)_