### PR TITLE
Harden deps: narrow the cffi&lt;2 cap to py3.9 so 3.10-3.13 clear cryptography

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,7 +118,7 @@ The daemon owns the DuckDB writer lock and runs a localhost query server so the 
 Minimal by design, and this list had drifted — `setup.py` is the source of truth:
 - **flask** (>=2.0,<4) — HTTP server framework
 - **waitress** (>=2.0) — WSGI application server
-- **cryptography** (>=50.0.0 on 3.14+; >=46.0.0 on 3.9.2–3.13, capped there by the `cffi<2` pin; >=3.0 on 3.8/3.9.0/3.9.1) — AES-256-GCM for cloud sync
+- **cryptography** (>=50.0.0 on 3.10+; >=46.0.0 on 3.9.2–3.9.x, capped there by the py3.9-only `cffi<2` pin; >=3.0 on 3.8/3.9.0/3.9.1) — AES-256-GCM for cloud sync
 - **duckdb** (>=0.10) — the local store at `~/.clawmetry/clawmetry.duckdb`
 - **websocket-client** (>=1.6) — cloud cold-data relay tunnel
 - **truststore** (>=0.8, 3.10+ only) — OS trust store, so corporate TLS-interception root CAs work

--- a/setup.py
+++ b/setup.py
@@ -97,39 +97,48 @@ setup(
         # an environment that already had a vulnerable cryptography kept it.
         #
         # The CEILING here is set by the cffi pin below, not by taste.
-        # cryptography 46.0.1+ requires cffi>=2.0.0 on 3.9+, which
-        # contradicts the `cffi<2` we pin under 3.14 (issue #5108), so
-        # 46.0.0 is the newest release that resolves under 3.14. Above
-        # 3.14, where we already take cffi>=2, the newest is reachable.
+        # cryptography 46.0.1+ requires cffi>=2.0.0 on 3.9+, so wherever we
+        # pin `cffi<2` the newest resolvable cryptography is exactly 46.0.0
+        # -- which carries nine published advisories (PYSEC-2026-2141, -35,
+        # -36, GHSA-537c-gmf6-5ccf, PYSEC-2026-3552/3553/3554), fixed across
+        # 46.0.5 through 50.0.0.
+        #
+        # That cap used to span every interpreter below 3.14. It no longer
+        # does, because both reasons behind `cffi<2` are specific to Python
+        # 3.9 (see the cffi comment below): the 2.0.0 finalizer SIGSEGV is a
+        # py3.9 bug, and the missing cp39 wheels on cffi 2.1+ are a py3.9
+        # packaging fact. cffi 2.x publishes wheels for 3.10, 3.11, 3.12 and
+        # 3.13, so holding those four at cffi<2 bought nothing and cost the
+        # nine advisories above on the interpreters most installs run.
         #
         # Interpreter bands, in the same conditional shape as cffi below:
-        #   3.14+            cffi>=2 already, so >=50.0.0 (advisory-clean)
-        #   3.9.2 - 3.13     capped at 46.0.0 by cffi<2
+        #   3.10+            cffi>=2, so >=50.0.0 (advisory-clean)
+        #   3.9.2 - 3.9.x    still capped at 46.0.0 by cffi<2 on py3.9
         #   3.8/3.9.0/3.9.1  46.0.4+ excludes 3.9.0/3.9.1, so the old floor
         #                    stays rather than making `pip install clawmetry`
         #                    a resolver error on an interpreter we support
         #
-        # Under 3.14 this closes the 36 advisories fixed up to 46.0.0. The
-        # six newer ones (fixed in 46.0.6, 46.0.7, 48.0.1, 49.0.0 x2 and
-        # 50.0.0, the last being CVE-2026-69247) are NOT reachable there at
-        # any floor: cffi<2 caps us at 46.0.0. Closing them means narrowing
-        # that pin -- it is load-bearing and retiring it is its own change.
-        'cryptography>=50.0.0; python_version >= "3.14"',
-        'cryptography>=46.0.0; python_full_version >= "3.9.2" and python_version < "3.14"',
+        # py3.9 keeps the nine open advisories, and that is the residual risk
+        # this change accepts rather than hides: closing them there requires
+        # cffi>=2, which reintroduces #5108 on the one interpreter it breaks.
+        # Python 3.9 reached end of life in October 2025.
+        'cryptography>=50.0.0; python_version >= "3.10"',
+        'cryptography>=46.0.0; python_full_version >= "3.9.2" and python_version < "3.10"',
         'cryptography>=3.0; python_full_version < "3.9.2"',
         # cffi is pinned per interpreter, and both halves are load-bearing:
-        # - Below 3.14: cffi 2.0.0 introduced a Python 3.9 finalizer
+        # - On 3.9 only: cffi 2.0.0 introduced a Python 3.9 finalizer
         #   regression that SIGSEGVs at sys.exit() when argparse prints
         #   --help text, crashing `clawmetry uninstall --help` on py3.9
-        #   (issue #5108) — and cffi 2.1+ ships no cp39 wheels at all, so
-        #   <2 stays correct there.
-        # - On 3.14+: cffi 1.x ships NO cp314 wheels, so an unconditional
-        #   <2 forces a source build that demands MSVC on end-user Windows
-        #   machines ("Microsoft Visual C++ 14.0 or greater is required")
-        #   and bricked a desktop first install in the field (2026-08-29).
-        #   cffi 2.x is the only series with 3.14 wheels.
-        'cffi<2; python_version < "3.14"',
-        'cffi>=2; python_version >= "3.14"',
+        #   (issue #5108) — and cffi 2.1+ ships no cp39 wheels at all
+        #   (it requires >=3.10), so <2 stays correct there.
+        # - On 3.10+: neither reason applies. cffi 1.x ships NO cp314
+        #   wheels, so an unconditional <2 forces a source build that
+        #   demands MSVC on end-user Windows machines ("Microsoft Visual
+        #   C++ 14.0 or greater is required") and bricked a desktop first
+        #   install in the field (2026-08-29). cffi 2.x is the only series
+        #   with 3.14 wheels, and it covers 3.10-3.13 as well.
+        'cffi<2; python_version < "3.10"',
+        'cffi>=2; python_version >= "3.10"',
         # Local store at ~/.clawmetry/clawmetry.duckdb. Holds events,
         # sessions, memory, heartbeats, system snapshots, traces. ~14 MB
         # wheel; columnar storage gives 10-100x speed vs SQLite for the

--- a/tests/test_desktop_bootstrap_resilience.py
+++ b/tests/test_desktop_bootstrap_resilience.py
@@ -214,21 +214,45 @@ def test_log_survives_unencodable_characters(tmp_path):
 
 # ── 5. the cffi pin must stay split per interpreter ──────────────────────
 #
-# setup.py pins cffi<2 below Python 3.14 (cffi 2.0.0 SIGSEGVs py3.9, #5108,
-# and cffi 2.1+ ships no cp39 wheels) and cffi>=2 on 3.14+ (cffi 1.x ships
-# NO cp314 wheels, so an unconditional <2 forces an MSVC source build on
-# end-user Windows — the 2026-08-29 field failure). Both halves are
-# load-bearing; collapsing them back to a bare "cffi<2" re-bricks every
-# Windows install on a current python.org Python.
+# setup.py pins cffi<2 on Python 3.9 only (cffi 2.0.0 SIGSEGVs py3.9, #5108,
+# and cffi 2.1+ requires >=3.10 so it ships no cp39 wheels) and cffi>=2 from
+# 3.10 up (cffi 1.x ships NO cp314 wheels, so an unconditional <2 forces an
+# MSVC source build on end-user Windows — the 2026-08-29 field failure).
+# Both halves are load-bearing; collapsing them back to a bare "cffi<2"
+# re-bricks every Windows install on a current python.org Python.
+#
+# The boundary sits at 3.10, not 3.14, because that is where the two py3.9
+# reasons stop applying. Holding 3.10-3.13 at cffi<2 capped cryptography at
+# 46.0.0 (46.0.1+ needs cffi>=2.0.0 on 3.9+) and so kept nine published
+# advisories open on the interpreters most installs run. Moving the boundary
+# back up would silently reopen them.
 
 
 def test_cffi_pin_is_split_per_interpreter():
     setup_src = (REPO_ROOT / "setup.py").read_text(encoding="utf-8")
-    assert 'cffi<2; python_version < "3.14"' in setup_src
-    assert 'cffi>=2; python_version >= "3.14"' in setup_src
+    assert 'cffi<2; python_version < "3.10"' in setup_src
+    assert 'cffi>=2; python_version >= "3.10"' in setup_src
     import re
     bare = re.search(r"""['"]cffi<2['"]""", setup_src)
     assert bare is None, "an unmarked cffi<2 would have no cp314 wheel"
+
+
+def test_cryptography_floor_tracks_the_cffi_boundary():
+    """Wherever cffi>=2 is allowed, cryptography must be advisory-clean.
+
+    The two pins are coupled: cryptography 46.0.1+ requires cffi>=2.0.0 on
+    3.9+, so a cffi<2 band caps cryptography at 46.0.0 no matter what floor
+    is written. Raising the cffi boundary without raising the cryptography
+    floor to match would leave the newer band pinned to a version whose
+    advisories are fixed and reachable.
+    """
+    setup_src = (REPO_ROOT / "setup.py").read_text(encoding="utf-8")
+    assert 'cryptography>=50.0.0; python_version >= "3.10"' in setup_src
+    assert (
+        'cryptography>=46.0.0; python_full_version >= "3.9.2" '
+        'and python_version < "3.10"' in setup_src
+    )
+    assert 'cryptography>=3.0; python_full_version < "3.9.2"' in setup_src
 
 
 # ── 6. field-failure reporting (AC-FFR-001) ──────────────────────────────


### PR DESCRIPTION
No-PRD: dependency-metadata security fix closing nine published upstream advisories on py3.10-3.13; explicitly deferred by the comment in `setup.py` that this change resolves.

**Risk:** `pip install clawmetry` on Python 3.10–3.13 now resolves `cffi` 2.1.1 and `cryptography` 50.0.1 instead of `cffi` 1.17.1 and `cryptography` 46.0.0. Both are the combination upstream `cryptography` itself declares and tests (50.x *requires* `cffi>=2.0.0`), and cffi 2.x publishes wheels for 3.10/3.11/3.12/3.13, so no source build is introduced. Python 3.9 resolution is byte-for-byte unchanged, as is 3.14+. Undone by reverting this commit. Nothing retroactive, no migration, no control-plane surface touched.

---

## Summary

- `cryptography` 46.0.1+ requires `cffi>=2.0.0` on 3.9+, so a `cffi<2` band caps `cryptography` at exactly **46.0.0** whatever floor is written beside it. That band spanned everything below 3.14, so **3.10, 3.11, 3.12 and 3.13 all sat on 46.0.0** — which carries nine published advisories, fixed across 46.0.5 → 50.0.0.
- Both reasons behind `cffi<2` are **specific to Python 3.9**: the cffi 2.0.0 finalizer SIGSEGV (#5108), and cffi 2.1+ declaring `requires_python >=3.10` so it ships no cp39 wheels. Neither applies to 3.10–3.13. Holding those four at `cffi<2` bought nothing and cost the advisories on the interpreters most installs run.
- The boundary moves **3.14 → 3.10** on both pins, and the `cryptography` floor moves with it so the newer band is not left pinned below fixes it can now reach. `setup.py` had already recorded this as deferred: *"Closing them means narrowing that pin — it is load-bearing and retiring it is its own change."*
- **py3.9 is unchanged and keeps those advisories.** That is the residual risk this accepts rather than hides, and it is stated in the comment: closing them there needs `cffi>=2`, which reintroduces #5108 on the one interpreter it breaks. Python 3.9 reached end of life in October 2025.

Advisories closed on 3.10–3.13: PYSEC-2026-2141, PYSEC-2026-35, PYSEC-2026-36, GHSA-537c-gmf6-5ccf, PYSEC-2026-3552, PYSEC-2026-3553, PYSEC-2026-3554.

## Test plan

Resolved against live PyPI metadata rather than read off the file:

- [x] Every `install_requires` entry parses as valid PEP 508, and **each interpreter matches exactly one band per package** — asserted in the harness, not eyeballed
- [x] Joint resolution honouring `cryptography`'s *own* `cffi` requirement (a naive per-package resolve gets py3.9 wrong):<br>`py3.9.2` / `py3.9.18` → cffi 1.17.1, cryptography 46.0.0 — **unchanged**<br>`py3.10` – `py3.14` → cffi 2.1.1, cryptography 50.0.1 — **was 46.0.0**
- [x] Real `pip install --dry-run .` on py3.11 resolves `cffi==2.1.1`, `cryptography==50.0.1` — the resolver agrees with the model
- [x] Confirmed from PyPI that cffi 2.x ships cp310/cp311/cp312/cp313 wheels, so 3.10–3.13 gain no source build
- [x] `pytest tests/test_desktop_bootstrap_resilience.py` — 35 passed
- [x] `ruff check setup.py tests/... --select E,W --ignore E501,E402` — clean
- [x] `python3 -m py_compile setup.py`

The existing cffi test asserted the old boundary strings, so it moves with the pin; its intent — the pin stays split, and never collapses to a bare `cffi<2` that would have no cp314 wheel — is unchanged and still asserted. A second test couples the two pins, so raising the cffi boundary again without raising the `cryptography` floor fails loudly rather than silently reopening these.

No runtime code, no version bump. Reaching installed users needs the usual `[RELEASE]` PR after this merges.

---
_Generated by [Claude Code](https://claude.ai/code/session_01L6wRxXdhhvT25NJ5EKszrC)_