### PR TITLE
[RELEASE] feat(sessions): style thinking apart from the reply + per-turn token/cost badges; fix dead Back buttons

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -382,6 +382,7 @@ jobs:
             tests/test_query_contract_drift.py \
             tests/test_query_contract_goldens.py \
             tests/test_local_store_concurrent_flush_1590.py \
+            tests/test_transcript_local_store.py \
             tests/test_moat_perf_benchmark.py \
             tests/test_runtime_detection_snapshot.py \
             tests/test_family_runtime_ingest.py \

--- a/clawmetry/static/css/dashboard.css
+++ b/clawmetry/static/css/dashboard.css
@@ -634,6 +634,13 @@
   .chat-msg.assistant { background: #1a3a2a; border: 1px solid #2a5a3a; color: #c0ffc0; align-self: flex-start; border-bottom-left-radius: 4px; }
   .chat-msg.system { background: #2a2a1a; border: 1px solid #4a4a2a; color: #f0e0a0; align-self: center; font-size: 12px; font-style: italic; max-width: 90%; }
   .chat-msg.tool { background: #1a1a24; border: 1px solid #2a2a3a; color: #a0a0b0; align-self: flex-start; font-family: 'SF Mono', monospace; font-size: 12px; border-left: 3px solid #555; }
+  /* Extended-thinking turns — the model reasoning on the user's behalf, not
+     the reply. Cyan accent matches the turn-anatomy "model" span color so the
+     mapping reads the same on both pages: cyan = model working, green = the
+     actual reply to the human, blue = the human. */
+  .chat-msg.thinking { background: rgba(34,211,238,0.06); border: 1px solid rgba(34,211,238,0.28); border-left: 3px solid #22d3ee; color: var(--text-secondary); align-self: flex-start; border-bottom-left-radius: 4px; }
+  .chat-msg.thinking .chat-role { color: #22d3ee; opacity: 1; }
+  .chat-msg.thinking .chat-content-truncated::after { background: linear-gradient(transparent, rgba(16,34,40,0.9)); }
   .chat-role { font-size: 10px; font-weight: 700; text-transform: uppercase; letter-spacing: 1px; margin-bottom: 4px; opacity: 0.7; }
   /* Compact chip for tool turns (no prose) so they don't render as blank
      bubbles. Role-accented left border keeps them consistent with the prose

--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -19408,6 +19408,9 @@ function _buildReplayEvent(m, idx) {
     content: m.content || '',
     timestamp: m.timestamp,
     tokens: m.tokens || null,
+    // Daemon-stamped per-event cost (stamped on the first message of each
+    // event row) — summed per turn for the chapter-header cost badge.
+    cost: m.cost_usd || null,
     params: m.params || null,
     // #1911: structured tool call/result detail for the deep-dive chip.
     tool: m.tool || null,
@@ -19618,7 +19621,10 @@ function _renderReplayEvent(ev, highlighted) {
   // (prose) turns stand out and the timeline reads cleanly.
   var _c = ev.content;
   if (!_c || !String(_c).trim()) {
-    var chipLabel = role === 'assistant' ? '🔧 Tool call'
+    // A thinking event whose text wasn't captured must not masquerade as a
+    // tool call — label it for what it is.
+    var chipLabel = ev.type === 'thinking' ? '🧠 ' + t("app.thinking_internal", null, "thinking (internal)")
+                  : role === 'assistant' ? '🔧 Tool call'
                   : role === 'user' ? '↩ Tool result'
                   : role === 'system' ? '⚙ System'
                   : (escHtml(role) + ' · no text');
@@ -19628,16 +19634,22 @@ function _renderReplayEvent(ev, highlighted) {
     return '<div class="chat-tool-chip ' + (role === 'user' ? 'tc-user' : 'tc-asst') + '" id="replay-msg-' + ev.originalIndex + '" style="align-self:' + chipSide + ';' + chipRing + '">'
       + '<span class="chat-tool-chip-label">' + chipLabel + '</span>'
       + (ev.tokens ? '<span class="chat-tool-chip-meta">' + ev.tokens + ' tok</span>' : '')
+      + (ev.cost > 0 ? '<span class="chat-tool-chip-meta">' + _taFmtCost(ev.cost) + '</span>' : '')
       + (chipTs ? '<span class="chat-tool-chip-meta">' + chipTs + '</span>' : '')
       + '</div>';
   }
   var cls = role === 'user' ? 'user' : role === 'assistant' ? 'assistant' : role === 'system' ? 'system' : 'tool';
+  // Extended-thinking turns are the model reasoning on the user's behalf, not
+  // the reply — cyan-accented (matching the turn-anatomy "model" color) so a
+  // reader can tell internal work from the actual answer at a glance.
+  var isThinking = ev.type === 'thinking';
+  if (isThinking) cls = 'thinking';
   var content = ev.content;
   var needsTruncate = content.length > 800;
   var displayContent = needsTruncate ? content.substring(0, 800) : content;
   var highlightStyle = highlighted ? 'box-shadow:0 0 0 2px #6366f1;' : '';
   var html = '<div class="chat-msg ' + cls + '" id="replay-msg-' + ev.originalIndex + '" style="' + highlightStyle + '">';
-  html += '<div class="chat-role">' + escHtml(role) + '</div>';
+  html += '<div class="chat-role">' + (isThinking ? '&#129504; ' + t("app.thinking_internal", null, "thinking (internal)") : escHtml(role)) + '</div>';
   if (needsTruncate) {
     html += '<div class="chat-content-truncated" id="msg-' + ev.originalIndex + '-short" style="white-space:pre-wrap;word-break:break-word;">' + escHtml(displayContent) + '</div>';
     html += '<div id="msg-' + ev.originalIndex + '-full" style="display:none;white-space:pre-wrap;word-break:break-word;">' + escHtml(content) + '</div>';
@@ -19645,7 +19657,7 @@ function _renderReplayEvent(ev, highlighted) {
   } else {
     html += '<div style="white-space:pre-wrap;word-break:break-word;">' + escHtml(content) + '</div>';
   }
-  if (ev.tokens) html += '<div style="font-size:11px;color:var(--text-muted);margin-top:4px;">&#128200; ' + ev.tokens + ' tokens</div>';
+  if (ev.tokens) html += '<div style="font-size:11px;color:var(--text-muted);margin-top:4px;">&#128200; ' + ev.tokens + ' tokens' + (ev.cost > 0 ? ' &middot; ' + _taFmtCost(ev.cost) : '') + '</div>';
   // Issue #564: decoding-config pill — small inline summary of the sampling
   // params that produced this assistant turn (only present when the backend
   // could extract at least one known key).
@@ -19727,7 +19739,9 @@ function _groupIntoTurns(events) {
         lastTs: ev.timestamp || null,
         events: [],
         toolCount: 0,
-        errorCount: 0
+        errorCount: 0,
+        tokens: 0,
+        cost: 0
       };
       turns.push(current);
     }
@@ -19735,6 +19749,8 @@ function _groupIntoTurns(events) {
     if (ev.timestamp) current.lastTs = ev.timestamp;
     if (ev.tool) current.toolCount++;
     if (ev.tool && ev.tool.is_error) current.errorCount++;
+    if (ev.tokens) current.tokens += ev.tokens;
+    if (ev.cost) current.cost += ev.cost;
   }
   return turns;
 }
@@ -19772,6 +19788,10 @@ function _renderTurnChapter(turn, highlightOriginal) {
   if (turn.toolCount > 0) pieces.push('🔧 ' + turn.toolCount);
   if (turn.errorCount > 0) pieces.push('<span style="color:#e0625a;">✕ ' + turn.errorCount + '</span>');
   if (duration) pieces.push('⏱ ' + duration);
+  // Turn spend — same per-event token/cost stamps the Turn anatomy page sums,
+  // so the two figures agree.
+  if (turn.tokens > 0) pieces.push('🪙 ' + (turn.tokens >= 1000 ? (turn.tokens / 1000).toFixed(1) + 'K' : turn.tokens) + ' tok');
+  if (turn.cost > 0) pieces.push('<span style="color:#34d399;">' + _taFmtCost(turn.cost) + '</span>');
   var meta = pieces.join(' · ');
   var html = '<section class="turn-chapter" id="turn-chapter-' + turn.turn + '">';
   html += '<header class="turn-chapter-head">';

--- a/clawmetry/static/locales/en.json
+++ b/clawmetry/static/locales/en.json
@@ -412,6 +412,7 @@
   "app.test_sent": "Test sent!",
   "app.test_sent_to": "Test sent to: ",
   "app.thinking": "Thinking…",
+  "app.thinking_internal": "thinking (internal)",
   "app.this_feature_requires_clawmetry_pro": "This feature requires ClawMetry Pro",
   "app.this_file_is_empty": "This file is empty.",
   "app.time_travel": "Time travel: ",

--- a/clawmetry/templates/tabs/tracing.html
+++ b/clawmetry/templates/tabs/tracing.html
@@ -5,7 +5,10 @@
       <div style="font-size:12px;color:var(--text-muted);margin-top:4px;" data-i18n="tracing.subtitle">Every session as a trace. Open one for the span tree, waterfall, and agent graph  -  with full inputs/outputs per span.</div>
     </div>
     <div style="display:flex;gap:6px;align-items:center;">
-      <button class="refresh-btn" id="trace-back-btn" style="display:none;" onclick="tracingShowList()">← <span data-i18n="tracing.back_to_traces">Back to traces</span></button>
+      <!-- Back must RELOAD the list (same trap as ta-back-btn): the deep-dive
+           handoff path skips loadTracing's list fetch, so a bare
+           tracingShowList() shows an empty/stale list container. -->
+      <button class="refresh-btn" id="trace-back-btn" style="display:none;" onclick="loadTracing()">← <span data-i18n="tracing.back_to_traces">Back to traces</span></button>
       <button class="refresh-btn" onclick="loadTracing()">↻</button>
     </div>
   </div>

--- a/clawmetry/templates/tabs/turn-anatomy.html
+++ b/clawmetry/templates/tabs/turn-anatomy.html
@@ -5,7 +5,11 @@
       <div style="font-size:12px;color:var(--text-muted);margin-top:4px;" data-i18n="app.decompose_one_agent_turn_into_a_waterfall_prompt_m">Decompose one agent turn into a waterfall: prompt → model call(s) → each tool (start→end) → compaction → reply. Bar width is proportional to wall-clock duration.</div>
     </div>
     <div style="display:flex;gap:6px;align-items:center;">
-      <button class="refresh-btn" id="ta-back-btn" style="display:none;" onclick="turnAnatomyShowList()" data-i18n="app.back_to_sessions">← Back to sessions</button>
+      <!-- Back must RELOAD the list, not just unhide it: arriving via the
+           session deep-dive handoff skips loadTurnAnatomy's list fetch, so a
+           bare turnAnatomyShowList() lands on the static "Loading sessions…"
+           placeholder forever. -->
+      <button class="refresh-btn" id="ta-back-btn" style="display:none;" onclick="loadTurnAnatomy()" data-i18n="app.back_to_sessions">← Back to sessions</button>
       <button class="refresh-btn" onclick="loadTurnAnatomy()">↻</button>
     </div>
   </div>

--- a/routes/sessions.py
+++ b/routes/sessions.py
@@ -4690,21 +4690,45 @@ def _pretty_json(x, cap: int = _TOOL_DETAIL_CAP) -> str:
     return _cap_text(s, cap)
 
 
+def _stamp_row_usage(messages: list, mark: int, ev: dict) -> None:
+    """Attach the daemon-stamped per-event ``token_count`` / ``cost_usd`` to
+    the FIRST message emitted for this event row (``messages[mark]``).
+
+    One event row can expand into several transcript turns (thinking + reply +
+    tool chips); stamping only the first keeps a client-side per-turn sum equal
+    to what /api/turn-anatomy reports for the same events. Never raises."""
+    if mark >= len(messages):
+        return
+    try:
+        tokens = int(ev.get("token_count") or 0)
+        cost = float(ev.get("cost_usd") or 0.0)
+    except (TypeError, ValueError):
+        return
+    if tokens > 0:
+        messages[mark].setdefault("tokens", tokens)
+    if cost > 0:
+        messages[mark]["cost_usd"] = cost
+
+
 def _anthropic_tool_turns(blocks, ts_ms, name_by_id):
-    """Map an Anthropic message ``content`` block list to ``(tool_turns, text)``.
+    """Map an Anthropic message ``content`` block list to
+    ``(tool_turns, text, thinking)``.
 
     ``tool_turns`` is one turn per ``tool_use`` / ``tool_result`` block, each
     carrying a ``tool`` dict (``{kind, name, input|output}``) the replay renders
     as an expandable deep-dive. ``text`` is the joined text blocks, used only
     when the session has no v3 prose event (pure Claude Code) so we never double
-    the assistant reply. ``name_by_id`` maps a ``tool_use`` id to its name so
-    the matching ``tool_result`` (which only references the id) can show which
-    tool it came from.
+    the assistant reply. ``thinking`` is the joined extended-thinking blocks —
+    returned separately so the caller can emit them as ``type: "thinking"``
+    turns the UI styles distinctly from the actual reply. ``name_by_id`` maps a
+    ``tool_use`` id to its name so the matching ``tool_result`` (which only
+    references the id) can show which tool it came from.
     """
     tool_turns: list[dict] = []
     texts: list[str] = []
+    thinkings: list[str] = []
     if not isinstance(blocks, list):
-        return tool_turns, ""
+        return tool_turns, "", ""
     for b in blocks:
         if not isinstance(b, dict):
             continue
@@ -4713,6 +4737,10 @@ def _anthropic_tool_turns(blocks, ts_ms, name_by_id):
             t = b.get("text")
             if t:
                 texts.append(t if isinstance(t, str) else str(t))
+        elif bt == "thinking":
+            t = b.get("thinking")
+            if t:
+                thinkings.append(t if isinstance(t, str) else str(t))
         elif bt == "tool_use":
             name = b.get("name") or "tool"
             tid = b.get("id")
@@ -4743,7 +4771,7 @@ def _anthropic_tool_turns(blocks, ts_ms, name_by_id):
                     "is_error": bool(b.get("is_error")),
                 },
             })
-    return tool_turns, "\n".join(texts)
+    return tool_turns, "\n".join(texts), "\n".join(thinkings)
 
 
 def _expand_openclaw_event(obj: dict, ts_ms):
@@ -5131,6 +5159,7 @@ def _try_local_store_transcript(session_id: str, _events=None):
             # can show the "T=… top_p=… max=…" pill inline with the reply.
             decoding = _extract_decoding_params(obj)
             raw_payload = _bounded_raw_payload(obj)
+            _mark = len(messages)
             for turn in _expand_openclaw_event(obj, ts_ms):
                 if not turn.get("content", "").strip():
                     continue
@@ -5139,6 +5168,7 @@ def _try_local_store_transcript(session_id: str, _events=None):
                 if raw_payload is not None:
                     turn["raw"] = raw_payload
                 messages.append(turn)
+            _stamp_row_usage(messages, _mark, ev)
             continue
 
         # Claude-Code shape (#1911): the real Anthropic message is nested under
@@ -5157,12 +5187,22 @@ def _try_local_store_transcript(session_id: str, _events=None):
                     (usage.get("input_tokens", 0) or 0)
                     + (usage.get("output_tokens", 0) or 0)
                 )
-            tool_turns, block_text = _anthropic_tool_turns(
+            tool_turns, block_text, thinking_text = _anthropic_tool_turns(
                 msg_obj.get("content"), ts_ms, tool_name_by_id)
+            _mark = len(messages)
             for tt in tool_turns:
                 if raw_payload is not None:
                     tt["raw"] = raw_payload
                 messages.append(tt)
+            if thinking_text.strip():
+                # Extended-thinking blocks — the model reasoning on the user's
+                # behalf, not the reply. Stamped ``type: "thinking"`` so the
+                # replay styles them distinctly from the actual answer.
+                tentry = {"role": role, "content": thinking_text,
+                          "timestamp": ts_ms, "type": "thinking"}
+                if raw_payload is not None:
+                    tentry["raw"] = raw_payload
+                messages.append(tentry)
             if block_text.strip() and not has_v3_messages:
                 entry = {"role": role, "content": block_text, "timestamp": ts_ms}
                 decoding = _extract_decoding_params(obj)
@@ -5171,12 +5211,14 @@ def _try_local_store_transcript(session_id: str, _events=None):
                 if raw_payload is not None:
                     entry["raw"] = raw_payload
                 messages.append(entry)
+            _stamp_row_usage(messages, _mark, ev)
             continue
 
         # Anthropic-style fallback (existing logic).
         role = obj.get("role", obj.get("type", "unknown"))
         content = _stringify_content(obj.get("content", ""))
         raw_payload = _bounded_raw_payload(obj)
+        _mark = len(messages)
         if obj.get("tool_calls") or obj.get("tool_use"):
             tools = obj.get("tool_calls") or obj.get("tool_use") or []
             if isinstance(tools, list):
@@ -5199,6 +5241,12 @@ def _try_local_store_transcript(session_id: str, _events=None):
             )
         if content or role in ("user", "assistant", "system"):
             msg_entry = {"role": role, "content": content, "timestamp": ts_ms}
+            # Family-adapter thinking rows (Claude Code extended-thinking
+            # blocks ingested as ``type: "thinking"``, role=assistant) are the
+            # model reasoning on the user's behalf, not the reply — forward
+            # the type so the UI styles them apart from the actual answer.
+            if "thinking" in (et, inner_type):
+                msg_entry["type"] = "thinking"
             if role == "assistant":
                 decoding = _extract_decoding_params(obj)
                 if decoding:
@@ -5206,6 +5254,7 @@ def _try_local_store_transcript(session_id: str, _events=None):
             if raw_payload is not None:
                 msg_entry["raw"] = raw_payload
             messages.append(msg_entry)
+        _stamp_row_usage(messages, _mark, ev)
     if not messages:
         # Same contract as the ``if not rows`` guard above, for the case where
         # rows EXIST but none of them is a transcript turn — e.g. a session_id

--- a/tests/test_transcript_local_store.py
+++ b/tests/test_transcript_local_store.py
@@ -184,3 +184,82 @@ def test_transcript_includes_external_api_calls(app):
     assert calls[0]["host"] == "api.github.com"
     assert calls[0]["method"] == "GET"
     assert calls[0]["status_code"] == 200
+
+
+def test_transcript_thinking_rows_are_typed_and_usage_stamped(app):
+    """Extended-thinking events keep ``type: "thinking"`` so the UI can style
+    the model's internal reasoning apart from the actual reply, and the
+    daemon-stamped per-event token/cost lands on the message (once per row)."""
+    a, ls = app
+    store = ls.get_store()
+    sid = "sess-thinking-typed"
+    store.ingest(_ev("t1", sid, "user", "how is life", "2026-05-12T10:00:00Z"))
+    think = _ev("t2", sid, "assistant", "casual small talk — reply warmly",
+                "2026-05-12T10:00:03Z")
+    think["event_type"] = "thinking"
+    think["data"] = json.dumps({"type": "thinking", "role": "assistant",
+                                "content": "casual small talk — reply warmly",
+                                "timestamp": "2026-05-12T10:00:03Z"})
+    think["token_count"] = 1276
+    think["cost_usd"] = 0.0886
+    store.ingest(think)
+    store.ingest(_ev("t3", sid, "assistant", "life is good!",
+                     "2026-05-12T10:00:05Z"))
+    _drain(store)
+
+    c = a.test_client()
+    r = c.get(f"/api/transcript/{sid}")
+    assert r.status_code == 200
+    msgs = r.get_json()["messages"]
+    assert [m["role"] for m in msgs] == ["user", "assistant", "assistant"]
+    # The thinking turn is typed; the actual reply is not.
+    assert msgs[1].get("type") == "thinking"
+    assert msgs[2].get("type") != "thinking"
+    # Usage stamped from the event row for the per-turn spend badge.
+    assert msgs[1].get("tokens") == 1276
+    assert abs(msgs[1].get("cost_usd", 0) - 0.0886) < 1e-9
+    assert "tokens" not in msgs[2]
+
+
+def test_transcript_nested_message_thinking_block_emitted(app):
+    """Claude-Code shape: a ``thinking`` content block nested under
+    ``data.message`` becomes its own ``type: "thinking"`` turn instead of
+    being silently dropped, and the row's usage lands once on the first
+    message emitted for the row."""
+    a, ls = app
+    store = ls.get_store()
+    sid = "sess-thinking-nested"
+    row = {
+        "id": "n1",
+        "node_id": "node-test",
+        "agent_id": "main",
+        "session_id": sid,
+        "event_type": "assistant",
+        "ts": "2026-05-12T10:00:00Z",
+        "token_count": 500,
+        "cost_usd": 0.05,
+        "data": json.dumps({
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {"type": "thinking", "thinking": "let me reason about it"},
+                    {"type": "text", "text": "the actual answer"},
+                ],
+            },
+            "timestamp": "2026-05-12T10:00:00Z",
+        }),
+    }
+    store.ingest(row)
+    _drain(store)
+
+    c = a.test_client()
+    r = c.get(f"/api/transcript/{sid}")
+    assert r.status_code == 200
+    msgs = r.get_json()["messages"]
+    assert len(msgs) == 2
+    assert msgs[0]["type"] == "thinking"
+    assert msgs[0]["content"] == "let me reason about it"
+    assert msgs[1]["content"] == "the actual answer"
+    # Row usage stamped exactly once (first message of the row).
+    assert msgs[0].get("tokens") == 500
+    assert "tokens" not in msgs[1]


### PR DESCRIPTION
## What

User report (desktop 0.12.787): in the Sessions transcript, the model's extended-thinking blocks rendered as identical green ASSISTANT bubbles next to the actual reply — you couldn't tell the internal reasoning from the answer to the human. Turn-level tokens/cost existed only on the Turn anatomy page. And Turn anatomy's "Back to sessions" landed on an eternal "Loading sessions…" placeholder when the page was entered via the session deep-dive handoff.

## Changes

**Backend (`routes/sessions.py`)**
- `/api/transcript` forwards `type: "thinking"` on family-adapter thinking rows, and lifts `thinking` content blocks nested under `data.message` into their own typed turn (previously silently dropped by `_anthropic_tool_turns`).
- The daemon-stamped per-event `token_count` / `cost_usd` are attached to the **first** message emitted per event row (`_stamp_row_usage`), so a client-side per-turn sum equals what `/api/turn-anatomy` reports for the same events — verified live: chapter badges read 34.0K/$2.37, 25.2K/$1.75, 3.3K/$0.23 exactly matching Turn anatomy's per-turn totals for the same session.

**Frontend (`app.js`, `dashboard.css`)**
- Thinking renders as a cyan-accented `🧠 thinking (internal)` bubble. Cyan matches Turn anatomy's *model* span color, so the mapping reads the same on both pages: cyan = model working, green = the reply to the human, blue = the human.
- A thinking row whose text wasn't captured (some harnesses write `thinking: ""` with only a signature) renders as a labelled 🧠 chip instead of masquerading as "🔧 Tool call".
- Turn chapter headers gain a spend badge: `🪙 34.0K tok · $2.37`; per-message token footers also show cost when known.
- The existing "🧠 Thinking" replay filter now actually matches Claude Code sessions.

**Back buttons (`turn-anatomy.html`, `tracing.html`)**
- "Back to sessions" / "Back to traces" now reload the list instead of just unhiding the never-fetched container.

**Tests**
- Two regression tests in `tests/test_transcript_local_store.py` (thinking typing + once-per-row usage stamping, both event shapes); wired that file into the CI MOAT job's explicit list (it wasn't run in CI before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CJtUZ2LbErywroWPUWV5be

## Product record

Requirement: https://factory.8090.ai/project/b415065f-ab2f-4f53-8864-0c009fd098cb/requirements/958e455a-bb58-4bd4-8e76-958851cdab95