### PR TITLE
fix(sync): never ingest a family session that has no timestamp and no events

### DIFF
--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -14893,6 +14893,7 @@ def sync_family_runtimes(config: dict, state: dict, paths: dict) -> int:
                 # the row was re-sent each cycle and sat at the top of
                 # /sessions for a week (live-hit 2026-09-02: a Cursor legacy
                 # prompt bucket, "where is my code?", with zero replies).
+                _time_basis = ""
                 if not started and not ended:
                     _ev_ts = []
                     for _e in _events:
@@ -14905,6 +14906,9 @@ def sync_family_runtimes(config: dict, state: dict, paths: dict) -> int:
                     if _ev_ts:
                         started = _epoch_to_iso(min(_ev_ts))
                         ended = _epoch_to_iso(max(_ev_ts))
+                        # Source timestamps the runtime wrote on its own
+                        # events, never the wall clock; say so on the row.
+                        _time_basis = "events"
                     else:
                         log.debug("family session %s: no timestamp and no "
                                   "events; not a session, skipped", ns_id)
@@ -14917,6 +14921,8 @@ def sync_family_runtimes(config: dict, state: dict, paths: dict) -> int:
                 _delegated_ids = _harvest_delegated_agent_ids(_events)
                 if _delegated_ids:
                     metadata["delegatedAgentIds"] = _delegated_ids
+                if _time_basis:
+                    metadata["timeBasis"] = _time_basis
                 _thealth = _session_tool_health(_events)
                 metadata.update(_thealth)
                 _idle = _session_idle_gaps(_events)

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -14885,6 +14885,30 @@ def sync_family_runtimes(config: dict, state: dict, paths: dict) -> int:
                 # oldest-first, so a low cap drops the freshest activity); the
                 # high-water filter below keeps the actual ingest to new events.
                 _events = list(adapter.list_events(s.id, limit=_family_event_read_cap()))
+                # A session the adapter could not place in time (no started_at,
+                # no ended_at) is placed by its events; with none of those
+                # either it is skipped. Upserting it with NULL timestamps made
+                # the cloud stamp it "just now" on EVERY push, because the
+                # high-water check above can never match a NULL activity, so
+                # the row was re-sent each cycle and sat at the top of
+                # /sessions for a week (live-hit 2026-09-02: a Cursor legacy
+                # prompt bucket, "where is my code?", with zero replies).
+                if not started and not ended:
+                    _ev_ts = []
+                    for _e in _events:
+                        try:
+                            _t = float(getattr(_e, "ts", 0) or 0)
+                        except (TypeError, ValueError):
+                            continue
+                        if _t > 0:
+                            _ev_ts.append(_t)
+                    if _ev_ts:
+                        started = _epoch_to_iso(min(_ev_ts))
+                        ended = _epoch_to_iso(max(_ev_ts))
+                    else:
+                        log.debug("family session %s: no timestamp and no "
+                                  "events; not a session, skipped", ns_id)
+                        continue
                 # Delegated agents: the vendor agent ids this session handed
                 # work to. Recording them here is what BOUNDS attribution --
                 # delegated usage may only ever land on a session whose own


### PR DESCRIPTION
No-PRD: bug fix — corrects ingestion of family sessions with no timestamp and no events; no new product behaviour, API surface, or feature flag.

## What
A Cursor row titled "where is my code?" sat at the top of app.clawmetry.com/sessions as "just now" for a week. Nobody ran it. The Cursor adapter emitted a legacy prompt bucket (typed text, zero replies) with `started_at=0.0` and no `ended_at`. The family loop upserted it with NULL timestamps, and the high-water check compares `ended or started`, which is None, so it could never skip the row. Every cycle re-pushed it and the cloud stamped it "just now" again.

## Fix
In `sync_family_runtimes`, a session with neither `started_at` nor `ended_at` is placed by its events (min and max event timestamp). With no events either it is skipped with a debug log. A row with no time and no content is not a session, and a row with no time can only ever render as "just now".

## Verification
- `tests/test_family_session_titles.py`, `test_family_runtime_ingest.py`, `test_sync_family_session_limit.py`, `test_family_subagent_fanout.py` pass. One test in `test_family_runtime_ingest.py` failed once in a full-file run and passes in isolation on both this branch and unmodified main, so it is a pre-existing ordering flake, not this change.

Companion PRs: clawmetry-pro 0.7.21 (the adapter stops emitting drafts and reply-less prompt lists) and clawmetry-cloud (single runtime prefix vocabulary, so a `grok_bot:` session stops rendering as OpenClaw).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ULRfVvwxYMgm3onczAV8cc