### PR TITLE
Harden deps: seven-day cooldown before Dependabot adopts a new release

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,23 @@
 version: 2
+
+# Every ecosystem below carries `cooldown: default-days: 7`.
+#
+# A version update that lands the hour a release is published is the window
+# a compromised package is published INTO. Registry takeovers are
+# opportunistic and short-lived: the malicious version is typically yanked
+# within a day or two, so the whole attack depends on somebody pulling it
+# before that happens. Waiting a week means an automated bump adopts a
+# release the rest of the ecosystem has already had time to look at. It
+# also keeps ordinary regressions out of the tree.
+#
+# This does NOT delay security fixes. Cooldown applies to version updates
+# only; a Dependabot SECURITY update opens immediately regardless of what
+# is configured here, so an advisory fix still arrives the day it exists.
+# That distinction is the reason the value can be this conservative --
+# nothing on the advisory path is slowed by it.
+#
+# Seven days rather than the built-in three: three is GitHub's default, and
+# it is inside the window where a compromised release is often still up.
 updates:
   # Python (pip) dependencies
   - package-ecosystem: "pip"
@@ -9,6 +28,8 @@ updates:
     open-pull-requests-limit: 5
     labels:
       - "dependencies"
+    cooldown:
+      default-days: 7
 
   # GitHub Actions
   - package-ecosystem: "github-actions"
@@ -19,6 +40,8 @@ updates:
     open-pull-requests-limit: 5
     labels:
       - "dependencies"
+    cooldown:
+      default-days: 7
 
   # npm — the React SPA. This is the repo's largest JS dependency tree and
   # the only one with a committed lockfile that ships into clawmetry/static/.
@@ -36,6 +59,8 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    cooldown:
+      default-days: 7
 
   # npm — Playwright E2E harness. Runs in CI on every PR, so its
   # dependencies are part of the CI supply chain.
@@ -52,6 +77,8 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    cooldown:
+      default-days: 7
 
   # npm — the ClawHub/OpenClaw plugin, which is published to npm
   # (openclaw.release.publishToNpm). No lockfile, so Dependabot updates the
@@ -64,3 +91,5 @@ updates:
     open-pull-requests-limit: 3
     labels:
       - "dependencies"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
`No-PRD: CI-only supply-chain hardening` (touches only `.github/dependabot.yml`, an exempt path)

## What

Sets `cooldown: default-days: 7` on all five entries in `.github/dependabot.yml` — pip, github-actions, and the three npm trees (`/frontend`, `/tests/e2e`, `/clawhub-plugin`). One file, +29 lines, of which 10 are the `cooldown` blocks and the rest a comment explaining the value.

## Why

Every ecosystem opened version-update PRs with **no cooldown**, so a bump could land the hour a release was published — which is the window a compromised package is published into. Registry takeovers are opportunistic and short-lived: the malicious version is typically yanked within a day or two, so the attack depends on somebody pulling it before that happens. An automated version bump is exactly that somebody. Waiting a week means a bump adopts a release the rest of the ecosystem has already had time to look at, and it keeps ordinary regressions out of the tree too.

Seven days rather than the built-in three: three is GitHub's default, and it sits inside the window where a compromised release is often still up. `zizmor`'s `dependabot-cooldown` audit flags anything under seven — five findings on this file, one per entry, High confidence / Medium severity.

This complements the supply-chain work already merged here (SHA-pinned action refs, least-privilege token scopes, no credential persistence): those control what CI *runs*, this controls how fast an unreviewed third-party release gets *in*.

## This does not delay security fixes

Worth being explicit, because this repo has just been unpicking a gate that did block advisory fixes (#5478).

Cooldown governs **version updates only**. A Dependabot **security** update — the kind opened off an advisory — opens immediately regardless of what this file says. So an advisory fix still arrives the day it exists, and nothing on the path #5478 is unblocking is slowed by this. That is what makes seven days safe to set outright rather than a tradeoff against patch latency.

Sources: [Dependabot options reference](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference), [The case for a cooldown](https://github.blog/security/supply-chain-security/the-case-for-a-cooldown-why-dependabot-now-waits-before-issuing-version-updates/).

## Verification

- `zizmor --no-online-audits .github/dependabot.yml` → **no findings** (was 5 medium).
- `yaml.safe_load` over all 36 `.github/workflows/*.yml` plus `dependabot.yml` → all parse.
- Re-read the parsed config back: all five entries carry `{'default-days': 7}`, and no other key changed.

The `cooldown` blocks are `zizmor`'s own safe auto-fix output, unmodified; only the explanatory comment is hand-written.

## Not in scope

`clawmetry-cloud` (5 ecosystems) and `clawmetry-pro` (2) have the same gap and no cooldown. Left for separate PRs on those repos rather than widening this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LA6sFuUbjTRmJGvrB7n7iA

---
_Generated by [Claude Code](https://claude.ai/code/session_01LA6sFuUbjTRmJGvrB7n7iA)_