### PR TITLE
Wake answers immediately: heartbeat inside the wake return, not after the next cycle

### DIFF
--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -23081,9 +23081,23 @@ def run_daemon() -> None:
             ),
         )
         if _wake_now:
-            # Zero the timer so the `now - last_heartbeat > interval` gate at
-            # the end of the next cycle body fires no matter the cadence.
-            last_heartbeat = 0.0
+            # Answer NOW, not after the next cycle body. The body's ingest
+            # passes can run 10-20s on a busy node, and waiting them out put
+            # a measured 22.5s on a transcript ask that the wake had already
+            # detected within ~2s (live measurement, 2026-08-29). A heartbeat
+            # here drains pending_queries and dispatches them synchronously;
+            # the cycle body then runs as usual with a fresh timer.
+            if send_heartbeat(config):
+                last_heartbeat = time.time()
+                consecutive_hb_failures = 0
+                heartbeat_interval = _pick_heartbeat_interval(
+                    _LAST_HEARTBEAT_RESPONSE
+                )
+            else:
+                # Fall back to the old shape: zero the timer so the normal
+                # end-of-cycle gate retries, and let its failure accounting
+                # take over from there.
+                last_heartbeat = 0.0
 
 
 # ── Telegram gateway-log ingest (#1192 follow-up) ──────────────────────────


### PR DESCRIPTION
Follow-up to #5342, from live verification. Cold transcript fetch measured **22.5s**: the wake long-poll detected the queued query within ~2s, but the handler only zeroed `last_heartbeat`, so the answer waited behind a full ingest cycle body (10-20s on a busy node) before the end-of-cycle heartbeat gate fired.

Fix: on a wake answer, call `send_heartbeat(config)` right there — `pending_queries` drain and dispatch synchronously — then run the cycle body with a fresh timer. On heartbeat failure the previous behavior is kept (timer zeroed; the normal gate's failure accounting takes over).

Expected cold-path budget: wake detect ≤2s + immediate heartbeat + dispatch ≈ **3-6s** when the subscribe lands during the idle hold (the common case: daemon idle, user clicks a session).

Requirement: https://factory.8090.ai/project/b415065f-ab2f-4f53-8864-0c009fd098cb/requirements/9297ce8e-6522-4690-b59e-73b8c5842815

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KDr9ivjLUPo1iTjFdVVvXt