### PR TITLE
[RELEASE] fix(replay): Load-earlier button broke the Sessions transcript layout

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -20055,7 +20055,10 @@ function _updateLoadEarlierBtn() {
   if (!host) {
     host = document.createElement('div');
     host.id = 'replay-load-earlier';
-    host.style.cssText = 'margin:0 0 8px 0;text-align:center;';
+    // Span the full row of .transcript-layout's grid: as a plain auto-placed
+    // sibling this button would take the wide first column and push
+    // #transcript-messages into the narrow 240px TOC column.
+    host.style.cssText = 'margin:0 0 8px 0;text-align:center;grid-column:1 / -1;';
     wrap.parentNode.insertBefore(host, wrap);
   }
   var p = window._transcriptPaging;


### PR DESCRIPTION
## What broke

The Sessions replay on app.clawmetry.com (and any local dashboard on 0.12.792) rendered the entire transcript squeezed into a ~240px column pinned to the right screen edge — turn headers overlapping their meta line, bubbles clipped off-screen.

## Why

#5369 added the "Load earlier messages" button by inserting `#replay-load-earlier` as a direct **sibling** of `#transcript-messages` inside `.transcript-layout`, which is a two-column grid (`minmax(0,1fr) 240px` — messages + turn TOC). Grid auto-placement then assigned:

- row 1, col 1 (wide): the button
- row 1, col 2 (240px TOC rail): the transcript ← the visible breakage
- row 2, col 1: the TOC

The bug only appears when the button exists (capped sessions with `has_more`), which is why short sessions looked fine.

## Fix

One line: give the host `grid-column: 1 / -1` so it spans the full grid row and auto-placement keeps the transcript in the 1fr column and the TOC in its rail. Inert in the single-column responsive layout and anywhere outside a grid.

Verified by applying the style to the live broken DOM on app.clawmetry.com: messages return to 902px/col 1, TOC to 240px/col 2, turn headers render cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0164bAMZhJL84ST1uCVf4i5H


No-PRD: one-line regression hotfix of the #5369 replay-paging layout break, live on app.clawmetry.com
