### PR TITLE
feat(adapters/openclaw): surface nemoclaw onboarding OTel trace spans (#5380)

### DIFF
--- a/clawmetry/adapters/openclaw.py
+++ b/clawmetry/adapters/openclaw.py
@@ -1251,6 +1251,99 @@ def _nemoclaw_agents_manifest() -> dict:
     return out
 
 
+def _nemoclaw_onboard_trace_spans() -> dict:
+    """Read the most-recent NemoClaw onboarding OTel-style trace artifact (#5380).
+
+    The harness writes a structured trace artifact per onboarding run when
+    ``NEMOCLAW_TRACE=1`` is set (``src/lib/trace.ts``). Each artifact contains
+    ``resource_spans`` with per-phase spans (e.g. ``nemoclaw.onboard.phase.gateway``,
+    ``nemoclaw.onboard.phase.inference``), each carrying ``start_time``,
+    ``end_time``, ``duration_ms``, ``status.code`` (OK/ERROR/UNSET), sanitized
+    ``attributes``, and child ``events``.  The top-level ``summary.slowest_spans``
+    ranks the slowest phases.
+
+    Path resolution (first match wins):
+    1. ``NEMOCLAW_TRACE_FILE`` env var (explicit path to one artifact).
+    2. Most-recent ``*.json`` in ``NEMOCLAW_TRACE_DIR``.
+    3. Most-recent ``*.json`` in ``.e2e/traces/`` (default harness path).
+
+    Returns ``{}`` when ``NEMOCLAW_TRACE`` is not set or no file is found.
+    Never raises.
+    """
+    import json as _json
+
+    if not os.environ.get("NEMOCLAW_TRACE"):
+        return {}
+
+    trace_file: Optional[str] = None
+    explicit = os.environ.get("NEMOCLAW_TRACE_FILE", "")
+    if explicit and os.path.isfile(explicit):
+        trace_file = explicit
+    else:
+        trace_dir = os.environ.get("NEMOCLAW_TRACE_DIR", "") or os.path.join(
+            os.getcwd(), ".e2e", "traces"
+        )
+        if os.path.isdir(trace_dir):
+            try:
+                candidates = [
+                    os.path.join(trace_dir, f)
+                    for f in os.listdir(trace_dir)
+                    if f.endswith(".json")
+                ]
+                if candidates:
+                    trace_file = max(candidates, key=os.path.getmtime)
+            except OSError:
+                pass
+
+    if not trace_file:
+        return {}
+
+    try:
+        with open(trace_file, encoding="utf-8") as fh:
+            data = _json.loads(fh.read(524288))  # 512 KB cap
+    except Exception:
+        return {}
+
+    if not isinstance(data, dict):
+        return {}
+
+    out: dict = {}
+
+    raw_spans = data.get("resource_spans")
+    if isinstance(raw_spans, list):
+        phases = []
+        for span in raw_spans:
+            if not isinstance(span, dict):
+                continue
+            phase: dict = {}
+            for key in ("name", "start_time", "end_time", "duration_ms"):
+                if key in span:
+                    phase[key] = span[key]
+            status = span.get("status")
+            if isinstance(status, dict):
+                code = status.get("code")
+                if code is not None:
+                    phase["status"] = code
+                msg = status.get("message")
+                if msg:
+                    phase["statusMessage"] = msg
+            events = span.get("events")
+            if isinstance(events, list) and events:
+                phase["events"] = events
+            if phase:
+                phases.append(phase)
+        if phases:
+            out["onboardTracePhases"] = phases
+
+    summary = data.get("summary")
+    if isinstance(summary, dict):
+        slowest = summary.get("slowest_spans")
+        if isinstance(slowest, list) and slowest:
+            out["onboardTraceSlowestPhases"] = slowest
+
+    return out
+
+
 def _discover_model_router_port() -> Optional[int]:
     """Find the ``--port`` of a running ``model-router proxy`` process.
 
@@ -2271,6 +2364,12 @@ class OpenClawAdapter(AgentAdapter):
             # from ~/.nemoclaw/agents.yaml (written by harness onboarding,
             # commit 01e5525).
             meta.update(_nemoclaw_agents_manifest())
+            # Onboarding OTel trace spans (#5380): per-phase duration/status
+            # from the harness trace artifact (NEMOCLAW_TRACE=1). Only
+            # meaningful on NemoClaw installs; returns {} when tracing is
+            # disabled or no artifact is found, so plain OpenClaw is unaffected.
+            if "modelRouterFingerprint" in meta:
+                meta.update(_nemoclaw_onboard_trace_spans())
             # External-supervisor mode env-var fallback (#4023): surface
             # OPENCLAW_SUPERVISOR_MODE even when the gateway is down (e.g. during
             # a supervised restart handoff). _gateway_host_status() below will

--- a/clawmetry/adapters/openclaw.py
+++ b/clawmetry/adapters/openclaw.py
@@ -1307,7 +1307,7 @@ def _nemoclaw_onboard_trace_spans() -> dict:
     if not isinstance(data, dict):
         return {}
 
-    out: dict = {}
+    out: dict = {"onboardTraceArtifact": trace_file}
 
     raw_spans = data.get("resource_spans")
     if isinstance(raw_spans, list):


### PR DESCRIPTION
## Summary

The NemoClaw harness writes an OTel-style trace artifact per onboarding run (`NEMOCLAW_TRACE=1`), recording per-phase `resource_spans` with duration, status, and child events. ClawMetry was discarding it entirely — a slow or failed onboarding phase was invisible in the dashboard. This PR wires up the reader and surfaces the structured data on `DetectResult.meta`.

No-PRD: automated harness-gap fix — issue #5380 is the product record (filed by scripts/harness/audit.py fingerprint hgap-4500eb8cb8, no design call needed, additive read-only parse of an already-written artifact)

## Changes

- **`clawmetry/adapters/openclaw.py`**: Add `_nemoclaw_onboard_trace_spans()` — resolves the trace artifact from `NEMOCLAW_TRACE_FILE`, `NEMOCLAW_TRACE_DIR`, or `.e2e/traces/` (default); parses `resource_spans` into `onboardTracePhases` (name, duration_ms, status, statusMessage, events); extracts `summary.slowest_spans` into `onboardTraceSlowestPhases`. Called from `detect()` gated on `"modelRouterFingerprint" in meta` (NemoClaw-only path). Returns `{}` when `NEMOCLAW_TRACE` is not set, so plain OpenClaw installs are unaffected.

## Test plan

- [ ] Set `NEMOCLAW_TRACE=1` and `NEMOCLAW_TRACE_FILE=<path to a trace JSON with resource_spans>`, call `/api/detect` — confirm `onboardTracePhases` and `onboardTraceSlowestPhases` appear in the response.
- [ ] Confirm `onboardTracePhases[*].status` is `"ERROR"` and `statusMessage` is populated when the span has `status.code: "ERROR"`.
- [ ] Without `NEMOCLAW_TRACE` set (plain OpenClaw install), confirm `/api/detect` is unchanged — no new keys, no errors.

## Bot meta

<!-- bot-autofix -->
Draft PR opened autonomously based on the plan in #5380. Marked draft for human review — mark Ready for Review once happy.

Closes #5380