### PR TITLE
docs(local_store): complete the invalidated-DB recovery recipe for PK indexes

### DIFF
--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -221,7 +221,14 @@ def _report_fatal_db_once(exc: BaseException) -> None:
         "(launchctl bootout / systemctl stop), then in a standalone python: "
         "con = duckdb.connect(<db>); con.execute('CHECKPOINT'); DROP INDEX "
         "each name from duckdb_indexes(); con.execute('CHECKPOINT'); then "
-        "start the daemon -- migrations recreate the indexes clean.",
+        "start the daemon -- migrations recreate the indexes clean. If the "
+        "error returns after that, the corrupt index is a PRIMARY KEY -- "
+        "those are not in duckdb_indexes() and cannot be dropped. Identify "
+        "the table from the error's Chunk column count, then copy-swap it "
+        "WITH the PK re-declared (CREATE TABLE t_new(<full DDL incl PRIMARY "
+        "KEY>); INSERT deduped rows; DROP old; RENAME; CHECKPOINT) -- a "
+        "plain CTAS drops the PK and every ON CONFLICT upsert then fails "
+        "differently. Verified 2026-08-29 on sessions + session_phase.",
         _brief_exc(exc),
     )
 


### PR DESCRIPTION
The invalidated-database error message prescribes DROP INDEX from duckdb_indexes() — but PRIMARY KEY ART indexes are not listed there and cannot be dropped. Tonight's brick (sessions + session_phase PKs, 'Failed to delete all rows from index. Only deleted 0 out of 1 rows' on every ON CONFLICT upsert) survived that recipe twice. The message now includes the PK path: identify the table from the error's Chunk column count, copy-swap with the PK re-declared (plain CTAS loses the PK), CHECKPOINT, sanity-run the upsert.

No-PRD: operator-facing error-message text only; documents a verified recovery, no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014cCdbTmcRyx4TqdCBDmoK7