### PR TITLE
fix(snapshot): keep the opening user prompt when capping long transcripts

### DIFF
--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -16053,6 +16053,69 @@ def _derive_transcript_title(msgs):
     return ""
 
 
+def _first_user_prompt_index(msgs):
+    """Index of the opening user prompt in a transcript message list, or
+    ``None``. Mirrors what the replay's turn grouping treats as a turn anchor:
+    ``role == "user"``, not a tool chip, non-empty text content."""
+    for i, m in enumerate(msgs):
+        if not isinstance(m, dict) or m.get("role") != "user" or m.get("tool"):
+            continue
+        c = m.get("content")
+        if isinstance(c, str) and c.strip():
+            return i
+    return None
+
+
+def _cap_transcript_messages(msgs, msg_cap):
+    """Cap a transcript to ~``msg_cap`` messages for the snapshot WITHOUT
+    losing the opening user prompt. Returns ``(messages, truncated)``.
+
+    The old ``msgs[-msg_cap:]`` tail-cap silently dropped the head of any
+    session longer than the cap, including the first user message, so the
+    cloud replay opened mid-session on a bare tool chip and long sessions
+    lost every turn anchor (user report 2026-08-29: 83-message session,
+    cap 80, opening prompt gone; 756-message session rendered as a single
+    turn). The title fix (_derive_transcript_title runs pre-cap) masked it
+    in the list view while the replay stayed headless.
+
+    Keep the opening user prompt, an honest omission marker, and the most
+    recent messages; the full transcript stays on the local dashboard.
+    """
+    if len(msgs) <= msg_cap:
+        return msgs, False
+    tail = msgs[-(msg_cap - 2):] if msg_cap > 2 else msgs[-msg_cap:]
+    tail_start = len(msgs) - len(tail)
+    keep = []
+    fu_idx = _first_user_prompt_index(msgs)
+    if fu_idx is not None and fu_idx < tail_start:
+        keep.append(msgs[fu_idx])
+    omitted = tail_start - len(keep)
+    if omitted > 0:
+        # Timestamp the marker just before the tail so the viewer's
+        # ts-sorted merge keeps it between the opening prompt and the
+        # recent messages.
+        marker_ts = None
+        for m in tail:
+            ts = m.get("timestamp") if isinstance(m, dict) else None
+            if isinstance(ts, (int, float)):
+                marker_ts = ts - 1
+                break
+        if marker_ts is None and keep:
+            ts = keep[0].get("timestamp")
+            if isinstance(ts, (int, float)):
+                marker_ts = ts + 1
+        keep.append({
+            "role": "system",
+            "content": (
+                "… %d earlier messages not shown here to keep cloud sync "
+                "light. Open your local ClawMetry dashboard for the full "
+                "transcript." % omitted
+            ),
+            "timestamp": marker_ts,
+        })
+    return keep + tail, True
+
+
 def _build_transcripts(limit_sessions=8, msg_cap=80, extra_sids=None):
     """Recent per-session transcripts for the cloud Embodied tab.
 
@@ -16113,9 +16176,9 @@ def _build_transcripts(limit_sessions=8, msg_cap=80, extra_sids=None):
                     title = _derive_transcript_title(msgs)
                 except Exception:
                     title = ""
-                if len(msgs) > msg_cap:
+                msgs, _was_capped = _cap_transcript_messages(msgs, msg_cap)
+                if _was_capped:
                     t = dict(t)
-                    msgs = msgs[-msg_cap:]
                     t["messages"] = msgs
                     t["_truncated"] = True
                 # Perf: the per-message `raw` payload (#1895) can be ~12 KB each

--- a/tests/test_transcript_local_store.py
+++ b/tests/test_transcript_local_store.py
@@ -263,3 +263,71 @@ def test_transcript_nested_message_thinking_block_emitted(app):
     # Row usage stamped exactly once (first message of the row).
     assert msgs[0].get("tokens") == 500
     assert "tokens" not in msgs[1]
+
+
+# ── Snapshot message cap keeps the opening user prompt ──────────────────────
+# The cloud replay renders the SNAPSHOT transcript (sync._build_transcripts),
+# which caps long sessions to the last N messages. The old tail-only cap
+# dropped the first user message, so the hosted replay opened mid-session on
+# a bare tool chip and its turn TOC lost the anchor turn (user report
+# 2026-08-29). _cap_transcript_messages must keep the opening prompt plus an
+# honest omission marker.
+
+
+def _msgs(n, first_user_at=0):
+    out = []
+    for i in range(n):
+        if i == first_user_at:
+            out.append({"role": "user", "content": f"the opening prompt {i}",
+                        "timestamp": 1000 + i})
+        else:
+            out.append({"role": "assistant", "content": f"reply {i}",
+                        "timestamp": 1000 + i})
+    return out
+
+
+def test_cap_keeps_short_transcripts_untouched():
+    from clawmetry.sync import _cap_transcript_messages
+    msgs = _msgs(10)
+    capped, truncated = _cap_transcript_messages(msgs, 80)
+    assert capped is msgs
+    assert truncated is False
+
+
+def test_cap_preserves_first_user_prompt_and_marks_omission():
+    from clawmetry.sync import _cap_transcript_messages
+    msgs = _msgs(83)  # the exact shape of the field report: 83 msgs, cap 80
+    capped, truncated = _cap_transcript_messages(msgs, 80)
+    assert truncated is True
+    assert len(capped) <= 80
+    # Opening user prompt survives, first in the list.
+    assert capped[0]["role"] == "user"
+    assert capped[0]["content"] == "the opening prompt 0"
+    # Honest omission marker sits between the prompt and the tail, timestamped
+    # so the viewer's ts-sorted merge keeps it in place.
+    marker = capped[1]
+    assert marker["role"] == "system"
+    assert "not shown" in marker["content"]
+    assert capped[0]["timestamp"] < marker["timestamp"] < capped[2]["timestamp"]
+    # Tail is the most recent messages, ending on the true last message.
+    assert capped[-1]["content"] == "reply 82"
+
+
+def test_cap_without_user_prompt_still_marks_omission():
+    from clawmetry.sync import _cap_transcript_messages
+    msgs = [{"role": "assistant", "content": f"reply {i}", "timestamp": 1000 + i}
+            for i in range(100)]
+    capped, truncated = _cap_transcript_messages(msgs, 80)
+    assert truncated is True
+    assert capped[0]["role"] == "system"
+    assert "not shown" in capped[0]["content"]
+    assert capped[-1]["content"] == "reply 99"
+
+
+def test_cap_first_user_prompt_already_in_tail_not_duplicated():
+    from clawmetry.sync import _cap_transcript_messages
+    msgs = _msgs(100, first_user_at=95)
+    capped, truncated = _cap_transcript_messages(msgs, 80)
+    assert truncated is True
+    user_turns = [m for m in capped if m.get("role") == "user"]
+    assert len(user_turns) == 1


### PR DESCRIPTION
## Problem

On the hosted dashboard (app.clawmetry.com), the session replay was missing the **first user message**. An 83-message session opened on a bare `Read` tool chip with Turn 0 labeled 'Session setup', and a 756-message session collapsed to a single turn with no user prompts at all.

## Root cause

`sync.py::_build_transcripts` caps snapshot transcripts to the last 80 messages via `msgs[-msg_cap:]` — a pure tail cut. Any session longer than the cap loses its head, which always includes the opening user prompt (83 msgs → first 3 dropped, exactly the prompt + 2 events). The replay's turn grouping anchors turns on user prompts, so long tool-heavy sessions whose last 80 messages contain no user text rendered as one anchorless turn. The earlier title fix (derive title pre-cap) masked this in the session list while the replay stayed headless.

## Fix

New `_cap_transcript_messages(msgs, msg_cap)` helper: keep the opening user prompt, insert an honest '… N earlier messages not shown here to keep cloud sync light' system marker (timestamped between the prompt and the tail so the viewer's ts-sorted merge keeps it in place), then fill the remaining budget with the most recent messages. Short sessions untouched; snapshot size unchanged (+1 small marker message).

Verified against the live 83-message session: capped output opens with the real first prompt, then the marker, then the 78-message tail.

## Tests

4 new tests in `tests/test_transcript_local_store.py` (already in CI's explicit file list): short-session passthrough, the exact 83/80 field shape, no-user-prompt sessions, and no duplication when the prompt is already in the tail.

No-PRD: user-reported replay bug, single-function fix in the snapshot cap

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014xPQzRMjjjU1RTtJkqu5cd