### PR TITLE
queue-priority never parks the [RELEASE] publish run

### DIFF
--- a/.github/workflows/queue-priority.yml
+++ b/.github/workflows/queue-priority.yml
@@ -56,7 +56,14 @@ jobs:
           set -u
           ok=0; fail=0
           for id in $(gh api "/repos/$REPO/actions/runs?status=queued&per_page=100" --paginate \
-                        --jq '.workflow_runs[] | select(.head_branch != "main") | .id'); do
+                        --jq '.workflow_runs[]
+                              | select(.head_branch != "main")
+                              # The PyPI publish fires on pull_request:closed, so its
+                              # head branch is the merged PR branch, not main. Cancelling
+                              # it left a [RELEASE] commit on main with nothing
+                              # published (2026-09-03, #5464 vs #5455). Never park it.
+                              | select(.name != "Auto-release on [RELEASE] merge")
+                              | .id'); do
             if gh api -X POST "/repos/$REPO/actions/runs/$id/cancel" >/dev/null 2>&1; then
               ok=$((ok+1))
             else


### PR DESCRIPTION
`release-on-merge.yml` fires on `pull_request: closed`, so its queued run has the merged PR branch as `head_branch`. The clear-queue step in `queue-priority.yml` selects every queued run whose head branch is not `main` and cancelled it when #5455 pushed to main five minutes after `[RELEASE]` #5464 merged. Main carried a `[RELEASE]` commit with nothing published until the run was re-run by hand.

The cancel filter now also excludes the workflow named "Auto-release on [RELEASE] merge". Everything else queue-priority does is unchanged.

**Product record**
- Requirement (RunnerQueuePrioritizer): https://factory.8090.ai/project/b415065f-ab2f-4f53-8864-0c009fd098cb/requirements/b7c0af6c-e262-4a17-a342-093e94db3014

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WHJPkVko2LZFXVmKJ6G6eN