### PR TITLE
Harden CI: scope queue-priority's token per job, keep the workflow name out of the jq filter

### DIFF
--- a/.github/workflows/queue-priority.yml
+++ b/.github/workflows/queue-priority.yml
@@ -27,10 +27,10 @@ on:
     - cron: "*/30 * * * *"
   workflow_dispatch:
 
-permissions:
-  actions: write
-  checks: read
-  pull-requests: read
+# Nothing at the workflow level: each job below declares exactly the scopes it
+# spends. `actions: write` is the scope that cancels and re-runs other people's
+# jobs, so it is granted per job rather than to every job in the file.
+permissions: {}
 
 # One instance at a time; a queued follow-up collapses into the latest.
 concurrency:
@@ -47,6 +47,9 @@ jobs:
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    # Lists queued runs and cancels them. No checks or pull-request reads here.
+    permissions:
+      actions: write
     steps:
       - name: Cancel every queued run not on main
         run: |
@@ -68,15 +71,27 @@ jobs:
     if: github.event_name == 'workflow_run' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    # actions: re-run parked runs; checks: read drift-bot's conclusion;
+    # pull-requests: list the open PRs to consider.
+    permissions:
+      actions: write
+      checks: read
+      pull-requests: read
     steps:
       - name: Skip while main still has queued or running jobs
         id: gate
+        # SELF is read by jq through `env`, not expanded into the filter. A
+        # `${{ }}` expression is substituted as text before jq (or bash) parses
+        # the line, so a workflow name containing a quote or a backslash would
+        # otherwise land in the filter as jq source rather than as a string.
+        env:
+          SELF: ${{ github.workflow }}
         run: |
           set -u
           busy=$(gh api "/repos/$REPO/actions/runs?branch=main&per_page=100" \
-                   --jq "[.workflow_runs[]
-                          | select(.status == \"queued\" or .status == \"in_progress\")
-                          | select(.name != \"${{ github.workflow }}\")] | length")
+                   --jq '[.workflow_runs[]
+                          | select(.status == "queued" or .status == "in_progress")
+                          | select(.name != env.SELF)] | length')
           echo "main busy runs: $busy"
           echo "idle=$([ "$busy" -eq 0 ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
**Product record:** No-PRD: CI-only hardening under `.github/`, no product surface changed.

**Risk:** Low, and contained to this one workflow. The change narrows a token grant and rewrites one `jq` filter; if either were wrong the symptom is that `queue-priority.yml` stops cancelling or re-running runs, which delays main's queue position but breaks no release, deploy or test. Nothing here pushes, publishes or deploys, and the workflow has no checkout. Undone by reverting the single file. Every scope the two jobs actually use is preserved.

---

## Summary

- `.github/workflows/queue-priority.yml` held `actions: write` at the **workflow** level, so both jobs carried it along with `checks: read` and `pull-requests: read`. Top level is now `{}` and each job declares exactly what it spends: `clear-queue` takes `actions: write` alone (it lists queued runs and cancels them — it never reads a check or a pull request), `requeue` takes `actions: write` plus `checks: read` and `pull-requests: read`.
- The gate step interpolated `${{ github.workflow }}` straight into its `jq` filter. `${{ }}` is substituted textually before `jq` or bash parses the line, so the workflow name arrived as filter source rather than as a string value. It is now bound to a step-level `env:` var and read through jq's `env` accessor — which also lets the filter go back to single quotes and drop the backslash-escaped inner quotes.
- This was the last workflow in the repo carrying either finding; both were reported at high confidence.

## Test plan

- [x] **Differential test of the old and new `jq` filters** over a fixture of six runs — both return `busy=3` (the two CI runs and the queued MOAT run, with this workflow's own two correctly excluded). Identical behaviour on real input.
- [x] **The case the old form could not survive:** a workflow name containing a double quote turns the old filter into a `jq` syntax error; the new one evaluates it as an ordinary string.
- [x] `bash -n` over all three `run:` blocks in the file — syntax OK.
- [x] `yaml.safe_load` over all **36** workflow files — every one parses.
- [x] `python3 scripts/check_action_refs.py` — exit 0, 17 references, all still pinned. No action reference is touched by this change.
- [x] Re-scanned the file: both high-confidence findings are gone.
- [x] Confirmed each job's remaining scopes against the API calls it actually makes (`runs` list + `cancel`; `runs` list, `pulls`, `check-runs` + `rerun`).

## Not addressed here, on purpose

The file still reports `workflow_run` under zizmor's `dangerous-triggers` rule. Reacting to another workflow completing is the entire purpose of this workflow — `requeue` runs once *Auto-deploy Cloud* finishes — so that trigger is the feature, not an oversight. Changing it would need a redesign of the queue-priority mechanism, which does not belong in a token-scoping PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01U46gRUHdsWxtF7rXpYtWND)_