### PR TITLE
fix(transcripts): turn list highlights the turn you scrolled to

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -19899,8 +19899,102 @@ function _renderTurnTOC(turns, activeTurn) {
 function _jumpToTurn(turnIdx) {
   var el = document.getElementById('turn-chapter-' + turnIdx);
   if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  _setActiveTurnTOC(turnIdx);
+  // Hold the clicked turn active until the smooth scroll lands; otherwise
+  // the scroll-spy would flicker through every turn in between.
+  window._turnTocPin = { turn: turnIdx, until: Date.now() + 2500 };
   return false;
 }
+
+// --- Scroll-spy for the turn TOC -------------------------------------------
+// _renderTurnTOC() marks the turn that owns the replay cursor as active, but
+// that only reflects the scrubber — not what the reader has scrolled to. This
+// keeps the highlighted TOC row in sync with the chapter under the top of the
+// viewport, whichever ancestor happens to be the scroll container (window on
+// the local dashboard, an overflow:auto pane on cloud).
+function _setActiveTurnTOC(turnIdx) {
+  var toc = document.getElementById('transcript-toc');
+  if (!toc) return;
+  var items = toc.querySelectorAll('.turn-toc-item');
+  var target = null;
+  for (var i = 0; i < items.length; i++) {
+    var isIt = (items[i].getAttribute('href') === '#turn-chapter-' + turnIdx);
+    items[i].classList.toggle('turn-toc-item-active', isIt);
+    if (isIt) target = items[i];
+  }
+  // Keep the active row visible inside a long, independently-scrolling TOC.
+  if (target && typeof target.scrollIntoView === 'function') {
+    var tr = target.getBoundingClientRect(), cr = toc.getBoundingClientRect();
+    if (tr.top < cr.top || tr.bottom > cr.bottom) target.scrollIntoView({ block: 'nearest' });
+  }
+}
+
+function _turnTocScrollContainer(el) {
+  var node = el && el.parentElement;
+  while (node && node !== document.body && node !== document.documentElement) {
+    var oy = getComputedStyle(node).overflowY;
+    if ((oy === 'auto' || oy === 'scroll') && node.scrollHeight > node.clientHeight + 1) return node;
+    node = node.parentElement;
+  }
+  return null; // the window scrolls
+}
+
+function _syncTurnTOCToScroll() {
+  var toc = document.getElementById('transcript-toc');
+  var wrap = document.getElementById('transcript-messages');
+  if (!toc || !wrap || !toc.firstChild) return;
+  var chapters = wrap.querySelectorAll('.turn-chapter');
+  if (!chapters.length) return;
+  var container = _turnTocScrollContainer(wrap);
+  var viewTop = container ? container.getBoundingClientRect().top : 0;
+  var viewBottom = container ? container.getBoundingClientRect().bottom : (window.innerHeight || document.documentElement.clientHeight);
+  // Reference line a little below the top edge so the sticky chapter header
+  // (and anything just scrolled past) counts as "current".
+  var refY = viewTop + Math.min(120, Math.max(48, (viewBottom - viewTop) * 0.25));
+  var pin = window._turnTocPin;
+  if (pin) {
+    var pinned = document.getElementById('turn-chapter-' + pin.turn);
+    var pTop = pinned ? pinned.getBoundingClientRect().top : NaN;
+    var arrived = !pinned || (pTop >= viewTop - 4 && pTop <= refY);
+    if (arrived || Date.now() >= pin.until) { window._turnTocPin = null; }
+    else { _setActiveTurnTOC(pin.turn); window._turnTocActive = pin.turn; return; }
+  }
+  var current = chapters[0];
+  for (var i = 0; i < chapters.length; i++) {
+    if (chapters[i].getBoundingClientRect().top <= refY) current = chapters[i];
+    else break;
+  }
+  // At the very end of the trace the last turn may be too short to ever reach
+  // the reference line — if we're scrolled to the bottom, it is the current one.
+  var atBottom = container
+    ? (container.scrollTop + container.clientHeight >= container.scrollHeight - 4)
+    : ((window.scrollY || window.pageYOffset || 0) + window.innerHeight >= (document.documentElement.scrollHeight - 4));
+  if (atBottom && chapters[chapters.length - 1].getBoundingClientRect().top < viewBottom) current = chapters[chapters.length - 1];
+  var id = current.id || '';
+  var turn = parseInt(id.replace('turn-chapter-', ''), 10);
+  if (isNaN(turn)) return;
+  if (window._turnTocActive === turn) return;
+  window._turnTocActive = turn;
+  _setActiveTurnTOC(turn);
+}
+
+(function _installTurnTOCScrollSpy() {
+  if (window._turnTocSpyInstalled) return;
+  window._turnTocSpyInstalled = true;
+  var scheduled = false;
+  function onScroll() {
+    if (scheduled) return;
+    scheduled = true;
+    (window.requestAnimationFrame || function(fn) { setTimeout(fn, 16); })(function() {
+      scheduled = false;
+      _syncTurnTOCToScroll();
+    });
+  }
+  // Capture phase: scroll events don't bubble, but they do reach document in
+  // capture, so this sees scrolling on the window *and* any inner pane.
+  document.addEventListener('scroll', onScroll, true);
+  window.addEventListener('resize', onScroll);
+})();
 
 // Toolbar toggle — flip the whole trace between oldest-first (default,
 // chat-native) and newest-first (skim recent activity for long sessions).
@@ -19960,6 +20054,14 @@ function _replayRenderCurrent() {
   }
   wrap.innerHTML = html;
   if (tocEl) tocEl.innerHTML = _renderTurnTOC(turns, activeTurn);
+  window._turnTocActive = activeTurn;
+  // Re-sync to the actual scroll position once the new DOM has laid out, so a
+  // re-render (filter change, sort flip, live refresh) never leaves the TOC
+  // pointing at the scrubber's turn while the reader is looking at another.
+  (window.requestAnimationFrame || function(fn) { setTimeout(fn, 16); })(function() {
+    window._turnTocActive = null;
+    _syncTurnTOCToScroll();
+  });
 
   document.getElementById('replay-pos').textContent = (idx + 1) + '/' + filtered.length;
   var scrubber = document.getElementById('replay-scrubber');

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -303,3 +303,112 @@ class TestFlowDiagram:
                 break
 
         # No crash occurred - success
+
+
+# ---------------------------------------------------------------------------
+# Transcript turn TOC scroll-spy
+# ---------------------------------------------------------------------------
+
+
+def _open_transcripts_page(page: Page):
+    """Switch to the transcripts (Sessions) page via the app's own router.
+
+    The nav item's data-tab key has moved between IA passes, so go through
+    switchTab() directly; it is the same call the nav click makes.
+    """
+    ok = page.evaluate(
+        """() => { if (typeof switchTab !== 'function') return false; switchTab('transcripts'); return true; }"""
+    )
+    assert ok, "switchTab() is not defined on the dashboard page"
+    page.wait_for_timeout(600)
+
+
+class TestTranscriptTocScrollSpy:
+    """The sticky turn list beside a transcript must highlight the turn the
+    reader has scrolled to, not just the turn the replay scrubber sits on.
+
+    Regression guard for the bug where the TOC stayed on turn 0 (or whatever
+    the scrubber pointed at) no matter how far the reader scrolled. CI has no
+    real sessions, so this builds a synthetic trace of tall chapters inside
+    the real transcript containers and drives the real scroll listener.
+    """
+
+    _BUILD_TRACE = """() => {
+        const wrap = document.getElementById('transcript-messages');
+        const toc = document.getElementById('transcript-toc');
+        if (!wrap || !toc) return false;
+        // Make the transcript page the visible one regardless of nav state.
+        document.querySelectorAll('.page, [id^="page-"]').forEach(p => {
+            if (p.id && p.id.startsWith('page-')) p.style.display = (p.id === 'page-transcripts') ? '' : 'none';
+        });
+        const viewer = document.getElementById('transcript-viewer');
+        if (viewer) viewer.style.display = '';
+        const list = document.getElementById('transcript-list');
+        if (list) list.style.display = 'none';
+        let html = '', tocHtml = '<div class="turn-toc-list">';
+        for (let i = 0; i < 6; i++) {
+            html += '<section class="turn-chapter" id="turn-chapter-' + i + '" style="min-height:1400px">'
+                  + '<header class="turn-chapter-head">Turn ' + i + '</header></section>';
+            tocHtml += '<a class="turn-toc-item' + (i === 0 ? ' turn-toc-item-active' : '') + '"'
+                     + ' href="#turn-chapter-' + i + '" onclick="return _jumpToTurn(' + i + ');">'
+                     + '<span class="turn-toc-num">' + i + '</span></a>';
+        }
+        wrap.innerHTML = html;
+        toc.innerHTML = tocHtml + '</div>';
+        window._turnTocActive = null;
+        window._turnTocPin = null;
+        return true;
+    }"""
+
+    _ACTIVE = """() => {
+        const a = document.querySelector('#transcript-toc .turn-toc-item-active');
+        return a ? a.querySelector('.turn-toc-num').textContent : null;
+    }"""
+
+    def _scroll_to_chapter(self, page: Page, idx: int, extra: int = 0):
+        page.evaluate(
+            """([idx, extra]) => {
+                const el = document.getElementById('turn-chapter-' + idx);
+                el.scrollIntoView({ block: 'start' });
+                // Nudge whichever ancestor actually scrolls (window or pane).
+                let node = el.parentElement, scroller = null;
+                while (node && node !== document.body) {
+                    const oy = getComputedStyle(node).overflowY;
+                    if ((oy === 'auto' || oy === 'scroll') && node.scrollHeight > node.clientHeight + 1) { scroller = node; break; }
+                    node = node.parentElement;
+                }
+                if (scroller) scroller.scrollTop += extra; else window.scrollBy(0, extra);
+            }""",
+            [idx, extra],
+        )
+        page.wait_for_timeout(250)
+
+    def test_toc_follows_scroll_position(self, page: Page):
+        load_dashboard(page)
+        _open_transcripts_page(page)
+        assert page.evaluate("typeof _syncTurnTOCToScroll === 'function'"), \
+            "transcript TOC scroll-spy (_syncTurnTOCToScroll) is missing from app.js"
+        built = page.evaluate(self._BUILD_TRACE)
+        assert built, "#transcript-messages / #transcript-toc not present on the Sessions page"
+
+        self._scroll_to_chapter(page, 3)
+        assert page.evaluate(self._ACTIVE) == "3", "TOC did not follow the scroll to turn 3"
+
+        self._scroll_to_chapter(page, 4, extra=400)
+        assert page.evaluate(self._ACTIVE) == "4", "TOC did not follow a scroll into the middle of turn 4"
+
+        self._scroll_to_chapter(page, 0)
+        assert page.evaluate(self._ACTIVE) == "0", "TOC did not return to turn 0 at the top"
+
+    def test_toc_click_holds_target_until_arrival(self, page: Page):
+        load_dashboard(page)
+        _open_transcripts_page(page)
+        assert page.evaluate(self._BUILD_TRACE)
+        page.evaluate("() => document.querySelector('#transcript-toc a[href=\"#turn-chapter-5\"]').click()")
+        # Sample during the smooth scroll: the clicked turn must stay active the
+        # whole way (no flicker through 1..4) and still be active once landed.
+        seen = set()
+        for _ in range(10):
+            page.wait_for_timeout(150)
+            seen.add(page.evaluate(self._ACTIVE))
+        assert seen == {"5"}, f"TOC flickered during jump to turn 5: {sorted(seen, key=str)}"


### PR DESCRIPTION
## Product record
Requirement: https://factory.8090.ai/project/b415065f-ab2f-4f53-8864-0c009fd098cb/requirements/8e389016-a9c8-4352-9121-72f0e361fdf6 (Runtime and Session Observability, section "Transcript Turn List Follows the Reader (PR #5447)", AC-OBS-RSO-001.4 to 001.9).

## Why
In the Sessions transcript view, the sticky turn list on the right only set its active row at render time from the replay scrubber. Scrolling the trace never moved it, so a reader looking at turn 4 still saw turn 0 highlighted (see the screenshots in the report: turn 4 in view, turn 0 lit). The only way to make it match was to click the row.

## What
- Scroll-spy on the turn TOC: on any scroll (window or an inner pane, caught in the capture phase) pick the last chapter whose top sits above a reference line near the viewport top; when scrolled to the bottom, the final turn wins.
- Active row is kept visible inside a long, independently scrolling TOC.
- A TOC click pins its target until the smooth scroll actually arrives, so the highlight does not flicker through every turn in between.
- Re-renders (filter change, sort flip, live refresh) re-sync to the real scroll position after layout.

## Verified
- Playwright against this branch on port 8901, real session `claude_code:1dd14b7f...` (9 turns): scrolling to turn 4 highlights 4, into turn 6 highlights 6, bottom highlights 8, top highlights 0; TOC click on 2 stays on 2 for the whole smooth scroll, then a page scroll to 3 highlights 3.
- Guard: `tests/test_e2e.py::TestTranscriptTocScrollSpy` (2 tests) builds a synthetic trace in the real containers and drives the real listener. Red on stock 0.12.800 (spy missing; click test sees the highlight stuck on 0), green with the fix. `TestTabsLoad` still 10/10.
- `node --check` on app.js clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S6zeXfF3naskZxM2utjUyW
