### PR TITLE
ci: main-first runner priority (park queued PR runs, requeue green-drift PRs)

### DIFF
--- a/.github/workflows/queue-priority.yml
+++ b/.github/workflows/queue-priority.yml
@@ -1,0 +1,108 @@
+# Main-first runner priority.
+#
+# GitHub Actions has no queue priority on hosted runners: a push to main can sit
+# behind hundreds of queued PR / dependabot jobs, which delays the release ->
+# PyPI -> cloud pipeline (the one queue position that actually matters). This
+# workflow implements the priority by hand:
+#
+#   1. clear-queue  — on every push to main, cancel all *queued* (never
+#      in-progress) runs on non-main refs so main's jobs take the runners next.
+#   2. requeue      — once main is quiet again (Auto-deploy Cloud completed, or
+#      the half-hourly sweep finds main idle), re-run the latest cancelled run
+#      of each workflow for every open PR whose drift-bot check is green.
+#      Red-drift PRs stay parked until their drift is fixed and re-reported.
+#
+# No third-party actions on purpose: every step is `gh api` against
+# GITHUB_TOKEN, so there is nothing to SHA-pin and no checkout needed.
+
+name: Queue priority (main first)
+
+on:
+  push:
+    branches: [main]
+  workflow_run:
+    workflows: ["Auto-deploy Cloud on OSS update"]
+    types: [completed]
+  schedule:
+    - cron: "*/30 * * * *"
+  workflow_dispatch:
+
+permissions:
+  actions: write
+  checks: read
+  pull-requests: read
+
+# One instance at a time; a queued follow-up collapses into the latest.
+concurrency:
+  group: queue-priority
+  cancel-in-progress: false
+
+env:
+  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  REPO: ${{ github.repository }}
+
+jobs:
+  clear-queue:
+    name: Cancel queued non-main runs
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Cancel every queued run not on main
+        run: |
+          set -u
+          ok=0; fail=0
+          for id in $(gh api "/repos/$REPO/actions/runs?status=queued&per_page=100" --paginate \
+                        --jq '.workflow_runs[] | select(.head_branch != "main") | .id'); do
+            if gh api -X POST "/repos/$REPO/actions/runs/$id/cancel" >/dev/null 2>&1; then
+              ok=$((ok+1))
+            else
+              # Already started / already finished / zombie run: not actionable.
+              fail=$((fail+1))
+            fi
+          done
+          echo "cancelled=$ok not-cancellable=$fail"
+
+  requeue:
+    name: Re-run green-drift PRs once main is idle
+    if: github.event_name == 'workflow_run' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Skip while main still has queued or running jobs
+        id: gate
+        run: |
+          set -u
+          busy=$(gh api "/repos/$REPO/actions/runs?branch=main&per_page=100" \
+                   --jq "[.workflow_runs[]
+                          | select(.status == \"queued\" or .status == \"in_progress\")
+                          | select(.name != \"${{ github.workflow }}\")] | length")
+          echo "main busy runs: $busy"
+          echo "idle=$([ "$busy" -eq 0 ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
+
+      - name: Re-run cancelled runs for open PRs with green drift-bot
+        if: steps.gate.outputs.idle == 'true'
+        run: |
+          set -u
+          CUTOFF=$(date -u -d '48 hours ago' +%Y-%m-%dT%H:%M:%SZ)
+          export CUTOFF
+          gh api "/repos/$REPO/pulls?state=open&per_page=100" --paginate \
+            --jq '.[] | select(.head.repo.full_name == env.REPO) | "\(.number)\t\(.head.ref)\t\(.head.sha)"' |
+          while IFS=$'\t' read -r pr branch sha; do
+            drift=$(gh api "/repos/$REPO/commits/$sha/check-runs?check_name=drift-bot&per_page=10" \
+                      --jq '[.check_runs[] | .conclusion] | first // "missing"')
+            [ "$drift" = "success" ] || { echo "PR #$pr: drift=$drift, parked"; continue; }
+            # Latest run per workflow on this head branch; re-run it only if it
+            # ended cancelled (i.e. we parked it) and recently.
+            gh api "/repos/$REPO/actions/runs?branch=$branch&event=pull_request&per_page=100" \
+              --jq '[.workflow_runs[] | select(.created_at > env.CUTOFF)]
+                   | group_by(.workflow_id) | .[] | max_by(.created_at)
+                   | select(.conclusion == "cancelled") | .id' |
+            while read -r id; do
+              if gh api -X POST "/repos/$REPO/actions/runs/$id/rerun" >/dev/null 2>&1; then
+                echo "PR #$pr: re-ran $id"
+              else
+                echo "PR #$pr: could not re-run $id"
+              fi
+            done
+          done


### PR DESCRIPTION
Product record: https://factory.8090.ai/project/b415065f-ab2f-4f53-8864-0c009fd098cb/requirements/b7c0af6c-e262-4a17-a342-093e94db3014

## Why

GitHub Actions has no queue priority on hosted runners. Today a `[RELEASE]` merge left **205 runs queued** with main's `Auto-deploy Cloud on OSS update` stuck behind ~190 PR/dependabot jobs — the release→PyPI→cloud pipeline waited on dependency-bump CI. Main must always go live first; PRs can wait.

## What

`.github/workflows/queue-priority.yml`, two jobs:

1. **clear-queue** (on push to main): cancels every *queued* — never in-progress — run on non-main refs, so main's jobs take the runners next.
2. **requeue** (on `Auto-deploy Cloud` completion + half-hourly sweep): once main has no queued/running jobs, re-runs the latest cancelled run per workflow for every open same-repo PR whose **drift-bot check is green**. Red-drift PRs stay parked until drift is fixed.

Only recently-cancelled runs (48h window) are requeued, so ancient cancels stay dead. No third-party actions — every step is `gh api` with `GITHUB_TOKEN` (`actions: write`), so there is nothing to SHA-pin and no checkout.

## Notes

- `[skip ci]` pushes (auto-bumps) don't fire clear-queue — GitHub skips push workflows natively.
- Fork PRs are skipped (their head branch isn't addressable for reruns).
- This automates the manual unblock performed on 2026-08-30 (190 queued runs cancelled by hand, green-drift PRs re-triggered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JFgNVcv7iGWkN2jeoFgVfC
