### PR TITLE
Harden CI: stop the read-only jobs persisting the job credential

### DIFF
--- a/.github/workflows/api-latency-smoke.yml
+++ b/.github/workflows/api-latency-smoke.yml
@@ -39,6 +39,8 @@ jobs:
       CLAWMETRY_LOCAL_STORE_PATH: ${{ github.workspace }}/.smoke/clawmetry.duckdb
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.11"

--- a/.github/workflows/auth-bootstrap-guard.yml
+++ b/.github/workflows/auth-bootstrap-guard.yml
@@ -26,6 +26,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:

--- a/.github/workflows/conformance-heartbeat.yml
+++ b/.github/workflows/conformance-heartbeat.yml
@@ -171,6 +171,8 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Run install script
         run: bash install.sh
       - name: Verify binary
@@ -187,6 +189,8 @@ jobs:
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
@@ -207,6 +211,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.11"

--- a/.github/workflows/cross-repo-handoff.yml
+++ b/.github/workflows/cross-repo-handoff.yml
@@ -28,6 +28,7 @@ jobs:
       - name: Checkout clawmetry (OSS)
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           path: oss
 
       # CLOUD_REPO_PAT is NOT exposed to pull_request runs from a fork (GitHub
@@ -54,6 +55,7 @@ jobs:
         if: steps.access.outputs.available == 'true'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           repository: vivekchand/clawmetry-landing
           token: ${{ secrets.CLOUD_REPO_PAT }}
           path: landing
@@ -63,6 +65,7 @@ jobs:
         if: steps.access.outputs.available == 'true'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           repository: vivekchand/clawmetry-cloud
           token: ${{ secrets.CLOUD_REPO_PAT }}
           path: cloud

--- a/.github/workflows/e2e-gate.yml
+++ b/.github/workflows/e2e-gate.yml
@@ -52,6 +52,8 @@ jobs:
       # from the working tree -- converting it to a script call silently broke
       # that assumption and the gate died with "No such file or directory".
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       # The gate logic lives in scripts/e2e_gate.py so it can be unit-tested
       # (tests/test_e2e_gate.py) instead of only being exercised in anger on a

--- a/.github/workflows/overhead-bench.yml
+++ b/.github/workflows/overhead-bench.yml
@@ -40,6 +40,8 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.11"

--- a/.github/workflows/product-record-gate.yml
+++ b/.github/workflows/product-record-gate.yml
@@ -30,6 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0

--- a/.github/workflows/quarantine-sweep.yml
+++ b/.github/workflows/quarantine-sweep.yml
@@ -34,6 +34,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:

--- a/.github/workflows/sync-test.yml
+++ b/.github/workflows/sync-test.yml
@@ -38,6 +38,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:

--- a/.github/workflows/windows-enterprise-tls.yml
+++ b/.github/workflows/windows-enterprise-tls.yml
@@ -33,6 +33,8 @@ jobs:
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:

--- a/.github/workflows/zero-click-auth-e2e.yml
+++ b/.github/workflows/zero-click-auth-e2e.yml
@@ -45,6 +45,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:


### PR DESCRIPTION
**Product record:** No-PRD: CI-only hardening under `.github/workflows/`, which FLYWHEEL exempts from the product-record gate. YAML only — no product surface, endpoint or behaviour changes.

**Risk:** Low, and the failure mode would be loud rather than silent. The only way `persist-credentials: false` breaks a job is if that job makes an authenticated git call after checkout, which fails immediately and visibly. Every one of the eleven workflows was checked for that and none contains a `git` invocation of any kind, nor calls a composite action that does. Undone by reverting the commit; nothing is retroactive, no migration, no data touched.

---

## Summary

- `actions/checkout` writes the credential it authenticated with into `.git/config` and leaves it there for the rest of the job. Every later step can read it, and any step that archives or uploads the workspace carries it off the runner. zizmor reports this as `artipacked`.
- This is the batch of **15 checkout sites whose jobs make no git network call at all**, so the credential is written and never used — pure standing exposure with no consumer.
- **`cross-repo-handoff.yml` is the one worth a reviewer's attention.** Two of its three checkouts authenticate with `CLOUD_REPO_PAT` rather than the job token, and that PAT covers every repository the account owns — so what it leaves behind outlives the scope of the run. That workflow triggers on `pull_request`, which is where this is most worth doing.
- `conformance-heartbeat.yml`'s issue-filing job is included deliberately: it spends its write scope through the `gh` CLI reading `GH_TOKEN` from the step env, and `persist-credentials` does not affect `gh`.

**Deliberately not included**, left for their own review: the workflows whose jobs push (`publish`, `release-on-merge`, `auto-deploy-cloud`, `desktop-artifacts`, `pr-screenshots`, `auto-quarantine`, `c6-schedule-heal`, `apply-required-checks`), and the two i18n autotranslate workflows, which hand the workspace to `peter-evans/create-pull-request` and so genuinely do depend on the persisted credential. Same staging as clawmetry-cloud#2168 / #2176; #5321 already covers `install-test.yml` and `supply-chain.yml`.

Diff is 26 added lines, all of them `with:` or `persist-credentials: false`. Nothing removed; no step, trigger, permission, or action version changed.

## Test plan

- [x] `zizmor` 1.29.0 `--persona regular`, base vs branch in separate worktrees: **`artipacked` 48 → 33**, and `adhoc-packages` 5, `cache-poisoning` 1, `dangerous-triggers` 2, `misfeature` 3, `superfluous-actions` 1, `template-injection` 30, `use-trusted-publishing` 1 all **unchanged** — no collateral
- [x] `yaml.safe_load` over all 35 workflow + composite-action files: every one parses
- [x] Semantic re-parse confirms `persist-credentials: false` landed under the right step's `with:` in all 15 sites, 0 missed inside the batch
- [x] `scripts/check_action_refs.py`: exit 0, 17 references, SHA-pinning ratchet still holds
- [x] `scripts/e2e_gate.py --list`: unchanged output (`e2e-gate.yml` is itself in this batch)
- [x] `pytest` over every test that reads `.github/workflows` (10 files, incl. `test_workflow_yaml_valid.py`, `test_c6_required_checks_single_source.py`, `test_product_record_gate.py`): **260 passed**, 54 skipped
- [x] Per-file grep for `git`/`gh` usage in all eleven workflows and in every composite action they reference

---
_Generated by [Claude Code](https://claude.ai/code/session_01LcMkXoBnG5GgDkaYkSpFAi)_