### PR TITLE
Split the cffi pin per interpreter; never compile on end-user Windows

### DIFF
--- a/clawmetry/update_respawn.py
+++ b/clawmetry/update_respawn.py
@@ -165,11 +165,15 @@ def main(argv=None) -> int:
             pip_kwargs = {"stdout": log, "stderr": log, "timeout": 300}
             if os.name == "nt":
                 pip_kwargs["creationflags"] = _NO_WINDOW
-            proc = subprocess.run(
-                [sys.executable, "-m", "pip", "install", "--upgrade",
-                 "--no-cache-dir", spec],
-                **pip_kwargs,
-            )
+            argv = [sys.executable, "-m", "pip", "install", "--upgrade",
+                    "--no-cache-dir", spec]
+            if os.name == "nt":
+                # No compiler on end-user Windows: a dependency without a
+                # wheel must fail as "no matching distribution", never as
+                # an MSVC source-build demand (field failure 2026-08-29,
+                # cffi<2 on Python 3.14).
+                argv.insert(5, "--only-binary=:all:")
+            proc = subprocess.run(argv, **pip_kwargs)
             if proc.returncode == 0:
                 ok = True
                 _prune_stale_dist_info(target, _say)

--- a/desktop/app.py
+++ b/desktop/app.py
@@ -898,13 +898,22 @@ class RuntimeSupervisor:
     # Hard-won pip flags for the first install:
     #   --no-input        never hang on a keyring/credential prompt in a
     #                     windowless app (there is no console to answer it)
-    #   --prefer-binary   never try to compile duckdb/cryptography from
-    #                     sdist when any wheel matches this interpreter
+    #   --only-binary=:all: on Windows — an end-user Windows machine has no
+    #                     compiler, so a source build can only ever fail
+    #                     with "Microsoft Visual C++ 14.0 or greater is
+    #                     required" (field failure 2026-08-29: cffi<2 had
+    #                     no cp314 wheel, pip fell back to the sdist).
+    #                     Every dependency ships wheels on Windows; a
+    #                     missing wheel must fail as a clear "no matching
+    #                     distribution", not an MSVC demand. Elsewhere a
+    #                     source build can succeed, so only prefer wheels.
     #   --timeout/--retries  fail over faster than pip's 15s default —
     #                     dual-stack networks with broken IPv6 burn the
     #                     whole budget timing out per AAAA address
     _PIP_FLAGS = (
-        "--disable-pip-version-check", "--no-input", "--prefer-binary",
+        "--disable-pip-version-check", "--no-input",
+        ("--only-binary=:all:" if platform.system() == "Windows"
+         else "--prefer-binary"),
         "--timeout", "20", "--retries", "4",
     )
 
@@ -954,6 +963,10 @@ class RuntimeSupervisor:
         low = output.lower()
         if "no python at" in low or "did not find executable" in low:
             return "The runtime environment was broken — relaunch the app to rebuild it."
+        if "microsoft visual c++" in low or "build wheel did not run successfully" in low:
+            return ("A dependency has no prebuilt package for this Python "
+                    "version — update ClawMetry (packaging fix), or install "
+                    "python.org Python 3.12/3.13 and relaunch.")
         if "no matching distribution" in low or "could not find a version" in low:
             return ("Python too old or PyPI unreachable — "
                     "install python.org Python 3.11+ and relaunch.")

--- a/install-clawmetry.ps1
+++ b/install-clawmetry.ps1
@@ -56,7 +56,9 @@ if ($LASTEXITCODE -ne 0) {
 & "$installDir\Scripts\python.exe" -m pip install --upgrade pip 2>&1 | Out-Null
 # Install clawmetry
 Write-Host "→ Installing clawmetry from PyPI..."
-& "$installDir\Scripts\pip.exe" install --no-cache-dir clawmetry 2>&1 | Out-Null
+# --only-binary: no compiler on user machines; a missing wheel must fail
+# clearly, not demand MSVC (field failure 2026-08-29, cffi on py3.14)
+& "$installDir\Scripts\pip.exe" install --no-cache-dir --only-binary=:all: clawmetry 2>&1 | Out-Null
 if ($LASTEXITCODE -ne 0) {
     Write-Host "❌ Failed to install clawmetry." -ForegroundColor Red
     exit 1

--- a/install.ps1
+++ b/install.ps1
@@ -159,7 +159,9 @@ if ((Test-Path $venvPython) -and (Test-Path "$installDir\pyvenv.cfg")) {
 
 # Install/upgrade clawmetry (python -m pip, so a running pip.exe can't lock it)
 Write-Host "→ Installing clawmetry from PyPI..."
-& $venvPython -m pip install --no-cache-dir --upgrade clawmetry 2>&1 | Out-Null
+# --only-binary: no compiler on user machines; a missing wheel must fail
+# clearly, not demand MSVC (field failure 2026-08-29, cffi on py3.14)
+& $venvPython -m pip install --no-cache-dir --only-binary=:all: --upgrade clawmetry 2>&1 | Out-Null
 if ($LASTEXITCODE -ne 0) {
     Write-Host "❌ Failed to install clawmetry." -ForegroundColor Red
     exit 1

--- a/setup.py
+++ b/setup.py
@@ -91,11 +91,19 @@ setup(
         "flask>=2.0,<4",
         "waitress>=2.0",
         "cryptography>=3.0",
-        # cffi 2.0.0 introduced a Python 3.9 finalizer regression that causes
-        # a SIGSEGV at sys.exit() when argparse prints --help text, crashing
-        # `clawmetry uninstall --help` on py3.9. Pin below 2.0 until cffi
-        # ships a fix upstream. See issue #5108.
-        "cffi<2",
+        # cffi is pinned per interpreter, and both halves are load-bearing:
+        # - Below 3.14: cffi 2.0.0 introduced a Python 3.9 finalizer
+        #   regression that SIGSEGVs at sys.exit() when argparse prints
+        #   --help text, crashing `clawmetry uninstall --help` on py3.9
+        #   (issue #5108) — and cffi 2.1+ ships no cp39 wheels at all, so
+        #   <2 stays correct there.
+        # - On 3.14+: cffi 1.x ships NO cp314 wheels, so an unconditional
+        #   <2 forces a source build that demands MSVC on end-user Windows
+        #   machines ("Microsoft Visual C++ 14.0 or greater is required")
+        #   and bricked a desktop first install in the field (2026-08-29).
+        #   cffi 2.x is the only series with 3.14 wheels.
+        'cffi<2; python_version < "3.14"',
+        'cffi>=2; python_version >= "3.14"',
         # Local store at ~/.clawmetry/clawmetry.duckdb. Holds events,
         # sessions, memory, heartbeats, system snapshots, traces. ~14 MB
         # wheel; columnar storage gives 10-100x speed vs SQLite for the

--- a/tests/test_desktop_bootstrap_resilience.py
+++ b/tests/test_desktop_bootstrap_resilience.py
@@ -148,7 +148,15 @@ def test_pip_install_retries_with_cold_cache_and_safe_flags(tmp_path, monkeypatc
     assert "--no-cache-dir" in install_attempts[1], "retry must bypass the cache"
     for a in install_attempts:
         assert "--no-input" in a, "windowless app: pip must never prompt"
-        assert "--prefer-binary" in a, "never build duckdb/cryptography from sdist"
+        # On Windows nothing may ever compile (no MSVC on user machines —
+        # field failure 2026-08-29: cffi<2 had no cp314 wheel and pip fell
+        # back to an sdist that demanded Visual C++); elsewhere wheels are
+        # preferred but a source build is allowed to succeed.
+        import platform as _plat
+        if _plat.system() == "Windows":
+            assert "--only-binary=:all:" in a, "Windows must be wheels-only"
+        else:
+            assert "--prefer-binary" in a, "never build from sdist when a wheel exists"
 
 
 def test_pip_install_gives_up_after_two_attempts(tmp_path, monkeypatch):
@@ -178,6 +186,11 @@ def test_pip_install_gives_up_after_two_attempts(tmp_path, monkeypatch):
         ("SSLError(SSLCertVerificationError: certificate verify failed)", "proxy"),
         ("Connection to pypi.org timed out. (connect timeout=20)", "pypi.org"),
         ("PermissionError: [WinError 5] Access is denied", "antivirus"),
+        ("distutils.compilers.errors.PlatformError: Microsoft Visual C++ 14.0 "
+         "or greater is required.", "update ClawMetry"),
+        ("ERROR: Failed to build 'cffi' when getting requirements to build "
+         "wheel\n  Getting requirements to build wheel did not run successfully.",
+         "update ClawMetry"),
     ],
 )
 def test_pip_failures_classify_to_actionable_hints(snippet, expect):
@@ -197,3 +210,22 @@ def test_log_survives_unencodable_characters(tmp_path):
     sup = _sup(tmp_path)
     sup._log("pip said: ✓ — ünïcode \u2713")
     assert "ünïcode" in sup.log_file.read_text(encoding="utf-8")
+
+
+# ── 5. the cffi pin must stay split per interpreter ──────────────────────
+#
+# setup.py pins cffi<2 below Python 3.14 (cffi 2.0.0 SIGSEGVs py3.9, #5108,
+# and cffi 2.1+ ships no cp39 wheels) and cffi>=2 on 3.14+ (cffi 1.x ships
+# NO cp314 wheels, so an unconditional <2 forces an MSVC source build on
+# end-user Windows — the 2026-08-29 field failure). Both halves are
+# load-bearing; collapsing them back to a bare "cffi<2" re-bricks every
+# Windows install on a current python.org Python.
+
+
+def test_cffi_pin_is_split_per_interpreter():
+    setup_src = (REPO_ROOT / "setup.py").read_text(encoding="utf-8")
+    assert 'cffi<2; python_version < "3.14"' in setup_src
+    assert 'cffi>=2; python_version >= "3.14"' in setup_src
+    import re
+    bare = re.search(r"""['"]cffi<2['"]""", setup_src)
+    assert bare is None, "an unmarked cffi<2 would have no cp314 wheel"


### PR DESCRIPTION
## The failure (same field machine as #5333, now with a readable log)

The v0.12.784 self-healing shell did its job — retried, logged everything — and the log shows the true root cause: **our own `cffi<2` pin forces a source build on Python 3.14**, because cffi 1.x ships no cp314 wheels. End-user Windows has no MSVC, so the install dies with "Microsoft Visual C++ 14.0 or greater is required". `--prefer-binary` can't help when no binary exists.

The pin itself is legitimate — cffi 2.0.0 SIGSEGVs Python 3.9 (#5108, added in #5144), and cffi 2.1+ ships **no cp39 wheels** — so this is a marker split, not an unpin:

```
cffi<2;  python_version < "3.14"
cffi>=2; python_version >= "3.14"   # the only series with cp314 wheels
```

**Verified on Python 3.14.6:** the branch wheel installs `--only-binary=:all:` end to end (cffi resolves to 2.1.1); the old pin reproduces the field failure exactly (`No matching distribution found for cffi<2` wheels-only).

**Self-healing delivery:** the desktop shell pip-installs the latest clawmetry on every launch, so once this is on PyPI the bricked machine fixes itself on next launch — no reinstall needed.

## Belt-and-braces: wheels-only on end-user Windows

Every pip that runs on a user's Windows machine now passes `--only-binary=:all:` — the desktop shell bootstrap, the in-place updater helper (`clawmetry/update_respawn.py`), and both PowerShell installers. A future missing wheel fails as a clear, classified "no matching distribution" instead of an MSVC demand. macOS/Linux keep `--prefer-binary` (source builds can succeed there). The shell's failure classifier now maps compiler demands to an actionable message.

## Tests

`tests/test_desktop_bootstrap_resilience.py` (already wired in ci.yml): platform-aware flag assertions, two MSVC classifier cases, and a guard that fails CI if the cffi pin is ever collapsed back to a bare `cffi<2`. All 112 desktop tests pass.

## Product record

Blueprint: https://factory.8090.ai/project/b415065f-ab2f-4f53-8864-0c009fd098cb/blueprints/5f6b2b76-97af-4c40-9f5f-e1564eac0afe (Desktop Application Distribution — first-install self-healing ADR updated ahead of this PR: per-platform wheels-only pip policy + the per-interpreter cffi pin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011aj9ezQGu8utv8zJ2QppW6