### PR TITLE
Report gate_shown once per install so the onboarding funnel splits

### DIFF
--- a/clawmetry/telemetry.py
+++ b/clawmetry/telemetry.py
@@ -405,6 +405,31 @@ def maybe_ping(version: str = "unknown") -> threading.Thread | None:
     return t
 
 
+def ping_once(event: str, version: str = "unknown",
+              extra: dict | None = None) -> threading.Thread | None:
+    """Fire ``event`` at most once per install, ever.
+
+    ``ping_event`` leaves dedup to the caller; some events have no natural
+    caller-side "already happened" (the onboarding gate is *served* on every
+    page load until a choice lands). The state file records which once-only
+    events this install has already reported under ``once_events``, so a
+    reload, a second browser, or a restart sends nothing. Same opt-out and
+    fire-and-forget contract as :func:`maybe_ping`; returns ``None`` when
+    nothing was sent."""
+    if _is_optout():
+        return None
+    state = _read_state()
+    sent = state.get("once_events")
+    if not isinstance(sent, dict):
+        sent = {}
+    if event in sent:
+        return None
+    sent[event] = int(time.time())
+    state["once_events"] = sent
+    _write_state(state)
+    return ping_event(event, version, extra)
+
+
 def ping_event(event: str, version: str = "unknown",
                extra: dict | None = None) -> threading.Thread | None:
     """Fire one explicit lifecycle event (e.g. ``onboarded`` with

--- a/docs/ac_coverage_baseline.json
+++ b/docs/ac_coverage_baseline.json
@@ -8,8 +8,8 @@
     "after coverage improves, so the ratchet is tightened in the same PR.",
     "Regenerate with: python3 scripts/check_ac_coverage.py --update-baseline"
   ],
-  "covered_count": 52,
-  "total_count": 117,
+  "covered_count": 79,
+  "total_count": 149,
   "uncovered": [
     "AC-GOV-001.1",
     "AC-GOV-001.2",
@@ -73,6 +73,11 @@
     "AC-OBS-RSO-003.7",
     "AC-OBS-RSO-003.8",
     "AC-OBS-RSO-003.9",
+    "AC-OGV-001.1",
+    "AC-OGV-001.2",
+    "AC-OGV-001.3",
+    "AC-OGV-001.4",
+    "AC-OGV-001.5",
     "AC-RSO-CWD-001.1",
     "AC-RSO-CWD-001.2",
     "AC-RSO-CWD-001.3"

--- a/docs/acceptance_criteria.json
+++ b/docs/acceptance_criteria.json
@@ -26,7 +26,8 @@
   "in_repo_prefixes": [
     "AC-OBS-",
     "AC-RSO-",
-    "AC-GOV-"
+    "AC-GOV-",
+    "AC-OGV-"
   ],
   "external_prefixes": {
     "AC-CLOUD-": "clawmetry-cloud",
@@ -898,6 +899,36 @@
       "doc": "Local Agent Observability",
       "doc_id": "d518c6c3-eb50-4b0f-9ed0-59440380b7bf",
       "text": "Remain available on every plan, including free, with no entitlement gate."
+    },
+    {
+      "id": "AC-OGV-001.1",
+      "doc": "Onboarding Gate Funnel Visibility",
+      "doc_id": "59a34a71-b779-478b-bf6f-9b4657f988bc",
+      "text": "When the dashboard resolves that an onboarding choice is required and serves that state to a browser, the system shall send one install lifecycle ping with event gate_shown carrying the same anonymous fields as the install ping."
+    },
+    {
+      "id": "AC-OGV-001.2",
+      "doc": "Onboarding Gate Funnel Visibility",
+      "doc_id": "59a34a71-b779-478b-bf6f-9b4657f988bc",
+      "text": "When the gate state is served again for the same install, the system shall not send a second gate_shown ping, regardless of how many browser sessions or page reloads occur."
+    },
+    {
+      "id": "AC-OGV-001.3",
+      "doc": "Onboarding Gate Funnel Visibility",
+      "doc_id": "59a34a71-b779-478b-bf6f-9b4657f988bc",
+      "text": "When telemetry is opted out by any existing mechanism (environment variable, do-not-track, marker file), the system shall not send the gate_shown ping."
+    },
+    {
+      "id": "AC-OGV-001.4",
+      "doc": "Onboarding Gate Funnel Visibility",
+      "doc_id": "59a34a71-b779-478b-bf6f-9b4657f988bc",
+      "text": "When the ping fails for any reason, the system shall serve the gate state unchanged and shall not surface an error to the user."
+    },
+    {
+      "id": "AC-OGV-001.5",
+      "doc": "Onboarding Gate Funnel Visibility",
+      "doc_id": "59a34a71-b779-478b-bf6f-9b4657f988bc",
+      "text": "When the hosted cloud dashboard serves onboarding state, the system shall not send a gate_shown ping, because hosted accounts never see the gate."
     }
   ]
 }

--- a/routes/onboarding.py
+++ b/routes/onboarding.py
@@ -328,6 +328,26 @@ def _ping_onboarded(choice: str) -> None:
         pass
 
 
+def _ping_gate_shown() -> None:
+    """Report, once per install, that the gate was served to a browser.
+
+    The funnel (2026-09-03: 285 first launches → 13 choices in 14 days)
+    could not tell an install that never opened the dashboard from one that
+    saw the three cards and left. ``telemetry.ping_once`` dedups on disk,
+    so the every-page-load nature of this endpoint sends one row, and the
+    same opt-out as every other lifecycle ping applies."""
+    try:
+        from clawmetry import telemetry as _telemetry
+
+        try:
+            from dashboard import __version__ as _ver
+        except Exception:
+            _ver = "unknown"
+        _telemetry.ping_once("gate_shown", _ver)
+    except Exception:
+        pass
+
+
 def _apply_marker_semantics(choice: str) -> None:
     """Managed clears the local-only marker (the June '0 nodes' bug class:
     connect without enable_cloud() silently no-ops sync). Self-host writes
@@ -412,7 +432,10 @@ def api_onboarding_state():
                                 "source": "ci"})
         except Exception:
             pass
-        return jsonify(_resolve_state())
+        state = _resolve_state()
+        if state.get("required"):
+            _ping_gate_shown()
+        return jsonify(state)
     except Exception as exc:
         # Never let gate plumbing brick the dashboard: fail open.
         log.warning("onboarding: state resolution failed: %s", exc)

--- a/tests/test_onboarding_gate.py
+++ b/tests/test_onboarding_gate.py
@@ -39,6 +39,7 @@ def ob(monkeypatch, tmp_path):
     _shell_dir.mkdir()
     monkeypatch.setattr(mod, "_desktop_shell_runtime_dir", lambda: _shell_dir)
     monkeypatch.setattr(mod, "_ping_onboarded", lambda choice: None)
+    monkeypatch.setattr(mod, "_ping_gate_shown", lambda: None)
     monkeypatch.setattr(mod, "_apply_marker_semantics", lambda choice: None)
     # Must never actually register/spawn a real daemon during a unit test —
     # see test_ensure_daemon_for_choice_* below for the real coverage.
@@ -427,3 +428,56 @@ def test_ensure_daemon_for_choice_dispatches_off_request_thread(monkeypatch):
     mod._ensure_daemon_for_choice("selfhost_trial")
     assert len(calls) == 1
     assert calls[0][1] is True, "must be a daemon thread so it never blocks process exit"
+
+
+# ── gate_shown ping (REQ-OGV-001) ────────────────────────────────────────────
+
+def test_required_state_reports_gate_shown(ob, client, monkeypatch):
+    """AC-OGV-001.1: serving ``required: true`` fires the once-per-install
+    ping. Dedup itself is telemetry.ping_once's job (tests/test_telemetry.py);
+    here we assert the route delegates to it."""
+    calls = []
+    monkeypatch.setattr(ob, "_ping_gate_shown", lambda: calls.append(1))
+    d = client.get("/api/onboarding/state").get_json()
+    assert d["required"] is True
+    assert calls == [1]
+
+
+def test_not_required_state_never_reports_gate_shown(ob, client, monkeypatch):
+    """A machine that already chose (here: a trial license on disk) never
+    sends gate_shown — it never sees the gate."""
+    calls = []
+    monkeypatch.setattr(ob, "_ping_gate_shown", lambda: calls.append(1))
+    monkeypatch.setattr(ob, "_license_state", lambda: "selfhost_trial")
+    d = client.get("/api/onboarding/state").get_json()
+    assert d["required"] is False
+    assert calls == []
+
+
+def test_cloud_mode_never_reports_gate_shown(ob, client, monkeypatch):
+    """AC-OGV-001.5: the hosted dashboard short-circuits before the gate."""
+    calls = []
+    monkeypatch.setattr(ob, "_ping_gate_shown", lambda: calls.append(1))
+    monkeypatch.setenv("CLAWMETRY_CLOUD", "1")
+    d = client.get("/api/onboarding/state").get_json()
+    assert d["required"] is False and calls == []
+
+
+def test_ping_gate_shown_uses_ping_once(monkeypatch):
+    """AC-OGV-001.2 wiring: the helper goes through telemetry.ping_once,
+    not ping_event, so the on-disk dedup applies. AC-OGV-001.4: a raising
+    telemetry module never escapes. Deliberately not using the ``ob``
+    fixture: it stubs ``_ping_gate_shown`` out, and this test needs the
+    real one."""
+    import routes.onboarding as ob
+    importlib.reload(ob)
+    import clawmetry.telemetry as t
+    seen = []
+    monkeypatch.setattr(t, "ping_once", lambda e, v, x=None: seen.append((e, v)))
+    ob._ping_gate_shown()
+    assert seen and seen[0][0] == "gate_shown"
+
+    def _boom(*a, **k):
+        raise RuntimeError("telemetry down")
+    monkeypatch.setattr(t, "ping_once", _boom)
+    ob._ping_gate_shown()  # must not raise

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -240,3 +240,52 @@ def test_ping_event_respects_optout(telemetry, monkeypatch):
     with patch("urllib.request.urlopen") as urlopen:
         assert telemetry.ping_event("onboarded", "1.0.0") is None
         urlopen.assert_not_called()
+
+
+# ── ping_once: once-per-install events (REQ-OGV-001) ─────────────────────────
+
+def test_ping_once_sends_first_time_then_never_again(telemetry):
+    """AC-OGV-001.1 / AC-OGV-001.2: the first call posts, every later call
+    for the same event is a no-op, even across a module reload (state is on
+    disk, not in memory)."""
+    sent = []
+    with patch.object(telemetry, "ping_event",
+                      side_effect=lambda e, v, x=None: sent.append(e) or object()):
+        assert telemetry.ping_once("gate_shown", "1.0.0") is not None
+        assert telemetry.ping_once("gate_shown", "1.0.0") is None
+        assert telemetry.ping_once("gate_shown", "1.0.1") is None
+    assert sent == ["gate_shown"]
+    state = json.loads((telemetry.STATE_FILE).read_text())
+    assert "gate_shown" in state["once_events"]
+
+
+def test_ping_once_is_per_event(telemetry):
+    sent = []
+    with patch.object(telemetry, "ping_event",
+                      side_effect=lambda e, v, x=None: sent.append(e) or object()):
+        telemetry.ping_once("gate_shown", "1.0.0")
+        telemetry.ping_once("something_else", "1.0.0")
+    assert sent == ["gate_shown", "something_else"]
+
+
+def test_ping_once_keeps_existing_lifecycle_state(telemetry):
+    """The once-marker must not clobber the version bookkeeping
+    ``_derive_event`` relies on, or the next startup would re-send
+    ``install``."""
+    telemetry._record_reported("abc", "1.0.0", "install")
+    with patch.object(telemetry, "ping_event", return_value=object()):
+        telemetry.ping_once("gate_shown", "1.0.0")
+    state = telemetry._read_state()
+    assert state["last_version"] == "1.0.0"
+    assert state["install_id"] == "abc"
+    assert telemetry._derive_event("abc", "1.0.0") is None
+
+
+def test_ping_once_respects_optout(telemetry, monkeypatch):
+    """AC-OGV-001.3: opted out means nothing is sent AND nothing is
+    recorded (so opting back in later still reports the first sighting)."""
+    monkeypatch.setenv("CLAWMETRY_NO_TELEMETRY", "1")
+    with patch("urllib.request.urlopen") as urlopen:
+        assert telemetry.ping_once("gate_shown", "1.0.0") is None
+        urlopen.assert_not_called()
+    assert "once_events" not in telemetry._read_state()


### PR DESCRIPTION
## Why

Production install registry, 14 days to 2026-09-03, non-CI: **285 first launches → 13 recorded onboarding choices → ~2.4 real Pro trials/day**. The gate is the only step that mints a trial, and nothing records whether the other 272 installs ever saw it. A headless daemon on a server, a browser that never opened, and a person who closed the three cards are indistinguishable today. Every decision about the gate (soften it, reorder the cards, change the trial copy) depends on knowing which of those is the big number.

## What

- `telemetry.ping_once(event, version)`: fires an event at most once per install. Marker lives in `telemetry_state.json` under `once_events`; existing version bookkeeping untouched; same opt-out as every lifecycle ping; opted-out installs record nothing so a later opt-in still reports.
- `/api/onboarding/state` calls `_ping_gate_shown()` whenever it serves `required: true`. Hosted mode, `CLAWMETRY_SKIP_ONBOARDING` and CI short-circuit before that point and never report.
- AC-OGV-001.1..5 mirrored into `docs/acceptance_criteria.json`, tests declare them, ratchet tightened (79/149).
- No UI change. The gate shows and requires exactly what it did.

Cloud half (allowlist + `gate_shown_7d` funnel step): clawmetry-cloud `telemetry/gate-shown`. Until that merges the cloud drops the event as an unknown type, which is harmless.

## Product record

https://factory.8090.ai/project/b415065f-ab2f-4f53-8864-0c009fd098cb/requirements/59a34a71-b779-478b-bf6f-9b4657f988bc (REQ-OGV-001, REQ-OGV-002)

## Verification

`pytest tests/test_telemetry.py tests/test_onboarding_gate.py`: 60 passed. `scripts/check_ac_coverage.py --check`: ratchet holding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rt5fq2BWxieLpR69MAbwjr