### PR TITLE
fix: make webview storage-path guard survive the binding refactor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,6 +183,13 @@ jobs:
       - name: Merge gate is reachable without privileged secrets
         run: python3 -m pytest tests/test_gate_needs_no_secrets.py -q
 
+      # Desktop onboarding/auth-gate guards (founder report 2026-08-10: a
+      # fresh install landed on the signed-in dashboard with zero login).
+      # Not wired into any job before #5350 -- which is how its private-
+      # storage-path assertion rotted silently against a refactor on main.
+      - name: Desktop onboarding gate guards
+        run: python3 -m pytest tests/test_desktop_onboarding_gate.py -q
+
       # Silent-CLI class guard (#3791): rebinding sys.stdout/sys.stderr to a
       # new TextIOWrapper over the same buffer orphans the previous wrapper;
       # its GC finalizer closes the SHARED buffer, and every later print(),

--- a/tests/test_desktop_onboarding_gate.py
+++ b/tests/test_desktop_onboarding_gate.py
@@ -14,6 +14,7 @@ signed-in dashboard without any login):
 
 from __future__ import annotations
 
+import ast
 import io
 import json
 import sys
@@ -187,8 +188,61 @@ def test_attach_path_respects_first_launch():
     )
 
 
+def _real_webview_start_calls():
+    """Every ``webview.start(...)`` call site outside ``_run_self_test``.
+
+    ``_run_self_test`` opens an ephemeral, CI-only window over synthetic
+    onboarding HTML (no real user session, no credentials) to smoke-test
+    the native backend -- it isn't a real launch path and carries no
+    browser state worth isolating, so it's excluded here.
+    """
+    tree = ast.parse(APP_SRC)
+    self_test_lines = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == "_run_self_test":
+            self_test_lines = set(range(node.lineno, node.end_lineno + 1))
+            break
+
+    return [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "start"
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id == "webview"
+        and node.lineno not in self_test_lines
+    ]
+
+
 def test_webview_uses_private_storage_path():
-    assert APP_SRC.count("storage_path=_webview_storage_dir()") >= 2, (
-        "every webview.start must use the private ClawMetry profile so the "
-        "uninstaller can remove browser state"
-    )
+    # Regex/literal-count assertions rot the moment the code binds the
+    # value to a local (`_storage = _webview_storage_dir()`) instead of
+    # inlining the call -- which is exactly what happened here (#5350).
+    # Walk the actual call sites instead of grepping for one spelling.
+    calls = _real_webview_start_calls()
+    assert calls, "expected at least one real webview.start() call site"
+
+    for call in calls:
+        kwargs = {kw.arg: kw.value for kw in call.keywords}
+        value = kwargs.get("storage_path")
+        assert value is not None, (
+            f"webview.start at desktop/app.py:{call.lineno} has no "
+            "storage_path -- every real launch must use the private "
+            "ClawMetry profile so the uninstaller can remove browser state"
+        )
+        if isinstance(value, ast.Call):
+            derives_from_helper = (
+                isinstance(value.func, ast.Name)
+                and value.func.id == "_webview_storage_dir"
+            )
+        elif isinstance(value, ast.Name):
+            derives_from_helper = (
+                f"{value.id} = _webview_storage_dir()" in APP_SRC
+            )
+        else:
+            derives_from_helper = False
+        assert derives_from_helper, (
+            f"webview.start at desktop/app.py:{call.lineno} storage_path "
+            "does not derive from _webview_storage_dir()"
+        )


### PR DESCRIPTION
## Reproduction

```
python3 -m pytest tests/test_desktop_onboarding_gate.py::test_webview_uses_private_storage_path -q
```
fails on current `main`:
```
assert APP_SRC.count("storage_path=_webview_storage_dir()") >= 2
E       assert 1 >= 2
```

## Root cause

The test counted the literal string `storage_path=_webview_storage_dir()` and required `>= 2` occurrences. `desktop/app.py`'s cold-boot path was refactored to bind `_storage = _webview_storage_dir()` once and pass `storage_path=_storage` to both of its `webview.start()` calls, dropping the literal-string count to 1. The invariant the test guards (every real `webview.start()` call scopes browser state to the private ClawMetry profile, so the uninstaller can sweep it) still holds — the test drifted from the code, not the other way round.

## Fix

Replaced the literal-count assertion with an `ast`-based walk of the actual `webview.start(...)` call sites in `desktop/app.py`. For each call outside `_run_self_test` (an ephemeral CI-only smoke-test window over synthetic HTML — no real user session or credentials to isolate, so it's exempt), the test now asserts `storage_path=` is present and resolves back to `_webview_storage_dir()`, either as a direct call or via a local variable bound from it. This survives future refactors that bind the value differently.

Verified the guard actually catches the regression class: temporarily stripped `storage_path` from one real call site, confirmed the test goes red with a clear message, restored, confirmed green.

Also wires `tests/test_desktop_onboarding_gate.py` into `.github/workflows/ci.yml` (added as a step in the `lint` job, alongside the other self-contained pytest files that need no server). This repo runs explicit file lists rather than `pytest tests/`, and this file wasn't named anywhere — which is exactly how the drift went unnoticed for as long as it did.

Closes #5350

No-PRD: fix of field-reported bug #5350

---
_Generated by [Claude Code](https://claude.ai/code/session_018NUMNToaJzbo4g6qzdp6Rz)_