### PR TITLE
Harden CI: disable setup-node's package-manager cache on the PyPI publish path

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,6 +42,24 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "20"
+          # This job builds the frontend bundle that is packaged into the
+          # wheel and uploaded to PyPI, so anything restored into the
+          # workspace before `python3 -m build` ends up inside a published,
+          # provenanced artifact. A GitHub Actions cache is not trusted
+          # input: an entry seeded from a less-trusted context on this repo
+          # can be restored by a later release run. zizmor reports the
+          # combination as `cache-poisoning` (High).
+          #
+          # setup-node's `package-manager-cache` defaults to true, but only
+          # actually caches when package.json declares `devEngines
+          # .packageManager` or a top-level `packageManager`. Neither is
+          # declared here, so nothing is cached TODAY -- the exposure is
+          # latent, and adding a `packageManager` field (an ordinary edit
+          # that looks harmless) would switch it on silently, on the two
+          # workflows where it matters most. Pinning it false keeps that
+          # decision out of package.json. Nothing is lost: `npm ci` in the
+          # next step installs from the committed lockfile either way.
+          package-manager-cache: false
 
       - name: Install build tools
         run: pip install build twine

--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -196,6 +196,14 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "20"
+          # Same reasoning as publish.yml: this is the [RELEASE] path that
+          # actually ships to PyPI, so a restored cache entry would land
+          # inside the published wheel. `package-manager-cache` defaults to
+          # true and only engages once package.json declares a
+          # `packageManager` / `devEngines.packageManager` field -- pinning
+          # it false here means adding that field later cannot silently turn
+          # caching on for the publish path. `npm ci` below is unaffected.
+          package-manager-cache: false
 
       - name: Build v2 React bundle (fresh)
         run: |


### PR DESCRIPTION
## What

Both workflows that build the frontend bundle shipped inside the PyPI wheel ran `actions/setup-node` with `package-manager-cache` left at its default of `true`. This sets it to `false` on those two steps.

A GitHub Actions cache is not trusted input: an entry seeded from a less-trusted context on this repo can be restored into the workspace of a later release run, and anything in the workspace before `python3 -m build` ends up inside a published, provenanced artifact. zizmor reports the combination as `cache-poisoning` (High).

## Why now, if nothing is cached today

Nothing is cached today. setup-node's default only engages once `package.json` declares a top-level `packageManager` or `devEngines.packageManager`, and this repo declares neither — checked across the root, `frontend/`, `tests/e2e/` and `clawhub-plugin/` manifests.

That is what makes it worth pinning rather than leaving alone. The exposure is latent, and adding a `packageManager` field later is an ordinary-looking edit that would switch caching on silently, on the two workflows where it matters most. Pinning it `false` keeps that decision out of `package.json`.

## Scope

| Step | Publishes? | Changed |
|---|---|---|
| `publish.yml` — tag-triggered PyPI publish | yes | ✅ the step zizmor flagged |
| `release-on-merge.yml` — the `[RELEASE]` path that actually ships to PyPI | yes | ✅ same concern, **not** flagged by zizmor |
| `release-on-merge.yml` — cloud-contract Playwright spec | no | left as-is |

The second one was found by reading the job rather than from the scanner: `setup-node` → `npm ci` → `python3 -m build` → `twine upload`. Hardening only the step the tool named would have left the primary release path open.

The third `setup-node` in `release-on-merge.yml` sets up the cloud-contract spec and publishes nothing, so it is out of scope for this concern.

## Risk

Builds are unaffected — `npm ci` installs from the committed lockfile either way; the only change is that a package-manager cache can never be restored on these two steps. No permissions were touched, so the release pipeline's write scopes are unchanged.

## Verification

- `python3 -c "import yaml,glob; [yaml.safe_load(open(f)) for f in glob.glob('.github/workflows/*.yml')]"` — all 36 workflows parse
- zizmor re-scan: `cache-poisoning` 1 → 0, total 54 → 53, no new findings
- `python3 scripts/check_action_refs.py` — passes

## Precedent

The identical fix landed in `clawmetry-cloud#2228` for that repo's npm publish job.

`No-PRD: CI-only hardening, all changes under .github/` (PRD-exempt path per `scripts/check_product_record.py`).

---
_Generated by [Claude Code](https://claude.ai/code/session_015zNbmjsBeo2ZeDmxXWMrDL)_