### PR TITLE
fix(deps): exclude duckdb 1.4.5 to fix Python 3.9 SIGSEGV on --help

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -100,7 +100,12 @@ setup(
         # sessions, memory, heartbeats, system snapshots, traces. ~14 MB
         # wheel; columnar storage gives 10-100x speed vs SQLite for the
         # dashboard's GROUP BY/time-window workloads (epic #964).
-        "duckdb>=0.10",
+        # duckdb 1.4.5 introduced a Python 3.9 regression that causes a
+        # SIGSEGV during `clawmetry --help` (Click eager-loads subcommands
+        # which trigger DuckDB C-extension init on py3.9). Exclude 1.4.5
+        # until DuckDB ships a fix. See clawmetry#5317 / heartbeat run
+        # #33214123048. Same class of bug as the cffi<2 pin above.
+        "duckdb>=0.10,!=1.4.5",
         # Cloud cold-data relay tunnel (epic #964 phase 3b). ~100 KB pure
         # Python. Was previously in extras_require["relay"]; the opt-in
         # made cloud users silently miss the relay. Now base install so


### PR DESCRIPTION
## Summary

`clawmetry 0.12.781` (the current PyPI release) segfaults with exit 139 on Python 3.9 when any user runs `clawmetry --help`. `import clawmetry` and `clawmetry --version` work fine -- only `--help` crashes.

**Root cause**: duckdb 1.4.5 introduced a Python 3.9 C-extension regression. When Click generates `--help` output it eagerly loads subcommand modules, which triggers the DuckDB C-extension initializer on Python 3.9 and causes the SIGSEGV. Python 3.11 is not affected.

**Detection**: Conformance Heartbeat run [#33214123048](https://github.com/vivekchand/clawmetry/actions/runs/33214123048), job `pypi-install (ubuntu-latest, py3.9)`, step "CLI must actually import and run".

**Fix**: Exclude duckdb 1.4.5 from the install set (`!=1.4.5`). pip will install 1.4.4 instead (last known-good), which unblocks Python 3.9 users today. Using `!=` rather than `<1.4.5` so a patched duckdb 1.4.6 reaches users without a further change here.

This is the same mitigation pattern already in the file for cffi (`cffi<2`, see #5108 comment in setup.py line 94-98).

**Open issue**: E2E regression tracking in #5317.

No-PRD: emergency hotfix for published-artifact regression; no new behaviour.

---
_Generated by [Claude Code](https://claude.ai/code/session_017738tHsPxcgfGetrFUS9mG)_