### PR TITLE
Trail: inputs card uses the cloud session-context hook on the hosted dashboard

### DIFF
--- a/clawmetry/static/js/trail.js
+++ b/clawmetry/static/js/trail.js
@@ -370,8 +370,24 @@
   // What the agent knew: system prompt / tools / MCP / model. Served by
   // /api/sessions/<id>/context once that stream lands; until then, and on
   // the hosted dashboard, it 404s and we say so.
+  // On the hosted dashboard the cloud bundle installs
+  // window._cmCloudSessionContext(sid) (cm-cloud-session-context), which
+  // slices the E2E-encrypted snapshot's sessionContext bucket; the transcript
+  // panel's _fetchSessionContext (app.js) already prefers it, so reuse that
+  // path here and only fall back to the honest empty state when it is absent.
+  async function fetchContext(sid) {
+    if (window.CLOUD_MODE) {
+      if (typeof window._cmCloudSessionContext !== 'function') return NOT_ON_CLOUD;
+      try {
+        var c = await window._cmCloudSessionContext(sid);
+        if (c && !c.error) return { ok: true, status: 200, data: c };
+      } catch (e) { /* fall through to the honest state */ }
+      return NOT_ON_CLOUD;
+    }
+    return jget('/api/sessions/' + encodeURIComponent(sid) + '/context');
+  }
   async function renderContext(sid, rt, seq) {
-    var r = await jgetLocal('/api/sessions/' + encodeURIComponent(sid) + '/context');
+    var r = await fetchContext(sid);
     if (seq !== state.seq) return;
     var d = r.ok ? (r.data || {}) : null;
     var items = [];


### PR DESCRIPTION
Follow-up to #5494 and #5484. The Trail page's "What the agent knew" card skipped its fetch on the hosted dashboard and showed the empty state even though the transcript panel already reads the encrypted snapshot's session-context slice through `window._cmCloudSessionContext` (installed by the cloud bundle's `cm-cloud-session-context` interceptor). The card now uses that same hook when present and keeps the honest empty state only when it is absent. Local behaviour is unchanged.

Verified: `node --check` on trail.js; `tests/test_trail_tab_template.py` passes; the one local `test_appjs_units` failure (`formatBrainTime` cross-year case) reproduces identically on origin/main and is unrelated.

Product record: https://factory.8090.ai/project/b415065f-ab2f-4f53-8864-0c009fd098cb/blueprints/b17fcb52-af45-43ee-af66-525548be8764 (Session Trail: Inputs, Decisions, Outcome)

🤖 Generated with [Claude Code](https://claude.com/claude-code)