### PR TITLE
[RELEASE] The Sessions replay gets its column back (carries #5537)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Unreleased
 
+### Release: the Sessions replay gets its column back (carries #5537) (2026-09-05)
+- **Why:** #5537 is on main but not in a published wheel, and nodes auto-update, so publishing is what makes the fix real on the machines showing the broken screen. Until a node takes this wheel, opening a session still renders the whole conversation as a narrow strip pinned to the right edge with the left half of the page blank, and a reloaded or shared `#trail=` link still sits forever on "Opening the trail..." with every card stuck on "Loading...".
+- **What:** this release carries #5537. Frontend only (`static/css/dashboard.css`, `static/js/app.js`), so the cloud pin follows.
+- **Verified:** #5537 shipped 7 guards in `tests/test_transcript_layout_grid.py`, 3 of them proven red against the unfixed tree (the CSS rule, the replay-tree inline style, the classList check), wired into the existing Trail page CI step. Re-ran all 7 against merged main: green. The 97 guards in `tests/test_needs_you_matches_the_hero.py` also pass against the merged `app.js`, so the two changes that touched that file do not conflict. Post-release check on a node that takes the wheel: the served `static/css/dashboard.css` contains the `.transcript-layout > *:not(#transcript-messages):not(.transcript-toc)` rule, and `#transcript-messages` measures the wide column rather than 240px.
+
 ### Release: the Overview stops contradicting itself (carries #5553) (2026-09-05)
 - **Why:** #5553 is on main but not in a published wheel, and nodes auto-update, so publishing is what makes the fix real on the machines showing the contradiction. The founder's node renders "No agents running" above a hero naming three working Claude Code sessions until it takes this wheel.
 - **What:** this release carries #5553. Dashboard-side (`routes/attention.py`, `routes/sessions.py`, `static/js/app.js`), so the cloud pin follows.


### PR DESCRIPTION
No-PRD: release-only PR. Carries the already-merged field fix #5537; the product record question was settled on that PR.

Publishes #5537 to PyPI so nodes auto-update onto it.

## Why release now

#5537 is on main but not in a published wheel. Until a node takes this wheel, both breakages are still live on every machine:

1. Opening a session renders the whole conversation as a narrow strip pinned to the right edge, with the left half of the page blank. `#transcript-messages` gets squeezed into the 240px turn-TOC column because the empty `#replay-tree-container` becomes an auto-placed third item in the `.transcript-layout` grid.
2. A reloaded, bookmarked or shared `#trail=<runtime>:<id>` link sits forever on "Opening the trail..." with every card stuck on "Loading...", and logs nothing, because `switchTab()` threw a TypeError on `event.target.classList` before reaching its per-tab loader dispatch.

## What is in it

Frontend only, so the cloud pin follows this release:

- `clawmetry/static/css/dashboard.css`, the layout rule so any future injected child spans the row
- `clawmetry/static/js/app.js`, the replay-tree inline `grid-column` and the `classList` guard

## Verified

- #5537 shipped 7 guards in `tests/test_transcript_layout_grid.py`. 3 were proven red against the unfixed tree by stashing the source fixes: the CSS rule, the replay-tree inline style, and the classList check.
- Re-ran all 7 against merged main (`4d6bb5537`): green.
- The 97 guards in `tests/test_needs_you_matches_the_hero.py` also pass against the merged `app.js`, so #5537 and #5553 touching the same file do not conflict.
- `node --check` clean on `app.js`.

## After merge

Poll PyPI for the new version, then pin clawmetry-cloud to the version whose wheel actually contains the CSS rule, not the one this PR opened. Post-release check on a node: served `dashboard.css` contains the `.transcript-layout > *:not(#transcript-messages):not(.transcript-toc)` rule and the messages column measures wide rather than 240px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KD4xg3aR6g74CGgnQheJRe
