### PR TITLE
fix(cli): bare `clawmetry --help`/`-h` must not import dashboard

### DIFF
--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -8786,6 +8786,22 @@ def main() -> None:
         parser.parse_args()
         return  # argparse's -h action always exits; unreachable in practice
 
+    # Bare `clawmetry --help`/`-h` (no subcommand) needs the same guard
+    # (#5492): argv[1] is "--help" itself, not a member of _subcmds, so the
+    # check above never caught it and this process fell all the way through
+    # to `from dashboard import main as dashboard_main` just to print help
+    # text -- the exact import the guard above exists to avoid. This is what
+    # the Conformance Heartbeat's `clawmetry --help > /dev/null` step hit on
+    # py3.9/Linux while `<subcmd> --help` (already guarded) passed in the
+    # same run. `parser` has no subcommand chosen here, so parse_args() would
+    # error on an "unrecognized argument" instead of printing help (its own
+    # -h action is off, by design, so a real subcommand's `-h` in argv[2:]
+    # above is the one that fires) -- print_help() is what argparse uses
+    # internally for -h and works the same without an -h action registered.
+    if len(sys.argv) > 1 and sys.argv[1] in ("-h", "--help"):
+        parser.print_help()
+        sys.exit(0)
+
     # Tag this process as the dashboard BEFORE importing dashboard, so every
     # get_store() in dashboard.py (module-level + handlers) is barred from the
     # DuckDB writer — only the sync daemon writes. Set before the import or a

--- a/tests/test_cli_help_no_dashboard_import.py
+++ b/tests/test_cli_help_no_dashboard_import.py
@@ -12,6 +12,14 @@ needed. `status`/`sync --help` happened to pass in both incidents while
 `connect --help` segfaulted, which is consistent with a native init that can
 land on any subcommand's dashboard import, not something specific to
 `connect`.
+
+Bare `clawmetry --help`/`-h` (no subcommand) was still missing this guard
+(#5492): argv[1] is the string "--help" itself, not a member of `_subcmds`,
+so the check that catches `<subcmd> --help` never matched it and the process
+fell all the way through to the dashboard import just to print help text --
+the published-wheel Conformance Heartbeat caught this crashing on
+`pypi-install (ubuntu-latest, py3.9)` with `free(): invalid pointer` /
+exit 134 on `clawmetry --help`, before the per-subcommand step even ran.
 """
 import builtins
 import sys
@@ -53,3 +61,39 @@ def test_subcommand_help_still_prints_usage(capsys, monkeypatch):
     assert exc.value.code == 0
     out = capsys.readouterr().out.lower()
     assert "usage: clawmetry connect" in out
+
+
+@pytest.mark.parametrize("flag", ["--help", "-h"])
+def test_bare_help_does_not_import_dashboard(flag, monkeypatch):
+    """Bare `clawmetry --help`/`-h` (#5492): argv[1] IS the flag, not a
+    subcommand, so it needs its own guard distinct from the one above."""
+    monkeypatch.setattr(sys, "argv", ["clawmetry", flag])
+    monkeypatch.delitem(sys.modules, "dashboard", raising=False)
+    real_import = builtins.__import__
+    imported = []
+
+    def _spy(name, *args, **kwargs):
+        if name == "dashboard" or name.startswith("dashboard."):
+            imported.append(name)
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _spy)
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main()
+
+    assert exc.value.code == 0
+    assert not imported, (
+        f"`clawmetry {flag}` imported dashboard ({imported}); bare top-level "
+        "help must be printed by argparse alone, same as a subcommand's."
+    )
+
+
+def test_bare_help_still_prints_usage(capsys, monkeypatch):
+    """The bare-help short-circuit must not swallow the actual help text."""
+    monkeypatch.setattr(sys, "argv", ["clawmetry", "--help"])
+    with pytest.raises(SystemExit) as exc:
+        cli.main()
+    assert exc.value.code == 0
+    out = capsys.readouterr().out.lower()
+    assert "usage: clawmetry" in out


### PR DESCRIPTION
## Reproduction

The Conformance Heartbeat against the published PyPI wheel (run [33863209820](https://github.com/vivekchand/clawmetry/actions/runs/33863209820)) failed on `pypi-install (ubuntu-latest, py3.9)`:

```
import ok /opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/clawmetry/__init__.py
clawmetry 0.12.809
free(): invalid pointer
.../line 3:  2031 Aborted   (core dumped) clawmetry --help > /dev/null
##[error]Process completed with exit code 134.
```

`import clawmetry, clawmetry.cli` and `clawmetry --version` both succeed in a fresh process; only `clawmetry --help` aborts with heap corruption.

## Root cause

`clawmetry/cli.py::main()` already has a guard for `<subcmd> --help` (e.g. `clawmetry connect --help`) that prints help via argparse's own subparser `-h` action **without** importing `dashboard` first — because that import chain is known to crash on some Python 3.9/Linux runners (#5108, #5309), and paying for it just to print static help text is wasteful and, on affected runners, fatal.

That guard checks `sys.argv[1] in _subcmds`. Bare `clawmetry --help`/`-h` (no subcommand at all) has `sys.argv[1] == "--help"`, which is *not* a member of `_subcmds`, so the guard never fires. Execution falls all the way through to `from dashboard import main as dashboard_main`, i.e. exactly the import the existing guard exists to avoid — and that's the path that aborts.

## Fix

Add a second, narrower short-circuit right after the existing one: when `sys.argv[1]` is `"--help"`/`"-h"` with no subcommand, call `parser.print_help()` (the local cli.py parser, already fully built at that point) and `sys.exit(0)` instead of importing dashboard. `parser.parse_args()` isn't used here (unlike the subcommand case) because with no subcommand chosen and `add_help=False` on this parser, it would raise "unrecognized arguments" instead of printing help.

## Tests

Extended the existing wired test file `tests/test_cli_help_no_dashboard_import.py` (already listed in `.github/workflows/ci.yml`) with the same pattern used for the subcommand case: a `dashboard` import spy for both `--help` and `-h`, plus a usage-text assertion.

Revert-proofed locally: with `clawmetry/cli.py` reverted to `main`, the two new bare-help cases go red (`dashboard` is actually imported); restoring the fix turns them green again. Full file: 8/8 passing.

Closes #5492

No-PRD: fix of field-reported bug #5492

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011YMju2cdznjQQh4Nogr9n8

---
_Generated by [Claude Code](https://claude.ai/code/session_011YMju2cdznjQQh4Nogr9n8)_