### PR TITLE
[RELEASE] perf: startup compaction runs in a helper process (carries #5519)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Unreleased
 
+### Release: startup compaction runs in a helper process (#5519) (2026-09-05)
+- **Why:** 0.12.811 shipped the store compaction (#5503) running inside the daemon process at startup. A torn copy of a live store segfaulted Python inside DuckDB's CHECKPOINT during release verification; a daemon never sees a torn file at its own start, but a native crash in that path would restart-loop the daemon with no traceback. #5519 moves the rewrite into a helper process with a timeout and rolls back a half-finished swap. Every node auto-updates, so this should reach them before the next restart cycle.
+- **What:** this release carries #5519. Daemon-side change; the cloud pin follows automatically.
+- **Verified:** #5519's tests ran green in CI before merge (real helper path, simulated crash mid-swap, simulated timeout).
+
 ### Release: the Raindrop gap closure, for every runtime (2026-09-05)
 
 - **Why:** operators could see cost and stuck loops but not what people and agents were saying about a run, could not compare a fleet before and after a change, and could not let an agent report its own trouble. These signals are now computed from transcripts ClawMetry already holds, judge-free and local, across every runtime in the store.


### PR DESCRIPTION
Product record: https://factory.8090.ai/project/b415065f-ab2f-4f53-8864-0c009fd098cb/requirements/760307fc-5445-4183-9035-41730b0876c8

Release carrying #5519: the store's startup compaction (shipped in 0.12.811 via #5503) now runs in a helper process with a timeout, so a crash inside the database engine during the rewrite cannot restart-loop the daemon; a half-finished swap is rolled back to the previous file.

Daemon-side change; the cloud pin follows automatically via the auto-deploy workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
