### PR TITLE
feat(pricing): add Meta muse-spark-1.1 provider recognition (#5455)

### DIFF
--- a/clawmetry/providers_pricing.py
+++ b/clawmetry/providers_pricing.py
@@ -186,6 +186,12 @@ MODEL_OVERRIDES: dict[tuple[str, str], tuple[float, float]] = {
     ("moonshot", "moonshot-v1-128k"): (2.00, 5.00),
     ("deepseek", "deepseek-v4-flash"): (0.14, 0.28),
     ("deepseek", "deepseek-v4-pro"): (0.435, 0.87),
+    # Meta muse-spark (ClawHub/npm standalone distribution), per-token rates not
+    # yet officially published — $1.00/$3.00 per 1M is a best-effort placeholder.
+    # Update once Meta publishes official pricing. Encrypted reasoning-replay
+    # turns are counted as regular output tokens (no separate rate known).
+    ("meta", "muse-spark-1.1"): (1.00, 3.00),
+    ("meta", "muse-spark"): (1.00, 3.00),
 }
 
 
@@ -301,7 +307,7 @@ def provider_for_model(model: str) -> str:
     m = (model or "").lower()
     if not m:
         return ""
-    for prov in ("openai", "anthropic", "google", "openrouter", "xai"):
+    for prov in ("openai", "anthropic", "google", "openrouter", "xai", "meta"):
         if m.startswith(prov + "/"):
             return prov
     if any(m.startswith(p + "/") for p in _LOCAL_PROVIDERS) or any(
@@ -326,6 +332,8 @@ def provider_for_model(model: str) -> str:
     # slash is a strong signal that the model is running locally on Ollama.
     if ":" in m and "/" not in m:
         return "local"
+    if "muse-spark" in m:
+        return "meta"
     return ""
 
 


### PR DESCRIPTION
## Summary

Sessions on OpenClaw's new Meta `muse-spark-1.1` model returned `cost_usd: unknown` because `providers_pricing.py` had no pricing entry for the Meta provider and `provider_for_model()` didn't handle the `meta/` namespace or bare `muse-spark` model names. This PR fixes the attribution gap so those sessions get a derived cost instead of falling through to the unknown-provider conservative default.

No-PRD: automated harness gap fix — additive pricing entry for Meta muse-spark-1.1; no user-facing behavior change beyond restoring cost attribution for sessions on this model

## Changes

- **`MODEL_OVERRIDES`**: Add `("meta", "muse-spark-1.1")` and `("meta", "muse-spark")` entries at `$1.00/$3.00 per 1M` input/output — a clearly-commented best-effort placeholder to be updated once Meta publishes official pricing. Encrypted reasoning-replay turns are counted as regular output tokens (no separate rate is documented yet).
- **`provider_for_model()`**: Add `"meta"` to the namespace-prefix loop so `meta/muse-spark-1.1`-style model IDs are routed to provider `"meta"` rather than the unknown-provider default.
- **`provider_for_model()`**: Add a bare-name branch (`if "muse-spark" in m: return "meta"`) so sessions that log the model name without a provider prefix are also correctly attributed.

## Test plan

- [ ] `python3 -c "from clawmetry.providers_pricing import estimate_event_cost_usd, provider_for_model; assert provider_for_model('meta/muse-spark-1.1') == 'meta'; assert provider_for_model('muse-spark-1.1') == 'meta'; assert estimate_event_cost_usd('muse-spark-1.1', 1_000_000, 1_000_000) > 0; print('ok')"` — passes locally
- [ ] Update placeholder rates once Meta publishes official pricing for muse-spark-1.1

## Bot meta
<!-- bot-autofix -->
Draft PR opened autonomously based on the plan in #5455. Marked draft for human review — mark Ready for Review once happy. Placeholder pricing ($1.00/$3.00/1M) should be updated when official rates are published.

Closes #5455

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NoDoqsD8VMYWQY2DA2h5NJ