### PR TITLE
fix(cli): don't import dashboard/DuckDB for a subcommand's own --help

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -411,6 +411,7 @@ jobs:
             tests/test_install_script_pro_upgrade.py \
             tests/test_wake_poll.py \
             tests/test_cli_unattended_update.py \
+            tests/test_cli_help_no_dashboard_import.py \
             -q
 
   # ── Entitlement API test suite (~2700+ hermetic tests) ─────────────────────────────────────────────

--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -7749,35 +7749,6 @@ def main() -> None:
             _v = "unknown"
         print(f"clawmetry {_v}")
         return
-    # Tag this process as the dashboard BEFORE importing dashboard, so every
-    # get_store() in dashboard.py (module-level + handlers) is barred from the
-    # DuckDB writer — only the sync daemon writes. Set before the import or a
-    # module-level open would race in before the gate is active. The daemon
-    # (-m clawmetry.sync) never takes this path and calls mark_writer_owner(),
-    # which overrides the gate.
-    os.environ["CLAWMETRY_ROLE"] = "dashboard"
-    from dashboard import main as dashboard_main
-
-    # Anonymous, opt-out install-lifecycle ping (install once ever, update
-    # once per new version). See clawmetry/telemetry.py for the privacy
-    # contract. Fires on a daemon thread so a network failure can't slow
-    # CLI startup; honours CLAWMETRY_NO_TELEMETRY=1 and
-    # ~/.clawmetry/notelemetry.
-    try:
-        from clawmetry import telemetry as _telemetry
-        try:
-            from dashboard import __version__ as _ver
-        except Exception:
-            _ver = "unknown"
-        _telemetry.maybe_ping(_ver)
-        # Desktop shell launched us? Report the open (which runtimes this
-        # machine has, cloud vs local) once things settle. No-ops for a
-        # plain `pip install clawmetry && clawmetry`.
-        _telemetry.maybe_desktop_ping(_ver)
-    except Exception:
-        # Never let telemetry plumbing break startup.
-        pass
-
     # Windows: protect against closed/detached stdout/stderr before any library
     # (argparse colour detection, click._winconsole) calls fileno() on them.
     #
@@ -7789,6 +7760,8 @@ def main() -> None:
     # click._winconsole._is_console() calls f.fileno() → ValueError when closed.
     # NO_COLOR suppresses argparse / click colour paths (Python 3.14+).
     # We *also* replace closed handles with devnull sinks so later code is safe.
+    # (Moved ahead of the parser build below so it also guards the `<subcmd>
+    # --help` short-circuit's own printing, not just the post-import path.)
     if sys.platform == "win32":
         import io as _io
 
@@ -8736,6 +8709,52 @@ def main() -> None:
         "compliance",
         "nemoclaw-daemons",
     )
+
+    # Short-circuit `<subcmd> --help`/`-h` (e.g. `clawmetry connect --help`)
+    # before importing dashboard. A subcommand's help is printed entirely by
+    # argparse's own subparser -h action (every sub.add_parser() above gets
+    # one for free) and never touches dashboard_main or the store, but the
+    # dashboard import below still ran first because it used to sit ahead of
+    # the parser build — paying for get_store()'s module-level DuckDB init
+    # just to print text argparse already knows how to print. That init
+    # SIGSEGVs on some Python 3.9/Linux runners (#5108, #5309: `clawmetry
+    # connect --help` observed crashing in CI while `status`/`sync --help`
+    # in the same run did not). Let argparse handle it and exit first.
+    if len(sys.argv) > 1 and sys.argv[1] in _subcmds and (
+        "-h" in sys.argv[2:] or "--help" in sys.argv[2:]
+    ):
+        parser.parse_args()
+        return  # argparse's -h action always exits; unreachable in practice
+
+    # Tag this process as the dashboard BEFORE importing dashboard, so every
+    # get_store() in dashboard.py (module-level + handlers) is barred from the
+    # DuckDB writer — only the sync daemon writes. Set before the import or a
+    # module-level open would race in before the gate is active. The daemon
+    # (-m clawmetry.sync) never takes this path and calls mark_writer_owner(),
+    # which overrides the gate.
+    os.environ["CLAWMETRY_ROLE"] = "dashboard"
+    from dashboard import main as dashboard_main
+
+    # Anonymous, opt-out install-lifecycle ping (install once ever, update
+    # once per new version). See clawmetry/telemetry.py for the privacy
+    # contract. Fires on a daemon thread so a network failure can't slow
+    # CLI startup; honours CLAWMETRY_NO_TELEMETRY=1 and
+    # ~/.clawmetry/notelemetry.
+    try:
+        from clawmetry import telemetry as _telemetry
+        try:
+            from dashboard import __version__ as _ver
+        except Exception:
+            _ver = "unknown"
+        _telemetry.maybe_ping(_ver)
+        # Desktop shell launched us? Report the open (which runtimes this
+        # machine has, cloud vs local) once things settle. No-ops for a
+        # plain `pip install clawmetry && clawmetry`.
+        _telemetry.maybe_desktop_ping(_ver)
+    except Exception:
+        # Never let telemetry plumbing break startup.
+        pass
+
     if len(sys.argv) > 1 and sys.argv[1] in _subcmds:
         args = parser.parse_args()
         # Issue #322: Set OpenClaw config directory from CLI flag

--- a/tests/test_cli_help_no_dashboard_import.py
+++ b/tests/test_cli_help_no_dashboard_import.py
@@ -1,0 +1,55 @@
+"""`clawmetry <subcmd> --help` must never import dashboard (#5108, #5309).
+
+dashboard.py calls get_store() at module level when CLAWMETRY_ROLE=dashboard
+is set, and on some Python 3.9/Linux runners DuckDB's init SIGSEGVs in that
+path. `--version` already short-circuited before the import for exactly this
+reason. A subcommand's own `--help`/`-h` (e.g. `clawmetry connect --help`) is
+printed entirely by argparse's subparser -h action and never needs dashboard
+or the store either -- but main() used to import dashboard unconditionally,
+before it even looked at argv[1], so every subcommand's --help paid for (and
+in the Conformance Heartbeat, twice crashed on -- #5309) an import it never
+needed. `status`/`sync --help` happened to pass in both incidents while
+`connect --help` segfaulted, which is consistent with a native init that can
+land on any subcommand's dashboard import, not something specific to
+`connect`.
+"""
+import builtins
+import sys
+
+import pytest
+
+import clawmetry.cli as cli
+
+
+@pytest.mark.parametrize("subcmd", ["status", "sync", "connect", "uninstall"])
+def test_subcommand_help_does_not_import_dashboard(subcmd, monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["clawmetry", subcmd, "--help"])
+    monkeypatch.delitem(sys.modules, "dashboard", raising=False)
+    real_import = builtins.__import__
+    imported = []
+
+    def _spy(name, *args, **kwargs):
+        if name == "dashboard" or name.startswith("dashboard."):
+            imported.append(name)
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _spy)
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main()
+
+    assert exc.value.code == 0
+    assert not imported, (
+        f"`clawmetry {subcmd} --help` imported dashboard ({imported}); "
+        "a subcommand's own --help must be printed by argparse alone."
+    )
+
+
+def test_subcommand_help_still_prints_usage(capsys, monkeypatch):
+    """The short-circuit must not swallow the actual help text."""
+    monkeypatch.setattr(sys, "argv", ["clawmetry", "connect", "--help"])
+    with pytest.raises(SystemExit) as exc:
+        cli.main()
+    assert exc.value.code == 0
+    out = capsys.readouterr().out.lower()
+    assert "usage: clawmetry connect" in out


### PR DESCRIPTION
**Product record:**

No-PRD: fix of field-reported bug #5309

**Risk:** Low. Purely a code-motion reorder inside `clawmetry/cli.py`'s `main()`: the argparse parser build, the Windows closed-stdout guard, and the `os.environ["CLAWMETRY_ROLE"]="dashboard"` + `from dashboard import main` + telemetry block now run in a different order, with one new early-return for `<subcmd> --help`/`-h`. `dashboard_main` has exactly one call site (the no-subcommand dashboard-mode fallback at the bottom of `main()`), and nothing between the moved blocks depends on the others — verified by running `--version`, bare `--help`, all four `_subcmds` help texts, and a real `clawmetry status` end to end (see Test plan). Nothing else changes: if it's not a pure `--help`/`-h` request, execution reaches the exact same import + dispatch code as before. Reversible with a plain revert; nothing persisted or migrated.

---

## Summary

- **Reproduction:** the Conformance Heartbeat (#5309) failed twice more after the earlier "could not reproduce" comment on this issue — most recently [run 33655178383](https://github.com/vivekchand/clawmetry/actions/runs/33655178383): `clawmetry connect --help` segfaulted (exit 139, core dumped) on Python 3.9/Ubuntu against the published wheel, while `status --help` and `sync --help` in the same loop passed.
- **Root cause:** `main()` ran `os.environ["CLAWMETRY_ROLE"] = "dashboard"; from dashboard import main as dashboard_main` **unconditionally**, before even inspecting `sys.argv[1]`. `dashboard.py` calls `get_store()` at module level, and DuckDB's init SIGSEGVs there on some Python 3.9/Linux runners — the exact class `--version` already short-circuits around (comment right above that guard names it explicitly). That short-circuit was never extended to a subcommand's own `--help`, even though `dashboard_main` has exactly one call site (the no-subcommand dashboard-mode fallback) and a subcommand's `--help` is printed entirely by argparse's own subparser `-h` action. Which subcommand's process happens to crash on a given CI run is effectively random, since the native init itself is what's flaky, not the code path — consistent with `connect --help` crashing twice while `status`/`sync --help` passed both times in the same loop.
- **Fix:** build the argparse parser before importing dashboard, and short-circuit `<subcmd> --help`/`-h` for any known subcommand right there, generalizing the existing `--version` guard to the whole "just print help" class instead of one flag. The Windows closed-stdout guard moves up so it also protects the new short-circuit's own printing (it no longer needs the dashboard import to run first).

## Test plan

- [x] New regression guard `tests/test_cli_help_no_dashboard_import.py`, wired into `.github/workflows/ci.yml`'s explicit CLI test list (this repo runs file lists, never `pytest tests/`): asserts `clawmetry status|sync|connect|uninstall --help` never imports `dashboard`, and that help text still prints.
- [x] Verified the guard is real: reverted `clawmetry/cli.py` only → all four parametrized cases went red (`imported dashboard`) → restored the fix → green again.
- [x] Manually ran, in a fresh venv with the real `clawmetry` deps installed: `clawmetry --version`, bare `clawmetry --help`, `clawmetry connect|status|sync|uninstall --help` (all print correct usage, exit 0), and a real `clawmetry status` (non-help) invocation — confirms the dispatch path for actual command execution is unchanged.
- [x] `python3 -m py_compile clawmetry/cli.py` and a full `ast.parse` of the file.
- [x] `.github/workflows/ci.yml` YAML re-validated with `yaml.safe_load` after the wiring edit.

Closes #5309

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QmFY3wdHC9KQ53mbvmohpz

---
_Generated by [Claude Code](https://claude.ai/code/session_01QmFY3wdHC9KQ53mbvmohpz)_