### PR TITLE
CI: dmg-detach retry + cancel-in-progress groups (installer builds + queue depth)

### DIFF
--- a/.github/workflows/auth-bootstrap-guard.yml
+++ b/.github/workflows/auth-bootstrap-guard.yml
@@ -6,6 +6,10 @@ on:
       - "clawmetry/static/js/*.js"
       - ".github/workflows/auth-bootstrap-guard.yml"
 
+concurrency:
+  group: abg-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/desktop-artifacts.yml
+++ b/.github/workflows/desktop-artifacts.yml
@@ -191,7 +191,30 @@ jobs:
           sync && sleep 2
           osascript -e 'tell application "Finder" to close every window' || true
           sleep 1
-          hdiutil detach "/Volumes/ClawMetry" -force
+          # Spotlight/fseventsd can hold the freshly-arranged volume busy
+          # for several seconds; a single -force detach failed two tagged
+          # builds in a row (v0.12.788 + v0.12.789: `hdiutil: couldn't
+          # eject "disk8" - Resource busy`, exit 16), which kept both
+          # Releases drafts and left /releases/latest serving the previous
+          # version's installers. Retry with backoff, fall back to
+          # diskutil, and only then fail.
+          detached=""
+          for i in 1 2 3 4 5 6; do
+            if hdiutil detach "/Volumes/ClawMetry" -force; then
+              detached=1; break
+            fi
+            echo "detach attempt $i failed; retrying in $((i * 3))s"
+            sleep $((i * 3))
+          done
+          if [ -z "$detached" ]; then
+            diskutil unmountDisk force "/Volumes/ClawMetry" || true
+            sleep 3
+            hdiutil detach "/Volumes/ClawMetry" -force || true
+          fi
+          if mount | grep -q "/Volumes/ClawMetry"; then
+            echo "::error::could not detach /Volumes/ClawMetry after retries"
+            exit 1
+          fi
 
           # Convert writable UDRW → compressed read-only UDZO (final shape).
           hdiutil convert "$TEMP_DMG" \

--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -8,6 +8,10 @@ on:
 
 # Least privilege: these jobs only read the repo. Any job needing more
 # must elevate with its own job-level `permissions:` block.
+concurrency:
+  group: insttest-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/product-record-gate.yml
+++ b/.github/workflows/product-record-gate.yml
@@ -20,6 +20,10 @@ on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
 
+concurrency:
+  group: prg-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/zero-click-auth-e2e.yml
+++ b/.github/workflows/zero-click-auth-e2e.yml
@@ -28,6 +28,10 @@ on:
       - "tests/e2e/package.json"
       - ".github/workflows/zero-click-auth-e2e.yml"
 
+concurrency:
+  group: zca-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 


### PR DESCRIPTION
`hdiutil detach -force` failed with `couldn't eject "disk8" - Resource busy` (exit 16) on **both** v0.12.788 and v0.12.789 macOS legs (runs 33272886189, 33273320094) — Spotlight/fseventsd holds the just-arranged volume busy for a few seconds after the Finder osascript. With `fail_on_unmatched_files` this keeps each Release a **draft**, so `/releases/latest/download/*` is still serving v0.12.784's installers while three newer releases exist on PyPI.

Fix: retry the detach 6× with growing backoff → `diskutil unmountDisk force` fallback → hard-fail only if the volume is genuinely still mounted.

CI-only change (`.github/` path). Once merged: the queued release for #5353 dispatches the build at its new tag; if that tag predates this fix I'll re-cut so the fixed workflow builds the installers carrying #5351 + #5356.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011aj9ezQGu8utv8zJ2QppW6