### PR TITLE
[RELEASE] Enterprise-console UI reskin + restored theme toggle (carries #5420)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Unreleased
 
+### Feature: the dashboard grows up visually, and light mode is back (carries #5420) (2026-09-01)
+- **Who this reaches:** everyone who opens the dashboard, and especially the person seeing it for the first time while deciding whether to trust it. The shell now reads like the enterprise consoles it sits next to: a flat near-black dark theme with hairline borders instead of blue-tinted panels and a glow, and a sidebar whose 10+ entries finally group under plain-word section labels — Observe (Agents, Activity, Sessions), Analyze (Cost, Quality, Harness Engineering), Govern (Approvals, Alerts, Notifications).
+- **Consistent icons, quieter selection.** Navigation icons are now one matched set of line icons instead of mixed text glyphs, and the selected entry is marked with a calm raised state rather than a loud blue pill. Nothing moved behind your back: every tab keeps its name, its tooltip, and its deep link.
+- **Light and dark are a click apart again.** The header regains its sun/moon toggle (it had quietly become dark-only), your choice is remembered across visits, and the wordmark stays readable in both themes.
+- **Verified:** rendered live in a browser on a real store — dark, light, the toggle round-trip surviving a reload, both collapsible drawers, and tab switching; before/after screenshots on the PR.
+
 ### Feature: the Harness Engineering tab, a scoreboard for the scaffold itself (carries #5415) (2026-09-01)
 - **Who this reaches:** anyone running more than one agent harness and wondering which one is engineered better for their work. The industry now agrees the harness often matters more than the model (a 2026 controlled study measured 7.8x more score variance from the scaffold than from the model), but every public leaderboard scores synthetic tasks. ClawMetry already watches your real traffic, so this tab measures harness engineering from it.
 - **One honest number per harness: $/done.** What a finished job costs, derived as the window's spend on measurable sessions (failed runs included, because failed runs burn real money) divided by the sessions that verifiably finished. Below 12 measurable runs the tab says "not enough runs" instead of printing a wobbly figure, and every price carries its uncertainty band and run count.


### PR DESCRIPTION
Product record: https://factory.8090.ai/project/b415065f-ab2f-4f53-8864-0c009fd098cb/requirements/19ef3b46-dd9f-4324-9e97-ef875a262549

Publishes #5420 (merged as 3fe9740) to PyPI:
- Neutral near-black dark theme, hairline borders, no blue cast or radial glow.
- Sidebar sections (Observe / Analyze / Govern) with matched stroke SVG icons and a quiet active state; every data-tab id, tooltip and i18n key unchanged.
- Light/dark toggle restored in the live header; saved preference honoured on boot; wordmark legible in both themes.

CHANGELOG entry added under Unreleased. Verified live in a browser pre-merge (dark, light, toggle round-trip surviving reload, drawers, tab switching); screenshots on #5420.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018BWUpWMfX5ehaFZvSP5xkb