### PR TITLE
Trail: replay tree mounts relative to the transcript anchor's real parent

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -21464,8 +21464,12 @@ async function _loadReplayTree(sessionId) {
   if (!mount) {
     mount = document.createElement('div');
     mount.id = 'replay-tree-container';
+    // The Trail page re-parents #transcript-messages into its own card, so
+    // the anchor is not always a child of #transcript-viewer; inserting
+    // relative to the anchor's real parent avoids the NotFoundError seen on
+    // the hosted dashboard (0.12.811) when a trail opened the replay.
     var anchor = document.getElementById('transcript-messages');
-    if (anchor) viewer.insertBefore(mount, anchor);
+    if (anchor && anchor.parentNode) anchor.parentNode.insertBefore(mount, anchor);
     else viewer.appendChild(mount);
   } else {
     mount.innerHTML = '';


### PR DESCRIPTION
Seen on the hosted dashboard at 0.12.811 while walking the Trail release: opening a trail logs `NotFoundError: Failed to execute 'insertBefore' on 'Node'` from `_loadReplayTree` (app.js:21467). The Trail page re-parents `#transcript-messages` into its own "What it did" card, so the anchor is no longer a child of `#transcript-viewer` and `viewer.insertBefore(mount, anchor)` throws. The replay tree now mounts relative to the anchor's actual parent, which is the same node on the classic transcript view and the trail card on the Trail page. The flat renderer fallback is unchanged.

Verified: `node --check` on app.js; `tests/test_trail_tab_template.py` passes; the one local `test_appjs_units` failure (`formatBrainTime` cross-year case) reproduces identically on origin/main.

Product record: https://factory.8090.ai/project/b415065f-ab2f-4f53-8864-0c009fd098cb/blueprints/b17fcb52-af45-43ee-af66-525548be8764 (Session Trail: Inputs, Decisions, Outcome)

🤖 Generated with [Claude Code](https://claude.com/claude-code)