### PR TITLE
[RELEASE] Bench v2: head-to-head, cloud slice, $/done watch (carries #5422)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - **Light and dark are a click apart again.** The header regains its sun/moon toggle (it had quietly become dark-only), your choice is remembered across visits, and the wordmark stays readable in both themes.
 - **Verified:** rendered live in a browser on a real store — dark, light, the toggle round-trip surviving a reload, both collapsible drawers, and tab switching; before/after screenshots on the PR.
 
-### Feature: the Harness Engineering tab goes deeper: head-to-head, a real $/done watch, and cloud data (2026-09-01)
+### Feature: the Harness Engineering tab goes deeper: head-to-head, a real $/done watch, and cloud data (carries #5422) (2026-09-01)
 - **Who this reaches:** everyone who opened the new Harness Engineering tab. Hosted users saw a deliberate empty state; local users could compare aggregates but not like-for-like work, and the tab ended in reading with nothing to act on.
 - **Head to head.** Two harnesses now compare side by side, but only when they did the same kind of work with at least 5 verified runs each: finish rate, cost per run, cost per finished job. Unlike work is never compared; the tab says so instead of drawing an unfair chart.
 - **The hosted dashboard fills in.** The sync daemon now bakes the bench (verdicts, $/done, profiles, recommendations, head-to-head) into the encrypted snapshot, bounded to a few kilobytes. Your machine computes and encrypts; the cloud stores bytes it cannot read; the browser decrypts and renders. The hosted interceptor ships in the matching cloud release.


### PR DESCRIPTION
Releases bench v2 (merged in #5422) to PyPI: head-to-head cohort comparison, the encrypted bench snapshot slice for the hosted dashboard, the real dollars_per_done_above alert type, the cheaper-options button, and the daemon fd-limit fix.

Live-verified pre-merge: the decrypted production snapshot carries the bench slice (12 runtimes, ~15KB); RLIMIT_NOFILE raise confirmed in the daemon log.

Product record: https://factory.8090.ai/project/b415065f-ab2f-4f53-8864-0c009fd098cb/blueprints/cb4497a2-2190-46fa-96d1-373999caf7fe

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VgUQ3YhY81gf7zxoafV2T2