### PR TITLE
feat(openclaw): surface gateway degraded-start state from migration warnings (#5547)

### DIFF
--- a/clawmetry/adapters/openclaw.py
+++ b/clawmetry/adapters/openclaw.py
@@ -774,6 +774,33 @@ def _gateway_log_events_probe(count: int = 50) -> tuple:
         return [], False
 
 
+def _gateway_migration_warning(events: list) -> Optional[str]:
+    """Return the first migration-warning message from gateway log events, or None.
+
+    OpenClaw 2026.9.1+ stays running when a migration warning is detected
+    instead of refusing to start, but enters a degraded state.  The warning
+    appears as a ``warn``/``warning``-level log entry whose ``msg`` contains
+    the word ``migration``.  Callers surface ``gatewayDegraded`` so the UI
+    can distinguish "up" from "up but degraded".
+
+    Accepts the already-fetched events list (no extra I/O).  Returns None
+    when no migration warning is present.  Never raises (#5547).
+    """
+    try:
+        for evt in events:
+            if not isinstance(evt, dict):
+                continue
+            level = str(evt.get("level", "")).lower()
+            if level not in ("warn", "warning"):
+                continue
+            msg = str(evt.get("msg", ""))
+            if "migration" in msg.lower():
+                return msg
+        return None
+    except Exception:
+        return None
+
+
 def _openshell_sandbox_logs(name: str, count: int = 20) -> list:
     """Retrieve OCSF JSON audit log lines for a NemoClaw sandbox.
 
@@ -2558,6 +2585,14 @@ class OpenClawAdapter(AgentAdapter):
             if _gw_events:
                 meta["gatewayLogEvents"] = _gw_events
             meta["gatewayLogSourceAvailable"] = _gw_available
+            # Migration-warning degraded-start state (#5547): OpenClaw 2026.9.1+
+            # keeps the gateway running when a migration warning fires but enters a
+            # partial/degraded boot state distinct from full healthy or full down.
+            # Scan the already-fetched events so there is no extra I/O.
+            _mig_warn = _gateway_migration_warning(_gw_events)
+            if _mig_warn is not None:
+                meta["gatewayDegraded"] = True
+                meta["gatewayMigrationWarning"] = _mig_warn
             # Skill Workshop approval-policy (#3992): surfaces
             # skills.workshop.approvalPolicy from openclaw.json so cloud-synced
             # fleet views know whether autonomous skill actions are gated by

--- a/tests/test_obs_gap_openclaw_degraded_start_5547.py
+++ b/tests/test_obs_gap_openclaw_degraded_start_5547.py
@@ -1,0 +1,116 @@
+"""Tests for #5547 — degraded-start (migration warning) Gateway state not captured.
+
+OpenClaw 2026.9.1+ keeps the gateway process running when it encounters a
+migration warning on boot, but enters a degraded state distinct from fully
+healthy.  ``_gateway_live()`` only checks PID/port and returns True for both,
+so the degraded state was previously invisible to ClawMetry.
+
+Fix: ``_gateway_migration_warning(events)`` scans the already-read gateway log
+events for warn/warning-level entries whose message contains "migration" and
+returns the first match.  ``detect()`` surfaces ``gatewayDegraded=True`` and
+``gatewayMigrationWarning=<msg>`` when a match is found.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+def _fn():
+    from clawmetry.adapters.openclaw import _gateway_migration_warning
+    return _gateway_migration_warning
+
+
+# ---------------------------------------------------------------------------
+# Empty / no-warning cases
+# ---------------------------------------------------------------------------
+
+def test_empty_events_returns_none():
+    """No events → None (no degraded state)."""
+    assert _fn()([]) is None
+
+
+def test_no_warning_level_returns_none():
+    """Info-level migration entry is not a warning — should not trigger."""
+    events = [{"level": "info", "msg": "migration check passed"}]
+    assert _fn()(events) is None
+
+
+def test_warn_unrelated_msg_returns_none():
+    """warn-level entry whose msg doesn't mention migration → None."""
+    events = [{"level": "warn", "msg": "slow disk I/O detected"}]
+    assert _fn()(events) is None
+
+
+def test_error_level_migration_returns_none():
+    """error-level migration entry is not a warn → None."""
+    events = [{"level": "error", "msg": "migration failed"}]
+    assert _fn()(events) is None
+
+
+# ---------------------------------------------------------------------------
+# Positive cases
+# ---------------------------------------------------------------------------
+
+def test_warn_migration_returns_msg():
+    """warn level + 'migration' in msg → returns the message string."""
+    msg = "migration warning: schema v3 not yet applied, running in degraded mode"
+    events = [{"level": "warn", "msg": msg, "ts": "2026-09-05T06:00:00Z"}]
+    result = _fn()(events)
+    assert result == msg
+
+
+def test_warning_level_variant_accepted():
+    """'warning' (spelled out) is also accepted as a warn level."""
+    msg = "migration warning detected, gateway degraded"
+    events = [{"level": "warning", "msg": msg}]
+    assert _fn()(events) == msg
+
+
+def test_returns_first_migration_warning():
+    """When multiple migration warnings exist, the first (newest) is returned."""
+    msg_first = "migration warning: pending migration foo"
+    msg_second = "migration warning: pending migration bar"
+    events = [
+        {"level": "warn", "msg": msg_first},
+        {"level": "warn", "msg": msg_second},
+    ]
+    assert _fn()(events) == msg_first
+
+
+def test_skips_non_migration_warns_before_match():
+    """Non-migration warns before the migration warn don't block the result."""
+    msg = "migration warning: legacy column present"
+    events = [
+        {"level": "warn", "msg": "disk space low"},
+        {"level": "warn", "msg": msg},
+    ]
+    assert _fn()(events) == msg
+
+
+def test_case_insensitive_migration():
+    """'Migration' (capitalised) is still matched."""
+    msg = "Migration warning: table rename pending"
+    events = [{"level": "warn", "msg": msg}]
+    assert _fn()(events) == msg
+
+
+# ---------------------------------------------------------------------------
+# Robustness
+# ---------------------------------------------------------------------------
+
+def test_malformed_non_dict_entries_skipped():
+    """Non-dict entries in the list are silently skipped; never raises."""
+    events = [None, "bad", 42, {"level": "warn", "msg": "migration warning: ok"}]
+    result = _fn()(events)
+    assert result == "migration warning: ok"
+
+
+def test_missing_keys_do_not_raise():
+    """Entries missing 'level' or 'msg' are treated as non-matching; never raises."""
+    events = [{"ts": "2026-09-05"}, {"level": "warn"}, {"msg": "migration warning"}]
+    assert _fn()(events) is None
+
+
+def test_none_input_returns_none():
+    """Passing None instead of a list doesn't raise."""
+    assert _fn()(None) is None  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary

OpenClaw 2026.9.1+ keeps the gateway process running when a migration warning fires on boot, but enters a degraded state. `_gateway_live()` only checks PID/port and returns `True` for both healthy and degraded gateways — ClawMetry showed them identically. This PR adds the missing detection and surfaces it in `detect()`.

## Changes

- **`clawmetry/adapters/openclaw.py`**: Add `_gateway_migration_warning(events: list) -> Optional[str]` that scans the already-fetched gateway log events for `warn`/`warning`-level entries whose `msg` contains `"migration"`. Returns the first match (or `None`). In `OpenClawAdapter.detect()`, call this helper against the already-read `_gw_events` — no extra I/O — and write `gatewayDegraded=True` + `gatewayMigrationWarning=<msg>` into `meta` when a warning is found.

- **`tests/test_obs_gap_openclaw_degraded_start_5547.py`**: 12 new tests covering: empty events, warn-level match, warning-level variant, case-insensitivity, first-match wins, non-migration warns skipped, malformed entries, missing keys, and `None` input.

## Test plan

- [x] `python3 -m pytest tests/test_obs_gap_openclaw_degraded_start_5547.py -q` → 12 passed
- [x] `python3 -c 'import ast; ast.parse(open("clawmetry/adapters/openclaw.py").read())'` → OK
- [ ] Manual: start a gateway with a pending migration, confirm `detect()` returns `gatewayDegraded: true` and `gatewayMigrationWarning` in the response

No-PRD: automated observability gap fix filed by the harness audit script; adds a read-only meta field with no user-visible behaviour change beyond surfacing the existing degraded state

## Bot meta

<!-- bot-autofix -->
Draft PR opened autonomously based on the plan in #5547. Marked draft for human review — mark Ready for Review once happy.

Closes #5547

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UEfvCagh3hk8PwPNfaSVXb