### PR TITLE
[RELEASE] Harness Engineering tab (carries #5415)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-### Feature: the Harness Engineering tab, a scoreboard for the scaffold itself (2026-09-01)
+### Feature: the Harness Engineering tab, a scoreboard for the scaffold itself (carries #5415) (2026-09-01)
 - **Who this reaches:** anyone running more than one agent harness and wondering which one is engineered better for their work. The industry now agrees the harness often matters more than the model (a 2026 controlled study measured 7.8x more score variance from the scaffold than from the model), but every public leaderboard scores synthetic tasks. ClawMetry already watches your real traffic, so this tab measures harness engineering from it.
 - **One honest number per harness: $/done.** What a finished job costs, derived as the window's spend on measurable sessions (failed runs included, because failed runs burn real money) divided by the sessions that verifiably finished. Below 12 measurable runs the tab says "not enough runs" instead of printing a wobbly figure, and every price carries its uncertainty band and run count.
 - **Verdict stamps, not a fabricated index.** Each harness is stamped Earning it / Burning it / Coasting / Can't see by stated rules, with the reason printed beside the stamp. Five dimension marks in plain words (keeps its head clear, picks the right brain, shares the work, knows what can wait, finishes the job) each carry their coverage state, so a harness that records nothing shows as unseen, never as a zero.


### PR DESCRIPTION
Releases the Harness Engineering tab (merged in #5415) to PyPI: verdict stamps, \$/done per harness, follow-a-job flow view, context-window curves, workload recommendations, and dated third-party benchmark context, measured from the user's own traffic.

CHANGELOG entry is under Unreleased (stamped with the carrying PR). Feature was live-verified pre-merge on a real box: 12 harnesses scored, one honestly priced at \$13.72/done, the rest reporting coasting/can't-see states.

Product record: https://factory.8090.ai/project/b415065f-ab2f-4f53-8864-0c009fd098cb/requirements/82fcb8c3-2554-42ab-8bcc-7fc05b741b86 and https://factory.8090.ai/project/b415065f-ab2f-4f53-8864-0c009fd098cb/blueprints/cb4497a2-2190-46fa-96d1-373999caf7fe

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VgUQ3YhY81gf7zxoafV2T2