### PR TITLE
Harden deps: floor cryptography past every published advisory

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,7 +118,7 @@ The daemon owns the DuckDB writer lock and runs a localhost query server so the 
 Minimal by design, and this list had drifted — `setup.py` is the source of truth:
 - **flask** (>=2.0,<4) — HTTP server framework
 - **waitress** (>=2.0) — WSGI application server
-- **cryptography** (>=50.0.0 on 3.9.2+; >=3.0 on 3.8/3.9.0/3.9.1, which have no advisory-clean release) — AES-256-GCM for cloud sync
+- **cryptography** (>=50.0.0 on 3.14+; >=46.0.0 on 3.9.2–3.13, capped there by the `cffi<2` pin; >=3.0 on 3.8/3.9.0/3.9.1) — AES-256-GCM for cloud sync
 - **duckdb** (>=0.10) — the local store at `~/.clawmetry/clawmetry.duckdb`
 - **websocket-client** (>=1.6) — cloud cold-data relay tunnel
 - **truststore** (>=0.8, 3.10+ only) — OS trust store, so corporate TLS-interception root CAs work

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,7 +118,7 @@ The daemon owns the DuckDB writer lock and runs a localhost query server so the 
 Minimal by design, and this list had drifted — `setup.py` is the source of truth:
 - **flask** (>=2.0,<4) — HTTP server framework
 - **waitress** (>=2.0) — WSGI application server
-- **cryptography** (>=3.0) — AES-256-GCM for cloud sync
+- **cryptography** (>=50.0.0 on 3.9.2+; >=3.0 on 3.8/3.9.0/3.9.1, which have no advisory-clean release) — AES-256-GCM for cloud sync
 - **duckdb** (>=0.10) — the local store at `~/.clawmetry/clawmetry.duckdb`
 - **websocket-client** (>=1.6) — cloud cold-data relay tunnel
 - **truststore** (>=0.8, 3.10+ only) — OS trust store, so corporate TLS-interception root CAs work

--- a/setup.py
+++ b/setup.py
@@ -90,22 +90,32 @@ setup(
     install_requires=[
         "flask>=2.0,<4",
         "waitress>=2.0",
-        # AES-256-GCM for the cloud-sync snapshot envelope. The floor was
-        # >=3.0, which accepts 42 releases carrying published advisories --
-        # the newest being CVE-2026-69247 (PKCS#7 Bleichenbacher oracle),
-        # first fixed in 50.0.0. Nothing pinned us to an old release; the
-        # open floor simply never forced the upgrade, so an existing
-        # environment that already had a vulnerable cryptography kept it.
-        # clawmetry-cloud floors its own copy at >=50.0.0 for this reason.
+        # AES-256-GCM for the cloud-sync snapshot envelope, so it is on the
+        # data path. The floor was >=3.0, which accepts 42 releases carrying
+        # published advisories. An open floor never FORCES an upgrade -- pip
+        # has no reason to move a requirement that is already satisfied -- so
+        # an environment that already had a vulnerable cryptography kept it.
         #
-        # Gated per interpreter, like the cffi ladder below, because
-        # cryptography's support window is narrower than ours
-        # (python_requires=">=3.8"): 48.0.0+ needs >=3.9, and every release
-        # from 46.0.4 on excludes 3.9.0/3.9.1. So 3.8.x, 3.9.0 and 3.9.1
-        # have NO advisory-clean release to move to and keep the old floor
-        # rather than become uninstallable -- an unconditional >=50.0.0
-        # would turn `pip install clawmetry` into a resolver error there.
-        'cryptography>=50.0.0; python_full_version >= "3.9.2"',
+        # The CEILING here is set by the cffi pin below, not by taste.
+        # cryptography 46.0.1+ requires cffi>=2.0.0 on 3.9+, which
+        # contradicts the `cffi<2` we pin under 3.14 (issue #5108), so
+        # 46.0.0 is the newest release that resolves under 3.14. Above
+        # 3.14, where we already take cffi>=2, the newest is reachable.
+        #
+        # Interpreter bands, in the same conditional shape as cffi below:
+        #   3.14+            cffi>=2 already, so >=50.0.0 (advisory-clean)
+        #   3.9.2 - 3.13     capped at 46.0.0 by cffi<2
+        #   3.8/3.9.0/3.9.1  46.0.4+ excludes 3.9.0/3.9.1, so the old floor
+        #                    stays rather than making `pip install clawmetry`
+        #                    a resolver error on an interpreter we support
+        #
+        # Under 3.14 this closes the 36 advisories fixed up to 46.0.0. The
+        # six newer ones (fixed in 46.0.6, 46.0.7, 48.0.1, 49.0.0 x2 and
+        # 50.0.0, the last being CVE-2026-69247) are NOT reachable there at
+        # any floor: cffi<2 caps us at 46.0.0. Closing them means narrowing
+        # that pin -- it is load-bearing and retiring it is its own change.
+        'cryptography>=50.0.0; python_version >= "3.14"',
+        'cryptography>=46.0.0; python_full_version >= "3.9.2" and python_version < "3.14"',
         'cryptography>=3.0; python_full_version < "3.9.2"',
         # cffi is pinned per interpreter, and both halves are load-bearing:
         # - Below 3.14: cffi 2.0.0 introduced a Python 3.9 finalizer

--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,23 @@ setup(
     install_requires=[
         "flask>=2.0,<4",
         "waitress>=2.0",
-        "cryptography>=3.0",
+        # AES-256-GCM for the cloud-sync snapshot envelope. The floor was
+        # >=3.0, which accepts 42 releases carrying published advisories --
+        # the newest being CVE-2026-69247 (PKCS#7 Bleichenbacher oracle),
+        # first fixed in 50.0.0. Nothing pinned us to an old release; the
+        # open floor simply never forced the upgrade, so an existing
+        # environment that already had a vulnerable cryptography kept it.
+        # clawmetry-cloud floors its own copy at >=50.0.0 for this reason.
+        #
+        # Gated per interpreter, like the cffi ladder below, because
+        # cryptography's support window is narrower than ours
+        # (python_requires=">=3.8"): 48.0.0+ needs >=3.9, and every release
+        # from 46.0.4 on excludes 3.9.0/3.9.1. So 3.8.x, 3.9.0 and 3.9.1
+        # have NO advisory-clean release to move to and keep the old floor
+        # rather than become uninstallable -- an unconditional >=50.0.0
+        # would turn `pip install clawmetry` into a resolver error there.
+        'cryptography>=50.0.0; python_full_version >= "3.9.2"',
+        'cryptography>=3.0; python_full_version < "3.9.2"',
         # cffi is pinned per interpreter, and both halves are load-bearing:
         # - Below 3.14: cffi 2.0.0 introduced a Python 3.9 finalizer
         #   regression that SIGSEGVs at sys.exit() when argparse prints


### PR DESCRIPTION
No-PRD: dependency-floor bump in `setup.py` packaging metadata plus the matching line in `CLAUDE.md` — no runtime code, no API and no shipped behaviour changes, only which version of an existing dependency pip is allowed to resolve.

`install_requires` carried `cryptography>=3.0`.

An open floor never *forces* an upgrade: pip has no reason to move a requirement that is already satisfied, so an environment that already had a vulnerable `cryptography` kept it indefinitely. OSV lists 42 advisories against the package. This library provides the AES-256-GCM that wraps every cloud-sync snapshot, so it is on the data path, not a dev-only dependency.

## What this actually closes — and what it cannot

| Interpreter | Floor | Why |
|---|---|---|
| 3.14+ | **`>=50.0.0`** | we already take `cffi>=2` there; advisory-clean |
| 3.9.2 – 3.13 | **`>=46.0.0`** | ceiling imposed by `cffi<2`, see below |
| 3.8 / 3.9.0 / 3.9.1 | `>=3.0` unchanged | 46.0.4+ excludes 3.9.0/3.9.1 |

Below 3.14 this closes the **36 advisories fixed up to 46.0.0**. It does **not** close the six newer ones (fixed in 46.0.6, 46.0.7, 48.0.1, 49.0.0 ×2 and 50.0.0 — the last being CVE-2026-69247, a PKCS#7 Bleichenbacher oracle).

**Those six are unreachable below 3.14 at any floor**, and that is the finding worth more attention than this diff: `cryptography` 46.0.1+ requires `cffi>=2.0.0` on 3.9+, and we deliberately pin `cffi<2` under 3.14 (issue #5108, the py3.9 finalizer SIGSEGV). So the `cffi` pin — not the `cryptography` floor — is what caps us at 46.0.0. Narrowing it is the only way to reach those six, and since it is load-bearing that is deliberately **not** attempted here. Flagging it for a decision rather than quietly widening this PR.

## A wrong floor got caught by CI, and is fixed in the second commit

The first commit floored at `>=50.0.0` on 3.9.2+, and CI's `PR build` correctly rejected it with `ResolutionImpossible` — it would have made `pip install clawmetry` fail outright on 3.9–3.13.

My pre-push check read only the **first** `cffi` line in each release's metadata. 46.0.1+ carries two (`cffi>=1.14` for `3.8.*`, `cffi>=2.0.0` for 3.9+), so evaluating every line under each target interpreter is what gives the real ceiling. Recorded here because the failure mode — a metadata check that looks thorough and silently reads half the constraint — is easy to repeat.

## Verified by resolution, not by reading metadata

- [x] `pip install --dry-run` over the **full** `install_requires` set on 3.11 resolves `cryptography-46.0.0` + `cffi-1.17.1` alongside flask/waitress/duckdb/truststore/certifi/websocket-client
- [x] The previously pushed `>=50.0.0` floor reproduces `ResolutionImpossible` locally — the fix is confirmed against the actual failure
- [x] Marker ladder selects **exactly one** arm on 3.8.18 / 3.9.0 / 3.9.1 / 3.9.2 / 3.9.25 / 3.10 / 3.11 / 3.12 / 3.13 / 3.14 — no gap, no double-pin
- [x] `setuptools egg_info` emits all three conditional sections
- [x] `setup.py` parses; no test or script asserts the old spec string (`grep` over `tests/`, `scripts/`, `docs/`)
- [x] `scripts/check_product_record.py` run locally against this body — opt-out matches, gate returns OK

## Scope

`setup.py` is the only place in the repo that declares `cryptography` — `requirements.txt` does not list it. One concern, two files.