### PR TITLE
feat(otlp): sessions materialized from spans, honest runtime attribution for OTLP apps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -548,6 +548,7 @@ jobs:
             tests/test_otlp_dos_auth.py \
             tests/test_otlp_rollup_cpu_budget.py \
             tests/test_spans_otlp_edge_cases.py \
+            tests/test_otlp_session_materialization.py \
             -q
           # NOT listed: tests/test_e2e_otlp_ingest.py — it drives a LIVE
           # dashboard over HTTP (BASE_URL), which this job does not boot. It

--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ the same machine. Docker instructions: [docs/DOCKER.md](docs/DOCKER.md).
 | [Entitlements](docs/ENTITLEMENTS.md) | Free vs paid, tier matrix, license CLI |
 | [Approvals & policies](docs/APPROVALS.md) | Pre-execution gating, risk scoring, phone approvals |
 | [OpenTelemetry](docs/OPENTELEMETRY.md) | Export traces anywhere, ingest OTLP from anything |
+| [Bring your own agent](docs/BRING_YOUR_OWN_AGENT.md) | AWS AgentCore, Pydantic AI, LangChain end to end, with runnable examples |
 | [SDK tracking](docs/SDK_TRACKING.md) | Cost attribution for agents you built yourself |
 | [Chat channels](docs/CHANNELS.md) | The chat adapters shown in Flow |
 | [NemoClaw / OpenShell](docs/NEMOCLAW.md) | Sandboxed NVIDIA NemoClaw setups |

--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -6644,8 +6644,11 @@ class LocalStore:
             last = float(last_ts or started)
             meta = {
                 "source": "otlp_spans",
-                # The liveness/roster bucketers read metadata.runtime and
-                # default to 'openclaw' without it (_live_counts_by_runtime).
+                # Liveness/roster bucketing keys on metadata.runtime, with
+                # 'openclaw' as the default for rows that lack it — so stamp
+                # the app's identity here. (The consumer already exists on
+                # main: sync.py _live_counts_by_runtime reads this field;
+                # pinned by test_live_counts_bucket_by_metadata_runtime.)
                 "runtime": str(agent_type or "custom"),
                 "service_name": str(service_name or ""),
                 "trace_count": int(trace_count or 0),

--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -1845,6 +1845,18 @@ def _clean_str(value: Any, limit: int = _MAX_PATH_LEN) -> str | None:
     return s[:limit] if s else None
 
 
+def _iso_utc(ts: float) -> str | None:
+    """Unix seconds -> ISO-8601 UTC string (the sessions table's timestamp
+    dialect). None for a missing/zero timestamp rather than the epoch."""
+    if not ts:
+        return None
+    try:
+        from datetime import datetime, timezone
+        return datetime.fromtimestamp(float(ts), tz=timezone.utc).isoformat()
+    except Exception:
+        return None
+
+
 def _to_blob(value: Any) -> bytes | None:
     """Coerce arbitrary value (dict / list / str / bytes / None) to a BLOB
     suitable for DuckDB. Used by the non-event ingest helpers (sessions,
@@ -6526,6 +6538,140 @@ class LocalStore:
             "events_skipped_daemon_owned": ev_skipped,
         }
 
+    def materialize_otlp_sessions(
+        self,
+        *,
+        session_ids: list[str] | None = None,
+        environments: dict[str, str] | None = None,
+    ) -> int:
+        """Upsert ``sessions`` rows derived from OTLP spans (WO-55).
+
+        A fleet that only ever sends OTLP traces (AWS Bedrock AgentCore, an
+        OpenLLMetry app, …) fills the ``spans`` table and the Tracing tab but
+        never creates a ``sessions`` row — so the Sessions tab and the runtime
+        switcher stay empty for exactly the app the person just wired up. This
+        closes that seam: a FULL recompute of the named sessions from their
+        spans, then one idempotent batch upsert.
+
+        Safety rails, each load-bearing:
+          * Full recompute per session (aggregate over ALL of its spans), so
+            OTLP's at-least-once delivery can never double a total — a retried
+            batch REPLACEs the same numbers.
+          * ``agent_type='openclaw'`` spans are ignored. OpenClaw sessions come
+            from transcripts via the daemon; materializing them here would mint
+            ghost sessions next to the real ones (the log-session-id burn).
+          * A pre-existing row for the same session_id NOT stamped
+            ``metadata.source='otlp_spans'`` belongs to a richer ingest path
+            (transcripts, WO-7 logs) and is left alone — same ownership rule
+            as ``put_otlp_batch``'s events_skipped_daemon_owned.
+
+        ``environments`` carries the per-session ``deployment.environment``
+        resource attribute the receiver saw (dev / tst / prod), stored on the
+        session metadata so an AgentCore-style fleet stays separable by stage.
+
+        Call by KEYWORD through the daemon proxy — it forwards **kwargs only
+        (the put_span trap). Returns the number of sessions upserted.
+        """
+        if self._read_only:
+            raise RuntimeError(
+                "local_store: materialize_otlp_sessions() on read-only store"
+            )
+        ids = sorted({str(s) for s in (session_ids or []) if s})
+        if not ids:
+            return 0
+        envs = environments if isinstance(environments, dict) else {}
+
+        rollups: list[tuple] = []
+        owned_elsewhere: set[str] = set()
+        for off in range(0, len(ids), 500):
+            chunk = ids[off:off + 500]
+            ph = ",".join("?" * len(chunk))
+            rollups.extend(self._fetch(
+                f"""
+                SELECT
+                    session_id,
+                    MAX(agent_type)                                   AS agent_type,
+                    MAX(service_name)                                 AS service_name,
+                    MAX(node_id)                                      AS node_id,
+                    MAX(agent_id)                                     AS agent_id,
+                    MIN(start_ts)                                     AS started_ts,
+                    MAX(COALESCE(end_ts, start_ts))                   AS last_ts,
+                    SUM(COALESCE(tokens_input, 0)
+                        + COALESCE(tokens_output, 0))                 AS tok_io,
+                    SUM(COALESCE(token_count, 0))                     AS tok_total,
+                    SUM(COALESCE(cost_usd, 0.0))                      AS cost_usd,
+                    COUNT(*)                                          AS span_count,
+                    COUNT(DISTINCT trace_id)                          AS trace_count,
+                    COUNT(CASE WHEN model IS NOT NULL AND model <> ''
+                          THEN 1 END)                                 AS llm_calls,
+                    arg_min(name, start_ts)                           AS root_name
+                FROM spans
+                WHERE session_id IN ({ph})
+                  AND agent_type IS NOT NULL AND agent_type <> 'openclaw'
+                GROUP BY session_id
+                """,
+                chunk,
+            ))
+            for row in self._fetch(
+                f"SELECT session_id, metadata FROM sessions"
+                f" WHERE session_id IN ({ph})",
+                chunk,
+            ):
+                src = None
+                meta = row[1]
+                try:
+                    if isinstance(meta, (bytes, bytearray, memoryview)):
+                        meta = bytes(meta).decode("utf-8", "replace")
+                    if isinstance(meta, str) and meta:
+                        meta = json.loads(meta)
+                    if isinstance(meta, dict):
+                        src = meta.get("source")
+                except Exception:
+                    src = None
+                if src != "otlp_spans":
+                    owned_elsewhere.add(str(row[0]))
+
+        now = time.time()
+        batch: list[dict[str, Any]] = []
+        for r in rollups:
+            (sid, agent_type, service_name, node_id, agent_id, started_ts,
+             last_ts, tok_io, tok_total, cost_usd, span_count, trace_count,
+             llm_calls, root_name) = r
+            sid = str(sid)
+            if sid in owned_elsewhere:
+                continue
+            started = float(started_ts or 0.0)
+            last = float(last_ts or started)
+            meta = {
+                "source": "otlp_spans",
+                # The liveness/roster bucketers read metadata.runtime and
+                # default to 'openclaw' without it (_live_counts_by_runtime).
+                "runtime": str(agent_type or "custom"),
+                "service_name": str(service_name or ""),
+                "trace_count": int(trace_count or 0),
+                "span_count": int(span_count or 0),
+            }
+            env = envs.get(sid)
+            if env:
+                meta["deployment_environment"] = str(env)
+            batch.append({
+                "session_id": sid,
+                "agent_type": str(agent_type or "custom"),
+                "agent_id": str(agent_id or "main"),
+                "node_id": node_id,
+                "title": str(root_name or service_name or sid)[:200],
+                "started_at": _iso_utc(started),
+                "last_active_at": _iso_utc(last),
+                "status": "active" if (now - last) < 600 else "inactive",
+                "total_tokens": max(int(tok_io or 0), int(tok_total or 0)),
+                "cost_usd": float(cost_usd or 0.0),
+                "message_count": int(llm_calls or 0),
+                "metadata": meta,
+            })
+        if not batch:
+            return 0
+        return self.ingest_sessions_batch(batch)
+
     def query_otlp_records(
         self,
         *,
@@ -7116,6 +7262,21 @@ class LocalStore:
                 f"CASE WHEN split_part(session_id, ':', 1) IN ({placeholders}) "
                 f"THEN split_part(session_id, ':', 1) ELSE 'openclaw' END"
             )
+            # Sessions-side variant (WO-55): a session materialized from OTLP
+            # spans has NO session-id prefix but a foreign ``agent_type`` (the
+            # slugified service.name). The prefix-only CASE dumped those into
+            # the 'openclaw' bucket, so a bring-your-own-agent app's tokens and
+            # cost showed under OpenClaw the moment its sessions materialized.
+            # Prefix stays authoritative for the family runtimes; the row's own
+            # agent_type wins only when it is a foreign slug.
+            rt_case_sessions = (
+                f"CASE WHEN split_part(session_id, ':', 1) IN ({placeholders}) "
+                f"THEN split_part(session_id, ':', 1) "
+                f"WHEN agent_type IS NOT NULL AND agent_type <> '' "
+                f"AND LOWER(agent_type) NOT IN ('openclaw', 'nemoclaw', 'clawmetry') "
+                f"AND agent_type NOT IN ({placeholders}) THEN agent_type "
+                f"ELSE 'openclaw' END"
+            )
             by_runtime: dict[str, dict[str, Any]] = {}
             # Per-runtime TOTALS use the same GREATEST(stored, SUM(events)) bridge
             # query_sessions_table uses — NOT a raw events sum. Family adapters
@@ -7146,6 +7307,7 @@ class LocalStore:
                 ),
                 combined AS (
                     SELECT COALESCE(s.session_id, ev.session_id) AS session_id,
+                           s.agent_type                          AS agent_type,
                            GREATEST(COALESCE(s.total_tokens, 0),
                                     COALESCE(ev.tok, 0))         AS tokens,
                            GREATEST(COALESCE(s.cost_usd, 0.0),
@@ -7157,7 +7319,7 @@ class LocalStore:
                     FROM sessions s
                     FULL OUTER JOIN ev ON s.session_id = ev.session_id
                 )
-                SELECT {rt_case} AS runtime,
+                SELECT {rt_case_sessions} AS runtime,
                        COUNT(*)      AS sessions,
                        SUM(tokens)   AS tokens,
                        SUM(cost_usd) AS cost_usd,
@@ -7165,7 +7327,9 @@ class LocalStore:
                 FROM combined
                 GROUP BY 1
             """
-            for r in self._fetch(sql_rt, list(prefixes)):
+            # rt_case_sessions binds the prefix list twice (prefix branch +
+            # foreign-agent_type NOT IN branch).
+            for r in self._fetch(sql_rt, list(prefixes) + list(prefixes)):
                 rt = r[0] or "openclaw"
                 by_runtime[rt] = {
                     "sessions": int(r[1] or 0),

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -15640,7 +15640,43 @@ def _merge_otlp_apps_into_summary(out: dict, store) -> None:
             continue
         # Never clobber a real session-prefix runtime that happens to share a key
         # (belt-and-braces; the query already excludes them).
-        if at.lower() in exclude or at in out:
+        if at.lower() in exclude:
+            continue
+        existing = out.get(at)
+        if existing is not None:
+            # WO-55: sessions materialized from these spans now surface the app
+            # in the sessions/daily-rollup passes, so a summary entry already
+            # exists. ENRICH it with the OTLP markers instead of skipping —
+            # without ``otlp=True`` + ``display_name`` the frontend treats the
+            # app as a session-prefix runtime and scopes it by a prefix it does
+            # not have. Numbers take the larger of the two measurements of the
+            # SAME underlying spans (never a sum — that would double-count).
+            if isinstance(existing, dict):
+                existing["otlp"] = True
+                if not existing.get("display_name"):
+                    existing["display_name"] = _humanize_service_name(
+                        r.get("service_name") or "", at)
+                existing["traces"] = int(r.get("traces") or 0)
+                existing["spans"] = int(r.get("spans") or 0)
+                for key in ("sessions", "turns", "tokens"):
+                    existing[key] = max(
+                        int(existing.get(key) or 0), int(r.get(key) or 0))
+                existing["total_turns"] = max(
+                    int(existing.get("total_turns") or 0),
+                    int(r.get("turns") or 0))
+                existing["cost_usd"] = round(max(
+                    float(existing.get("cost_usd") or 0.0),
+                    float(r.get("cost_usd") or 0.0)), 4)
+                primary = r.get("primary_model") or ""
+                if primary and not existing.get("primary_model"):
+                    existing["primary_model"] = primary
+                    if not existing.get("models"):
+                        existing["models"] = [{
+                            "model": primary,
+                            "turns": int(r.get("turns") or 0),
+                            "sessions": int(r.get("sessions") or 0),
+                            "share_pct": 100,
+                        }]
             continue
         primary = r.get("primary_model") or ""
         out[at] = {

--- a/dashboard.py
+++ b/dashboard.py
@@ -2749,6 +2749,18 @@ def _otel_to_row(span, resource_attrs):
     for attr in span.attributes:
         attrs[attr.key] = _otel_attr_value(attr.value)
 
+    # deployment.environment is a RESOURCE attribute (deployment.environment
+    # .name since semconv 1.27; the bare key before that), so it used to be
+    # dropped with the rest of the resource. Keep it on the span's attribute
+    # blob so a dev/tst/prod fleet (AgentCore's normal shape) stays separable
+    # after ingest; the session materializer lifts it onto session metadata.
+    if "deployment.environment" not in attrs:
+        for _env_key in ("deployment.environment.name", "deployment.environment"):
+            _env_val = attrs.get(_env_key) or resource_attrs.get(_env_key)
+            if _env_val not in (None, ""):
+                attrs["deployment.environment"] = str(_env_val)
+                break
+
     # Time columns. OTel proto carries unix-nano; we store unix-seconds in
     # ``start_ts`` / ``end_ts`` (DOUBLE) so chart libs can format them
     # without converting twice.
@@ -2990,6 +3002,11 @@ def _process_otlp_traces(pb_data, content_encoding=None, content_type=None):
     """
     req = _otlp_request(pb_data, "traces", content_encoding, content_type)
 
+    # session_id -> deployment.environment (or None) for every non-OpenClaw
+    # span in this batch. Feeds ONE materialize_otlp_sessions call at the end
+    # so span-only apps (AgentCore, OpenLLMetry) get a sessions row (WO-55).
+    _otlp_sessions_seen = {}
+
     # Resolve the local store lazily so unit tests that monkeypatch the
     # singleton in advance (or run without DuckDB) don't pay the import
     # cost upfront.
@@ -3109,7 +3126,17 @@ def _process_otlp_traces(pb_data, content_encoding=None, content_type=None):
                         # real install). put_span is allowlisted in
                         # routes/local_query._DAEMON_METHODS so the daemon
                         # executes the real write.
-                        _store.put_span(span=_otel_to_row(span, resource_attrs))
+                        _row = _otel_to_row(span, resource_attrs)
+                        _store.put_span(span=_row)
+                        # Track for session materialization (WO-55). OpenClaw
+                        # sessions come from transcripts; only foreign apps
+                        # need a span-derived sessions row.
+                        _sid = _row.get("session_id")
+                        if _sid and (_row.get("agent_type") or "") != "openclaw":
+                            _env = (_row.get("attributes") or {}).get(
+                                "deployment.environment")
+                            if _env or str(_sid) not in _otlp_sessions_seen:
+                                _otlp_sessions_seen[str(_sid)] = _env
                     except Exception as e:
                         try:
                             import logging as _lg
@@ -3118,6 +3145,25 @@ def _process_otlp_traces(pb_data, content_encoding=None, content_type=None):
                             )
                         except Exception:
                             pass
+
+    # One materialization call per export batch (not per span — get_store()
+    # here can be an HTTP proxy to the daemon; FLYWHEEL 1e). Recomputes the
+    # touched sessions from their spans and upserts sessions rows so the
+    # Sessions tab and runtime switcher show a span-only OTLP app (WO-55).
+    if _store is not None and _otlp_sessions_seen:
+        try:
+            _store.materialize_otlp_sessions(
+                session_ids=sorted(_otlp_sessions_seen),
+                environments={k: v for k, v in _otlp_sessions_seen.items() if v},
+            )
+        except Exception as e:
+            try:
+                import logging as _lg
+                _lg.getLogger("clawmetry.dashboard").warning(
+                    "materialize_otlp_sessions failed: %s", e
+                )
+            except Exception:
+                pass
 
 
 def _process_otlp_logs(pb_data, content_encoding=None, content_type=None):
@@ -11570,6 +11616,18 @@ def _otel_to_row(span, resource_attrs):
     for attr in span.attributes:
         attrs[attr.key] = _otel_attr_value(attr.value)
 
+    # deployment.environment is a RESOURCE attribute (deployment.environment
+    # .name since semconv 1.27; the bare key before that), so it used to be
+    # dropped with the rest of the resource. Keep it on the span's attribute
+    # blob so a dev/tst/prod fleet (AgentCore's normal shape) stays separable
+    # after ingest; the session materializer lifts it onto session metadata.
+    if "deployment.environment" not in attrs:
+        for _env_key in ("deployment.environment.name", "deployment.environment"):
+            _env_val = attrs.get(_env_key) or resource_attrs.get(_env_key)
+            if _env_val not in (None, ""):
+                attrs["deployment.environment"] = str(_env_val)
+                break
+
     # Time columns. OTel proto carries unix-nano; we store unix-seconds in
     # ``start_ts`` / ``end_ts`` (DOUBLE) so chart libs can format them
     # without converting twice.
@@ -11811,6 +11869,11 @@ def _process_otlp_traces(pb_data, content_encoding=None, content_type=None):
     """
     req = _otlp_request(pb_data, "traces", content_encoding, content_type)
 
+    # session_id -> deployment.environment (or None) for every non-OpenClaw
+    # span in this batch. Feeds ONE materialize_otlp_sessions call at the end
+    # so span-only apps (AgentCore, OpenLLMetry) get a sessions row (WO-55).
+    _otlp_sessions_seen = {}
+
     # Resolve the local store lazily so unit tests that monkeypatch the
     # singleton in advance (or run without DuckDB) don't pay the import
     # cost upfront.
@@ -11930,7 +11993,17 @@ def _process_otlp_traces(pb_data, content_encoding=None, content_type=None):
                         # real install). put_span is allowlisted in
                         # routes/local_query._DAEMON_METHODS so the daemon
                         # executes the real write.
-                        _store.put_span(span=_otel_to_row(span, resource_attrs))
+                        _row = _otel_to_row(span, resource_attrs)
+                        _store.put_span(span=_row)
+                        # Track for session materialization (WO-55). OpenClaw
+                        # sessions come from transcripts; only foreign apps
+                        # need a span-derived sessions row.
+                        _sid = _row.get("session_id")
+                        if _sid and (_row.get("agent_type") or "") != "openclaw":
+                            _env = (_row.get("attributes") or {}).get(
+                                "deployment.environment")
+                            if _env or str(_sid) not in _otlp_sessions_seen:
+                                _otlp_sessions_seen[str(_sid)] = _env
                     except Exception as e:
                         try:
                             import logging as _lg
@@ -11939,6 +12012,25 @@ def _process_otlp_traces(pb_data, content_encoding=None, content_type=None):
                             )
                         except Exception:
                             pass
+
+    # One materialization call per export batch (not per span — get_store()
+    # here can be an HTTP proxy to the daemon; FLYWHEEL 1e). Recomputes the
+    # touched sessions from their spans and upserts sessions rows so the
+    # Sessions tab and runtime switcher show a span-only OTLP app (WO-55).
+    if _store is not None and _otlp_sessions_seen:
+        try:
+            _store.materialize_otlp_sessions(
+                session_ids=sorted(_otlp_sessions_seen),
+                environments={k: v for k, v in _otlp_sessions_seen.items() if v},
+            )
+        except Exception as e:
+            try:
+                import logging as _lg
+                _lg.getLogger("clawmetry.dashboard").warning(
+                    "materialize_otlp_sessions failed: %s", e
+                )
+            except Exception:
+                pass
 
 
 # ── Daemon-free OTLP intake (WO-7) ───────────────────────────────────────────

--- a/docs/BRING_YOUR_OWN_AGENT.md
+++ b/docs/BRING_YOUR_OWN_AGENT.md
@@ -1,0 +1,141 @@
+# Bring your own agent: OpenTelemetry ingestion end to end
+
+ClawMetry ships adapters for 30 agent runtimes with local footprints (Claude Code, Codex, Cursor, OpenClaw and friends). This guide covers everything else: **any agent that speaks OpenTelemetry**, including fleets you do not run on your laptop.
+
+Who this is for:
+
+- **AWS Bedrock AgentCore** fleets (Strands, LangGraph, CrewAI agents deployed to AgentCore Runtime)
+- **Pydantic AI** apps (native OTel instrumentation)
+- **LangChain / LangGraph** apps (via OpenLLMetry instrumentation)
+- Anything else that can set `OTEL_EXPORTER_OTLP_ENDPOINT`
+
+If you are already paying a hosted tracing SaaS to look at these traces, note that the integration below is the same OTLP exporter you already configured, pointed at software you run yourself.
+
+Companion pages: [`docs/OPENTELEMETRY.md`](OPENTELEMETRY.md) for the receiver and exporter basics, and [`examples/bring-your-own-agent/`](../examples/bring-your-own-agent/) for the runnable code below.
+
+## How it works
+
+ClawMetry's dashboard includes a native OTLP receiver:
+
+| Endpoint | Accepts |
+|---|---|
+| `POST /v1/traces` | OTLP protobuf or JSON, gzip ok |
+| `POST /v1/metrics` | same |
+| `POST /v1/logs` | same |
+
+Spans following the [OpenTelemetry GenAI semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/) are mapped onto typed columns at ingest:
+
+| Your telemetry | Becomes |
+|---|---|
+| `gen_ai.usage.input_tokens` / `output_tokens`, cache token attrs | Token accounting, cache-aware |
+| `gen_ai.request.model`, `gen_ai.provider.name` / `gen_ai.system` | Model and provider attribution |
+| tokens x model (when spans carry no cost, the OTel norm) | Dollar cost, derived from a maintained multi-provider pricing table |
+| `gen_ai.tool.name` | Tool call visibility |
+| `gen_ai.conversation.id` / `session.id` | A session row per conversation |
+| `service.name` (resource) | The app's identity: one entry in the runtime switcher and Agent Inventory, shown as `your-app (OTel)` |
+| `deployment.environment` (resource) | Kept on spans and sessions so dev / test / prod stay separable |
+
+What lights up in the dashboard: the **Tracing** tab (span trees per trace), **Sessions** (one row per conversation, with tokens, cost, title and liveness), **Usage** (per-model tokens and cost), **Agent Inventory** and the runtime switcher (one row per app), and budget caps and alert rules driven by the same telemetry.
+
+Honesty notes, so nothing surprises you later:
+
+- This path is **observation only**. Pause / stop / kill and pre-tool gates need a runtime ClawMetry can reach as a process or hook; a span stream is not that.
+- OTLP arrives at the receiver in **plaintext**. The end-to-end encryption ClawMetry's sync daemon provides covers the daemon path; for OTLP the answer is to self-host the receiver inside your network, where the plaintext never leaves.
+
+## Five-minute local start (no API key needed)
+
+```bash
+pip install 'clawmetry[otel]' && clawmetry      # dashboard + receiver on :8900
+pip install pydantic-ai-slim opentelemetry-sdk opentelemetry-exporter-otlp-proto-http
+export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:8900
+python examples/bring-your-own-agent/pydantic_ai_agent.py
+```
+
+The example runs a real Pydantic AI agent with a tool call. Without an `ANTHROPIC_API_KEY` it uses Pydantic AI's built-in `TestModel`, so the whole pipeline is testable at zero cost. Open `http://localhost:8900`: the Tracing tab shows the run as `invoke_agent -> chat -> execute_tool -> chat`, Sessions shows the conversation, and the switcher shows `invoice-copilot (OTel)`.
+
+## AWS Bedrock AgentCore, end to end
+
+AgentCore auto-instruments every agent with ADOT (the AWS OpenTelemetry distro) and exports GenAI-semconv spans over OTLP. Re-pointing that exporter is the same partner-observability pattern AWS documents for Langfuse, Instana and Datadog.
+
+### Topology
+
+```
+AgentCore Runtime (ADOT)  ->  OTel Collector (your VPC)  ->  ClawMetry (self-hosted, your VPC)
+                                     \->  CloudWatch / X-Ray (unchanged)
+```
+
+Use the collector fan-out so CloudWatch keeps working. A direct exporter connection to ClawMetry also works if you do not need CloudWatch.
+
+### Configuration (Terraform)
+
+The whole integration is environment variables on the AgentCore runtime resource, rolled out by your existing pipeline:
+
+```hcl
+environment_variables = {
+  AGENT_OBSERVABILITY_ENABLED = "true"
+  OTEL_EXPORTER_OTLP_PROTOCOL = "http/protobuf"
+  OTEL_EXPORTER_OTLP_ENDPOINT = "https://clawmetry.observability.internal:8900"
+  OTEL_EXPORTER_OTLP_HEADERS  = "Authorization=Bearer ${var.clawmetry_token}"
+  OTEL_RESOURCE_ATTRIBUTES    = "service.name=${var.agent_name},deployment.environment=${var.environment}"
+}
+```
+
+Notes:
+
+- `service.name` is the fleet's legibility: `payments-agent` in Dev and Prod stays one app, separable by `deployment.environment`. One hundred agents in Dev and twenty in Prod stay distinguishable in every view.
+- AgentCore stamps a session id on the telemetry of each runtime session; ClawMetry groups spans into sessions by it (`session.id` / `gen_ai.conversation.id`).
+- The Python OTLP exporters (and ADOT) send protobuf, so install the receiver as `pip install 'clawmetry[otel]'` (the Docker image includes it). OTLP/JSON senders work on a bare install.
+- ClawMetry self-hosts as a single Docker container (`docker run -p 8900:8900 clawmetry`); data lives in an embedded DuckDB on your infrastructure.
+- Off-box senders authenticate with the gateway token as a `Bearer` header. `CLAWMETRY_OTLP_ALLOW_UNAUTH=1` disables auth for the `/v1/*` endpoints when something else (a collector inside a private network) already gates access.
+
+### A reference app to try
+
+The [awslabs/agentcore-samples](https://github.com/awslabs/agentcore-samples) repository is a working open-source AgentCore project; its `06-AgentCore-observability` tutorials include the partner-observability notebooks whose exporter re-pointing this guide uses. `examples/bring-your-own-agent/strands_agentcore_agent.py` in this repo is the same Strands agent shape, runnable locally with Anthropic or AWS credentials and deployable to AgentCore unchanged.
+
+## Pydantic AI
+
+Pydantic AI instruments itself with OpenTelemetry; no third-party instrumentation package is needed:
+
+```python
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from pydantic_ai import Agent
+from pydantic_ai.models.instrumented import InstrumentationSettings
+
+provider = TracerProvider(resource=Resource.create({
+    "service.name": "invoice-copilot",
+    "deployment.environment": "dev",
+}))
+provider.add_span_processor(BatchSpanProcessor(
+    OTLPSpanExporter(endpoint="http://localhost:8900/v1/traces")))
+Agent.instrument_all(InstrumentationSettings(tracer_provider=provider))
+```
+
+Everything after that is a normal Pydantic AI agent. Pydantic AI stamps its own `gen_ai.conversation.id`, so each run appears as its own session with no extra work. Call `provider.shutdown()` before a short-lived process exits so the batch exporter flushes.
+
+## LangChain and LangGraph
+
+LangChain emits OTel through the OpenLLMetry instrumentation package, which hooks the callback system LangGraph nodes also run through:
+
+```python
+from opentelemetry.instrumentation.langchain import LangchainInstrumentor
+LangchainInstrumentor().instrument(tracer_provider=provider)   # same provider as above
+```
+
+LangChain does not stamp a conversation id on its spans, so put one on the resource to group a run as a session:
+
+```python
+Resource.create({"service.name": "support-triage", "session.id": run_id})
+```
+
+ClawMetry also understands OpenLLMetry's indexed prompt attributes (`gen_ai.prompt.0.role` and friends), so message content shows in the span detail where the instrumentation records it.
+
+## Troubleshooting
+
+- **Traces but no session rows**: spans carry no `session.id` / `gen_ai.conversation.id`. Add one (span attribute or resource attribute). Traces and usage work without it; sessions need it.
+- **App missing from the switcher**: the resource has no `service.name`, so spans bucket under `custom`. Set it.
+- **Cost shows zero**: spans carry neither token attributes nor a cost attribute. Token counts are enough; ClawMetry derives dollars from the model id, cache-aware.
+- **401 from the receiver**: off-box senders need `Authorization: Bearer <gateway token>`, or set `CLAWMETRY_OTLP_ALLOW_UNAUTH=1` when the network already gates access.
+- **Nothing arrives at all**: the exporter protocol must be `http/protobuf` (or JSON); a gRPC-only exporter (port 4317 style) needs an OTel Collector in front, receiving gRPC and exporting `otlphttp` to ClawMetry.

--- a/examples/bring-your-own-agent/README.md
+++ b/examples/bring-your-own-agent/README.md
@@ -1,0 +1,43 @@
+# Bring your own agent: AgentCore, Pydantic AI, LangChain
+
+ClawMetry observes any agent that speaks OpenTelemetry. These examples point three popular stacks at ClawMetry's built-in OTLP receiver, with no ClawMetry SDK and no code changes beyond standard OTel setup. Full guide: [`docs/BRING_YOUR_OWN_AGENT.md`](../../docs/BRING_YOUR_OWN_AGENT.md).
+
+Start ClawMetry first:
+
+```bash
+pip install 'clawmetry[otel]' && clawmetry     # dashboard + OTLP receiver on :8900
+```
+
+| Example | Stack | Needs an API key? |
+|---|---|---|
+| `pydantic_ai_agent.py` | Pydantic AI (native OTel instrumentation) | No. Falls back to `TestModel`, zero cost |
+| `langchain_agent.py` | LangChain via OpenLLMetry instrumentation | No. Falls back to `GenericFakeChatModel` |
+| `strands_agentcore_agent.py` | Strands (the AWS Bedrock AgentCore SDK) | Yes: `ANTHROPIC_API_KEY` or AWS credentials |
+
+Run any of them:
+
+```bash
+pip install pydantic-ai-slim opentelemetry-sdk opentelemetry-exporter-otlp-proto-http
+export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:8900
+python pydantic_ai_agent.py
+```
+
+Then open the dashboard: the app appears in the runtime switcher and Agent Inventory as `<service.name> (OTel)`, its runs land in the Tracing tab as span trees, each conversation becomes a row in Sessions, and Usage shows tokens plus dollar cost (derived from the model's pricing when spans carry token counts but no cost, which is the OTel norm).
+
+## Deploying to AWS Bedrock AgentCore
+
+The integration is environment variables on the AgentCore runtime resource. With Terraform:
+
+```hcl
+environment_variables = {
+  AGENT_OBSERVABILITY_ENABLED = "true"
+  OTEL_EXPORTER_OTLP_PROTOCOL = "http/protobuf"
+  OTEL_EXPORTER_OTLP_ENDPOINT = "https://clawmetry.observability.internal:8900"
+  OTEL_EXPORTER_OTLP_HEADERS  = "Authorization=Bearer ${var.clawmetry_token}"
+  OTEL_RESOURCE_ATTRIBUTES    = "service.name=${var.agent_name},deployment.environment=${var.environment}"
+}
+```
+
+Keep CloudWatch and X-Ray working by pointing the exporter at an OTel Collector that fans out to both destinations. `deployment.environment` keeps Dev, Test and Prod fleets separable in ClawMetry. Off-box senders authenticate with the gateway token as a Bearer header.
+
+A working AgentCore project to try this on: the [awslabs agentcore-samples](https://github.com/awslabs/agentcore-samples) repository, whose partner-observability tutorials use exactly this exporter re-pointing pattern.

--- a/examples/bring-your-own-agent/langchain_agent.py
+++ b/examples/bring-your-own-agent/langchain_agent.py
@@ -1,0 +1,68 @@
+"""LangChain chain observed by ClawMetry via OpenLLMetry instrumentation.
+
+Start ClawMetry first (``pip install clawmetry && clawmetry``), then:
+
+    pip install langchain-core opentelemetry-instrumentation-langchain \
+        opentelemetry-sdk opentelemetry-exporter-otlp-proto-http
+    export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:8900
+    python langchain_agent.py
+
+Works with any LangChain chat model. With no API key it uses LangChain's
+built-in ``GenericFakeChatModel`` so the telemetry pipeline is testable end
+to end at zero cost. The same three lines of OpenTelemetry setup cover
+LangGraph too: the instrumentor hooks LangChain's callback system, which
+LangGraph nodes run through.
+"""
+
+import os
+import uuid
+
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+# ── 1. Point OpenTelemetry at ClawMetry ─────────────────────────────────────
+endpoint = os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:8900")
+resource = Resource.create({
+    "service.name": os.environ.get("OTEL_SERVICE_NAME", "support-triage"),
+    "deployment.environment": os.environ.get("DEPLOYMENT_ENV", "dev"),
+    # LangChain does not stamp a conversation id on its spans, so group this
+    # process run as one ClawMetry session at the resource level.
+    "session.id": os.environ.get("AGENT_SESSION_ID", f"support-triage-{uuid.uuid4().hex[:8]}"),
+})
+provider = TracerProvider(resource=resource)
+provider.add_span_processor(
+    BatchSpanProcessor(OTLPSpanExporter(endpoint=endpoint.rstrip("/") + "/v1/traces"))
+)
+
+# ── 2. Instrument LangChain (OpenLLMetry) ───────────────────────────────────
+from opentelemetry.instrumentation.langchain import LangchainInstrumentor  # noqa: E402
+
+LangchainInstrumentor().instrument(tracer_provider=provider)
+
+# ── 3. A normal LangChain chain ─────────────────────────────────────────────
+from langchain_core.prompts import ChatPromptTemplate  # noqa: E402
+
+if os.environ.get("ANTHROPIC_API_KEY"):
+    from langchain_anthropic import ChatAnthropic
+    model = ChatAnthropic(model="claude-sonnet-5")
+else:
+    from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
+    model = GenericFakeChatModel(messages=iter([
+        "Priority: HIGH. Route to billing. The customer reports a duplicate charge.",
+    ]))
+    print("(no ANTHROPIC_API_KEY: using LangChain GenericFakeChatModel, zero cost)")
+
+prompt = ChatPromptTemplate.from_messages([
+    ("system", "You triage support tickets. Answer with a priority and a route."),
+    ("human", "{ticket}"),
+])
+chain = prompt | model
+
+if __name__ == "__main__":
+    out = chain.invoke({"ticket": "I was charged twice for my ClawMetry Pro seat."})
+    print("chain said:", getattr(out, "content", out))
+    provider.shutdown()  # flush the span batch before the process exits
+    print("spans exported to", endpoint)
+    print("open the ClawMetry dashboard: Tracing tab -> support-triage")

--- a/examples/bring-your-own-agent/pydantic_ai_agent.py
+++ b/examples/bring-your-own-agent/pydantic_ai_agent.py
@@ -1,0 +1,75 @@
+"""Pydantic AI agent observed by ClawMetry over pure OpenTelemetry.
+
+Start ClawMetry first (``pip install clawmetry && clawmetry``), then:
+
+    export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:8900
+    python pydantic_ai_agent.py
+
+Works with any model Pydantic AI supports. With ``ANTHROPIC_API_KEY`` set it
+runs a real Claude call; without one it falls back to Pydantic AI's built-in
+``TestModel`` so the whole telemetry pipeline is testable end to end at zero
+cost. Either way the agent, its model calls, and its tool calls land in
+ClawMetry's Tracing, Sessions, and Usage tabs.
+
+No ClawMetry SDK, no vendor lock-in: this file only uses the OpenTelemetry
+SDK and Pydantic AI's own ``InstrumentationSettings``.
+"""
+
+import os
+import uuid
+
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+# ── 1. Point OpenTelemetry at ClawMetry ─────────────────────────────────────
+# ClawMetry's OTLP receiver listens on the dashboard port at /v1/traces.
+# service.name becomes the app's identity in the runtime switcher and the
+# Agent Inventory; deployment.environment keeps dev/tst/prod separable.
+endpoint = os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:8900")
+resource = Resource.create({
+    "service.name": os.environ.get("OTEL_SERVICE_NAME", "invoice-copilot"),
+    "deployment.environment": os.environ.get("DEPLOYMENT_ENV", "dev"),
+    # One process run = one conversation. AgentCore stamps a session id for
+    # you; a local framework needs to say which spans belong together so
+    # ClawMetry can show them as one session.
+    "session.id": os.environ.get("AGENT_SESSION_ID", f"invoice-copilot-{uuid.uuid4().hex[:8]}"),
+})
+provider = TracerProvider(resource=resource)
+provider.add_span_processor(
+    BatchSpanProcessor(OTLPSpanExporter(endpoint=endpoint.rstrip("/") + "/v1/traces"))
+)
+
+# ── 2. A normal Pydantic AI agent, instrumented ─────────────────────────────
+from pydantic_ai import Agent  # noqa: E402
+from pydantic_ai.models.instrumented import InstrumentationSettings  # noqa: E402
+
+if os.environ.get("ANTHROPIC_API_KEY"):
+    model = "anthropic:claude-sonnet-5"
+else:
+    from pydantic_ai.models.test import TestModel
+    model = TestModel()
+    print("(no ANTHROPIC_API_KEY: using pydantic-ai TestModel, zero cost)")
+
+# One line turns on OpenTelemetry for every agent in the process.
+Agent.instrument_all(InstrumentationSettings(tracer_provider=provider))
+
+agent = Agent(
+    model,
+    system_prompt="You are an invoice lookup copilot. Use your tools.",
+)
+
+
+@agent.tool_plain
+def lookup_invoice(invoice_id: str) -> str:
+    """Look up one invoice by its id."""
+    return f"Invoice {invoice_id}: $1,240.00, due 2026-09-15, status OPEN"
+
+
+if __name__ == "__main__":
+    result = agent.run_sync("What is the status of invoice INV-1042?")
+    print("agent said:", result.output)
+    provider.shutdown()  # flush the span batch before the process exits
+    print("spans exported to", endpoint)
+    print("open the ClawMetry dashboard: Tracing tab -> invoice-copilot")

--- a/examples/bring-your-own-agent/strands_agentcore_agent.py
+++ b/examples/bring-your-own-agent/strands_agentcore_agent.py
@@ -1,0 +1,59 @@
+"""Strands agent (the AWS Bedrock AgentCore SDK) observed by ClawMetry.
+
+This is the same agent shape the awslabs agentcore-samples tutorials deploy
+to AgentCore Runtime. Locally it runs with Anthropic or Bedrock credentials;
+deployed to AgentCore it needs NO code change, because the integration is
+environment variables on the runtime resource (see the Terraform snippet in
+README.md and docs/BRING_YOUR_OWN_AGENT.md).
+
+Local run:
+
+    pip install 'strands-agents[anthropic]' opentelemetry-exporter-otlp-proto-http
+    export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:8900
+    export OTEL_RESOURCE_ATTRIBUTES="service.name=payments-agent,deployment.environment=dev"
+    export ANTHROPIC_API_KEY=...   # or AWS credentials for the Bedrock default
+    python strands_agentcore_agent.py
+
+On AgentCore Runtime, ADOT auto-instruments the agent; re-pointing
+OTEL_EXPORTER_OTLP_ENDPOINT at a ClawMetry inside your VPC is the same
+partner-observability pattern AWS documents for Langfuse, Instana and
+Datadog. Keep CloudWatch too by fanning out through an OTel Collector.
+"""
+
+import os
+import uuid
+
+from strands import Agent, tool
+from strands.telemetry import StrandsTelemetry
+
+# ── 1. Point Strands' OpenTelemetry at ClawMetry ────────────────────────────
+# StrandsTelemetry honors OTEL_EXPORTER_OTLP_ENDPOINT and
+# OTEL_RESOURCE_ATTRIBUTES; nothing ClawMetry-specific in the agent.
+os.environ.setdefault("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:8900")
+os.environ.setdefault(
+    "OTEL_RESOURCE_ATTRIBUTES",
+    "service.name=payments-agent,deployment.environment=dev,"
+    f"session.id=payments-{uuid.uuid4().hex[:8]}",
+)
+StrandsTelemetry().setup_otlp_exporter()
+
+
+# ── 2. A normal Strands agent ───────────────────────────────────────────────
+@tool
+def lookup_invoice(invoice_id: str) -> str:
+    """Look up one invoice by its id."""
+    return f"Invoice {invoice_id}: $1,240.00, due 2026-09-15, status OPEN"
+
+
+if os.environ.get("ANTHROPIC_API_KEY"):
+    from strands.models.anthropic import AnthropicModel
+    model = AnthropicModel(model_id="claude-sonnet-5", max_tokens=512)
+    agent = Agent(model=model, tools=[lookup_invoice])
+else:
+    # Default: Bedrock, using your AWS credentials, same as on AgentCore.
+    agent = Agent(tools=[lookup_invoice])
+
+if __name__ == "__main__":
+    result = agent("What is the status of invoice INV-1042?")
+    print(result)
+    print("open the ClawMetry dashboard: Tracing tab -> payments-agent")

--- a/routes/local_query.py
+++ b/routes/local_query.py
@@ -787,6 +787,13 @@ _DAEMON_METHODS = frozenset({
     # put_otlp_batch(records=[...], events=[...]) — the proxy forwards
     # **kwargs only. One call per OTLP export batch, not per record.
     "put_otlp_batch",
+    # WO-55: sessions materialized from OTLP spans. The /v1/traces receiver
+    # (dashboard process, no writer lock) recomputes the touched sessions'
+    # rollups from the spans table and upserts sessions rows through the
+    # daemon, so a span-only app (AgentCore, OpenLLMetry) shows in the
+    # Sessions tab + runtime switcher. Keyword-only through the proxy:
+    # materialize_otlp_sessions(session_ids=[...], environments={...}).
+    "materialize_otlp_sessions",
     # Read side of the same table: per-team / per-repo / per-person rollups
     # over the daemon-free path, and the persisted-row count /api/otel-status
     # shows so an operator can tell durable storage from the in-memory cache.

--- a/tests/test_otlp_session_materialization.py
+++ b/tests/test_otlp_session_materialization.py
@@ -1,0 +1,268 @@
+"""WO-55: sessions materialized from OTLP spans (bring-your-own-agent).
+
+A fleet that only ever sends OTLP traces (AWS Bedrock AgentCore, an
+OpenLLMetry app, ...) fills the ``spans`` table and the Tracing tab but used
+to create no ``sessions`` row — so the Sessions tab and the runtime switcher
+stayed empty for exactly the app the person just wired up. The /v1/traces
+receiver now recomputes the touched sessions from their spans and upserts
+sessions rows (``LocalStore.materialize_otlp_sessions``) once per export
+batch.
+
+Pinned here, through the REAL ingest path (``POST /v1/traces`` →
+``_process_otlp_traces`` → DuckDB):
+
+  * a GenAI-semconv span batch with ``session.id`` produces a sessions row
+    with the right agent_type, token/cost rollup, message_count, title, and
+    ``metadata.source='otlp_spans'`` + ``deployment_environment``;
+  * an OTLP retry (same batch re-POSTed) does NOT double any total —
+    delivery is at-least-once by spec;
+  * OpenClaw-labelled spans never mint a session row (ghost-session guard:
+    OpenClaw sessions come from transcripts);
+  * a pre-existing session row owned by a richer ingest path is left alone.
+
+Gated on ``opentelemetry-proto`` (the receiver 501s without it).
+"""
+
+from __future__ import annotations
+
+import importlib
+import json as _json
+import time
+
+import pytest
+from flask import Flask
+
+try:
+    from opentelemetry.proto.collector.trace.v1 import trace_service_pb2 as _ts_pb2
+    from opentelemetry.proto.common.v1 import common_pb2 as _common_pb2
+    from opentelemetry.proto.trace.v1 import trace_pb2 as _trace_pb2
+    _HAS_OTEL_PROTO = True
+except Exception:  # pragma: no cover
+    _HAS_OTEL_PROTO = False
+
+pytestmark = pytest.mark.skipif(
+    not _HAS_OTEL_PROTO,
+    reason="opentelemetry-proto not installed (pip install clawmetry[otel])",
+)
+
+
+@pytest.fixture
+def app(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "5")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_READ", "1")
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    # Hermetic: force the in-process direct store past any host daemon proxy
+    # (CI has no daemon; this makes the suite pass on a dev box too).
+    monkeypatch.setattr(ls, "_daemon_registered", lambda *a, **k: False)
+    monkeypatch.delenv("CLAWMETRY_ROLE", raising=False)
+    import routes.local_query as lq
+    importlib.reload(lq)
+    monkeypatch.setattr(lq, "_read_discovery", lambda: None)
+    import routes.meta as meta
+    importlib.reload(meta)
+
+    a = Flask(__name__)
+    a.register_blueprint(meta.bp_otel)
+    yield a, ls
+    try:
+        ls.get_store().stop(flush=True)
+    except Exception:
+        pass
+
+
+def _kv(key, s=None, i=None):
+    v = _common_pb2.AnyValue()
+    if s is not None:
+        v.string_value = s
+    elif i is not None:
+        v.int_value = i
+    return _common_pb2.KeyValue(key=key, value=v)
+
+
+def _agentcore_batch(session_id, *, service="payments-agent-prod",
+                     environment="prod", trace_seed=1):
+    """An ADOT/Strands-shaped export: invoke_agent root + two chat spans +
+    one execute_tool span, GenAI semconv attrs, session id on every span."""
+    now = int(time.time() * 1e9)
+    trace_id = bytes([trace_seed]) * 16
+
+    def _span(span_id, parent, name, off_ms, dur_ms, attrs):
+        s = _trace_pb2.Span(
+            trace_id=trace_id,
+            span_id=span_id,
+            name=name,
+            start_time_unix_nano=now + int(off_ms * 1e6),
+            end_time_unix_nano=now + int((off_ms + dur_ms) * 1e6),
+        )
+        if parent:
+            s.parent_span_id = parent
+        s.attributes.extend(attrs)
+        return s
+
+    chat_attrs = [
+        _kv("gen_ai.operation.name", s="chat"),
+        _kv("gen_ai.system", s="aws.bedrock"),
+        _kv("gen_ai.request.model", s="anthropic.claude-sonnet-5-20250929-v1:0"),
+        _kv("gen_ai.conversation.id", s=session_id),
+    ]
+    spans = [
+        _span(b"\x0a" * 8, b"", "invoke_agent payments-agent", 0, 5000, [
+            _kv("gen_ai.operation.name", s="invoke_agent"),
+            _kv("session.id", s=session_id),
+        ]),
+        _span(b"\x0b" * 8, b"\x0a" * 8, "chat claude", 100, 2000, chat_attrs + [
+            _kv("gen_ai.usage.input_tokens", i=1000),
+            _kv("gen_ai.usage.output_tokens", i=200),
+        ]),
+        _span(b"\x0c" * 8, b"\x0a" * 8, "execute_tool lookup_invoice", 2200, 700, [
+            _kv("gen_ai.operation.name", s="execute_tool"),
+            _kv("gen_ai.tool.name", s="lookup_invoice"),
+            _kv("session.id", s=session_id),
+        ]),
+        _span(b"\x0d" * 8, b"\x0a" * 8, "chat claude", 3000, 1500, chat_attrs + [
+            _kv("gen_ai.usage.input_tokens", i=2000),
+            _kv("gen_ai.usage.output_tokens", i=500),
+        ]),
+    ]
+    resource = _trace_pb2.ResourceSpans(
+        scope_spans=[_trace_pb2.ScopeSpans(spans=spans)])
+    resource.resource.attributes.extend([
+        _kv("service.name", s=service),
+        _kv("deployment.environment", s=environment),
+        _kv("host.name", s="agentcore-runtime-1"),
+    ])
+    return _ts_pb2.ExportTraceServiceRequest(resource_spans=[resource])
+
+
+def _post(app_obj, req):
+    client = app_obj.test_client()
+    resp = client.post("/v1/traces", data=req.SerializeToString(),
+                       content_type="application/x-protobuf")
+    assert resp.status_code == 200, resp.data
+    return resp
+
+
+def _session_row(ls, session_id):
+    store = ls.get_store()
+    rows = store._fetch(
+        "SELECT agent_type, title, total_tokens, cost_usd, message_count,"
+        " status, started_at, last_active_at, metadata"
+        " FROM sessions WHERE session_id = ?", [session_id])
+    if not rows:
+        return None
+    (agent_type, title, total_tokens, cost_usd, message_count,
+     status, started_at, last_active_at, metadata) = rows[0]
+    if isinstance(metadata, (bytes, bytearray, memoryview)):
+        metadata = bytes(metadata).decode("utf-8", "replace")
+    if isinstance(metadata, str) and metadata:
+        try:
+            metadata = _json.loads(metadata)
+        except ValueError:
+            pass
+    return {
+        "agent_type": agent_type, "title": title,
+        "total_tokens": int(total_tokens or 0),
+        "cost_usd": float(cost_usd or 0.0),
+        "message_count": int(message_count or 0), "status": status,
+        "started_at": started_at, "last_active_at": last_active_at,
+        "metadata": metadata if isinstance(metadata, dict) else {},
+    }
+
+
+def test_span_only_app_gets_session_row(app):
+    a, ls = app
+    sid = "agentcore-sess-mat-1"
+    _post(a, _agentcore_batch(sid))
+
+    row = _session_row(ls, sid)
+    assert row is not None, "no sessions row materialized from spans"
+    assert row["agent_type"] == "payments_agent_prod"
+    assert row["total_tokens"] == 3700  # 1000+200 + 2000+500
+    assert row["cost_usd"] > 0, "cost should be derived from tokens x model"
+    assert row["message_count"] == 2  # the two chat spans
+    assert row["title"] == "invoke_agent payments-agent"
+    assert row["started_at"] and row["last_active_at"]
+    assert row["metadata"].get("source") == "otlp_spans"
+    assert row["metadata"].get("deployment_environment") == "prod"
+    assert row["metadata"].get("service_name") == "payments-agent-prod"
+
+
+def test_otlp_retry_does_not_double_totals(app):
+    a, ls = app
+    sid = "agentcore-sess-mat-retry"
+    req = _agentcore_batch(sid)
+    _post(a, req)
+    first = _session_row(ls, sid)
+    assert first is not None and first["total_tokens"] == 3700
+
+    # At-least-once delivery: the exporter re-sends the same batch.
+    _post(a, req)
+    second = _session_row(ls, sid)
+    assert second["total_tokens"] == 3700, "retry doubled the token rollup"
+    assert abs(second["cost_usd"] - first["cost_usd"]) < 1e-9
+
+
+def test_openclaw_spans_never_mint_a_session(app):
+    a, ls = app
+    sid = "openclaw-sess-from-spans"
+    # service.name 'openclaw' maps to agent_type 'openclaw' — those sessions
+    # come from transcripts via the daemon, not from spans.
+    _post(a, _agentcore_batch(sid, service="openclaw", environment=""))
+    assert _session_row(ls, sid) is None
+
+
+def test_rollup_buckets_materialized_session_under_its_app(app):
+    """The prefix-only runtime CASE used to dump prefix-less OTLP sessions into
+    the 'openclaw' bucket, so a bring-your-own-agent app's tokens and cost
+    showed under OpenClaw the moment its sessions materialized."""
+    a, ls = app
+    sid = "agentcore-sess-bucket"
+    _post(a, _agentcore_batch(sid, service="billing-agent-tst", environment="tst"))
+    br = (ls.get_store().query_model_rollup() or {}).get("by_runtime") or {}
+    assert "billing_agent_tst" in br, f"buckets: {sorted(br)}"
+    assert br["billing_agent_tst"]["sessions"] == 1
+    assert br["billing_agent_tst"]["tokens"] == 3700
+    oc = br.get("openclaw") or {}
+    assert int(oc.get("tokens") or 0) == 0, (
+        "OTLP session tokens leaked into the openclaw bucket")
+    assert float(oc.get("cost_usd") or 0.0) == 0.0
+
+
+def test_runtime_summary_entry_keeps_otlp_markers(app):
+    """With a sessions row present, the summary already holds a key for the
+    app, and the spans merge used to SKIP it — losing otlp=True and
+    display_name, so the frontend scoped the app by a session-id prefix it
+    does not have. The merge must enrich, and never double the numbers."""
+    a, ls = app
+    sid = "agentcore-sess-summary"
+    _post(a, _agentcore_batch(sid, service="billing-agent-tst", environment="tst"))
+    from clawmetry import sync as _sync
+    summ = _sync._build_runtime_summary() or {}
+    entry = summ.get("billing_agent_tst")
+    assert entry, f"no summary entry for the app; keys={sorted(summ)}"
+    assert entry.get("otlp") is True
+    assert "(OTel)" in (entry.get("display_name") or "")
+    assert entry["sessions"] == 1
+    assert entry["tokens"] == 3700, "sessions pass + spans merge double-counted"
+
+
+def test_richer_ingest_owned_session_is_not_clobbered(app):
+    a, ls = app
+    sid = "agentcore-sess-owned"
+    store = ls.get_store()
+    store.ingest_session({
+        "session_id": sid,
+        "agent_type": "payments_agent_prod",
+        "title": "real transcript title",
+        "total_tokens": 999,
+        "metadata": {"origin": "daemon"},
+    })
+    _post(a, _agentcore_batch(sid))
+    row = _session_row(ls, sid)
+    assert row["title"] == "real transcript title"
+    assert row["total_tokens"] == 999, (
+        "span materialization overwrote a session owned by a richer ingest")

--- a/tests/test_otlp_session_materialization.py
+++ b/tests/test_otlp_session_materialization.py
@@ -250,6 +250,27 @@ def test_runtime_summary_entry_keeps_otlp_markers(app):
     assert entry["tokens"] == 3700, "sessions pass + spans merge double-counted"
 
 
+def test_live_counts_bucket_by_metadata_runtime(app):
+    """The materialized session's metadata carries ``runtime`` because
+    ``sync._live_counts_by_runtime`` buckets liveness by ``metadata.runtime``
+    (defaulting to 'openclaw' without it). Proven end to end here: rows read
+    back through ``query_sessions_table`` (metadata JSON-decoded) land the
+    app's live count under its own runtime key, never under openclaw."""
+    a, ls = app
+    sid = "agentcore-sess-live"
+    _post(a, _agentcore_batch(sid, service="billing-agent-tst", environment="tst"))
+    rows = ls.get_store().query_sessions_table(limit=50)
+    ours = [r for r in rows if r.get("session_id") == sid]
+    assert ours and (ours[0].get("metadata") or {}).get("runtime") == "billing_agent_tst"
+    from clawmetry import sync as _sync
+    live = _sync._live_counts_by_runtime(ours)
+    assert "billing_agent_tst" in live, f"live buckets: {sorted(live)}"
+    assert "openclaw" not in live, "OTLP session liveness bucketed under openclaw"
+    # The batch's spans just happened, so the session must read as working/live.
+    b = live["billing_agent_tst"]
+    assert (b.get("working") or 0) + (b.get("waiting") or 0) >= 1
+
+
 def test_richer_ingest_owned_session_is_not_clobbered(app):
     a, ls = app
     sid = "agentcore-sess-owned"


### PR DESCRIPTION
Product record: https://factory.8090.ai/project/b415065f-ab2f-4f53-8864-0c009fd098cb/requirements/8e389016-a9c8-4352-9121-72f0e361fdf6 (Runtime and Session Observability; tracked as WO-55)

## Why

An enterprise prospect runs ~160 agents on AWS Bedrock AgentCore (ADOT/Strands, OTLP GenAI spans). Pointing OTEL_EXPORTER_OTLP_ENDPOINT at ClawMetry already fills the Tracing tab, Usage and the spans table, but:

1. No sessions rows ever materialize from spans, so the Sessions tab stays empty and the runtime switcher never lists the app locally.
2. deployment.environment (dev/tst/prod) was dropped with the resource attributes.
3. Once sessions rows exist, the prefix-only runtime bucketing in query_model_rollup dumps the app's tokens and cost into the openclaw bucket, and _merge_otlp_apps_into_summary then skips the app (key already present), losing otlp=true and display_name.

## What

- LocalStore.materialize_otlp_sessions(): full recompute of the touched sessions from their spans, upserted through ingest_sessions_batch. Idempotent under OTLP at-least-once retries. Skips agent_type=openclaw (ghost-session guard) and any session owned by a richer ingest path (metadata.source ownership rule, same as put_otlp_batch).
- The /v1/traces receiver calls it once per export batch and passes deployment.environment per session; _otel_to_row keeps that attribute on the span blob.
- query_model_rollup sessions-side runtime CASE prefers a foreign agent_type over the openclaw fallback (prefix stays authoritative for family runtimes).
- _merge_otlp_apps_into_summary enriches an existing summary entry (otlp=true, display_name, max-not-sum numbers) instead of skipping.
- Session metadata carries runtime so _live_counts_by_runtime buckets liveness correctly.

## Verification

- tests/test_otlp_session_materialization.py (in the CI OTLP list): materialization, retry idempotence, openclaw ghost guard, ownership no-clobber, rollup bucketing, summary markers. Revert-proof: positive tests red on unfixed code, green restored.
- Full OTLP receiver suite: 100 passed. Neighboring builder suites pass (2 pre-existing dev-box-only failures in test_agent_inventory reproduce identically on clean origin/main).
- Live E2E on a fresh isolated server: POST AgentCore-shaped OTLP -> Sessions row (agent_type payments_agent_prod, 5007 tokens, derived cost 0.0069 from the Bedrock model id, title, env in metadata), 4-span trace tree, and exactly one inventory roster row 'payments-agent-prod (OTel)' with sessions:1 and no openclaw mis-attribution.
- make lint: 224 findings before and after (all pre-existing, none introduced).

Closes the core of WO-55.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AHS9axpM7w3pwG7jJpFhEB