### PR TITLE
Harden CI: stop the supply-chain and install jobs persisting the job credential

### DIFF
--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -16,6 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Run install script
         run: bash install.sh
       - name: Verify clawmetry binary
@@ -35,6 +37,8 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Run install script
         run: bash install.sh
       - name: Add bin to PATH
@@ -54,6 +58,8 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
@@ -111,6 +117,8 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
@@ -149,5 +157,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: ShellCheck
         run: shellcheck install.sh

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -33,6 +33,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.11"
@@ -44,6 +46,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.11"
@@ -55,6 +59,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.11"
@@ -80,6 +86,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.11"
@@ -106,6 +114,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.11"


### PR DESCRIPTION
**Product record:** No-PRD: CI-only change confined to `.github/`, a PRD-exempt path. No shipped code, no dependency, no runtime behaviour.

## Summary

`actions/checkout` writes the job's `GITHUB_TOKEN` into `.git/config` as an extraheader and leaves it there for the rest of the job. Anything that runs afterwards — a test, a scanner, an installed dependency — can read it, and it is trivially captured into an uploaded artifact. zizmor reports this class as `artipacked`; OSSF Scorecard reports it on this repo.

This adds `persist-credentials: false` to the **10** checkout sites in `supply-chain.yml` and `install-test.yml`. No other change.

### Why these two files first

The exposure is not abstract in this particular pair:

- **`supply-chain.yml` → `python-deps`** pip-installs the full requirements set and then uploads an artifact from the workspace. Third-party code executes in a job whose `.git/config` holds a live credential.
- **`install-test.yml`** runs `install.sh` / `install.ps1` / `install.cmd` — the installer as an end user receives it — across five runners. Executing the installer is the entire purpose of the job, and it is exactly the shape that should not have a token sitting next to it.

### Why it is safe

**Neither file contains a `git` invocation at all** — no push, tag, commit, fetch or clone, in any job. The scripts these jobs call (`verify_no_external_assets.py`, `verify_vendor.py`, `vendor_fonts.py`, `check_action_refs.py`, `install.sh`) run no git remote operation either; the only `git` strings in them are a `.git` directory name in a filesystem walk and a `git/ref/tags` **REST API URL path**.

The one job needing API credentials, `action-refs`, passes `GITHUB_TOKEN` explicitly through a step-level `env:` block. `persist-credentials` does not affect an env var, so that job is untouched.

Both workflows already declare a least-privilege top-level `permissions: contents: read`, and neither is in the six write-scoped release/publish/deploy workflows.

### Scope

48 of this repo's 62 checkout sites still persist the credential. A single 48-site PR would be unreviewable, and the release/publish/deploy workflows need their remaining git usage read carefully first. This takes the supply-chain and install-verification family, where the absence of git usage is provable by reading two files. The rest follow in later batches.

The `scorecard` job in `supply-chain.yml` already carried `persist-credentials: false`, so this extends a pattern the repo set for itself. Same fix and same reasoning as `clawmetry-cloud#2168` / `#2176` and `clawmetry-pro#193`.

## Test plan

- [x] `yaml.safe_load` over all **35** workflow + composite-action files — all parse
- [x] 11/11 checkout sites in the two files now carry `persist-credentials: false` (10 added; `scorecard` already had it), asserted by re-parsing the YAML rather than reading the diff
- [x] No duplicate `persist-credentials` key introduced anywhere
- [x] `python3 scripts/check_action_refs.py` → exit 0, 17 references, shape checks pass
- [x] `pytest tests/test_workflow_yaml_valid.py tests/test_ci_workflow_invocations_are_real.py` → **189 passed, 2 skipped**, matching the baseline on `main`
- [x] Grepped both workflow files and every script they invoke for git remote usage → none

**Risk:** Low. The failure mode of a wrong `persist-credentials: false` is a job that can no longer reach the remote; these jobs never do. Undone by reverting one commit.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DB5MHpCgSnn9yFm7WUhK6c)_