### PR TITLE
Gzip large sealed blobs before encryption, negotiated with the server

### DIFF
--- a/clawmetry/static/js/cm-e2e.js
+++ b/clawmetry/static/js/cm-e2e.js
@@ -117,6 +117,20 @@
           { name: 'AES-GCM', iv: raw.slice(0, 12) }, ck, raw.slice(12)
         );
       }).then(function (pt) {
+        /* The daemon may gzip the JSON before encrypting it (sync.py
+         * encrypt_payload, negotiated by the heartbeat `caps.blob_gzip`).
+         * gzip's magic bytes 0x1f 0x8b cannot begin a JSON document, so the
+         * plaintext says which it is. A browser without DecompressionStream
+         * gets null here, the same empty-card outcome as any unreadable
+         * blob; the server never advertises the codec to a node whose
+         * readers cannot inflate. */
+        var bytes = new Uint8Array(pt);
+        if (bytes.length > 2 && bytes[0] === 0x1f && bytes[1] === 0x8b) {
+          if (typeof DecompressionStream === 'undefined') { return null; }
+          var inflated = new Blob([bytes]).stream()
+            .pipeThrough(new DecompressionStream('gzip'));
+          return new Response(inflated).text().then(JSON.parse);
+        }
         return JSON.parse(new TextDecoder().decode(pt));
       }).catch(function () { return null; });
     } catch (e) {

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -653,15 +653,58 @@ def _get_aesgcm(key_b64: str):
         )
 
 
-def encrypt_payload(data: dict, key_b64: str) -> str:
+# ── Blob compression (negotiated) ───────────────────────────────────────────
+# A system snapshot is 1.2 to 1.4 MB of JSON every minute, roughly 2 GB a day
+# per node, and JSON shrinks about 4x under gzip. Ciphertext does not compress,
+# so the compression happens BEFORE encryption: plaintext = gzip(json), and the
+# reader recognises it by the gzip magic (0x1f 0x8b), which no JSON document
+# can start with. There is no marker to strip and an uncompressed blob decrypts
+# exactly as before.
+#
+# The daemon compresses only when the server has said every reader it serves
+# can inflate (heartbeat response ``caps.blob_gzip``): the browser decryptor
+# (cm-e2e.js) needs DecompressionStream, and a paired desk device decrypts
+# blobs in firmware with no inflater at all, so the cloud withholds the cap
+# for a node with a paired device. ``CLAWMETRY_BLOB_GZIP=1|0`` overrides for
+# self-hosted deployments. Tiny blobs (session titles) are never compressed:
+# gzip grows them.
+_SERVER_CAPS: dict = {}
+BLOB_GZIP_MIN_BYTES = 4096
+
+
+def _record_server_caps(resp: dict) -> None:
+    caps = resp.get("caps") if isinstance(resp, dict) else None
+    if isinstance(caps, dict):
+        _SERVER_CAPS.update(caps)
+
+
+def blob_gzip_enabled() -> bool:
+    env = str(os.environ.get("CLAWMETRY_BLOB_GZIP", "")).strip().lower()
+    if env in ("1", "true", "yes"):
+        return True
+    if env in ("0", "false", "no"):
+        return False
+    return _SERVER_CAPS.get("blob_gzip") is True
+
+
+def encrypt_payload(data: dict, key_b64: str, compress: bool | None = None) -> str:
     """
     Encrypt a dict as AES-256-GCM.
     Returns base64url(nonce || ciphertext) — a single opaque string.
     Cloud stores this blob and never sees plaintext.
+
+    ``compress`` forces gzip-before-encrypt on or off; ``None`` (the default)
+    follows ``blob_gzip_enabled()``, so every call site gains compression the
+    moment the server advertises it and none of them has to know.
     """
     cipher = _get_aesgcm(key_b64)
     nonce = secrets.token_bytes(12)  # 96-bit nonce (GCM standard)
     plain = json.dumps(data).encode()
+    if compress is None:
+        compress = blob_gzip_enabled()
+    if compress and len(plain) >= BLOB_GZIP_MIN_BYTES:
+        import gzip as _gzip
+        plain = _gzip.compress(plain, compresslevel=6, mtime=0)
     ct = cipher.encrypt(nonce, plain, None)
     return base64.urlsafe_b64encode(nonce + ct).decode()
 
@@ -735,7 +778,11 @@ def decrypt_payload(blob: str, key_b64: str) -> dict:
     cipher = _get_aesgcm(key_b64)
     raw = base64.urlsafe_b64decode(blob + "==")
     nonce, ct = raw[:12], raw[12:]
-    return json.loads(cipher.decrypt(nonce, ct, None))
+    plain = cipher.decrypt(nonce, ct, None)
+    if plain[:2] == b"\x1f\x8b":  # gzip magic; see encrypt_payload
+        import gzip as _gzip
+        plain = _gzip.decompress(plain)
+    return json.loads(plain)
 
 
 # ── Sync DLQ for AES-GCM encryption failures (#1601) ────────────────────────
@@ -1204,6 +1251,7 @@ def _post(path: str, payload: dict, api_key: str, timeout: int = 45) -> dict:
             # fields leave the cache untouched.
             if isinstance(resp_body, dict) and "sync_allowed" in resp_body:
                 _update_trial_state(resp_body)
+            _record_server_caps(resp_body)
             return resp_body
         except urllib.error.HTTPError as e:
             code = e.code

--- a/docs/EGRESS.md
+++ b/docs/EGRESS.md
@@ -61,7 +61,10 @@ make them.
 After `clawmetry connect`, two kinds of data leave the machine.
 
 **Sealed.** Encrypted on the node with AES-256-GCM (96-bit random nonce per
-blob) under a key the server never receives. The server stores the blob; the
+blob) under a key the server never receives. Large blobs are gzip-compressed
+*before* encryption (about 4x smaller; ciphertext itself does not compress),
+but only once the server has said every reader it serves can inflate
+(heartbeat `caps.blob_gzip`); `CLAWMETRY_BLOB_GZIP=0` turns it off. The server stores the blob; the
 browser decrypts it. A node with no key **skips** these uploads rather than
 sending them in the clear (`content_egress_permitted` in `clawmetry/sync.py`,
 enforced by `tests/test_e2e_invariants.py`).
@@ -182,7 +185,7 @@ Codex sessions on the machine.
 |---|---|---|---|
 | `POST /ingest/heartbeat` | every 3 s while a viewer is open, else 60 s | node_id, platform, version, e2e flag, install_id, detected runtimes with session counts, tool names and counts today, last tool used, detector messages, Ollama model names, billing plan labels, activity counters, store size, cache-key names | `cache_pushes` blobs: last 50 brain events, memory files, cron list, alert rules, approval queue |
 | `POST /ingest/sessions` | every 60 s when rows change | session_id, runtime, model, status, timestamps, total_tokens, cost_usd, token_split, cache stats, tool_error_pct, tool_call_count, message_count, surface | `title_blob` (the readable title) |
-| `POST /ingest/system-snapshot` | every ~60 s, 1.2 to 1.4 MB | node_id | 80 keys: transcripts with full message text, machine info, security posture, audit log, agent inventory with workspace paths, MCP servers, tool catalog, spending, traces, skills |
+| `POST /ingest/system-snapshot` | every ~60 s; about 300 KB once the server advertises gzip (1.2 to 1.4 MB before) | node_id | 80 keys: transcripts with full message text, machine info, security posture, audit log, agent inventory with workspace paths, MCP servers, tool catalog, spending, traces, skills |
 | `POST /ingest/events` | as transcripts change (OpenClaw JSONL path) | node_id | raw transcript events |
 | `POST /ingest/logs` | every 60 s when the gateway log grows | node_id | gateway log records |
 | `POST /ingest/stream` | every 2 s when the log tail moves | node_id | raw gateway log lines |

--- a/tests/test_e2e_invariants.py
+++ b/tests/test_e2e_invariants.py
@@ -431,3 +431,79 @@ def test_every_relayed_action_is_written_to_the_local_audit_log(monkeypatch):
     assert calls[0][1]["target"] == "selfevolve_fix"
     # The action body (which may carry a server-supplied prompt) is not stored.
     assert "suggestion" not in json.dumps(calls[0][1].get("metadata") or {})
+
+
+# ── Bandwidth: gzip before encrypt, negotiated, never assumed ────────────────
+
+
+def _big_payload():
+    return {"rows": [{"i": i, "text": "the same line of transcript " * 8} for i in range(200)]}
+
+
+def test_gzip_blob_round_trips_and_is_smaller(monkeypatch):
+    monkeypatch.delenv("CLAWMETRY_BLOB_GZIP", raising=False)
+    key = sync.generate_encryption_key()
+    payload = _big_payload()
+    plain_blob = sync.encrypt_payload(payload, key, compress=False)
+    gz_blob = sync.encrypt_payload(payload, key, compress=True)
+    assert sync.decrypt_payload(gz_blob, key) == payload
+    assert sync.decrypt_payload(plain_blob, key) == payload
+    assert len(gz_blob) < len(plain_blob) / 3, "gzip should shrink repetitive JSON several-fold"
+
+
+def test_small_blobs_are_never_compressed():
+    """A session title is a few dozen bytes; gzip would grow it."""
+    key = sync.generate_encryption_key()
+    tiny = {"display_name": "Reset prod DB password"}
+    blob = sync.encrypt_payload(tiny, key, compress=True)
+    raw = sync.base64.urlsafe_b64decode(blob + "==")
+    plain = sync._get_aesgcm(key).decrypt(raw[:12], raw[12:], None)
+    assert plain[:1] == b"{"
+
+
+def test_compression_is_off_until_the_server_advertises_it(monkeypatch):
+    monkeypatch.delenv("CLAWMETRY_BLOB_GZIP", raising=False)
+    monkeypatch.setattr(sync, "_SERVER_CAPS", {})
+    assert sync.blob_gzip_enabled() is False
+    key = sync.generate_encryption_key()
+    blob = sync.encrypt_payload(_big_payload(), key)  # default follows the negotiation
+    raw = sync.base64.urlsafe_b64decode(blob + "==")
+    plain = sync._get_aesgcm(key).decrypt(raw[:12], raw[12:], None)
+    assert plain[:1] == b"{", "no cap advertised: plaintext must stay plain JSON"
+    sync._record_server_caps({"sync_allowed": True, "caps": {"blob_gzip": True}})
+    assert sync.blob_gzip_enabled() is True
+    blob = sync.encrypt_payload(_big_payload(), key)
+    raw = sync.base64.urlsafe_b64decode(blob + "==")
+    plain = sync._get_aesgcm(key).decrypt(raw[:12], raw[12:], None)
+    assert plain[:2] == b"\x1f\x8b"
+
+
+def test_env_override_beats_the_server_cap(monkeypatch):
+    monkeypatch.setattr(sync, "_SERVER_CAPS", {"blob_gzip": True})
+    monkeypatch.setenv("CLAWMETRY_BLOB_GZIP", "0")
+    assert sync.blob_gzip_enabled() is False
+    monkeypatch.setattr(sync, "_SERVER_CAPS", {})
+    monkeypatch.setenv("CLAWMETRY_BLOB_GZIP", "1")
+    assert sync.blob_gzip_enabled() is True
+
+
+def test_post_records_caps_from_any_cloud_response(monkeypatch):
+    monkeypatch.setattr(sync, "_SERVER_CAPS", {})
+
+    class _Resp:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def read(self):
+            return b'{"ok": true, "caps": {"blob_gzip": true}}'
+
+    import urllib.request as _ur
+
+    monkeypatch.setattr(_ur, "urlopen", lambda req, timeout=0: _Resp())
+    monkeypatch.setattr(sync, "is_cloud_disabled", lambda: False, raising=False)
+    out = sync._post("/ingest/heartbeat", {"node_id": "n1"}, "cm_test")
+    assert out.get("ok") is True
+    assert sync._SERVER_CAPS.get("blob_gzip") is True

--- a/tests/test_published_e2e_js.py
+++ b/tests/test_published_e2e_js.py
@@ -169,3 +169,18 @@ def test_storage_key_requires_both_node_and_account():
     assert a is None and b is None
     # slice(0, 16) of the account token — the namespace, not the whole key
     assert c == "cm-enc-key-mac-cm_acct_abcdef12"
+
+
+def test_published_js_inflates_a_gzip_blob():
+    """The daemon gzips large blobs before encrypting them once the server
+    advertises the codec; the published decryptor must read both forms."""
+    key = generate_encryption_key()
+    payload = {"rows": [{"i": i, "line": "same transcript line " * 6} for i in range(300)]}
+    blob = encrypt_payload(payload, key, compress=True)
+    plain_blob = encrypt_payload(payload, key, compress=False)
+    assert len(blob) < len(plain_blob) / 3
+    out = _node(
+        f"window.cmE2E.decryptBlob({json.dumps(blob)}, {json.dumps(key)})"
+        f".then(r => console.log(JSON.stringify(r)));"
+    )
+    assert json.loads(out) == payload


### PR DESCRIPTION
Closes the last open item from the 2026-09-03 wire audit: a 1.2 to 1.4 MB sealed snapshot every minute (about 2 GB a day per node). Measured on captured snapshots, the JSON compresses 4x; the snapshot is not idle-skippable (36 of 80 keys change every cycle), so compression is the fix.

**How**
- `encrypt_payload` gzips the JSON before AES-GCM when the server has advertised `caps.blob_gzip` in a heartbeat response (`_record_server_caps`, `blob_gzip_enabled`). Ciphertext itself does not compress. Blobs under 4 KB (session titles) are never compressed.
- `decrypt_payload` and the published browser decryptor `cm-e2e.js` inflate on the gzip magic bytes, which no JSON document can start with, so uncompressed blobs read exactly as before.
- `CLAWMETRY_BLOB_GZIP=1|0` overrides the negotiation for self-hosted deployments.
- Nothing changes on the wire until the cloud advertises the cap, and the cloud will do that only after pinning the release that carries this decryptor (clawmetry-cloud#2265, draft). A paired desk device decrypts in firmware and is never offered the codec.

**Tests**
- `tests/test_published_e2e_js.py`: the real published JS under Node inflates and parses a gzip blob produced by `encrypt_payload`.
- `tests/test_e2e_invariants.py`: round trip and size, tiny blobs stay plain, off until advertised, env override, `_post` records caps.

Pre-existing on main, unrelated: the three `tests/test_brain_cache_push.py` failures.

**Product record**
- Blueprint: Tenant Access and Encryption (compression-before-encryption contract) https://factory.8090.ai/project/b415065f-ab2f-4f53-8864-0c009fd098cb/blueprints/f1e31e54-f1d4-4b9a-9100-e246f4a5150a
- Requirement: Local Audit and Data Control https://factory.8090.ai/project/b415065f-ab2f-4f53-8864-0c009fd098cb/requirements/1e232fe6-5b9b-48dd-8873-70e52684067a

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WHJPkVko2LZFXVmKJ6G6eN