### PR TITLE
Egress hardening: key in headers only, evals opt-in, config files never pushed, relayed actions audited

### DIFF
--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -3018,13 +3018,15 @@ def _resolve_account_email(api_key: str):
             return None, None
         import json as _json
         import os as _os
-        import urllib.parse as _up
         import urllib.request as _ur
 
         from clawmetry.endpoints import app_url as _resolve_app_url
         base = _resolve_app_url()
-        url = base + "/api/cloud/account?token=" + _up.quote(api_key)
-        with _ur.urlopen(url, timeout=2.5) as resp:
+        # Key in a header, never the query string: the server logs the
+        # request line, and a cm_ key is a whole account credential.
+        req = _ur.Request(base + "/api/cloud/account",
+                          headers={"X-Api-Key": api_key}, method="GET")
+        with _ur.urlopen(req, timeout=2.5) as resp:
             data = _json.loads(resp.read() or b"{}")
         email = (data.get("email") or "").strip()
         plan = (data.get("plan") or "").strip()

--- a/clawmetry/eval_runner.py
+++ b/clawmetry/eval_runner.py
@@ -45,11 +45,35 @@ log = logging.getLogger("clawmetry.eval_runner")
 
 # ── Config ─────────────────────────────────────────────────────────────────────
 
-# Disable the whole eval surface (env switch). Default-on per PRD; user
-# escape hatch for cost-sensitive or air-gapped setups.
+# The judge posts a redacted transcript excerpt to a third-party model API.
+# That is content leaving the machine, so it is OPT-IN: the presence of an
+# ANTHROPIC_API_KEY / OPENAI_API_KEY in the environment is not consent.
+# Enable with CLAWMETRY_EVALS_ENABLED=1 or ``"evals": true`` in
+# ~/.clawmetry/config.json. CLAWMETRY_EVALS_ENABLED=0 always wins.
+_TRUTHY = ("1", "true", "True", "yes", "on")
+_FALSY = ("0", "false", "False", "no", "off")
+
+
+def _config_opt_in() -> bool:
+    try:
+        path = Path(os.path.expanduser("~/.clawmetry/config.json"))
+        if not path.exists():
+            return False
+        data = json.loads(path.read_text(encoding="utf-8") or "{}")
+        return bool(isinstance(data, dict) and data.get("evals") is True)
+    except Exception:
+        return False
+
+
 def is_enabled() -> bool:
-    """Env-gated kill switch. Default True (Phase 1 ships default-on)."""
-    return os.environ.get("CLAWMETRY_EVALS_ENABLED", "1") not in ("0", "false", "False", "")
+    """Opt-in switch. Default False: no transcript excerpt leaves the machine
+    for scoring until the user asks for it."""
+    env = os.environ.get("CLAWMETRY_EVALS_ENABLED", "").strip()
+    if env in _FALSY:
+        return False
+    if env in _TRUTHY:
+        return True
+    return _config_opt_in()
 
 
 # Rate-limit knobs — bound worst-case spend even with a chatty workspace.

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -9476,6 +9476,11 @@ MEMORY_PUSH_MIN_INTERVAL_SEC = MEMORY_CACHE_TTL_SEC // 2
 # not a live feed; a fresh file reaching it within ten minutes is plenty, and
 # the push is the whole 5.9 MB snapshot encrypted and uploaded, not a delta.
 MEMORY_PUSH_CHANGED_MIN_INTERVAL_SEC = 600
+# Catalog categories that are runtime CONFIG rather than memory: hook
+# settings (settings.json / settings.local.json), MCP server manifests and
+# openclaw.json. They stay in the local catalog but never ride the cloud push,
+# because they routinely carry gateway tokens, bot tokens and provider keys.
+MEMORY_PUSH_EXCLUDED_CATEGORIES = frozenset({"hooks", "mcp"})
 # A file whose hash has changed on this many consecutive builds is runtime
 # state, not memory (2026-09-02: Grok Bot's ``local-exec-supervisor.json`` and
 # ``local-exec-daemon-connection.json`` rewrote every cycle, so the fingerprint
@@ -9646,6 +9651,12 @@ def _build_memory_cache_pushes(config: dict) -> list:
     dropped = 0
     for r in rows:
         path = r.get("path") or ""
+        # Runtime CONFIG files (settings.json, openclaw.json, mcp.json) are
+        # catalogued locally so the Memory tab can show hooks and servers, but
+        # they routinely hold gateway tokens, bot tokens and API keys. Those
+        # have no reason to leave the machine, sealed or not.
+        if (r.get("category") or "memory") in MEMORY_PUSH_EXCLUDED_CATEGORIES:
+            continue
         # Dedup on (runtime, path), never path alone. Several runtimes read
         # the SAME file on disk — AGENTS.md is Codex, opencode and Copilot;
         # a path-only key kept it for whichever runtime sorted first and left
@@ -10077,6 +10088,30 @@ def _build_alert_rules_cache_pushes(config: dict) -> list:
     }]
 
 
+def _audit_remote_action(atype: str, action: dict, refused: bool = False) -> None:
+    """Record a cloud-relayed action in ~/.clawmetry/audit.db. Never raises.
+
+    Only the action type and its identifiers are stored; the action body may
+    carry a server-supplied prompt, and the audit log is not the place to
+    persist that."""
+    try:
+        from clawmetry import audit as _audit
+        _audit.audit_event(
+            "remote_action.refused" if refused else "remote_action.received",
+            actor="cloud-relay",
+            target=str(atype or ""),
+            result="refused" if refused else "accepted",
+            source="heartbeat",
+            metadata={
+                "id": str(action.get("id") or "")[:64],
+                "session_id": str(action.get("session_id") or "")[:128],
+                "cache_key": str(action.get("cache_key") or "")[:160],
+            },
+        )
+    except Exception:
+        pass
+
+
 def _dispatch_pending_action(config: dict, action: dict) -> None:
     """Handle a single action-style pending entry. Routes by ``type``.
 
@@ -10100,6 +10135,12 @@ def _dispatch_pending_action(config: dict, action: dict) -> None:
     atype = action.get("type")
     if atype not in _PENDING_ACTIONS:
         return
+    # Every cloud-relayed action lands in the local audit log first, accepted
+    # or refused, so a node owner can see exactly what the server asked of
+    # this machine without trusting the server's own record of it.
+    _audit_remote_action(atype, action,
+                         refused=(atype in _PROMPT_BEARING_ACTIONS
+                                  and not _remote_prompts_enabled(config)))
     if atype in _PROMPT_BEARING_ACTIONS and not _remote_prompts_enabled(config):
         log.warning(
             "Refusing relayed action %r: it would run a server-supplied prompt "
@@ -22190,11 +22231,19 @@ def _is_placeholder_email(email) -> bool:
     return e.endswith("@clawmetry.auto") or e.endswith("@clawmetry.linked")
 
 
-def _cloud_get_json(path: str, timeout: float = 4.0):
-    """Best-effort GET app.clawmetry.com<path> -> dict (or None). Never raises."""
+def _cloud_get_json(path: str, timeout: float = 4.0, api_key: str = ""):
+    """Best-effort GET app.clawmetry.com<path> -> dict (or None). Never raises.
+
+    The account key rides in the ``X-Api-Key`` header, never in ``path``: the
+    server records the request line, so a ``?token=`` query would write a
+    whole account credential into its access logs on every call. Callers
+    must not put the key in the query string themselves.
+    """
     try:
         import urllib.request as _ur
-        with _ur.urlopen(_APP_BASE + path, timeout=timeout) as r:
+        headers = {"X-Api-Key": api_key} if api_key else {}
+        req = _ur.Request(_APP_BASE + path, headers=headers, method="GET")
+        with _ur.urlopen(req, timeout=timeout) as r:
             return json.loads(r.read() or b"{}")
     except Exception:
         return None
@@ -22221,7 +22270,7 @@ def start_claim_watcher(config: dict):
         if not token.startswith("cm_") or not node_id:
             return
         # Only watch placeholder accounts; a real account never gets "claimed".
-        acct = _cloud_get_json("/api/cloud/account?token=" + _up.quote(token))
+        acct = _cloud_get_json("/api/cloud/account", api_key=token)
         if not acct or not _is_placeholder_email(acct.get("email")):
             return
         log.info("Placeholder account — watching for a one-step account claim (every 5s)")
@@ -22229,8 +22278,8 @@ def start_claim_watcher(config: dict):
             time.sleep(5)
             try:
                 res = _cloud_get_json(
-                    "/api/cloud/claim-status?token=%s&node_id=%s"
-                    % (_up.quote(token), _up.quote(node_id)))
+                    "/api/cloud/claim-status?node_id=%s" % _up.quote(node_id),
+                    api_key=token)
                 if not res or not res.get("claimed"):
                     continue
                 new_key = (res.get("api_key") or "").strip()

--- a/docs/EGRESS.md
+++ b/docs/EGRESS.md
@@ -5,9 +5,13 @@ to turn it off.
 
 This exists because "does this tool send our source code anywhere?" is the
 first question in any review of a tool that reads developer machines, and the
-only useful answer is a complete list someone can verify with `tcpdump`. If you
-find traffic to a host that is not in this table, that is a bug — please report
+only useful answer is a complete list someone can verify on the wire. If you
+find traffic to a host that is not in this table, that is a bug. Please report
 it (see [SECURITY.md](../SECURITY.md)).
+
+The tables below were rebuilt from a wire capture of clawmetry 0.12.802 on
+2026-09-03, not from reading comments. The capture method is at the end so you
+can repeat it in five minutes without trusting this page.
 
 **Verify it yourself.** These commands should produce no unexpected hosts:
 
@@ -19,7 +23,7 @@ python3 scripts/verify_no_external_assets.py
 python3 scripts/verify_vendor.py
 
 # The full-suppression path, exercised in tests
-python3 -m pytest tests/test_egress_suppression.py
+python3 -m pytest tests/test_egress_suppression.py tests/test_e2e_invariants.py
 ```
 
 ---
@@ -30,19 +34,71 @@ python3 -m pytest tests/test_egress_suppression.py
 |---|---|---|
 | **Self-hosted** (`SELF_HOSTED=true`) | No | No |
 | **Air-gapped** (`CLAWMETRY_OFFLINE=1`) | No | No |
-| **Local only** (no `clawmetry connect`) | Update check only | No |
-| **Managed cloud** (`clawmetry connect`) | Yes — encrypted snapshots | No |
+| **Local only** (no `clawmetry connect`) | One install ping; nothing else | PyPI version check |
+| **Managed cloud** (`clawmetry connect`) | Yes: sealed content plus plaintext metadata (table below) | PyPI version check |
 
-**No ClawMetry deployment contacts a third-party host for any reason.** Not a
-CDN, not a font provider, not an analytics vendor, not an error tracker. There
-is no Google Analytics, no Segment, no Sentry, no PostHog, no advertising or
-tracking pixel anywhere in the product. Web assets are vendored into the
-package and served from the local process; CI fails on any absolute `http(s)`
-asset reference in a served page.
+No ClawMetry deployment loads a CDN, font, analytics script, error tracker or
+tracking pixel. Web assets are vendored into the package and served from the
+local process; CI fails on any absolute `http(s)` asset reference in a served
+page.
+
+Two optional features can contact a **model provider** with your own API key.
+Both are **off** until you turn them on: transcript quality scoring
+(`CLAWMETRY_EVALS_ENABLED=1`) and the Claude rate-limit probe
+(`CLAWMETRY_CLAUDE_LIMIT_PROBE=1`). One is on when an `ANTHROPIC_API_KEY` is
+present: the alert narrator, which sends the alert's own one-line message and
+rule id, never session content (`CLAWMETRY_NARRATOR_ENABLED=0` to stop it).
 
 Destinations belonging to *your* agents (`api.anthropic.com`, `api.openai.com`
-and similar) appear in this codebase only as strings used to attribute costs
-and parse pricing. ClawMetry observes those calls; it does not make them.
+and similar) otherwise appear in this codebase only as strings used to
+attribute costs and parse pricing. ClawMetry observes those calls; it does not
+make them.
+
+---
+
+## What the server can read, and what it cannot
+
+After `clawmetry connect`, two kinds of data leave the machine.
+
+**Sealed.** Encrypted on the node with AES-256-GCM (96-bit random nonce per
+blob) under a key the server never receives. The server stores the blob; the
+browser decrypts it. A node with no key **skips** these uploads rather than
+sending them in the clear (`content_egress_permitted` in `clawmetry/sync.py`,
+enforced by `tests/test_e2e_invariants.py`).
+
+* Prompts, replies, thinking, tool inputs and tool outputs
+* Session titles (the plaintext session row carries only the session id)
+* Working directory and workspace paths
+* Gateway log lines and log records
+* Memory and instruction files: `MEMORY.md`, `SOUL.md`, `AGENTS.md`, project
+  memory notes, skills and plugin `SKILL.md` files. **Runtime config files
+  (`settings.json`, `openclaw.json`, MCP manifests) are catalogued locally but
+  never pushed**, sealed or not, because they tend to hold tokens
+* Local IP, CPU and RAM details, the security posture scan, the audit log
+* Cron prompt text, alert rule bodies, the approval queue
+* Everything the cloud pulls on demand: transcript pages, traces, search results
+
+**Plaintext.** JSON over TLS that the server parses so it can list, sort and
+bill. Readable by ClawMetry and by anyone who obtains the server's data.
+
+* Machine hostname, on almost every request, as `node_id` and the `X-Node-Id`
+  header
+* The account key, as the `X-Api-Key` header on every request (never in a URL)
+* Per session: id, runtime and model names, status, start and last-active
+  times, token counts, cost in USD, cache read/write split, cache savings,
+  tool error rate, tool call count, message count, surface (terminal/editor)
+* Heartbeat: names of tools used today with counts, the last tool used,
+  detector one-liners such as `Bash failed 5 times` or `27 files changed in
+  one stretch`, installed runtimes with session counts and last-active time,
+  local Ollama model names, billing plan labels, daily activity counters, a
+  random install id, the local DuckDB size, and the names of cache keys
+* Cron job names, cron expressions and models (prompt text, watched command
+  and last error are stripped)
+* Alert rule names and counter-style summaries when a rule fires
+* Trial days left and plan name, at most once a day on a trial
+
+If the plaintext column is more than your review allows, run self-hosted or
+local-only. There is no "metadata-minimal" cloud mode yet.
 
 ---
 
@@ -55,14 +111,14 @@ Set `SELF_HOSTED=true` on the server. Node daemons point at it with
 
 **Outbound calls: none.** Node daemons talk only to your server. The server
 talks to nothing. Telemetry, funnel analytics, public-IP lookup and update
-checks are all suppressed — see the suppression gate below.
+checks are all suppressed. See the suppression gate below.
 
 One optional exception, **off by default**: setting `CLAWMETRY_LICENSE_PING=1`
 starts a daily POST to `https://app.clawmetry.com/api/license/ping` carrying
 exactly this and nothing else:
 
 ```json
-{"kind": "selfhosted_ping", "version": "0.12.727", "license": "<sub claim>", "tier": "pro", "ts": "..."}
+{"kind": "selfhosted_ping", "version": "0.12.802", "license": "<sub claim>", "tier": "pro", "ts": "..."}
 ```
 
 No hostnames, node IDs, counts, usage, or telemetry. It exists so a license can
@@ -78,14 +134,19 @@ it together with `SELF_HOSTED=true` on a network with no route out.
 ### Local only (default `pip install clawmetry`)
 
 Runs entirely on `127.0.0.1` against your own filesystem. Nothing is uploaded.
-The only outbound call is the PyPI version check described below.
+Two outbound calls remain: the one-time install ping (`DO_NOT_TRACK=1` stops
+it) and the PyPI version check described below.
 
 ### Managed cloud (after `clawmetry connect`)
 
-The daemon pushes snapshots to `ingest.clawmetry.com`. Payloads are encrypted
-client-side with AES-256-GCM; **the key never leaves your machine** and is not
-recoverable by ClawMetry — the browser decrypts for display. See
+The daemon pushes to `ingest.clawmetry.com` on the cadence in the table below.
+Content is sealed client-side; **the key never leaves your machine** and is not
+recoverable by ClawMetry. The browser decrypts for display. See
 [ARCHITECTURE.md](../ARCHITECTURE.md).
+
+`CLAWMETRY_NO_CLOUD=1`, or `touch ~/.clawmetry/nocloud`, turns every upload
+into a no-op without a restart. It does not gate the entitlement probe
+(`CLAWMETRY_OFFLINE=1` does).
 
 ---
 
@@ -101,7 +162,7 @@ discretionary outbound call must pass. It returns `True` when **any** of:
 | `SELF_HOSTED=true` / `CLAWMETRY_SELF_HOSTED=true` | this process *is* your server |
 | `CLAWMETRY_OFFLINE=1` | air-gapped |
 
-"Discretionary" excludes the deployment's own configured ingest endpoint — that
+"Discretionary" excludes the deployment's own configured ingest endpoint. That
 push is the product, and repointing it is what self-hosting means.
 
 The gate **fails closed**: if the check itself raises (partial install, older
@@ -112,24 +173,55 @@ package), the call is suppressed rather than allowed. Covered by
 
 ## Full destination table
 
-### ClawMetry-operated
+### ClawMetry-operated, managed cloud only
 
-| Host | Purpose | When | Sends | Disable |
-|---|---|---|---|---|
-| `ingest.clawmetry.com` | Encrypted snapshot upload | After `clawmetry connect`, managed cloud only | AES-256-GCM ciphertext; key never transmitted. A node with no key skips the upload — content is never sent in the clear | Don't connect, or set `CLAWMETRY_ENDPOINT` |
-| `ingest.clawmetry.com/ingest/heartbeat` | Node liveness + the fleet card's machine identity | Every few seconds after `clawmetry connect` | **Not encrypted**, by design — the cloud needs it to find the machine: hostname, OS name and version, CPU/RAM class, ClawMetry version, whether a key is configured. No prompts, replies, tool arguments or file contents | Don't connect, or set `CLAWMETRY_ENDPOINT` |
-| `ingest.clawmetry.com/ingest/sessions` | Session rows for the cloud sessions list | After `clawmetry connect` | Structural fields in cleartext (ids, timestamps, token counts, cost, model, runtime) so the server can query them. The session **title** is content and travels encrypted alongside them | Don't connect, or set `CLAWMETRY_ENDPOINT` |
-| `app.clawmetry.com` | OAuth/device claim, entitlement + tier resolution, pro wheel download | Managed cloud only | Account identifiers, license subject, version | `CLAWMETRY_ENDPOINT`, `SELF_HOSTED`, or `CLAWMETRY_OFFLINE` |
-| `app.clawmetry.com/api/install` | First-run install counter | Once per version, managed cloud only | Anonymous install ID, version, OS, Python version, CI flag | `DO_NOT_TRACK=1`, `CLAWMETRY_NO_TELEMETRY=1`, `~/.clawmetry/notelemetry`, or any suppression condition |
-| `app.clawmetry.com/api/admin/anon-event` | Anonymous funnel analytics | Managed cloud only | Anonymous event names | Any suppression condition |
-| `app.clawmetry.com/api/license/ping` | Self-hosted license revocation + update check | **Off unless** `CLAWMETRY_LICENSE_PING=1` | Version, license subject, tier, timestamp | Leave unset (the default) |
+Cadence is what the daemon did in the 2026-09-03 capture with Claude Code and
+Codex sessions on the machine.
+
+| Path | Cadence | Plaintext the server reads | Sealed |
+|---|---|---|---|
+| `POST /ingest/heartbeat` | every 3 s while a viewer is open, else 60 s | node_id, platform, version, e2e flag, install_id, detected runtimes with session counts, tool names and counts today, last tool used, detector messages, Ollama model names, billing plan labels, activity counters, store size, cache-key names | `cache_pushes` blobs: last 50 brain events, memory files, cron list, alert rules, approval queue |
+| `POST /ingest/sessions` | every 60 s when rows change | session_id, runtime, model, status, timestamps, total_tokens, cost_usd, token_split, cache stats, tool_error_pct, tool_call_count, message_count, surface | `title_blob` (the readable title) |
+| `POST /ingest/system-snapshot` | every ~60 s, 1.2 to 1.4 MB | node_id | 80 keys: transcripts with full message text, machine info, security posture, audit log, agent inventory with workspace paths, MCP servers, tool catalog, spending, traces, skills |
+| `POST /ingest/events` | as transcripts change (OpenClaw JSONL path) | node_id | raw transcript events |
+| `POST /ingest/logs` | every 60 s when the gateway log grows | node_id | gateway log records |
+| `POST /ingest/stream` | every 2 s when the log tail moves | node_id | raw gateway log lines |
+| `POST /ingest/memory` | on file-hash change | node_id | OpenClaw workspace memory files |
+| `POST /ingest/cache` | only when the cloud asks | node_id, cache_key, shape name, args hash | on-demand query results and action outcomes |
+| `POST /api/ingest` (crons) | each tick when a job changes | job_id, name, cron expression, model, run state | none |
+| `POST /api/cloud/alerts/dispatch` | on rule match, checked every 60 s | rule id and name, node_id, event id, 500-char summary | none |
+| `GET /ingest/wake` | long-poll held 15 s, continuous | node_id in the query, key in a header | none |
+| `GET /api/cloud/policies` | every ~30 s | key in a header | none |
+| `GET /api/license/entitlement` | daemon start, then every ~30 min | key in a header; an entitled node downloads and installs the pro wheel | none |
+| `GET /api/cloud/account`, `GET /api/cloud/claim-status` | once per daemon start; every 5 s only while on a placeholder account | key in a header, node_id | none |
+| `POST /auth` | only during `clawmetry connect` | api_key, hostname, machine_id (hash of hardware id) | none |
+| `POST /api/install` | once per install, first run | random install id, version, OS, Python version, detected agent name, CI flag | none |
+| `POST /api/admin/anon-event` | first dashboard load that fails auth | event name, version, browser family | none |
+| `POST /ingest/trial-warning` | at most once a day on a trial | days_left, plan | none |
+| `POST /api/license/ping` | self-hosted, **off unless** `CLAWMETRY_LICENSE_PING=1` | version, license subject, tier, timestamp | none |
+
+### Inbound control channel
+
+The heartbeat response can carry actions for the daemon: pause, stop or kill
+a session, edit or disable a cron, answer an approval, run an allow-listed
+DuckDB query and return the sealed result. Every relayed action is written to
+`~/.clawmetry/audit.db` as it arrives, accepted or refused, so the node owner
+has their own record of what the server asked.
+
+Actions that would run a **server-supplied prompt** through a local agent
+(`selfevolve_fix`, `cron_create`, `cron_fix`) are refused unless the node has
+opted in with `CLAWMETRY_ALLOW_REMOTE_PROMPTS=1` or
+`clawmetry config set remote_prompts true`.
 
 ### Third-party
 
-| Host | Purpose | When | Disable |
+| Host | Purpose | When | Default |
 |---|---|---|---|
-| `pypi.org` | Version/update check against the public package index | Periodic, `CLAWMETRY_UPDATE_CHECK_SECS`. **Not contacted** by self-hosted, air-gapped or repointed installs — upgrades there go through your own change process | `CLAWMETRY_AUTO_UPDATE=0`, or any suppression condition |
-| `api.ipify.org` | Public IP for one cosmetic startup banner line | Startup, managed cloud only | Any suppression condition |
+| `pypi.org` | version check; a newer release is pip-installed | every 60 s from the daemon (`CLAWMETRY_UPDATE_CHECK_SECS`). Not contacted by self-hosted, air-gapped or repointed installs | on; `CLAWMETRY_AUTO_UPDATE=0` stops installs, `CLAWMETRY_AUTOUPDATE_MIN_AGE_HOURS` adds a stability window. Every attempt is recorded locally |
+| `api.anthropic.com` / `api.openai.com` | transcript quality scoring with your own key: a redacted 8 KB head-and-tail excerpt per session | after a session ends | **off**; `CLAWMETRY_EVALS_ENABLED=1` or `"evals": true` in config |
+| `api.anthropic.com` | alert narration: the alert message and rule id | when an alert fires and `ANTHROPIC_API_KEY` is set | on; `CLAWMETRY_NARRATOR_ENABLED=0` |
+| `api.anthropic.com` with the Claude Code OAuth token | a one-token request to read rate-limit headers | every 5 min | **off**; `CLAWMETRY_CLAUDE_LIMIT_PROBE=1` |
+| `api.ipify.org` | public IP for one cosmetic startup banner line | dashboard start, managed cloud only | on; any suppression condition |
 
 Third-party telemetry inside optional integrations is forced off rather than
 merely left unconfigured. The DeepEval evaluation bridge, for example, phones
@@ -162,14 +254,50 @@ These fire only if you configure them, to a destination you choose:
 
 Regardless of mode:
 
-* **The encryption key.** Generated locally, stored at `~/.clawmetry/`, never
-  transmitted. Cloud snapshots are opaque to ClawMetry.
+* **The encryption key.** Generated locally by `clawmetry connect`, stored in
+  `~/.clawmetry/config.json` and the OS keychain, handed to the browser in a
+  URL fragment (which browsers do not send to servers). Cloud blobs are opaque
+  to ClawMetry. The cloud never mints a key for a node.
 * **Your source code.** ClawMetry reads agent *transcripts and metadata*, not
-  your repository.
-* **Gateway and provider API keys.** Read to talk to your local gateway; never
-  uploaded.
+  your repository. Transcripts can quote code your agent read or wrote; those
+  travel sealed.
+* **Gateway, bot and provider API keys.** Read locally to talk to your gateway
+  and to attribute billing; runtime config files are excluded from every
+  upload.
 * **The DuckDB store** at `~/.clawmetry/clawmetry.duckdb`, unless you enable
-  cloud sync — and then only as ciphertext.
+  cloud sync, and then only as ciphertext plus the plaintext metadata listed
+  above.
+
+---
+
+## Repeat the capture
+
+```bash
+S=$(mktemp -d); mkdir -p $S/home/.clawmetry
+# copy api_key, node_id and encryption_key from ~/.clawmetry/config.json into $S/home/.clawmetry/config.json
+# symlink the agent directories you want scanned: ln -s ~/.claude $S/home/.claude   (and so on)
+python3 - <<'EOF' &
+import json, sys, time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+class H(BaseHTTPRequestHandler):
+    def _log(self):
+        n = int(self.headers.get("Content-Length") or 0)
+        body = self.rfile.read(n) if n else b""
+        print(json.dumps({"path": self.path, "headers": dict(self.headers), "body": body.decode("utf-8", "replace")}), flush=True)
+        b = b'{"ok": true, "sync_allowed": true, "plan": "pro"}'
+        self.send_response(200); self.send_header("Content-Length", str(len(b))); self.end_headers(); self.wfile.write(b)
+    do_GET = do_POST = do_PUT = _log
+    def log_message(self, *a): pass
+ThreadingHTTPServer(("127.0.0.1", 8999), H).serve_forever()
+EOF
+env -i PATH="$PATH" HOME=$S/home CLAWMETRY_ENDPOINT=http://127.0.0.1:8999 CLAWMETRY_AUTO_UPDATE=0 \
+  python3 -m clawmetry.sync
+```
+
+`CLAWMETRY_ENDPOINT` repoints both hosts, so nothing reaches the real cloud.
+Every request the daemon makes prints as one JSON line. Decrypt any `blob`
+with `clawmetry.sync.decrypt_payload(blob, config["encryption_key"])`. Delete
+`$S` afterwards: it holds a copy of your key.
 
 ---
 

--- a/docs/ac_coverage_baseline.json
+++ b/docs/ac_coverage_baseline.json
@@ -8,8 +8,8 @@
     "after coverage improves, so the ratchet is tightened in the same PR.",
     "Regenerate with: python3 scripts/check_ac_coverage.py --update-baseline"
   ],
-  "covered_count": 79,
-  "total_count": 149,
+  "covered_count": 83,
+  "total_count": 153,
   "uncovered": [
     "AC-GOV-001.1",
     "AC-GOV-001.2",

--- a/docs/acceptance_criteria.json
+++ b/docs/acceptance_criteria.json
@@ -607,6 +607,30 @@
       "text": "When the operator disables cloud synchronization, the system shall stop new optional synchronization activity."
     },
     {
+      "id": "AC-OBS-LADC-003.6",
+      "doc": "Local Audit and Data Control",
+      "doc_id": "1e232fe6-5b9b-48dd-8873-70e52684067a",
+      "text": "The system shall not send a transcript excerpt to a third-party model for quality scoring unless the operator has turned scoring on for the node. The presence of a model provider credential in the environment shall not count as consent."
+    },
+    {
+      "id": "AC-OBS-LADC-003.7",
+      "doc": "Local Audit and Data Control",
+      "doc_id": "1e232fe6-5b9b-48dd-8873-70e52684067a",
+      "text": "The system shall record every cloud-relayed action in the node's local audit log when it arrives, whether it is then carried out or refused, so the operator holds their own record of what the service asked of the machine. The record shall name the action and its identifiers and shall not store the action body."
+    },
+    {
+      "id": "AC-OBS-LADC-003.8",
+      "doc": "Local Audit and Data Control",
+      "doc_id": "1e232fe6-5b9b-48dd-8873-70e52684067a",
+      "text": "A request the node makes to the cloud service shall carry the account credential in a request header, never in the request URL."
+    },
+    {
+      "id": "AC-OBS-LADC-003.9",
+      "doc": "Local Audit and Data Control",
+      "doc_id": "1e232fe6-5b9b-48dd-8873-70e52684067a",
+      "text": "The system shall not include a runtime's configuration files, meaning hook settings, MCP server manifests and gateway configuration, in any upload to the cloud service, encrypted or not. Such files may remain in the local catalog."
+    },
+    {
       "id": "AC-OBS-LADC-004.1",
       "doc": "Local Audit and Data Control",
       "doc_id": "1e232fe6-5b9b-48dd-8873-70e52684067a",

--- a/tests/test_e2e_invariants.py
+++ b/tests/test_e2e_invariants.py
@@ -345,3 +345,80 @@ def test_claude_limit_probe_does_not_impersonate_claude_code():
     assert '"claude-code/' not in src, (
         "sending another product's User-Agent to its own API is impersonation"
     )
+
+
+# ── Wire audit 2026-09-03: the key never rides a query string ────────────────
+
+
+def test_claim_watcher_sends_the_key_in_a_header_not_the_url():
+    """The server logs the request line; a ``?token=cm_…`` query writes a
+    whole account credential into its access logs on every daemon start."""
+    import inspect
+
+    src = inspect.getsource(sync.start_claim_watcher)
+    assert "token=" not in src, "claim watcher still puts the key in the URL"
+    assert "api_key=token" in src
+
+
+def test_cloud_get_json_puts_the_key_in_x_api_key(monkeypatch):
+    seen = {}
+
+    class _Resp:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def read(self):
+            return b'{"ok": true}'
+
+    def _fake_urlopen(req, timeout=0):
+        seen["url"] = req.full_url
+        seen["headers"] = dict(req.header_items())
+        return _Resp()
+
+    import urllib.request as _ur
+
+    monkeypatch.setattr(_ur, "urlopen", _fake_urlopen)
+    out = sync._cloud_get_json("/api/cloud/account", api_key="cm_secret")
+    assert out == {"ok": True}
+    assert "cm_secret" not in seen["url"]
+    assert seen["headers"].get("X-api-key") == "cm_secret"
+
+
+def test_cli_status_lookup_has_no_token_in_the_url():
+    path = os.path.join(os.path.dirname(sync.__file__), "cli.py")
+    src = open(path, encoding="utf-8").read()
+    assert "/api/cloud/account?token=" not in src
+
+
+# ── Wire audit 2026-09-03: config files stay home ────────────────────────────
+
+
+def test_memory_push_never_carries_runtime_config_files():
+    """settings.json / openclaw.json / mcp.json are catalogued locally so the
+    Memory tab can show hooks and servers, but they hold tokens. Sealed or
+    not, they have no reason to leave the machine."""
+    assert {"hooks", "mcp"} <= set(sync.MEMORY_PUSH_EXCLUDED_CATEGORIES)
+    import inspect
+
+    src = inspect.getsource(sync._build_memory_cache_pushes)
+    assert "MEMORY_PUSH_EXCLUDED_CATEGORIES" in src
+
+
+# ── Wire audit 2026-09-03: cloud-relayed actions are audited locally ────────
+
+
+def test_every_relayed_action_is_written_to_the_local_audit_log(monkeypatch):
+    calls = []
+    from clawmetry import audit as _audit
+
+    monkeypatch.setattr(_audit, "audit_event", lambda *a, **k: calls.append((a, k)))
+    monkeypatch.delenv("CLAWMETRY_ALLOW_REMOTE_PROMPTS", raising=False)
+    monkeypatch.setattr(sync, "_action_selfevolve_fix", lambda *a, **k: None)
+    sync._dispatch_pending_action({}, {"type": "selfevolve_fix", "id": "x1"})
+    assert calls and calls[0][0][0] == "remote_action.refused"
+    assert calls[0][1]["target"] == "selfevolve_fix"
+    # The action body (which may carry a server-supplied prompt) is not stored.
+    assert "suggestion" not in json.dumps(calls[0][1].get("metadata") or {})

--- a/tests/test_e2e_invariants.py
+++ b/tests/test_e2e_invariants.py
@@ -352,7 +352,10 @@ def test_claude_limit_probe_does_not_impersonate_claude_code():
 
 def test_claim_watcher_sends_the_key_in_a_header_not_the_url():
     """The server logs the request line; a ``?token=cm_…`` query writes a
-    whole account credential into its access logs on every daemon start."""
+    whole account credential into its access logs on every daemon start.
+
+    * AC-OBS-LADC-003.8 -- the account credential travels in a header, never the URL.
+    """
     import inspect
 
     src = inspect.getsource(sync.start_claim_watcher)
@@ -399,7 +402,10 @@ def test_cli_status_lookup_has_no_token_in_the_url():
 def test_memory_push_never_carries_runtime_config_files():
     """settings.json / openclaw.json / mcp.json are catalogued locally so the
     Memory tab can show hooks and servers, but they hold tokens. Sealed or
-    not, they have no reason to leave the machine."""
+    not, they have no reason to leave the machine.
+
+    * AC-OBS-LADC-003.9 -- runtime configuration files are never uploaded.
+    """
     assert {"hooks", "mcp"} <= set(sync.MEMORY_PUSH_EXCLUDED_CATEGORIES)
     import inspect
 
@@ -411,6 +417,9 @@ def test_memory_push_never_carries_runtime_config_files():
 
 
 def test_every_relayed_action_is_written_to_the_local_audit_log(monkeypatch):
+    """
+    * AC-OBS-LADC-003.7 -- every relayed action is audited locally on arrival, body excluded.
+    """
     calls = []
     from clawmetry import audit as _audit
 

--- a/tests/test_eval_runner.py
+++ b/tests/test_eval_runner.py
@@ -361,7 +361,10 @@ def test_disabled_env_var_short_circuits(monkeypatch):
 
 def test_disabled_by_default_when_env_unset(monkeypatch, tmp_path):
     """The judge sends a transcript excerpt to a third-party model API, so a
-    key in the environment is not consent: scoring is opt-in."""
+    key in the environment is not consent: scoring is opt-in.
+
+    * AC-OBS-LADC-003.6 -- transcript scoring is off until the operator opts in.
+    """
     monkeypatch.delenv("CLAWMETRY_EVALS_ENABLED", raising=False)
     monkeypatch.setenv("HOME", str(tmp_path))
     assert eval_runner.is_enabled() is False

--- a/tests/test_eval_runner.py
+++ b/tests/test_eval_runner.py
@@ -33,6 +33,7 @@ if _REPO_ROOT not in sys.path:
 
 from clawmetry import eval_runner  # noqa: E402
 from clawmetry.eval_runner import (  # noqa: E402
+
     EvalRunner,
     DEFAULT_RUBRIC,
     DEFAULT_RUBRIC_YAML,
@@ -41,6 +42,13 @@ from clawmetry.eval_runner import (  # noqa: E402
     parse_score,
     save_rubric_yaml,
 )
+
+
+@pytest.fixture(autouse=True)
+def _evals_opted_in(monkeypatch):
+    """Scoring is opt-in since the 2026-09-03 egress hardening; the runner
+    tests exercise the scoring path, so opt in unless a test says otherwise."""
+    monkeypatch.setenv("CLAWMETRY_EVALS_ENABLED", "1")
 
 
 # ── Fakes ────────────────────────────────────────────────────────────────────
@@ -351,9 +359,29 @@ def test_disabled_env_var_short_circuits(monkeypatch):
     assert eval_runner.is_enabled() is False
 
 
-def test_enabled_by_default_when_env_unset(monkeypatch):
+def test_disabled_by_default_when_env_unset(monkeypatch, tmp_path):
+    """The judge sends a transcript excerpt to a third-party model API, so a
+    key in the environment is not consent: scoring is opt-in."""
     monkeypatch.delenv("CLAWMETRY_EVALS_ENABLED", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    assert eval_runner.is_enabled() is False
+
+
+def test_enabled_by_env_opt_in(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("CLAWMETRY_EVALS_ENABLED", "1")
     assert eval_runner.is_enabled() is True
+
+
+def test_enabled_by_config_opt_in(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_EVALS_ENABLED", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    (tmp_path / ".clawmetry").mkdir()
+    (tmp_path / ".clawmetry" / "config.json").write_text('{"evals": true}')
+    assert eval_runner.is_enabled() is True
+    # An explicit env "0" still wins over the config opt-in.
+    monkeypatch.setenv("CLAWMETRY_EVALS_ENABLED", "0")
+    assert eval_runner.is_enabled() is False
 
 
 # ── Live-API smoke (gated on CI_ANTHROPIC_API_KEY) ─────────────────────────


### PR DESCRIPTION
Follow-up to a wire-level audit of what the daemon sends to ClawMetry Cloud (every request captured against a local listener via `CLAWMETRY_ENDPOINT`, blobs decrypted with the node key to inventory contents). The sealed/plaintext split held; these are the tightenings it called for.

**Changes**
- **Key never in a URL.** `start_claim_watcher` and `clawmetry status` send the account key as `X-Api-Key`. Pairs with clawmetry-cloud#2259, which accepts the header on `/api/cloud/claim-status` (the query form stays accepted for older daemons, so ordering does not matter).
- **Transcript scoring is opt-in.** `eval_runner.is_enabled()` defaults to off; enable with `CLAWMETRY_EVALS_ENABLED=1` or `"evals": true` in `~/.clawmetry/config.json`. The judge posts a transcript excerpt to a third-party model, and a provider key in the environment is not consent for that.
- **Config files stay home.** `_build_memory_cache_pushes` skips catalog categories `hooks` and `mcp` (settings.json, settings.local.json, openclaw.json, MCP manifests). They remain in the local Memory tab. Sealed or not, files that tend to hold tokens have no reason to leave.
- **Relayed actions are audited locally.** `_dispatch_pending_action` records every cloud-relayed action in `~/.clawmetry/audit.db` on arrival, accepted or refused, with type and ids only (never the body, which may carry a prompt).
- **docs/EGRESS.md** rebuilt from the capture: per-path cadence, what is plaintext vs sealed, the inbound control channel and its opt-in, third-party defaults, and a recipe to repeat the capture in five minutes.

**Tests**
- `tests/test_e2e_invariants.py`: header-not-URL for the claim watcher, `_cloud_get_json` and `clawmetry status`; config categories excluded; relayed actions audited.
- `tests/test_eval_runner.py`: default off, env opt-in, config opt-in, env `0` wins; runner tests opt in via an autouse fixture.

Pre-existing, unrelated: `test_runtime_memory_sync.py::test_unchanged_snapshot_is_not_repushed_every_heartbeat` fails on `origin/main` as well; the five `test_eval_runner.py` scoring tests need a judge key in the environment (pass with one set).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WHJPkVko2LZFXVmKJ6G6eN

**Product record**
- Requirement: Local Audit and Data Control, AC-OBS-LADC-003.6 to 003.9 https://factory.8090.ai/project/b415065f-ab2f-4f53-8864-0c009fd098cb/requirements/1e232fe6-5b9b-48dd-8873-70e52684067a
- Blueprint: Local Audit and Data Control (egress hardening section, RemoteActionAuditor) https://factory.8090.ai/project/b415065f-ab2f-4f53-8864-0c009fd098cb/blueprints/92b2a3b7-2c0a-4d15-ade0-b04dc102b448
- Blueprint: Local Agent Observability (memory push excludes runtime configuration files) https://factory.8090.ai/project/b415065f-ab2f-4f53-8864-0c009fd098cb/blueprints/e42834c9-33d0-4ee8-b1f3-423970a6527a
- Blueprint: Tenant Access and Encryption (DaemonCredentialHeader) https://factory.8090.ai/project/b415065f-ab2f-4f53-8864-0c009fd098cb/blueprints/f1e31e54-f1d4-4b9a-9100-e246f4a5150a