### PR TITLE
fix(c6-health): post to active tracking issue #5266, not closed #4552

### DIFF
--- a/.github/workflows/c6-health.yml
+++ b/.github/workflows/c6-health.yml
@@ -10,7 +10,7 @@ name: C6 daily health check (branch-protection audit -- all 3 repos)
 # (can't verify) rather than "error" (broken). The health check gate
 # decision is based only on the clawmetry/main result (same-repo readable).
 #
-# On failure: posts an @-mentioned reminder to tracking issue #4552
+# On failure: posts an @-mentioned reminder to tracking issue #5266
 # at most once per calendar day. On success: posts a GREEN confirmation.
 #
 # To close C6 (any of these paths -- all take under 2 minutes):
@@ -20,7 +20,7 @@ name: C6 daily health check (branch-protection audit -- all 3 repos)
 #   2. Or: bash scripts/close-c6.sh
 #   3. Or: Settings > Branches > main > Required status checks (each repo)
 #
-# Tracking: vivekchand/clawmetry#4552
+# Tracking: vivekchand/clawmetry#5266
 
 on:
   schedule:
@@ -52,7 +52,7 @@ jobs:
 
           TOKEN = os.environ["GITHUB_TOKEN"]
           OWNER = "vivekchand"
-          TRACKING_ISSUE = 4552
+          TRACKING_ISSUE = 5266
           MARKER = "<!-- c6-health-check -->"
           # Repo this workflow runs in. GITHUB_TOKEN is repo-scoped: it can
           # read clawmetry (same-repo) but returns 403 for other repos.
@@ -289,14 +289,17 @@ jobs:
                       "**Action required:** disable the E2E robustness cron at "
                       "https://claude.ai/code/scheduled"
                   )
-                  # Tick the C6 checkbox in the issue body if still unchecked.
+                  # Flip C6 row from AMBER to GREEN in the criterion table.
+                  # The tracking issue uses a markdown table, not checkboxes.
                   issue_data, _ = api_get(
                       f"/repos/{OWNER}/clawmetry/issues/{TRACKING_ISSUE}"
                   )
-                  if issue_data and "- [ ] **C6" in (issue_data.get("body") or ""):
-                      new_body = (issue_data["body"] or "").replace(
-                          "- [ ] **C6", "- [x] **C6", 1
-                      )
+                  old_body = (issue_data.get("body") or "") if issue_data else ""
+                  # Match the exact table row pattern used in issue #5266.
+                  C6_AMBER_MARKER = "| C6 | Required-status-checks on all 3 repos | AMBER |"
+                  C6_GREEN_MARKER = "| C6 | Required-status-checks on all 3 repos | GREEN |"
+                  if old_body and C6_AMBER_MARKER in old_body:
+                      new_body = old_body.replace(C6_AMBER_MARKER, C6_GREEN_MARKER, 1)
                       patch_data = json.dumps({"body": new_body}).encode()
                       patch_req = urllib.request.Request(
                           f"https://api.github.com/repos/{OWNER}/clawmetry"
@@ -307,7 +310,7 @@ jobs:
                       )
                       try:
                           with urllib.request.urlopen(patch_req) as r:
-                              print("Checked C6 box in issue body.")
+                              print("Updated C6 row to GREEN in issue body.")
                       except Exception as exc:
                           print(f"Warning: could not update issue body: {exc}")
               else:


### PR DESCRIPTION
## What was wrong

`c6-health.yml` has `TRACKING_ISSUE = 4552` -- the old, **closed** tracker. All 83 daily health-check comments and the 7-day green-streak countdown have been accumulating there since the active tracker migrated to #5266 on 2026-08-26.

The E2E Robustness Driver cron reads #5266 to decide what gaps remain. Because no health-check posts ever land in #5266, the cron always sees C6 as AMBER even though clawmetry/main has had its required check configured for days. The stop-condition countdown is invisibly advancing in a closed issue nobody monitors.

Second bug in the same run: the stop-condition body-update looked for `"- [ ] **C6"` (checkbox format). Issue #5266 uses a markdown criterion table (`| C6 | Required-status-checks on all 3 repos | AMBER |`). The regex would never match, so the issue body would never flip to GREEN even when the 7-day streak completed.

## What changed

1. `TRACKING_ISSUE = 4552` -> `5266` (three comment references updated too).
2. Body-update logic: replace the checkbox search with a targeted table-row replace: `"| C6 | Required-status-checks on all 3 repos | AMBER |"` -> `"... | GREEN |"`.

## Acceptance test

Next scheduled `c6-health.yml` run (daily at 09:00 UTC) posts its comment to [#5266](https://github.com/vivekchand/clawmetry/issues/5266), not #4552. When the 7-day green streak is reached, the C6 row in #5266 flips to GREEN and the cron stops reporting C6 as a gap.

No-PRD: self-contained workflow bug fix. No code paths, tests, or user-visible behaviour changed.

---

### Per-fire log entry (E2E Robustness Driver -- 2026-09-05)

**Gap addressed:** `c6-health.yml` posts to wrong tracking issue (#4552 closed, not #5266 active). Green-streak countdown invisible to both cron and user. Body-update logic never matches #5266 table format.

**Criterion:** C6 (required-status-checks). Not yet GREEN -- this PR enables the health check to correctly detect and declare when C6 goes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015j3tvDvBP3Ed4tEUZxSLbT

---
_Generated by [Claude Code](https://claude.ai/code/session_015j3tvDvBP3Ed4tEUZxSLbT)_