### PR TITLE
[RELEASE] heartbeat rows stop storing cache pushes; DuckDB OOM self-heal; store-sized memory ceiling (carries #5434)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-### Fix: the daemon heals itself after DuckDB runs out of memory, and the memory ceiling follows the store (2026-09-02)
+### Fix: heartbeat rows stop storing 8 MB cache pushes, the daemon heals itself after DuckDB runs out of memory, and the memory ceiling follows the store (carries #5434) (2026-09-02)
 - **Who this reaches:** anyone whose local store has grown past about 1.3 GB. On 2026-09-02 a 4.2 GB store overran the flat 2 GB DuckDB buffer pool on the daily cost rollup, the rollback ran out too, and DuckDB invalidated the connection. The daemon kept running and looked healthy to launchd and to `clawmetry status`, but every dashboard query answered 500 for two hours until someone restarted it by hand.
 - **Reads heal the handle now, not only writes.** The one recovery that existed ran only when a batch of events failed to flush. On a quiet morning nothing was queued, so it never ran. A failed read now detects the invalidated handle, recovers once, and answers; a burst of concurrent failures on the same dead handle costs one recovery, not one per request thread.
 - **Out of memory gets the right recovery.** Nothing on disk is wrong after an OOM, so the store reopens under a ceiling one notch higher instead of spending its one index rebuild. A second OOM inside five minutes is refused and logged with the query, because a ceiling that already moved once and still does not fit needs a person, not a loop.


### PR DESCRIPTION
Releases #5434 to PyPI so every node picks it up on the daemon's next self-update.

**Why this needs a release now.** Every cloud-connected node stores its heartbeat POST payload, cache pushes included, in `heartbeats.data`. On the founder Mac that reached 2 GB in nine hours and ran DuckDB out of its 2 GB buffer pool on the dashboard's heartbeat poll, invalidating the store; the daemon stayed up, looked healthy, and served 500s for two hours. After a restart the same poll held the store lock for tens of seconds per call and every tab rendered empty. Any node with an active Brain cache push is on the same path.

**What ships.** Schema v14 empties the stored payloads without reading them; heartbeat rows never store cache pushes again; heartbeat reads skip the payload column; a failed read heals an invalidated handle; an out-of-memory invalidation reopens under a larger ceiling; the default DuckDB memory ceiling is derived from the store size. Details, tests and live verification are on #5434.

**Verified live** on the founder Mac with the exact merged files: `/api/heartbeat-status` 28 s to 28 ms, `/api/overview` from a 60 s timeout to 1.4 s, `schema_version: 14`, zero errors since.

No-PRD: release PR carrying #5434 (changelog only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JQsz4KH5YGjbF9Dow4s1WK