### PR TITLE
fix: roll back to the previous version when clawmetry update fails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -401,6 +401,7 @@ jobs:
             tests/test_license_sync_pro_from_config.py \
             tests/test_install_script_pro_upgrade.py \
             tests/test_wake_poll.py \
+            tests/test_cli_unattended_update.py \
             -q
 
   # ── Entitlement API test suite (~2700+ hermetic tests) ─────────────────────────────────────────────

--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -5192,6 +5192,43 @@ def _print_pro_sync_result() -> None:
         print(f"clawmetry-pro {after} kept — could not confirm entitlement right now")
 
 
+def _restore_previous_install(current: str) -> None:
+    """Best-effort pip-reinstall of ``current`` after a failed upgrade (#5357).
+
+    ``pip install --upgrade`` uninstalls the old version before installing
+    the new one; if the new install then fails (live-hit on Windows: the
+    daemon still holds ``clawmetry.exe`` open seconds after a fresh wheel
+    upload, so pip's overwrite fails AFTER the uninstall already ran), the
+    venv is left with the launcher stub but no ``clawmetry`` package at all.
+    ``--force-reinstall`` regenerates the console-script entry points
+    regardless of what site-packages metadata claims, matching the rollback
+    ``routes/meta.py::perform_self_update`` already does for the
+    daemon/dashboard self-update path. Never raises; ``current == "unknown"``
+    (the version probe itself failed) has nothing to roll back to.
+    """
+    if not current or current == "unknown":
+        return
+    import subprocess as _sp
+
+    try:
+        restore = _sp.run(
+            [
+                sys.executable, "-m", "pip", "install", "--no-cache-dir",
+                "--force-reinstall", "--no-deps", "--break-system-packages",
+                f"clawmetry=={current}",
+            ],
+            capture_output=True, text=True, timeout=120,
+        )
+        if restore.returncode == 0:
+            print(f"Restored previous version ({current}) after the failed update")
+        else:
+            tail = ((restore.stdout or "") + (restore.stderr or "")).strip()[-300:]
+            print(f"Warning: could not restore previous version ({current}): "
+                  f"{tail or '(no output)'}")
+    except Exception as exc:
+        print(f"Warning: could not restore previous version ({current}): {exc}")
+
+
 def _cmd_update(args=None) -> None:
     """Self-update clawmetry to the latest PyPI version.
 
@@ -5277,9 +5314,16 @@ def _cmd_update(args=None) -> None:
                     print("Tip: restart the daemon to use the new version")
         else:
             print(f"Update failed:\n{result.stderr}")
+            # pip already ran the uninstall half of --upgrade; the venv may
+            # now have zero clawmetry installed (#5357). Never leave a failed
+            # update worse than a no-op.
+            _restore_previous_install(current)
             sys.exit(1)
     except subprocess.TimeoutExpired:
         print("Update timed out. Try manually: pip install --upgrade clawmetry")
+        # A pip KILLED mid-install can leave the same uninstall-without-
+        # reinstall gap as a nonzero exit (#5357).
+        _restore_previous_install(current)
         sys.exit(1)
     except Exception as e:
         print(f"Update error: {e}")

--- a/tests/test_cli_unattended_update.py
+++ b/tests/test_cli_unattended_update.py
@@ -15,6 +15,8 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
+
 REPO_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(REPO_ROOT))
 
@@ -220,6 +222,97 @@ def test_cmd_update_plain_still_upgrades_unpinned(monkeypatch):
     monkeypatch.setattr(cli, "_unattended_update_target", _no_policy)
     cli._cmd_update(SimpleNamespace(unattended=False))
     assert "clawmetry" in calls[0]
+
+
+# ── #5357: a failed upgrade must never leave zero packages installed ───────
+#
+# `pip install --upgrade` uninstalls the old version before installing the
+# new one. Live-hit on Windows 2026-08-29: the daemon still held
+# `clawmetry.exe` open seconds after a fresh wheel upload, so pip's overwrite
+# failed AFTER the uninstall already ran, leaving the venv with the launcher
+# stub but no `clawmetry` package at all. `_cmd_update` must roll back to the
+# version that was running before the attempt, mirroring the rollback
+# `routes/meta.py::perform_self_update` already does for the daemon path
+# (tests/test_self_update_timeout_rollback.py).
+
+def _multi_run_recorder(monkeypatch, responses):
+    """Like ``_run_recorder`` but returns a DIFFERENT canned result per call,
+    so a test can tell the failed upgrade call apart from the rollback call
+    that follows it."""
+    import subprocess
+
+    calls = []
+
+    def _fake_run(cmd, **kw):
+        calls.append(cmd)
+        idx = len(calls) - 1
+        if idx < len(responses):
+            return responses[idx]
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+    return calls
+
+
+def test_cmd_update_failure_restores_previous_version(monkeypatch, capsys):
+    from dashboard import __version__ as current
+
+    calls = _multi_run_recorder(monkeypatch, [
+        SimpleNamespace(returncode=1, stdout="", stderr="boom"),  # failed upgrade
+        SimpleNamespace(returncode=0, stdout="", stderr=""),      # rollback reinstall
+    ])
+    with pytest.raises(SystemExit) as exc:
+        cli._cmd_update(SimpleNamespace(unattended=False))
+    assert exc.value.code == 1
+    assert len(calls) == 2, calls
+    rollback_cmd = calls[1]
+    assert "--force-reinstall" in rollback_cmd
+    assert f"clawmetry=={current}" in rollback_cmd
+    assert "Restored previous version" in capsys.readouterr().out
+
+
+def test_cmd_update_timeout_restores_previous_version(monkeypatch):
+    from dashboard import __version__ as current
+    import subprocess
+
+    calls = []
+
+    def _fake_run(cmd, **kw):
+        calls.append(cmd)
+        if len(calls) == 1:
+            raise subprocess.TimeoutExpired(cmd, 120)
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+    with pytest.raises(SystemExit) as exc:
+        cli._cmd_update(SimpleNamespace(unattended=False))
+    assert exc.value.code == 1
+    assert len(calls) == 2, calls
+    assert "--force-reinstall" in calls[1]
+    assert f"clawmetry=={current}" in calls[1]
+
+
+def test_cmd_update_success_never_rolls_back(monkeypatch):
+    from dashboard import __version__ as current
+
+    # stdout echoes `current` back so the command takes the quiet
+    # "already latest" branch (no daemon-restart shell-out to record too).
+    calls = _run_recorder(monkeypatch, returncode=0, stdout=current + "\n")
+    cli._cmd_update(SimpleNamespace(unattended=False))
+    assert not any("--force-reinstall" in c for c in calls)
+
+
+def test_restore_previous_install_skips_unknown_version(monkeypatch):
+    """No version to roll back to (the pre-upgrade probe itself failed) must
+    never shell out — reinstalling ``clawmetry==unknown`` can only fail."""
+    import subprocess
+
+    def _boom(*a, **k):
+        raise AssertionError("must not attempt a reinstall with no known version")
+
+    monkeypatch.setattr(subprocess, "run", _boom)
+    cli._restore_previous_install("unknown")
+    cli._restore_previous_install("")
 
 
 def test_real_parser_wires_unattended_into_cmd_update(monkeypatch):


### PR DESCRIPTION
## Reproduction

`pip install --upgrade` uninstalls the old version before installing the new one. Field-reported on Windows 11 / Python 3.14, 2026-08-29 ~20:12 UTC: the desktop shell watcher ran `clawmetry update --unattended` seconds after a fresh wheel upload, while the daemon (spawned from `venv\Scripts\clawmetry.exe`) was still running and holding the exe open. The update returned rc=1, and afterwards the venv had the launcher stub but **no `clawmetry` package at all** — pip's uninstall half of `--upgrade` succeeded, the install half failed (Windows can't overwrite an open file), and nothing rolled it back.

Faithful-simulation repro added in `tests/test_cli_unattended_update.py`: `_cmd_update` is exercised with a `subprocess.run` stand-in that fails the upgrade call (nonzero exit, and separately a `TimeoutExpired`) and asserts a follow-up pip call happens. Confirmed both new tests fail against the pre-fix code (`AssertionError: 1 == 2` — no rollback call was made) and pass after the fix.

## Fix

`clawmetry/cli.py::_cmd_update` (the desktop shell's `clawmetry update --unattended` path) did a bare `pip install --upgrade` with no rollback on failure — unlike `routes/meta.py::perform_self_update`, the daemon/dashboard self-update path, which already force-reinstalls the previous version on a failed or timed-out pip run (see `tests/test_self_update_timeout_rollback.py`). This PR adds the same rollback to `_cmd_update`: on a nonzero pip exit or a `TimeoutExpired`, it force-reinstalls the version that was running before the attempt (skipped if that version couldn't even be determined), so a failed update is never worse than a no-op.

## Tests

- `tests/test_cli_unattended_update.py`: 4 new cases — rollback fires on pip failure, rollback fires on timeout, a successful upgrade never triggers a rollback, and an unknown pre-upgrade version is never used as a reinstall target.
- Wired `tests/test_cli_unattended_update.py` into the MOAT verifier job in `.github/workflows/ci.yml` — it was a real, already-existing test file for this exact function that CI never ran (this repo's CI runs explicit file lists, not `pytest tests/`).
- `tests/test_workflow_yaml_valid.py` still passes (194 total incl. skips) after the ci.yml edit.

Closes #5357

No-PRD: fix of field-reported bug #5357

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gv7MDkvzP7DPuATy7URFi3)_