### PR TITLE
fix: short-circuit --help before DuckDB init to prevent SIGSEGV on py3.9 (#5309)

### DIFF
--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -7698,6 +7698,50 @@ def main() -> None:
             _v = "unknown"
         print(f"clawmetry {_v}")
         return
+    # Short-circuit --help / -h before loading dashboard + DuckDB.
+    # Same class as the --version SIGSEGV fixed for #5108: dashboard.py calls
+    # get_store() at module level when CLAWMETRY_ROLE=dashboard is set, and on
+    # some Linux / Python 3.9 runners that duckdb init SIGSEGVs. --help never
+    # needs the store — print the help text directly and return.
+    if "--help" in sys.argv or "-h" in sys.argv:
+        print(
+            "\U0001f99e ClawMetry -- See your agent think.\n"
+            "\n"
+            "Usage: clawmetry [command] [options]\n"
+            "\n"
+            "Commands:\n"
+            "  start          Start ClawMetry as a background service\n"
+            "  stop           Stop the background service\n"
+            "  restart        Restart the background service\n"
+            "  status         Show service status, port, and uptime\n"
+            "  uninstall      Remove the background service\n"
+            "\n"
+            "Cloud:\n"
+            "  login                  Log in / sign up for ClawMetry Cloud\n"
+            "  connect                Activate cloud sync with an API key\n"
+            "  disconnect             Stop cloud sync\n"
+            "  doctor                 Diagnose cloud connectivity\n"
+            "  --turn-on-cloud-sync   Resume cloud sync\n"
+            "  --turn-off-cloud-sync  Pause cloud sync\n"
+            "\n"
+            "Options:\n"
+            "  --port <port>        Port to listen on (default: 8900)\n"
+            "  --host <host>        Host to bind to (default: 127.0.0.1)\n"
+            "  --workspace <path>   OpenClaw workspace path (auto-detected)\n"
+            "  --name <name>        Your name in Flow visualization\n"
+            "  --no-debug           Disable Flask debug/auto-reload\n"
+            "  -v, --version        Show version\n"
+            "  -h, --help           Show this help\n"
+            "\n"
+            "Examples:\n"
+            "  clawmetry                    Start dashboard on port 8900\n"
+            "  clawmetry --port 9000        Custom port\n"
+            "  clawmetry start              Start as background service\n"
+            "  clawmetry connect            Connect to ClawMetry Cloud\n"
+            "\n"
+            "Docs: https://clawmetry.com/how-it-works\n"
+        )
+        return
     # Tag this process as the dashboard BEFORE importing dashboard, so every
     # get_store() in dashboard.py (module-level + handlers) is barred from the
     # DuckDB writer — only the sync daemon writes. Set before the import or a

--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -7705,7 +7705,7 @@ def main() -> None:
     # needs the store — print the help text directly and return.
     if "--help" in sys.argv or "-h" in sys.argv:
         print(
-            "\U0001f99e ClawMetry -- See your agent think.\n"
+            "ClawMetry -- See your agent think.\n"
             "\n"
             "Usage: clawmetry [command] [options]\n"
             "\n"


### PR DESCRIPTION
## Summary

`clawmetry --help` was causing a SIGSEGV (exit 139) on Python 3.9 / Ubuntu because `dashboard.py` calls `get_store()` at module level when `CLAWMETRY_ROLE=dashboard` is set, and on some Linux/Python 3.9 runners DuckDB's initialization segfaults in that path. This is the same class of bug as #5108 (where cffi's finalizers caused the same crash on `--help`). The `--version` flag already short-circuits before the dangerous import; this PR extends the same guard to `--help` and `-h`.

## Changes

- `clawmetry/cli.py`: add a `--help`/`-h` early-return (before `os.environ["CLAWMETRY_ROLE"] = "dashboard"` and the `from dashboard import main` line) that prints the help text directly, mirroring the existing `--version` short-circuit pattern. The help text uses ASCII-only characters so it prints correctly on Windows cp1252 consoles.

## Test plan

- [ ] `clawmetry --help` on Ubuntu + Python 3.9 exits 0 without segfault
- [ ] `clawmetry -h` on Ubuntu + Python 3.9 exits 0 without segfault
- [ ] `clawmetry --version` still works (unaffected)
- [ ] `clawmetry --help` on Windows + Python 3.11 exits 0, output contains "usage"
- [ ] The help text is accurate (matches the options in `dashboard.py`'s argparse)

No-PRD: bug fix — restores `clawmetry --help` to non-crashing; no new behaviour, no new options

## Bot meta
<!-- bot-autofix -->
Draft PR opened autonomously based on the plan in #5309. Marked draft for human review — mark Ready for Review once happy.

Closes #5309