### PR TITLE
Desktop shell: an exe stub is not an install — recover package corpses

### DIFF
--- a/desktop/app.py
+++ b/desktop/app.py
@@ -1106,7 +1106,21 @@ class RuntimeSupervisor:
         self.failure_class: Optional[str] = None
         self.bootstrap_python_version: str = ""
         if self._venv_clawmetry().exists():
-            return True
+            # The exe stub existing is NOT the package existing. A pip
+            # upgrade that dies between uninstall and install (live field
+            # case 2026-08-29: the watcher updated in place seconds after
+            # a release while the daemon held clawmetry.exe open) leaves
+            # the stub with no clawmetry module behind it — every spawn
+            # then dies with ModuleNotFoundError, and trusting the stub
+            # here made that state permanent across relaunches. Require a
+            # COMPLETE install (dist-info with RECORD — a directory glob,
+            # so the healthy warm launch stays spawn-free and fast) and
+            # fall through to the normal install path when it is absent.
+            if self._get_installed_version() is not None:
+                return True
+            self._log("entry point exists but no complete clawmetry "
+                      "dist-info — package corpse from a half-failed "
+                      "in-place update; reinstalling")
 
         cache = self.runtime / "bootstrap-python.json"
         py = _bootstrap_python(cache)
@@ -1413,6 +1427,7 @@ class RuntimeSupervisor:
             self._log(f"watcher clawmetry-update rc={r.returncode}")
             if r.returncode != 0:
                 self._log(r.stderr[:2000])
+                self._heal_package_corpse(r.stderr or "")
             # Stamp regardless of rc: see the docstring. A failed attempt
             # still consumed an interval, and not stamping it turns the
             # 60s cadence into "retry forever, every tick".
@@ -1423,6 +1438,32 @@ class RuntimeSupervisor:
             # hanging PyPI is exactly the failure that would otherwise
             # re-enter pip on every tick and starve crash-respawn.
             self._mark_upgraded(self._get_installed_version())
+
+    def _heal_package_corpse(self, update_stderr: str) -> None:
+        """Reinstall clawmetry when an in-place update destroyed it.
+
+        Live field case 2026-08-29: `clawmetry update` ran seconds after
+        a release (watcher cadence is 60s, releases can be minutes
+        apart), pip uninstalled the old version and failed to install
+        the new one while the daemon held `clawmetry.exe` open — from
+        then on every `clawmetry ...` invocation died with
+        ModuleNotFoundError, every 60s, forever, because the updater the
+        watcher shells IS the package that no longer exists. The venv's
+        python and pip survive a corpse, so the shell repairs it
+        directly rather than asking the corpse to fix itself."""
+        if "No module named" not in update_stderr:
+            # Only the corpse signature. Other update failures (index
+            # propagation races, transient network) resolve themselves
+            # on a later tick and must not trigger surprise installs.
+            return
+        if self._get_installed_version() is not None:
+            return
+        self._log("update left an exe stub with no clawmetry package — "
+                  "reinstalling via the venv's pip")
+        rc, out = self._pip_install_clawmetry()
+        self._log(f"package-corpse reinstall rc={rc}")
+        if rc != 0:
+            self._log(f"reinstall output tail: {out[-2000:]}")
 
     def restart_daemon(self) -> bool:
         """Stop the current daemon and spawn a fresh one on the same

--- a/tests/test_desktop_bootstrap_resilience.py
+++ b/tests/test_desktop_bootstrap_resilience.py
@@ -354,3 +354,68 @@ def test_version_reader_tolerates_legacy_cache(tmp_path):
     cache.write_text('{"python": "/usr/bin/python3"}')
     assert dapp._bootstrap_python_version(cache) == ""
     assert dapp._bootstrap_python_version(None) == ""
+
+
+# ── 7. an exe stub is not an install (package-corpse recovery) ───────────
+#
+# Live field case 2026-08-29, second failure of the day on the same
+# machine: the watcher's in-place `clawmetry update` fired seconds after
+# a release, pip uninstalled the old package and failed to install the
+# new one while the daemon held clawmetry.exe open. Result: an exe stub
+# with no clawmetry module. The warm-launch short-circuit trusted the
+# stub, so every relaunch showed "Daemon did not come up" forever, and
+# the watcher shelled the corpse to update itself every 60s forever.
+
+
+def test_warm_launch_requires_a_complete_install(tmp_path, monkeypatch):
+    sup = _sup(tmp_path)
+    exe = sup._venv_clawmetry()
+    exe.parent.mkdir(parents=True, exist_ok=True)
+    exe.write_text("stub")
+    # no dist-info anywhere -> the install is a corpse
+    monkeypatch.setattr(sup, "_get_installed_version", lambda: None)
+    # prove bootstrap FALLS THROUGH to the install path rather than
+    # trusting the stub: with no usable python it must fail with
+    # no_python (the old code returned True here and bricked relaunches)
+    monkeypatch.setattr(dapp, "_bootstrap_python", lambda cache_file=None: None)
+    monkeypatch.setattr(dapp.platform, "system", lambda: "Linux")
+    assert sup.bootstrap() is False
+    assert sup.failure_class == "no_python"
+
+
+def test_warm_launch_stays_fast_when_install_is_complete(tmp_path, monkeypatch):
+    sup = _sup(tmp_path)
+    exe = sup._venv_clawmetry()
+    exe.parent.mkdir(parents=True, exist_ok=True)
+    exe.write_text("stub")
+    monkeypatch.setattr(sup, "_get_installed_version", lambda: "1.2.3")
+
+    def boom(cache_file=None):
+        raise AssertionError("healthy warm launch must not probe interpreters")
+
+    monkeypatch.setattr(dapp, "_bootstrap_python", boom)
+    assert sup.bootstrap() is True
+
+
+def test_corpse_heal_reinstalls_only_on_the_corpse_signature(tmp_path, monkeypatch):
+    sup = _sup(tmp_path)
+    calls = []
+    monkeypatch.setattr(sup, "_pip_install_clawmetry",
+                        lambda: calls.append(1) or (0, "ok"))
+
+    monkeypatch.setattr(sup, "_get_installed_version", lambda: None)
+    sup._heal_package_corpse("Connection to pypi.org timed out")
+    assert not calls, "transient update failures must not trigger reinstalls"
+
+    sup._heal_package_corpse("ModuleNotFoundError: No module named 'clawmetry'")
+    assert len(calls) == 1, "the corpse signature must trigger a reinstall"
+
+
+def test_corpse_heal_noops_when_package_is_actually_present(tmp_path, monkeypatch):
+    sup = _sup(tmp_path)
+    calls = []
+    monkeypatch.setattr(sup, "_pip_install_clawmetry",
+                        lambda: calls.append(1) or (0, "ok"))
+    monkeypatch.setattr(sup, "_get_installed_version", lambda: "1.2.3")
+    sup._heal_package_corpse("No module named 'somethingelse'")
+    assert not calls

--- a/tests/test_desktop_unattended_update.py
+++ b/tests/test_desktop_unattended_update.py
@@ -79,6 +79,9 @@ def _stub_shell(tmp_path):
     stub._venv_clawmetry = lambda: cli
     stub._get_installed_version = lambda: "0.12.999"
     stub._mark_upgraded = stub.upgraded.append
+    # a version is installed per _get_installed_version above, so the
+    # corpse-heal hook (called on any nonzero update rc) must be a no-op
+    stub._heal_package_corpse = lambda stderr: None
     return stub, cli
 
 


### PR DESCRIPTION
Second field failure on the same Windows machine (2026-08-29 evening), from its bootstrap.log: the cffi fix healed it at 18:19 UTC (0.12.787, healthy daemon, 2h of heartbeats) — then the watcher's in-place `clawmetry update` fired **seconds after 0.12.788's wheel upload**, pip uninstalled the old package and failed to install the new one while the daemon held `clawmetry.exe` open. Result: an exe stub with no `clawmetry` module. Every invocation then died with `ModuleNotFoundError` every 60s (the updater the watcher shells IS the missing package), and every relaunch bricked because `bootstrap()`'s warm-launch short-circuit trusted the stub's existence.

**Fixes:**
1. Warm launch requires a **complete** install — stub + `clawmetry-*.dist-info` with `RECORD` (directory glob, healthy path stays spawn-free). A corpse falls through to the install path: permanent brick → ~15s reinstall on next launch.
2. The watcher self-heals: failed update + `No module named` signature + no complete dist-info → direct reinstall via the venv's pip (`_heal_package_corpse`). Transient failures don't trigger reinstalls.

**Tests:** 4 new cases in the CI-wired resilience file; all 160 desktop tests pass. The deeper root cause (in-place update can destroy the install while the daemon holds the exe) is filed separately for a durable fix.

## Product record

Requirement: https://factory.8090.ai/project/b415065f-ab2f-4f53-8864-0c009fd098cb/requirements/69b515ab-12cf-403c-b60f-3619a73e01f5
Blueprint: https://factory.8090.ai/project/b415065f-ab2f-4f53-8864-0c009fd098cb/blueprints/5f6b2b76-97af-4c40-9f5f-e1564eac0afe (package-corpse recovery + warm-launch ADR updated ahead of this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011aj9ezQGu8utv8zJ2QppW6