### PR TITLE
Harden CI: stop the gate, nightly and audit jobs persisting the job credential

### DIFF
--- a/.github/workflows/apply-required-checks.yml
+++ b/.github/workflows/apply-required-checks.yml
@@ -70,6 +70,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Preview checks (dry run)
         if: github.event_name == 'workflow_dispatch' && github.event.inputs.confirm != 'APPLY'

--- a/.github/workflows/browserstack.yml
+++ b/.github/workflows/browserstack.yml
@@ -21,6 +21,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:

--- a/.github/workflows/c6-pr-gate.yml
+++ b/.github/workflows/c6-pr-gate.yml
@@ -65,6 +65,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       # Read-only audit: verify clawmetry/main has the required E2E status
       # checks configured. The script detects the ghs_ GITHUB_TOKEN prefix,

--- a/.github/workflows/c6-schedule-heal.yml
+++ b/.github/workflows/c6-schedule-heal.yml
@@ -92,6 +92,8 @@ jobs:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Check for admin token
         id: pat-check

--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -32,6 +32,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.11"

--- a/.github/workflows/harness-observability-audit.yml
+++ b/.github/workflows/harness-observability-audit.yml
@@ -47,6 +47,8 @@ jobs:
     steps:
       - name: Checkout clawmetry (OSS)
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:

--- a/.github/workflows/openclaw-boot.yml
+++ b/.github/workflows/openclaw-boot.yml
@@ -44,6 +44,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup OpenClaw
         id: openclaw

--- a/.github/workflows/oss-golden-path.yml
+++ b/.github/workflows/oss-golden-path.yml
@@ -43,6 +43,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:

--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -54,6 +54,8 @@ jobs:
       version: ${{ steps.resolve.outputs.version }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.11"
@@ -106,6 +108,8 @@ jobs:
             python-version: "3.9"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ matrix.python-version }}


### PR DESCRIPTION
**Product record:** No-PRD: CI-only change confined to `.github/`, a PRD-exempt path. No shipped code, no dependency, no runtime behaviour.

## Summary

`actions/checkout` writes the job's `GITHUB_TOKEN` into `.git/config` as an extraheader and leaves it there for the rest of the job. Anything that runs afterwards — a test, a scanner, an installed dependency — can read it, and it is trivially captured into an uploaded artifact. zizmor reports this class as `artipacked`; OSSF Scorecard reports it on this repo.

This adds `persist-credentials: false` to the **10** checkout sites in **nine** PR-gate, nightly and audit workflows. No other change.

| workflow | sites | top-level permissions |
|---|---|---|
| `apply-required-checks.yml` | 1 | `contents: read`, `issues: write` |
| `browserstack.yml` | 1 | `contents: read` |
| `c6-pr-gate.yml` | 1 | `contents: read`, `pull-requests: write` |
| `c6-schedule-heal.yml` | 1 | `contents: read`, `issues: write` |
| `e2e-nightly.yml` | 1 | `contents: read` |
| `harness-observability-audit.yml` | 1 | `contents: read`, `issues: write` |
| `openclaw-boot.yml` | 1 | `contents: read` |
| `oss-golden-path.yml` | 1 | `contents: read` |
| `release-canary.yml` | 2 | `contents: read` |

### Why these nine

They are the batch where "this job never reaches the remote" is provable by reading the file rather than argued. Every one of the nine:

- contains **no `git` invocation at all**, in any job — no push, tag, commit, fetch, clone or ls-remote;
- uses no branch-pushing or PR-creating action;
- already declares a least-privilege top-level `permissions:`;
- is **not** one of the six write-scoped release/publish/deploy workflows.

The four holding a write scope (`apply-required-checks`, `c6-pr-gate`, `c6-schedule-heal`, `harness-observability-audit`) spend it through the `gh` CLI reading `GH_TOKEN` / `github.token` from a step- or job-level `env:` block. `persist-credentials` does not affect an env var, so those paths are untouched.

The three calling `./.github/actions/setup-openclaw` were checked one level down as well: the composite action runs only `setup-node` and `actions/cache`, and performs no git operation of its own.

`release-canary.yml` is named for the release path but declares `contents: read` and pushes nothing — it installs the published wheel from PyPI and verifies it. It is not in the six.

### Deliberately not included

Left for later batches, each for a stated reason:

- `i18n-autotranslate.yml`, `i18n-docs-autotranslate.yml` — `peter-evans/create-pull-request` pushes a branch.
- `auto-deploy-cloud.yml`, `auto-quarantine.yml`, `pr-screenshots.yml`, `release-on-merge.yml` — each contains a live git network call that needs reading first.
- `desktop-artifacts.yml`, `publish.yml` — release-path workflows; their remaining token usage deserves its own review rather than riding along here.

### Scope

A single 38-site PR would be unreviewable, so this takes the family whose safety is provable from the file itself. Same fix and same reasoning as #5312, #5321, #5327, and as `clawmetry-cloud#2168` / `#2176` and `clawmetry-pro#193`.

## Test plan

Originally measured against `main` at `e5ef9ab` (**artipacked 38 → 28**). #5327 has since merged and `main` was merged into this branch at `bb8865a`, so the numbers below are **re-measured on the current head against `main` at `0bec119`**. The delta this PR is responsible for is unchanged at **−10**.

- [x] `zizmor 1.29.0 --persona regular`, `main@0bec119` vs current head: **artipacked 23 → 13** (exactly the 10 sites); `adhoc-packages` 6, `cache-poisoning` 1, `dangerous-triggers` 2, `dependabot-cooldown` 5, `github-env` 2, `misfeature` 3, `superfluous-actions` 1, `template-injection` 30, `use-trusted-publishing` 1 — **all unchanged, no collateral**
- [x] `yaml.safe_load` over all **35** workflow + composite-action files — all parse (re-verified after the merge)
- [x] Re-parsed the YAML and diffed it **structurally** against the base: the only delta is the added `with.persist-credentials` key; no step, trigger, permission or action version changed
- [x] No duplicate `persist-credentials` key introduced anywhere — re-checked after the merge with #5327, which touched a disjoint set of files
- [x] All 10 sites confirmed present on the merged head by re-parsing the YAML, not by reading the diff
- [x] `python3 scripts/check_action_refs.py` → exit 0, 17 references
- [x] `pytest tests/test_workflow_yaml_valid.py tests/test_ci_workflow_invocations_are_real.py` → **189 passed, 2 skipped**, matching the baseline on `main`
- [x] Grepped all nine workflows, and the composite action they call, for git remote usage → none
- [x] **49 of 62** checkout sites now set `persist-credentials: false` on the merged head (39 from `main` after #5327, plus this PR's 10)

**Risk:** Low. The failure mode of a wrong `persist-credentials: false` is a job that can no longer reach the remote; these jobs never do. Undone by reverting one commit.