### PR TITLE
Harden CI: bind matrix.source before it reaches the smoke-test shell

### DIFF
--- a/.github/workflows/api-latency-smoke.yml
+++ b/.github/workflows/api-latency-smoke.yml
@@ -52,10 +52,19 @@ jobs:
           python -m build --wheel
 
       - name: Install into isolated venv
+        # `matrix.source` is bound to an env var rather than expanded into the
+        # script. GitHub substitutes `${{ }}` textually before bash parses the
+        # line, so an expression in a run: block is script source, not data --
+        # the surrounding quotes give no protection. This matrix is closed
+        # (both fromJSON arrays above are literals), so nothing here is
+        # reachable today; binding it keeps that true if the matrix ever
+        # starts deriving a value from an input or event payload.
+        env:
+          SOURCE: ${{ matrix.source }}
         run: |
           python -m venv /tmp/vsmoke
           /tmp/vsmoke/bin/pip install --upgrade pip
-          if [ "${{ matrix.source }}" = "pypi" ]; then
+          if [ "$SOURCE" = "pypi" ]; then
             /tmp/vsmoke/bin/pip install --no-cache-dir clawmetry flask waitress cryptography duckdb requests
           else
             /tmp/vsmoke/bin/pip install dist/clawmetry-*.whl flask waitress cryptography duckdb requests


### PR DESCRIPTION
## What

`api-latency-smoke.yml`'s "Install into isolated venv" step interpolated `${{ matrix.source }}` directly into its `run:` block. The value now travels through a step-level `env:` var and is read as a quoted shell variable.

GitHub substitutes `${{ }}` expressions textually, before bash parses the line, so an expression in a `run:` block arrives as script source rather than as data — the surrounding quotes give no protection. zizmor reports this as `template-injection` (Medium), and it was the last non-informational finding of that family in the repository.

## Scope, stated plainly

**Nothing is reachable through this today.** The matrix is closed:

```yaml
source: ${{ github.event_name == 'schedule' && fromJSON('["wheel", "pypi"]') || fromJSON('["wheel"]') }}
```

Both `fromJSON` arrays are literals, so `matrix.source` can only ever be the string `wheel` or `pypi`. This is defence in depth, not a fix for an exploitable path — zizmor flags it because it cannot prove the matrix is closed, and I am not claiming more than that.

What the binding buys is durability. If the matrix ever starts deriving its value from a workflow input or an event payload, this line becomes a live injection site with nobody editing it, and the change would not look like a security change. Binding now means that edit stays safe.

The other two references to `matrix.source` — the job `name:` and the step `if:` — are expression contexts rather than shell, and are correct as they are. They are left alone.

## Verification

| Check | Result |
|---|---|
| `yaml.safe_load` over all workflow + composite-action files | 35/35 parse |
| zizmor on `api-latency-smoke.yml` | 1 → **0** findings |
| Repo-wide scan for untrusted interpolation in `run:` blocks | 0 sites |
| SHA-pinning ratchet | holds, 151/151 refs pinned |

Behaviour is unchanged, and that was measured rather than assumed. The run block was extracted and executed under `bash -e` with a stubbed `pip`, for both matrix values, comparing the old (pre-substituted) form against the new (env-bound) form:

| `matrix.source` | Resolved command | Old vs new |
|---|---|---|
| `wheel` | `pip install dist/clawmetry-*.whl flask waitress cryptography duckdb requests` | byte-identical |
| `pypi` | `pip install --no-cache-dir clawmetry flask waitress cryptography duckdb requests` | byte-identical |

## Notes for review

One file, one step, `.github/` only — exempt from the product-record gate (`No-PRD` recorded in the commit message).

This is the last item I could find in this hardening batch that is both unclaimed and safe to fix without a judgement call. For the record, the remaining zizmor findings on this repo are deliberately **not** in this PR:

- `artipacked` × 13 — 10 are covered by open PRs #5331, #5338 and #5343. The other 3 (`auto-deploy-cloud.yml:82`, `release-on-merge.yml`, `auto-quarantine.yml`) all push from the working copy, so their credential has a real consumer and removing it would break the release path.
- `dangerous-triggers` × 2 (`workflow_run` in `auto-deploy-cloud.yml`, `release-canary.yml`) and `cache-poisoning` × 1 (`publish.yml`) — load-bearing for the release and publish pipelines. These want a deliberate design decision, not a sweep.
- `github-env` × 2 in `.github/actions/setup-openclaw/action.yml` — legitimate `GITHUB_PATH` / `GITHUB_ENV` writes with internal values; restructuring them is a bigger change than a hardening tick should make unasked.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FcrEBdhyYY8etBZMtAL6UK)_