### PR TITLE
Make the architecture docs true again, and generate the part that keeps drifting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,8 +108,28 @@ jobs:
       # of those drifted from the catalogue before this guard existed
       # (2026-08-15: catalogue 20, README 14, PyPI 12). setup.py derives the
       # PyPI summary; this keeps the rest honest.
-      - name: Runtime count matches the entitlement catalogue
+      # Also checks the chat-channel count against ALL_CHANNELS, which drifted
+      # the same way (2026-09-05: catalogue 23, CLAUDE.md/FLYWHEEL/AGENTS 21,
+      # PRD 22).
+      - name: Runtime and channel counts match the entitlement catalogue
         run: python3 scripts/sync_runtime_count.py --check
+
+      # docs/MODULE_MAP.md is generated from the source tree, because the
+      # hand-written inventories in CLAUDE.md and ARCHITECTURE.md drifted to
+      # the point of being misleading (2026-09-05: the route table listed 17
+      # of 70 modules and none of the 82 registered blueprints, so an agent
+      # went looking for features in dashboard.py that had moved out months
+      # earlier). Size bands are coarse so ordinary PRs do not trip this.
+      - name: Module map matches the source tree
+        run: python3 scripts/gen_module_map.py --check
+
+      # Named explicitly because this repo's CI runs FILE LISTS, not
+      # `pytest tests/`: a guard added without a line here runs in no job at
+      # all. Covers the half the --check above cannot: every blueprint
+      # dashboard.py registers is in the map, and CLAUDE.md / ARCHITECTURE.md
+      # name no module that has since moved or been deleted.
+      - name: Architecture docs name modules that exist
+        run: python3 -m pytest tests/test_module_map_drift.py -q
 
       # Acceptance-criteria traceability (FLYWHEEL.md 1g). Drift Bot asks "does
       # this diff contradict a Blueprint?"; it is a changed-code check and has

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,14 +123,6 @@ jobs:
       - name: Module map matches the source tree
         run: python3 scripts/gen_module_map.py --check
 
-      # Named explicitly because this repo's CI runs FILE LISTS, not
-      # `pytest tests/`: a guard added without a line here runs in no job at
-      # all. Covers the half the --check above cannot: every blueprint
-      # dashboard.py registers is in the map, and CLAUDE.md / ARCHITECTURE.md
-      # name no module that has since moved or been deleted.
-      - name: Architecture docs name modules that exist
-        run: python3 -m pytest tests/test_module_map_drift.py -q
-
       # Acceptance-criteria traceability (FLYWHEEL.md 1g). Drift Bot asks "does
       # this diff contradict a Blueprint?"; it is a changed-code check and has
       # no opinion on whether untouched code still SATISFIES a criterion
@@ -165,6 +157,16 @@ jobs:
       # was itself dead, silently, for months.
       - name: Every workflow file must parse
         run: python3 -m pytest tests/test_workflow_yaml_valid.py -q
+
+      # Named explicitly because this repo's CI runs FILE LISTS, not
+      # `pytest tests/`: a guard added without a line here runs in no job at
+      # all. Covers the half `gen_module_map.py --check` cannot: every
+      # blueprint dashboard.py registers is in the map, and CLAUDE.md /
+      # ARCHITECTURE.md name no module that has since moved or been deleted.
+      # Must sit AFTER "Install verification test deps" -- this job's
+      # interpreter has no pytest before that step.
+      - name: Architecture docs name modules that exist
+        run: python3 -m pytest tests/test_module_map_drift.py -q
 
       # The declared product surface must match reality: every cell names a
       # verifier that exists, and nothing claims to be "gated" while sitting

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,19 +5,19 @@
 > **Read [`FLYWHEEL.md`](./FLYWHEEL.md) first.** It is how you ship a change end to end in this repo (code → PR → green CI → `[RELEASE]` → PyPI → cloud → verified live) and the non-negotiable "done" bar. Then [`CLAUDE.md`](./CLAUDE.md) for the architecture deep-dive. This file is the short "what to do"; those two carry the detail.
 
 ## Quick context
-ClawMetry is an open-source, real-time observability dashboard for OpenClaw (and other) AI agents. `pip install clawmetry && clawmetry` — zero config, observation by default. It's a Flask app with an embedded, no-build vanilla-JS frontend; a sync daemon ingests filesystem/gateway/OTLP data into a local **DuckDB** store, and the app reads from DuckDB to serve the UI.
+ClawMetry is an open-source, real-time observability and governance layer for **30 AI agent runtimes** (OpenClaw, NemoClaw and Goose free in OSS; Claude Code, Codex, Cursor and 24 more with the Pro plugin). The catalogue is `entitlements.FREE_RUNTIMES | PAID_RUNTIMES`; never hardcode the list or the count. `pip install clawmetry && clawmetry` — zero config, observation by default. It's a Flask app with an embedded, no-build vanilla-JS frontend; a sync daemon ingests filesystem/gateway/OTLP data into a local **DuckDB** store, and the app reads from DuckDB to serve the UI.
 
 ## Where new code goes (open-core split)
 
 ClawMetry is open-core — there are **four repos**. Pick the right one *before* writing code; see `FLYWHEEL.md §1b` for the full decision tree.
 
-- **clawmetry** (this repo, public OSS) — OpenClaw runtime + NeMo governance + 21 chat channels + entitlement gate (`clawmetry/entitlements.py`) + license client (`clawmetry/license.py`) + Enterprise feature **endpoints** (entitlement-gated; impl may defer to clawmetry-pro). Examples: `routes/otel_export.py`, `routes/audit.py`.
-- **clawmetry-pro** (private; not on public PyPI; shipped via the license-server wheel download) — the 10 gated runtime adapters (Claude Code, Codex, Cursor, …), Pro paid CLI capabilities, advanced-feature implementations. Plugs in via `clawmetry.extensions` entry point.
+- **clawmetry** (this repo, public OSS) — the FREE runtime adapters (OpenClaw, NemoClaw, Goose) + NeMo governance + 23 chat channels + entitlement gate (`clawmetry/entitlements.py`) + license client (`clawmetry/license.py`) + Enterprise feature **endpoints** (entitlement-gated; impl may defer to clawmetry-pro). Examples: `routes/otel_export.py`, `routes/audit.py`.
+- **clawmetry-pro** (private; not on public PyPI; shipped via the license-server wheel download) — the 27 gated runtime adapters (Claude Code, Codex, Cursor, …), Pro paid CLI capabilities, advanced-feature implementations. Plugs in via `clawmetry.extensions` entry point.
 - **clawmetry-cloud** (private) — cloud SaaS app + license server (`clawmetry-cloud/routes/license.py`) + Stripe + admin + closed-wheel hosting (`wheels/`).
 - **clawmetry-landing** (private, public site) — marketing + pricing page + Buy buttons. No gated code.
 
 Quick chooser:
-- New non-OpenClaw runtime adapter → **clawmetry-pro**.
+- New runtime adapter → **clawmetry-pro** if the runtime is a commercial vendor product, **this repo** (`clawmetry/adapters/`, `FREE_RUNTIMES`, `sync._FAMILY_ADAPTER_SPECS`) if it is open source. Either way it is inert until it is named in `sync._FAMILY_ADAPTER_SPECS`.
 - New Enterprise feature (OTel export, SSO, audit, RBAC) → **OSS** route, gated by `entitlements.allows_feature(...)`.
 - New billing/Stripe/license endpoint → **clawmetry-cloud**.
 - New pricing/copy/Buy → **clawmetry-landing**.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -485,8 +485,9 @@ a warehouse.
   every core on the box. Hot rollups are result-cached with a short TTL
   (`CLAWMETRY_AGG_CACHE_TTL`, default 20s) so handlers never run a full-table
   scan per request.
-- **Memory**: tens of MB for the dashboard; the daemon's footprint follows the
-  DuckDB buffer pool.
+- **Memory**: the daemon idles near 50 MB. The DuckDB memory limit is a
+  ceiling on the buffer pool, not a reservation, so a large number there does
+  not mean a large resident process.
 - **Disk**: the store grows with your history. It is compacted, and
   `docs/EVENT_RETENTION.md` covers trimming it.
 - **Startup**: under 2 seconds.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,36 +1,93 @@
 # ClawMetry Architecture — How It Works
 
-> A human-friendly guide to how ClawMetry sees everything your AI agents do.
+> A human-friendly guide to how ClawMetry sees what your AI agents do, and to
+> the narrow set of places where it can act on them.
+>
+> Companion documents: [`CLAUDE.md`](CLAUDE.md) is the working reference for
+> agents changing this repo, [`FLYWHEEL.md`](FLYWHEEL.md) is how a change ships
+> end to end, and [`docs/MODULE_MAP.md`](docs/MODULE_MAP.md) is the generated
+> inventory of every module and blueprint.
 
 ## The Big Picture
 
 ```
-┌─────────────────────────────────────────────────────────┐
-│                    Your Machine                          │
-│                                                          │
-│  ┌──────────────┐     reads      ┌──────────────────┐   │
-│  │              │ ──────────────► │                  │   │
-│  │   OpenClaw   │   filesystem   │    ClawMetry     │   │
-│  │   Gateway    │ ◄──────────────│    Dashboard     │   │
-│  │              │   WebSocket    │   (Flask app)    │   │
-│  │  port 18789  │    JSON-RPC    │   port 8900      │   │
-│  └──────┬───────┘                └────────┬─────────┘   │
-│         │                                 │              │
-│         │  spawns/manages                 │  serves UI   │
-│         ▼                                 ▼              │
-│  ┌──────────────┐                ┌──────────────────┐   │
-│  │  AI Agents   │                │  Your Browser    │   │
-│  │  (Claude,    │                │  http://...:8900 │   │
-│  │   sessions)  │                └──────────────────┘   │
-│  └──────────────┘                                        │
-└─────────────────────────────────────────────────────────┘
+┌──────────────────────────────────────────────────────────────────────┐
+│  Your Machine                                                        │
+│                                                                      │
+│   30 agent runtimes            ClawMetry                             │
+│  ┌──────────────────┐        ┌───────────────────────────────────┐   │
+│  │ OpenClaw         │  files │  Sync daemon (clawmetry sync)     │   │
+│  │ Claude Code      │───────►│  • reads sessions, logs, hooks    │   │
+│  │ Codex, Cursor    │        │  • taps the gateway WebSocket     │   │
+│  │ Goose, Gemini    │  WS/RPC│  • receives OTLP                  │   │
+│  │ ...              │◄──────►│  • owns the DuckDB writer lock    │   │
+│  └──────────────────┘        └────────────────┬──────────────────┘   │
+│           ▲                                   │ writes               │
+│           │                                   ▼                      │
+│           │ signals, only              ┌──────────────┐              │
+│           │ when you opt in            │   DuckDB     │              │
+│           │ (Guard: pause/stop/kill)   │ ~/.clawmetry │              │
+│           │                            └──────┬───────┘              │
+│           │                                   │ reads (localhost     │
+│           │                                   │ query server)        │
+│  ┌────────┴──────────────────────────────────▼──────────────────┐   │
+│  │  Dashboard (Flask + waitress, 127.0.0.1:8900)                │   │
+│  │  REST API + single-page UI, no build step                    │   │
+│  └───────────────────────────┬──────────────────────────────────┘   │
+└──────────────────────────────┼──────────────────────────────────────┘
+                               │ optional, opt-in
+                               ▼
+                   ClawMetry Cloud (E2E-encrypted snapshot,
+                   decrypted in your browser)
 ```
 
-ClawMetry is a **read-only observer** that sits alongside your OpenClaw gateway. It never modifies your agents or their data. It reads what OpenClaw already writes to disk and connects to the gateway's WebSocket API for real-time updates.
+Everything lands in one local DuckDB store first. The dashboard reads that
+store, never the raw files, which is what makes the same code work both
+locally and in the hosted view.
+
+## What ClawMetry does, and does not, do to your agents
+
+**Observation is read-only and always on. Intervention exists, is opt-in, and
+is off by default.** This document used to say ClawMetry "never modifies your
+agents", which stopped being true when Guard shipped. The honest statement is
+narrower and more useful: there are exactly five surfaces through which
+ClawMetry can affect a running agent, and every one of them is listed here.
+
+| Surface | Where | Gate |
+|---|---|---|
+| Approval denial ends a session | `clawmetry/approvals.py`; the pre-tool gates that feed it are `clawmetry/claude_code_gate.py` + `routes/hooks.py` | The user answered "deny", or a rule they wrote did. Only where the runtime exposes a hook, and only once installed |
+| Signals across the session's process tree (pause / stop / kill) | `routes/guard.py` (manual) and `clawmetry/policy_engine.py` (autonomous), both through `clawmetry/guard_actuator.py` → `clawmetry/process_control.py` | Manual: a human clicked, origin-checked. Autonomous: the three locks below |
+| HITL pause | `routes/hitl.py`, a flag file enforced *only* by `clawmetry/proxy.py` | Advisory unless the proxy is actually running, and it says so rather than claiming the agent was held |
+| Enforcement proxy: budget block, loop detection, model routing | `clawmetry/proxy.py` (`localhost:4100`) | Only when you point the runtime's base URL at it |
+| Cron management | `routes/crons.py` via gateway RPC | User-initiated CRUD |
+
+The three locks on autonomous policy, all required:
+
+1. the policy's own action is `pause` / `stop` / `kill` (new policies default
+   to `monitor`, which records what it *would* have done and changes nothing),
+2. `CLAWMETRY_POLICY_ENFORCE=1` on the node (default `0`, so one environment
+   variable disables every policy on the machine),
+3. an entitlement check that fails closed.
+
+Both the manual and the automatic path end in the **same** actuator
+(`clawmetry/guard_actuator.py` → `clawmetry/process_control.py`), so a policy
+pause and a hand-pressed pause are identical to the agent process.
+Whether a given session can be controlled at all is answered in one place,
+`process_control.runtime_control_support(runtime, session_id, cwd)`, because
+the answer varies by operating system, by runtime, and even by session (a
+Cursor CLI session is a real process tree; a Cursor editor conversation shares
+the one IDE process and is not controllable). A control that cannot work says
+why, next to a disabled button.
+
+Reads never require permission. Writes are user-initiated or declared in a
+policy the user wrote, scoped to a single session, reversible where physics
+allows, and attributed in the approvals audit table.
 
 ## Architecture diagrams (C4 model)
 
-Two views of the open-source app. (Mermaid renders on GitHub.) The optional ClawMetry Cloud is shown as a single opaque box: the daemon only ever sends it an end-to-end-encrypted snapshot, which your browser decrypts locally.
+Two views of the open-source app. (Mermaid renders on GitHub.) The optional
+ClawMetry Cloud is shown as a single opaque box: the daemon only ever sends it
+an end-to-end-encrypted snapshot, which your browser decrypts locally.
 
 ### C1: System context
 
@@ -38,16 +95,16 @@ Two views of the open-source app. (Mermaid renders on GitHub.) The optional Claw
 C4Context
 title C1: ClawMetry (open source) system context
 
-Person(dev, "Developer / Operator", "Runs AI agents; wants to see what they do and what they cost")
-System(clawmetry, "ClawMetry", "Local-first, real-time observability for 30 agent runtimes. Reads what your agents already write; never modifies them.")
+Person(dev, "Developer / Operator", "Runs AI agents; wants to see what they do, what they cost, and to stop one that has gone wrong")
+System(clawmetry, "ClawMetry", "Local-first observability and governance for 30 agent runtimes. Reads what your agents already write; acts on them only through the five gated surfaces above.")
 
-System_Ext(runtimes, "AI Agent Runtimes", "OpenClaw + NVIDIA NemoClaw (free in OSS) and, with the optional Pro plugin, Claude Code, Codex, Cursor, Goose, Hermes, Aider, NanoClaw, opencode, PicoClaw, Qwen Code")
+System_Ext(runtimes, "AI Agent Runtimes", "OpenClaw, NVIDIA NemoClaw and Goose are free in OSS; the other 27 (Claude Code, Codex, Cursor, Copilot, Gemini CLI, Hermes, Aider, opencode, ...) come with the optional Pro plugin")
 System_Ext(gateway, "OpenClaw Gateway", "WebSocket control plane (JSON-RPC, :18789) for live data + cron RPC")
 System_Ext(llm, "LLM Provider APIs", "Anthropic / OpenAI / Google / OpenRouter ... (the spend ClawMetry meters)")
 System_Ext(cloud, "ClawMetry Cloud (optional)", "Receives an E2E-encrypted snapshot for remote viewing; decrypted in your browser")
 
 Rel(dev, clawmetry, "Installs (pip), watches the local dashboard :8900")
-Rel(clawmetry, runtimes, "Observes (read-only): session files, gateway, OTLP")
+Rel(clawmetry, runtimes, "Observes: session files, hooks, gateway, OTLP")
 Rel(clawmetry, gateway, "Taps live events + cron RPC", "WebSocket :18789")
 Rel(clawmetry, llm, "Meters cost (interceptor) / optional enforcement proxy")
 Rel(clawmetry, cloud, "Optional: pushes E2E-encrypted snapshot", "HTTPS")
@@ -60,17 +117,18 @@ C4Container
 title C2: ClawMetry (open source) containers
 
 Person(dev, "Developer / Operator", "")
-System_Ext(runtimes, "AI Agent Runtimes", "session files / OTLP")
+System_Ext(runtimes, "AI Agent Runtimes", "session files / hooks / OTLP")
 System_Ext(gateway, "OpenClaw Gateway", "WS :18789")
 System_Ext(llm, "LLM Provider APIs", "")
 System_Ext(cloud, "ClawMetry Cloud (optional)", "E2E snapshot target; browser decrypts")
 
 System_Boundary(machine, "Your machine") {
-    Container(cli, "clawmetry CLI", "Python (cli.py)", "Entry point: clawmetry / connect / sync / status")
-    Container(daemon, "Sync Daemon", "Python (sync.py)", "Ingests filesystem + gateway + OTLP into DuckDB; owns the writer lock; builds the E2E-encrypted snapshot")
+    Container(cli, "clawmetry CLI", "Python (cli.py)", "Entry point: clawmetry / connect / sync / status / license / hook")
+    Container(daemon, "Sync Daemon", "Python (sync.py)", "Ingests filesystem + gateway + OTLP into DuckDB; runs the detectors and Guard policies; owns the writer lock; builds the E2E-encrypted snapshot")
     ContainerDb(duck, "Local Store", "DuckDB (local_store.py)", "Single data layer; capped threads + TTL-cached rollups (light CPU)")
     Container(lqs, "Local Query Server", "Python (local_server.py)", "Localhost /__local_query__/* so the dashboard reads DuckDB without the writer lock")
     Container(dash, "Dashboard", "Flask + waitress :8900", "UI + REST API; per-feature route blueprints; embedded frontend (static/ + templates/)")
+    Container(actuate, "Guard Actuator", "Python (process_control.py)", "Opt-in: pause / stop / kill, POSIX signals or the Windows native equivalents")
     Container(proxy, "Enforcement Proxy", "Python :4100 (proxy.py)", "Optional: budget limits, loop detection, model routing")
     Container(intercept, "Cost Interceptor", "Python (interceptor.py)", "Zero-config httpx/requests patch for LLM token/cost")
     Container(pro, "Pro Adapters", "Optional plugin (clawmetry-pro)", "Closed-source; adds the paid runtime adapters via the clawmetry.extensions entry point")
@@ -79,170 +137,251 @@ System_Boundary(machine, "Your machine") {
 Rel(dev, cli, "runs")
 Rel(cli, daemon, "starts")
 Rel(cli, dash, "starts")
-Rel(runtimes, daemon, "session files / logs", "filesystem")
+Rel(runtimes, daemon, "session files / logs / hooks", "filesystem")
 Rel(gateway, daemon, "live events + crons", "WS :18789")
 Rel(daemon, duck, "writes (writer lock)")
 Rel(pro, daemon, "adds runtime adapters")
 Rel(dash, lqs, "reads", "HTTP localhost")
 Rel(lqs, duck, "reads")
+Rel(daemon, actuate, "policy decision (only with all three locks open)")
+Rel(dash, actuate, "manual Pause / Stop / Kill")
+Rel(actuate, runtimes, "signals one session's process tree")
 Rel(intercept, llm, "observes calls")
 Rel(proxy, llm, "gates / routes calls")
 Rel(daemon, cloud, "E2E snapshot push", "HTTPS")
 ```
 
-## Claude Code as a Second Data Source
-
-ClawMetry supports **Claude Code** (`~/.claude/projects/`) as a data source through the main dashboard's runtime scope — pick `claude_code` in the runtime switcher and the same `/api/sessions`, `/api/transcripts`, etc. render its data. Claude Code stores session transcripts as JSONL files with a similar schema to OpenClaw sessions.
-
-```
-~/.claude/
-├── projects/
-│   ├── -Users-you-Developer-myproject/   # Per-project directories
-│   │   ├── <session-uuid>.jsonl          # Session transcripts
-│   │   └── memory/MEMORY.md              # Project memory
-│   └── ...more projects
-└── settings.json
-```
-
-Key differences from the OpenClaw data source:
-| Aspect | OpenClaw | Claude Code |
-|--------|----------|-------------|
-| Session dir | `~/.openclaw/agents/main/sessions/` | `~/.claude/projects/<slug>/` |
-| Real-time | WebSocket JSON-RPC | Filesystem polling (10s) |
-| Tool names | OpenClaw tools | `Bash`, `Read`, `Write`, `Glob`, etc. |
-| Pricing | Gateway-managed | Estimated from model pricing table |
-
 ## How ClawMetry Gets Its Data
 
-ClawMetry has **three data sources**, all local to your machine:
+Five ingest paths, all local to your machine, all landing in the same DuckDB
+store. Nothing reads a raw file inside an HTTP handler; see "The data-flow
+rule" below for why that matters.
 
-### 1. Filesystem Reading (Primary)
+### 1. Filesystem reading (primary)
 
-OpenClaw stores everything as files. ClawMetry reads them directly:
+Agent runtimes store their work as files, and ClawMetry reads them directly.
+For OpenClaw:
 
 | What | Where | Format |
 |------|-------|--------|
-| Session transcripts | `~/.openclaw/agents/main/sessions/*.jsonl` | JSON Lines — one event per line |
-| Gateway config | `~/.openclaw/openclaw.json` | JSON — model, channels, auth |
-| Gateway logs | `/tmp/moltbot/moltbot-YYYY-MM-DD.log` | Structured JSON logs |
-| Memory files | `{workspace}/memory/*.md` | Markdown — agent's daily notes |
-| Cron state | Internal gateway state | Via WebSocket RPC |
+| Session transcripts | `~/.openclaw/agents/main/sessions/*.jsonl` | JSON Lines, one event per line |
+| Chat-channel transcripts | `~/.openclaw/<channel>/*.jsonl` | One directory per adapter, 23 of them |
+| Gateway config | `~/.openclaw/openclaw.json` | JSON: model, channels, auth |
+| Gateway logs | `~/.openclaw/logs/` (older installs and Docker: `/tmp/openclaw`, `/tmp/moltbot`) | Structured JSON logs |
+| Memory files | `{workspace}/memory/*.md` | Markdown, the agent's notes |
 
-**Session transcripts** are the richest data source. Each `.jsonl` file contains every message, tool call, tool result, thinking block, and token count for a session. ClawMetry parses these to build timelines, calculate costs, and show what each agent decided.
+Every other runtime has its own layout, read by its own adapter: Claude Code
+under `~/.claude/projects/<slug>/*.jsonl`, Codex, Cursor, Goose, and the rest.
+The daemon loads them from the hardcoded `sync._FAMILY_ADAPTER_SPECS` tuple,
+which is the list of adapters that actually get loaded (there is no dynamic
+discovery). Free adapters live in `clawmetry/adapters/`; the paid ones arrive
+with the `clawmetry-pro` plugin over the `clawmetry.extensions` entry point.
 
-### 2. Gateway WebSocket (Real-time)
+**Session transcripts are the richest source.** Each file carries every
+message, tool call, tool result, thinking block and token count for a session,
+which is what timelines, costs and detectors are built from.
 
-ClawMetry connects to the OpenClaw gateway via WebSocket (`ws://localhost:18789`) using JSON-RPC:
+Family runtimes are polled on a 60s cycle
+(`CLAWMETRY_FAMILY_SESSION_LIMIT` bounds how many sessions per runtime are
+ingested), the main daemon loop runs every 15s, and the snapshot is rebuilt
+every 60s.
 
-- **Session list** — which sessions are active right now
-- **Cron jobs** — scheduled tasks, their status, run history
-- **Gateway config** — model settings, channel config
-- **Tool invocations** — ClawMetry can invoke gateway tools (e.g., restart crons)
+### 2. Gateway WebSocket (real-time)
 
-This is how the dashboard updates in real-time without polling.
+For OpenClaw, ClawMetry connects to the gateway over WebSocket
+(`ws://localhost:18789`) using JSON-RPC, for the session list, cron jobs and
+config, and for cron CRUD. This is how live data arrives without polling the
+filesystem harder.
 
-### 3. OpenTelemetry Receiver (Optional)
+### 3. OpenTelemetry receiver (optional)
 
-ClawMetry can receive OTLP metrics and traces on:
-- `POST /v1/metrics` — Prometheus-style metrics in protobuf
-- `POST /v1/traces` — Distributed traces in protobuf
+`POST /v1/metrics`, `POST /v1/traces` and `POST /v1/logs` accept OTLP, so any
+runtime or custom instrumentation that speaks OTel can feed ClawMetry.
+Claude Code's native OTel output lands here. The receiver binds `127.0.0.1` by
+default (`CLAWMETRY_OTLP_HOST`).
 
-This allows external tools or custom instrumentation to feed data into ClawMetry.
+### 4. Runtime hooks (optional, and the only pre-tool path)
+
+Where a runtime exposes a hook, `clawmetry hook <runtime>` installs one. Hooks
+are how ClawMetry sees a tool call *before* it runs, which is what makes
+approvals and pre-tool gates possible at all. Hook installation never deletes
+a hook it did not write (`clawmetry/hook_ownership.py`); see
+[`docs/HOOK_COEXISTENCE.md`](docs/HOOK_COEXISTENCE.md).
+
+### 5. HTTP ingest (bring your own agent)
+
+`routes/runtime_ingest.py` accepts runs from a runtime ClawMetry has no
+adapter for, over `POST /api/v1/runs/*`. See
+[`docs/CUSTOM_RUNTIME_INGEST.md`](docs/CUSTOM_RUNTIME_INGEST.md).
+
+## The Local Store
+
+`clawmetry/local_store.py` is the single data layer, a DuckDB file at
+`~/.clawmetry/clawmetry.duckdb` (schema version 15, ~68 tables). `events` is
+the spine; the rest are rollups (`rollup_session`, `rollup_runtime_daily`,
+`rollup_model_daily`, `daily_aggregates`) and per-feature tables (`sessions`,
+`spans`, `approvals`, `crons`, `loop_signals`, `policy_actions`,
+`signal_turns`, `git_commits`, ...).
+
+### One writer, many readers
+
+DuckDB takes an exclusive file lock, so a second process cannot open the file
+even read-only. The daemon owns that lock, and hosts an HTTP query server
+inside its own process to serve everyone else:
+
+1. On start the daemon binds `127.0.0.1` on an ephemeral port, mints a 32-hex
+   token, and writes `{"port", "token", "pid"}` to `~/.clawmetry/local_query.json`
+   (mode 0600).
+2. The dashboard's `/api/local/*` routes read that file and call
+   `http://127.0.0.1:<port>/local/query` with a bearer token.
+3. If the daemon is down, the dashboard opens DuckDB directly, which works in
+   single-process mode.
+
+The set of methods reachable this way is a declared contract
+(`clawmetry/query_contract.py`, rendered to
+[`docs/QUERY_CONTRACT.md`](docs/QUERY_CONTRACT.md)), and `make lint-daemon-allowlist`
+fails when a route calls a method the daemon does not serve.
+
+### Durability contract
+
+**Ring buffer → flush → WAL**:
+
+1. `LocalStore.ingest(event)` appends to an in-memory `deque` (10,000 slots).
+2. At `FLUSH_BATCH` entries (1,000) or on the 2s flusher tick,
+   `_flush_now_locked()` writes the batch inside an explicit `BEGIN / COMMIT`.
+3. DuckDB commits to its WAL synchronously, so a `SIGKILL` straight after
+   `COMMIT` loses nothing.
+
+**Crash and replay**: events still in the ring at crash time are lost from
+DuckDB's perspective, but the source (the runtime's own JSONL) is never
+mutated, so the daemon re-reads from the beginning on restart.
+`INSERT OR IGNORE` on the `events.id` primary key makes every re-ingest
+idempotent. Final count is always exactly N.
+
+**Invariant asserted in CI**: `tests/test_moat_daemon_crash_recovery.py`,
+SIGKILL mid-burst plus a full source replay, then
+`COUNT(*) = COUNT(DISTINCT id) = N`.
+
+### The data-flow rule
+
+Every feature persists to and reads from DuckDB. Reading raw JSONL, log files
+or process stats *inside a request handler* is a violation: it works on your
+laptop and returns empty in the hosted view, because that container has no
+`~/.openclaw`. Most "works locally, broken in cloud" bugs are exactly this.
+
+OSS routes that serve event-derived data tag their JSON with
+`_source: "local_store"` to prove which path they used. `routes/__init__.py`
+provides `@event_data` (marks an endpoint for the canary) and
+`@source_exempt(reason=...)` (documents a deliberate exception such as a
+gateway pass-through). `tests/test_oss_routes_source_canary.py` walks Flask's
+URL map and fails when an event-data response omits the tag or reports
+anything else.
 
 ## Auto-Detection — Zero Config
 
-When you run `clawmetry`, it automatically finds everything:
+When you run `clawmetry`, it finds everything itself:
 
-1. **Workspace** — Checks `OPENCLAW_HOME`, then `~/.openclaw`, then common paths
-2. **Gateway port** — Reads `openclaw.json` for the bind port (default 18789)
-3. **Gateway token** — Reads auth token from config for API access
-4. **Log directory** — Checks `/tmp/moltbot/` for gateway logs
-5. **Sessions directory** — Finds `~/.openclaw/agents/main/sessions/`
+1. **Runtimes** — probes every known store root (`clawmetry/runtime_probe.py`)
+2. **Workspace** — `OPENCLAW_HOME`, then `~/.openclaw`, then common paths
+3. **Gateway port** — read from `openclaw.json` (default 18789)
+4. **Gateway token** — read from the same config
+5. **Log directory** — `~/.openclaw/logs`, falling back to the legacy `/tmp` paths
+6. **Sessions directory** — `~/.openclaw/agents/main/sessions/`
 
-No environment variables, no config files, no database setup. If OpenClaw is running, ClawMetry finds it.
+No environment variables, no config file, no database setup.
 
 ## The Dashboard — What You See
 
-ClawMetry serves a single-page web app (frontend in `clawmetry/static/` + `clawmetry/templates/`) with these views:
+A single-page app served from `clawmetry/static/` and
+`clawmetry/templates/tabs/*.html`, with a runtime switcher in the header that
+re-scopes every tab to one runtime. The main views:
 
-### Overview (`/api/overview`)
-The main dashboard. Aggregates:
-- **Active sessions** — main + sub-agents, their status, last activity
-- **Token usage** — input/output/cache tokens, cost estimates per session
-- **Cron status** — running jobs, failures, next run times
-- **System health** — disk, memory, uptime, gateway version
+| View | Endpoint | What it answers |
+|---|---|---|
+| Overview | `/api/overview` | Is anything running, what did today cost, what needs me |
+| Sessions & transcripts | `/api/sessions`, `/api/transcript/<id>` | What did this agent actually do, turn by turn |
+| Sub-agents | `/api/subagents` | What did it spawn, and what did that cost |
+| Flow | `/api/flow` | Channels → gateway → models → tools, live |
+| Brain | `/api/brain-history`, `/api/brain-stream` (SSE) | The reasoning and tool-call stream as it happens |
+| Cost & usage | `/api/usage`, `/api/usage/outcomes` | Spend by runtime, model, session, day; cost per merged change |
+| Guard | `/api/guard/sessions`, `/api/guard/policies` | What has gone off track, and the stop button |
+| Signals | `/api/signals` | Frustration, refusal, retry and other judge-free rates |
+| Trail | `/api/replay-tree/<id>`, `/api/trail/coverage` | One session's typed event trail, and what each runtime can expose |
+| Crons | `/api/crons` | Scheduled jobs, history, CRUD |
+| Health | `/api/system-health` | Disk, memory, uptime, rate limits, GPU |
+| Fleet | `/api/nodes` | Every node, one table |
 
-### Flow Visualization
-An interactive graph showing how data flows through your system:
+The full endpoint surface is generated at `/openapi.json` and browsable at
+`/api/docs`. The full module and blueprint inventory is
+[`docs/MODULE_MAP.md`](docs/MODULE_MAP.md).
+
+## Guard: detectors, policies, and money
+
+Guard is the governance half of the product, and it is deliberately
+judge-free: no LLM decides whether your agent is stuck.
+
+**Detectors** run over the tool stream on the daemon tick, in two families:
+
+* **Trajectory** (is it stuck?) — `stuck_loop`, `no_progress`,
+  `repeated_tool_failure`, `action_discrepancy`, in `clawmetry/detectors.py`.
+* **Behavioural** (is it doing something it does not normally do?) —
+  `file_blast_radius`, `credential_access`, `network_egress`,
+  `privilege_change`, in `clawmetry/detector_behaviour.py`.
+
+**Thresholds are resolved, not hard-coded.** `detectors.resolve_thresholds()`
+layers four sources, each overriding the last: module defaults → the runtime
+profile → the cohort's learned baseline from `guard_session_stats` /
+`guard_egress_hosts` → a per-runtime environment override
+(`CLAWMETRY_NOPROG_TOOLS__CODEX=40`). Every incident carries a
+`threshold_source` so a reader can tell a measured threshold from a shipped
+constant, and learned values are clamped to a band around the default: a
+cohort where everything loops cannot teach Guard to go blind, and three
+sessions cannot make it scream.
+
+**Severity maps to money, or says it does not know.** An incident carries
+`spend_at_risk_usd` (the cost of the flagged stretch, not the session bill)
+plus the `spend_basis` that produced it. Where no cost can be derived the
+field is `0.0` with basis `unknown`, never an invented figure, because sorting
+a list of incidents by a made-up dollar number is worse than sorting by
+severity.
+
+**Policies** turn an incident into an action, evaluated by
+`clawmetry/policy_engine.py` under the three locks described at the top. A
+policy may carry an escalation ladder (`steps`: `[{action, after_secs}, ...]`)
+so the response can be *pause now, kill in five minutes if still stuck*. Rung
+0 fires on the match; rung *n* becomes due `after_secs` after rung *n-1*
+actually fired, and only if the session is still matching that tick. The
+durable latch on `(session_id, policy_id, step_index)` means each rung fires at
+most once per session, even across a daemon restart.
+
+## Behaviour Signals
+
+Six preset, judge-free signals over every transcript in the store:
+`user_frustration`, `user_praise`, `assistant_refusal`, `assistant_laziness`,
+`task_failure`, `user_retry` (`clawmetry/behaviour_signals.py`). Precompiled
+word-boundary matchers with negation and positive-context guards run on the
+daemon tick over new turns and persist to `signal_turns` / `signal_matches`.
+The matched text is never stored. `/api/signals` reports rates per window with
+per-runtime coverage, and a runtime that cannot expose the needed text says so
+rather than reporting a flattering zero.
+
+## Budget & Alerts
+
 ```
-Channels (Telegram, etc.) → Gateway → Models (Claude, etc.) → Tools → Nodes
-```
-Each node shows real-time metrics (messages, tokens, calls).
-
-### Session Timeline (`/api/timeline`)
-A chronological view of every action in a session:
-- User messages, assistant responses
-- Tool calls with arguments and results
-- Thinking blocks (when reasoning is enabled)
-- Token counts per turn
-
-### Transcripts (`/api/transcript/<id>`)
-Full conversation history for any session. Supports:
-- **Main sessions** — direct user conversations
-- **Sub-agent sessions** — background tasks
-- **Event filtering** — show only tool calls, only messages, etc.
-
-### Sub-Agent Tracker (`/api/subagents`)
-Real-time view of all spawned sub-agents:
-- What task they were given
-- Their current status (running, completed, failed)
-- Token consumption and runtime
-- Link to full transcript
-
-### Cost & Usage (`/api/usage`)
-Token and cost analytics:
-- **Per-model breakdown** — which models consume the most
-- **Per-session costs** — find expensive sessions
-- **Time series** — cost trends over hours/days
-- **Export** — CSV download for billing
-
-### Cron Manager (`/api/crons`)
-Full cron job management:
-- View all scheduled jobs with next run time
-- See run history and errors
-- Toggle enable/disable
-- Trigger manual runs
-- Create and edit jobs
-
-### System Health (`/api/system-health`)
-Infrastructure monitoring:
-- Disk usage (warns at 85%+)
-- Memory consumption
-- Gateway uptime and version
-- Service port checks
-- GPU status (if available)
-
-## Budget & Alerts System
-
-ClawMetry includes a built-in budget monitor:
-
-```
-Budget Config → Monitor Loop (every 60s) → Check Spend
-                                              │
-                              ┌────────────────┼────────────────┐
-                              ▼                ▼                ▼
-                        Under budget     Warning (80%)    Over budget
-                          (no-op)        Send alert       Pause gateway
+Budget config → daemon tick → check spend
+                                  │
+                  ┌───────────────┼───────────────┐
+                  ▼               ▼               ▼
+            Under budget    Warning (80%)    Over budget
+              (no-op)        Send alert      Alert + optional
+                                             enforcement action
 ```
 
-- **Daily/monthly budgets** with configurable limits
-- **Alert channels**: Telegram, webhooks, email
-- **Auto-pause**: Can automatically pause the gateway when budget exceeded
-- **Custom alert rules**: Token spikes, error rates, session duration
+Daily and monthly budgets, alert channels (Slack, Discord, PagerDuty,
+Telegram, email, webhooks), and custom rules including `signal_rate_above`,
+which fires on a behaviour signal's rate over a window with a minimum sample.
 
-## Multi-Node Fleet Mode
-
-For users running multiple OpenClaw instances:
+## Multi-Node Fleet
 
 ```
 ┌──────────┐    ┌──────────┐    ┌──────────┐
@@ -255,107 +394,142 @@ For users running multiple OpenClaw instances:
             ┌────────────────┐
             │   ClawMetry    │
             │  Fleet View    │
-            │  (central)     │
             └────────────────┘
 ```
 
-Nodes register via `POST /api/nodes/register` and send periodic metrics. The fleet view shows all nodes, their health, sessions, and aggregated costs.
+Nodes register via `POST /api/nodes/register` and send periodic metrics.
+Secured with `CLAWMETRY_FLEET_KEY`.
 
-Secured with `CLAWMETRY_FLEET_KEY` — nodes must provide the API key to register.
+## Optional Cloud Sync
+
+`clawmetry connect` opts a node into the hosted view. The daemon builds a
+snapshot from its own store handle and encrypts it with AES-256-GCM before it
+leaves the machine; the key never does, so the browser decrypts client-side and
+the server holds ciphertext. Session and content-bearing payloads are always
+sealed; a small set of aggregate counters rides the heartbeat in plaintext,
+and which is which is declared per method in `clawmetry/query_contract.py`.
+
+Nothing about this is on by default. Without `clawmetry connect` the only
+outbound traffic is one install ping and the PyPI version check;
+`CLAWMETRY_OFFLINE=1` removes even those. The complete destination list, what
+each carries, and how to verify it on the wire is
+[`docs/EGRESS.md`](docs/EGRESS.md).
 
 ## Technical Details
 
-### Modular Blueprint Architecture
-ClawMetry is a Flask app organised as a small core (`dashboard.py`, ~19,000 lines) plus a `routes/` package of feature-scoped Blueprints (sessions, channels, components, usage, health, brain, infra, overview, crons, meta, alerts, fleet_history, nemoclaw). Shared helpers live in `dashboard.py`; the live UI is served from `clawmetry/static/` + `clawmetry/templates/`. Route handlers reach shared helpers via a late `import dashboard as _d`.
+### Modular blueprint architecture
 
-This layout keeps the install story simple while letting each feature evolve in its own module:
+A Flask app organised as a core (`dashboard.py`) plus a `routes/` package of
+feature-scoped blueprints, with helpers migrating into `helpers/`. Route
+handlers reach the helpers still living in `dashboard.py` through a late
+`import dashboard as _d`, which avoids a circular import.
+
+New endpoints go in `routes/<feature>.py`, never in `dashboard.py`. That rule
+replaced an older "keep it in one file" convention, which became
+counterproductive somewhere north of 30,000 lines: illegible to humans, and a
+guaranteed merge conflict for every parallel PR.
+
+The complete list of modules, their blueprints and the URL space each owns is
+generated into [`docs/MODULE_MAP.md`](docs/MODULE_MAP.md) by
+`scripts/gen_module_map.py`; CI fails when it drifts from the source tree.
+
+This layout keeps the install story simple while letting each feature evolve
+on its own:
+
 - Easy to install (`pip install clawmetry`)
-- Easy to audit (one Blueprint per feature, see `CLAUDE.md` for the full table)
-- Easy to deploy (pure-Python, no build step)
+- Easy to audit (one blueprint per feature)
+- Easy to deploy (pure Python, no build step)
 - Portable (runs on a Raspberry Pi)
 
-The HTML/CSS/JS dashboard is served from `clawmetry/static/css/dashboard.css`, `clawmetry/static/js/app.js`, and `clawmetry/templates/tabs/*.html` — not embedded inline in `dashboard.py`.
-
-### Event Data Source Contract
-OSS API routes that serve event-derived dashboard data must tag their JSON
-response with `_source: "local_store"`. This proves the endpoint used the
-local DuckDB store instead of silently falling back to gateway, JSONL, OTLP, or
-cloud-only paths.
-
-`routes/__init__.py` provides two route markers for this contract:
-- `@event_data` marks new event-derived endpoints for the source canary.
-- `@source_exempt(reason="...")` documents intentional exceptions such as
-  gateway pass-throughs or OTLP receivers.
-
-`tests/test_oss_routes_source_canary.py` walks Flask's registered URL map,
-builds canary URLs from endpoint names, and fails with guidance when an
-event-data response omits `_source` or reports anything other than
-`local_store`.
+The UI is served from `clawmetry/static/css/dashboard.css`,
+`clawmetry/static/js/app.js` and `clawmetry/templates/tabs/*.html`.
+`dashboard.py` defines `DASHBOARD_HTML` twice and the **second** definition
+wins; the inline copy earlier in the file is dead code.
 
 ### Entitlements & open-core
-ClawMetry is open-core. `clawmetry/entitlements.py` is the single source of truth for what an install is allowed to do; `clawmetry/license.py` verifies self-hosted license keys offline with Ed25519 (using the `cryptography` dep, no new packages); `routes/entitlement.py` exposes the resolved entitlement plus the preview/diff family at `/api/entitlement*`. The resolver currently runs in GRACE mode (every `allows_*` check answers "allowed" regardless of tier), so wiring the gate in changes no behaviour today. See [`docs/ENTITLEMENTS.md`](docs/ENTITLEMENTS.md) for the FREE vs paid split, per-tier feature/capacity matrix, resolution order, and the `clawmetry license` CLI.
+
+ClawMetry is open-core. `clawmetry/entitlements.py` is the single source of
+truth for what an install may do, and for the runtime and channel catalogues
+that every count in this repo is derived from. `clawmetry/license.py` verifies
+self-hosted license keys offline with Ed25519, using the `cryptography`
+dependency rather than a new one. `routes/entitlement.py` exposes the resolved
+entitlement at `/api/entitlement*`.
+
+The resolver runs in **GRACE** mode until the announced enforce date: every
+`allows_*` check answers "allowed" regardless of tier, so wiring the gate into
+a new feature changes no behaviour today. Set `CLAWMETRY_ENFORCE=1` to turn it
+on. Entitlement failures fail *open*: a licence lookup that errors leaves the
+agent running, because a billing bug must never stop a customer's work. Policy
+failures fail *closed*. See [`docs/ENTITLEMENTS.md`](docs/ENTITLEMENTS.md).
 
 ### Dependencies
-Minimal by design:
-- **Flask** — Web server
-- **DuckDB** — local store; the sync daemon ingests all events and owns the writer lock; the dashboard reads through the daemon proxy (`/__local_query__/`)
-- **Optional**: `opentelemetry-proto` for OTLP support
-- **Optional**: `history.py` for time-series storage (SQLite-based)
 
-### History Module (`history.py`)
-An optional companion that adds persistent time-series:
-- Stores snapshots every 60 seconds in SQLite
-- Enables historical charts (token usage over days/weeks)
-- Session history with cost trends
-- Cron execution history
+Minimal by design; `setup.py` is the source of truth.
 
-### LocalStore Durability Contract
-
-`clawmetry/local_store.py` provides the write-side durability guarantee for the sync daemon.
-
-**Ring-buffer → flush → WAL model**:
-1. `LocalStore.ingest(event)` appends the event to an in-memory `deque` (ring buffer, max 10 000 slots).
-2. When the ring reaches `FLUSH_BATCH` entries (default 1 000) **or** the background flusher timer fires (every 2 s), `_flush_now_locked()` writes the batch to DuckDB inside an explicit `BEGIN / COMMIT` transaction.
-3. DuckDB writes the commit to its WAL synchronously before returning. The data is durable: even a `SIGKILL` immediately after `COMMIT` will not lose the row.
-
-**Crash and replay**:
-- Events **in the ring buffer at crash time** (not yet flushed) are lost from DuckDB's perspective.
-- The daemon source (JSONL transcripts) is never mutated — on restart the daemon re-reads from the beginning and re-ingests all events.
-- `INSERT OR IGNORE` on `events.id` (the PRIMARY KEY) makes every re-ingest idempotent: already-committed rows are silently skipped, missing rows are inserted. Final count is always exactly N.
-
-**Invariant asserted in CI**: `tests/test_moat_daemon_crash_recovery.py` — SIGKILL mid-burst + full source replay → `COUNT(*) = COUNT(DISTINCT id) = N`.
+- **flask**, **waitress** — HTTP server
+- **duckdb** — the local store
+- **cryptography** (with a per-interpreter **cffi** pin) — AES-256-GCM for the snapshot envelope
+- **websocket-client** — the cloud relay tunnel
+- **truststore** (3.10+) and **certifi** — so corporate TLS interception works
+- **Optional**: `clawmetry[otel]` for OTLP, `clawmetry[deepeval]` for the eval bridge
+- **Optional**: `history.py`, a separate SQLite time-series (snapshots every 60s for long-range charts)
 
 ### Performance
-- **Memory**: ~30-80MB typical
-- **CPU**: Negligible (event-driven, no polling loops except health)
-- **Disk**: Zero (reads existing files, history.db is optional)
-- **Startup**: <2 seconds
+
+ClawMetry runs on your machine all day, so it is budgeted like a sidecar, not
+a warehouse.
+
+- **CPU**: the daemon idles near zero and is held to roughly 5-10% of one core.
+  DuckDB connections pass an explicit thread cap (default 2) and a memory
+  ceiling derived from the store size, because DuckDB otherwise defaults to
+  every core on the box. Hot rollups are result-cached with a short TTL
+  (`CLAWMETRY_AGG_CACHE_TTL`, default 20s) so handlers never run a full-table
+  scan per request.
+- **Memory**: tens of MB for the dashboard; the daemon's footprint follows the
+  DuckDB buffer pool.
+- **Disk**: the store grows with your history. It is compacted, and
+  `docs/EVENT_RETENTION.md` covers trimming it.
+- **Startup**: under 2 seconds.
 
 ### Security
-- **Gateway token auth** — Dashboard requires the gateway token to access sensitive APIs
-- **Local-only by default** — Binds to `0.0.0.0:8900` but designed for LAN use
-- **Read-only** — Cannot modify agent behavior (except cron management via gateway RPC)
-- **No external calls** — Your data never leaves your machine
+
+- **Loopback by default** — the dashboard binds `127.0.0.1:8900`; `--host` is
+  how you widen that, deliberately.
+- **Token auth** — sensitive APIs require the gateway token; the daemon's
+  localhost query server requires a per-boot bearer token and a 0600 port file.
+- **Observation is read-only; intervention is opt-in** — the five surfaces at
+  the top of this document are the complete list, and adding a sixth means
+  adding it there with locks of the same strength.
+- **A user's repository is read, never written** — `clawmetry/git_outcomes.py`
+  is the only place ClawMetry runs `git` against a directory you chose, and
+  every invocation goes through one chokepoint that rejects anything outside an
+  allowlist of read-only plumbing subcommands.
+- **Egress is documented and verifiable** — see [`docs/EGRESS.md`](docs/EGRESS.md).
+  No ClawMetry deployment loads a CDN, font, analytics script or error tracker.
 
 ## Data Flow Example
 
-Here's what happens when you open ClawMetry and look at a running sub-agent:
+What happens when you open the dashboard and look at a running sub-agent:
 
-1. **Browser** requests `/api/subagents`
-2. **ClawMetry** reads `~/.openclaw/agents/main/sessions/sessions.json` (session index)
-3. **ClawMetry** identifies sub-agent sessions, reads each `.jsonl` transcript
-4. For each session, it parses events to extract:
-   - Task description (from the spawn message)
-   - Current status (running if no completion event)
-   - Token counts (summed from all assistant turns)
-   - Tools used (from tool_use events)
-   - Runtime (first event timestamp to last)
-5. **ClawMetry** also queries the gateway via WebSocket for live session state
-6. **Response** sent to browser as JSON
-7. **Browser** renders the sub-agent cards with live-updating metrics
+1. **The daemon**, on its 15s tick, reads new lines from each runtime's session
+   files and any gateway or OTLP events, normalises them, and ingests them into
+   the DuckDB ring buffer.
+2. **The ring flushes** to DuckDB within 2 seconds (or immediately at 1,000
+   events), inside one transaction. Rollups and detector passes run on the same
+   tick.
+3. **Your browser** requests `/api/subagents`.
+4. **The dashboard** calls the daemon's localhost query server, which runs the
+   query against the store the daemon already has open. No file in
+   `~/.openclaw` is touched by the handler.
+5. **The response** carries `_source: "local_store"`, which is what the source
+   canary in CI asserts.
+6. **The browser** renders the sub-agent cards.
 
-All of this happens in <100ms for typical setups.
+The same handler serves the hosted view, where step 4 reads a decrypted
+snapshot slice instead of a local store. That is the whole reason the rule in
+step 4 exists.
 
 ---
 
-*ClawMetry is open source under MIT License. See [github.com/vivekchand/clawmetry](https://github.com/vivekchand/clawmetry)*
+*ClawMetry is open source under the MIT License. See
+[github.com/vivekchand/clawmetry](https://github.com/vivekchand/clawmetry)*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,104 +3,153 @@
 > **Read [`FLYWHEEL.md`](./FLYWHEEL.md) first.** It is how you ship a change end to end here (code → PR → green CI → `[RELEASE]` → PyPI → cloud → verified live) and the non-negotiable "done" bar. This file is the architecture reference; FLYWHEEL.md is the shipping loop.
 
 ## What is this?
-ClawMetry is an open-source, real-time observability dashboard for [OpenClaw](https://github.com/openclaw/openclaw) AI agents. `pip install clawmetry && clawmetry` — that's it. Zero config, observation by default.
+ClawMetry is an open-source, real-time observability and governance layer for **30 AI agent runtimes** — [OpenClaw](https://github.com/openclaw/openclaw), NVIDIA NemoClaw and Goose free in OSS, the other 27 (Claude Code, Codex, Cursor, Copilot, Gemini CLI, Hermes, Aider, opencode, ...) with the optional Pro plugin. `pip install clawmetry && clawmetry` — that's it. Zero config, observation by default.
+
+**Never hardcode the runtime count or the runtime list anywhere new.** The authoritative sources are `entitlements.FREE_RUNTIMES | entitlements.PAID_RUNTIMES` (the catalogue, and what every quoted number is derived from) and `sync._FAMILY_ADAPTER_SPECS` (what the daemon actually loads — a `clawmetry-pro` adapter is inert until it is named there). `scripts/sync_runtime_count.py` rewrites the number in prose and CI fails on drift; the same script checks the chat-channel count against `entitlements.ALL_CHANNELS`.
 
 ## Architecture
-See `ARCHITECTURE.md` for the full deep dive. TL;DR:
+See `ARCHITECTURE.md` for the full deep dive, and `docs/MODULE_MAP.md` (generated) for every module and blueprint. TL;DR:
 - **Flask app** with embedded HTML/CSS/JS frontend (no build step, no npm)
-- **Per-feature route modules** under `routes/` — `routes/sessions.py`, `routes/usage.py`, etc. — each owns one Blueprint and the endpoints registered on it. New endpoints land in their feature's module so parallel PRs don't stomp on each other.
-- **Shared helpers** stay in `dashboard.py` for now and are accessed from route modules via late `import dashboard as _d`. (Helpers will migrate to `helpers/` over time.)
-- **Zero config** — auto-detects OpenClaw workspace, gateway, sessions, logs
+- **Per-feature route modules** under `routes/` — `routes/sessions.py`, `routes/usage.py`, etc. — each owns one or more Blueprints and the endpoints registered on them. New endpoints land in their feature's module so parallel PRs don't stomp on each other.
+- **Shared helpers** are migrating out of `dashboard.py` into `helpers/`; route modules reach the ones still in `dashboard.py` via late `import dashboard as _d`.
+- **Zero config** — auto-detects runtimes, OpenClaw workspace, gateway, sessions, logs
 - **Observation by default, control when asked** — see "Control plane" below. Reads never require permission; writes are always user-initiated or policy-declared
 - **DuckDB-first** — the sync daemon ingests filesystem/gateway/OTLP into a local **DuckDB** store (`clawmetry/local_store.py`; the daemon owns the writer lock). Request handlers read from DuckDB via `routes/local_query.py`, **not** raw files — reading raw JSONL/logs inside a handler works locally but returns empty in cloud (the container has no `~/.openclaw`). Optional `history.py` adds a separate SQLite time-series.
-- **Three ingest sources** (all land in DuckDB): filesystem (JSONL/logs), gateway WebSocket (JSON-RPC), optional OTLP receiver
+- **Five ingest paths** (all land in DuckDB): filesystem (JSONL/logs), gateway WebSocket (JSON-RPC), optional OTLP receiver (`/v1/metrics`, `/v1/traces`, `/v1/logs`), runtime hooks (`clawmetry hook <runtime>`, the only pre-tool path), and the HTTP ingest API (`/api/v1/runs/*`) for a runtime with no adapter
 
 ## Key Files
 
+`docs/MODULE_MAP.md` is the **generated** inventory: every module, the blueprints it defines, the URL space it owns, and a coarse size band. `scripts/gen_module_map.py` regenerates it and CI fails when it drifts. The tables below are a short curated index of what you reach for most often, deliberately without line counts (they went stale within weeks every time they were written down).
+
+**Five files are big enough to change how you work on them**: `routes/entitlement.py` (~48k lines), `clawmetry/entitlements.py` (~31k), `clawmetry/sync.py` (~26k), `dashboard.py` (~21k), `clawmetry/local_store.py` (~20k). Drift Bot reads only the head of a long file, so anything added deep inside one is reported as "not implemented" forever. Put new capability in a new short module and re-export it, rather than appending 300 lines to a 20k-line file.
+
 ### Core
-| File | Lines | Purpose |
-|------|-------|---------|
-| `dashboard.py` | ~17,300 | Flask app, blueprint registration, shared helpers (live frontend now lives in `static/` + `templates/`) |
-| `history.py` | ~555 | Optional time-series collector (SQLite, polls gateway every 60s) |
+| File | Purpose |
+|------|---------|
+| `dashboard.py` | Flask app, blueprint registration, `before_request` auth, the shared helpers that have not moved yet (the live frontend lives in `clawmetry/static/` + `clawmetry/templates/`) |
+| `helpers/gateway.py` | OpenClaw gateway WebSocket RPC + HTTP invoke client |
+| `helpers/logs.py` | Log directory discovery, tail and grep |
+| `helpers/openapi.py` | `bp_openapi` — the OpenAPI 3.1 spec generated from the Flask URL map, served at `/openapi.json` and `/api/docs` |
+| `history.py` | Optional time-series collector (SQLite, polls gateway every 60s) |
 
 ### Route modules (`routes/`)
-All HTTP endpoints live here, organised by feature. Each module owns one or more Flask Blueprints; handlers do late `import dashboard as _d` to reach shared helpers still in `dashboard.py`.
+All HTTP endpoints live here, organised by feature: 70 modules, 82 blueprints, listed in full in `docs/MODULE_MAP.md`. Handlers do late `import dashboard as _d` to reach shared helpers still in `dashboard.py`.
 
-| File | Lines | Blueprints / Purpose |
-|------|-------|----------------------|
-| `routes/sessions.py` | ~7,300 | `bp_sessions` — sessions list, transcripts, compactions, tool timeline, cost split, subagents, exports |
-| `routes/channels.py` | ~2,800 | `bp_channels` — 21 chat-channel adapters (Telegram, Signal, WhatsApp, Discord, Slack, IRC, iMessage, WebChat, …) |
-| `routes/components.py` | ~2,100 | `bp_components` — Flow-panel detail endpoints (tool / runtime / machine / gateway / brain) |
-| `routes/usage.py` | ~4,500 | `bp_usage` — token/cost analytics, anomaly detection, model + skill attribution |
-| `routes/health.py` | ~3,500 | `bp_health` — system-health, reliability, diagnostics, rate-limits, sandbox-status, health-stream (SSE) |
-| `routes/brain.py` | ~1,900 | `bp_brain` — `/api/brain-history` + `/api/brain-stream` (SSE) |
-| `routes/local_query.py` | ~850 | `bp_local_query` — `/api/local/*` DuckDB read API + the daemon-proxy `_dispatch` (shape→store bridge shared by HTTP and the cloud relay) |
-| `routes/infra.py` | ~2,400 | `bp_logs` + `bp_memory` + `bp_security` + `bp_config` — logs stream, memory files, security posture, cost-optimizer |
-| `routes/overview.py` | ~1,900 | `bp_overview` — main dashboard endpoint, channels list, timeline, cloud-CTA OTP |
-| `routes/crons.py` | ~1,500 | `bp_crons` — cron CRUD + run log + health summary |
-| `routes/meta.py` | ~1,600 | `bp_auth` + `bp_gateway` + `bp_otel` + `bp_version` + `bp_version_impact` + `bp_cloud_relay` + `bp_otlp_traces` — auth, gateway proxy, OTLP ingestion, version meta |
-| `routes/alerts.py` | ~980 | `bp_alerts` + `bp_budget` — alert rules, webhooks, velocity, budget config |
-| `routes/signals.py` | ~200 | `bp_signals` — Behaviour Signals read API: `/api/signals` (per signal: rate, count, eligible turns, trend, per-day, by model, by runtime version; plus coverage per runtime and a plain-words headline), `/api/signals/<name>/sessions` (sessions, never phrases), `/api/signals/coverage`. Reads the store through the daemon proxy |
-| `routes/fleet_history.py` | ~240 | `bp_fleet` + `bp_history` — multi-node fleet + SQLite time-series |
-| `routes/nemoclaw.py` | ~125 | `bp_nemoclaw` — NeMo Guardrails governance + approval queue |
-| `routes/runtime_ingest.py` | ~87 | `bp_runtime_ingest` — custom runtime HTTP ingest API (`/api/v1/runtimes`, `/api/v1/runs/*`; Pro feature) |
-| `routes/__init__.py` | — | Package marker |
+| File | Blueprints / Purpose |
+|------|----------------------|
+| `routes/sessions.py` | `bp_sessions` — sessions list, transcripts, compactions, tool timeline, cost split, subagents, exports |
+| `routes/usage.py` | `bp_usage` — token/cost analytics, anomaly detection, model + skill attribution, `/api/usage/outcomes` |
+| `routes/health.py` | `bp_health` — system-health, reliability, diagnostics, rate-limits, sandbox-status, health-stream (SSE) |
+| `routes/overview.py` | `bp_overview` — main dashboard endpoint, channels list, timeline, cloud-CTA OTP |
+| `routes/brain.py` | `bp_brain` — `/api/brain-history` + `/api/brain-stream` (SSE) |
+| `routes/channels.py` | `bp_channels` — 23 chat-channel adapters (Telegram, Signal, WhatsApp, Discord, Slack, IRC, iMessage, WebChat, …) |
+| `routes/components.py` | `bp_components` — Flow-panel detail endpoints (tool / runtime / machine / gateway / brain) |
+| `routes/local_query.py` | `bp_local_query` — `/api/local/*` DuckDB read API + the daemon-proxy `_dispatch` (shape→store bridge shared by HTTP and the cloud relay) |
+| `routes/guard.py` | `bp_guard` — live session control (Pause/Stop/Kill), Guard policy CRUD, policy decision log, learned baselines. Sessions ranked by **spend at risk**, not severity |
+| `routes/policy.py` | `bp_policy` — the *pre-tool* sandbox/permission surface (`/api/tool-policy`). Deliberately a different axis from `routes/guard.py`: different table, no shared state |
+| `routes/hooks.py` | `bp_hooks` — hook install / status / uninstall per runtime, and the gate's decision log |
+| `routes/infra.py` | `bp_logs` + `bp_memory` + `bp_security` + `bp_config` — logs stream, memory files, security posture, cost-optimizer |
+| `routes/meta.py` | `bp_auth` + `bp_gateway` + `bp_otel` + `bp_version` + `bp_version_impact` + `bp_cloud_relay` + `bp_otlp_traces` — auth, gateway proxy, OTLP ingestion, version meta |
+| `routes/entitlement.py` | `bp_entitlement` — the resolved entitlement plus the preview / diff / batch family at `/api/entitlement*` |
+| `routes/alerts.py` | `bp_alerts` + `bp_budget` — alert rules, webhooks, velocity, budget config |
+| `routes/crons.py` | `bp_crons` — cron CRUD + run log + health summary |
+| `routes/signals.py` | `bp_signals` — Behaviour Signals read API: `/api/signals` (rate, count, eligible turns, trend, by model and runtime, coverage, plain-words headline), `/api/signals/<name>/sessions` (sessions, never phrases) |
+| `routes/tracing.py` | `bp_tracing` — spans and the trace view |
+| `routes/trail.py` | `bp_trail` — `/api/trail/coverage`: per runtime, which trail streams it can actually expose |
+| `routes/fleet_history.py` | `bp_fleet` + `bp_history` — multi-node fleet + SQLite time-series |
+| `routes/nemoclaw.py` | `bp_nemoclaw` — NeMo Guardrails governance + approval queue |
+| `routes/runtime_ingest.py` | `bp_runtime_ingest` — custom runtime HTTP ingest API (`/api/v1/runs/*`; Pro feature) |
+| `routes/__init__.py` | Package marker plus the `@event_data` / `@source_exempt` route markers the source canary reads |
 
 ### Package (`clawmetry/`)
-| File | Lines | Purpose |
-|------|-------|---------|
-| `clawmetry/cli.py` | ~6,100 | CLI entry point — `clawmetry`, `clawmetry connect`, `clawmetry sync`, `clawmetry status` |
-| `clawmetry/sync.py` | ~20,200 | Cloud sync daemon — ingests into DuckDB, owns the writer lock, E2E-encrypted (AES-256-GCM) snapshot streaming to `ingest.clawmetry.com` |
-| `clawmetry/local_store.py` | ~12,000 | **DuckDB store** — the single data layer features read/write (daemon holds the writer lock) |
-| `clawmetry/local_server.py` | ~200 | Daemon-hosted localhost query server (`/__local_query__/<method>`) so the dashboard/sync read DuckDB without grabbing the writer lock |
-| `clawmetry/proxy.py` | ~2,700 | Enforcement proxy — budget limits, loop detection, model routing (port 4100) |
-| `clawmetry/detectors.py` | ~870 | Event normalization, the four **trajectory** detectors (is it stuck?), the registry, `run_all` and `session_profile`. Keeps its original shape; the new capability lives in the four modules below and is re-exported here, so `clawmetry.detectors` stays the single import |
-| `clawmetry/detector_surface.py` | ~290 | What a tool call touched (paths, command, hosts, heredoc bodies stripped) and what a finding may repeat back. Every function here is new in this change |
-| `clawmetry/detector_behaviour.py` | ~470 | The four **behavioural** detectors (is it doing something it does not normally do?): `file_blast_radius`, `credential_access`, `network_egress`, `privilege_change`, with their pattern tables |
-| `clawmetry/detector_calibration.py` | ~280 | Where a threshold comes from: module defaults → `RUNTIME_PROFILES` → the cohort's learned baseline → a per-runtime env override. `resolve_thresholds` reports which layer set each value |
-| `clawmetry/behaviour_signals.py` | ~750 | Behaviour Signals (WO-58): six preset judge-free signals over every transcript in the store (`user_frustration`, `user_praise`, `assistant_refusal`, `assistant_laziness`, `task_failure`, `user_retry`). Precompiled word-boundary matchers with negation, positive-context and front-of-turn guards, evaluated on the daemon tick over new turns (watermark on `events.created_at`, capped per pass), persisted to the additive `signal_turns` + `signal_matches` tables (never the text; PK dedupes re-runs). Also the rate aggregation, per-runtime coverage (`user_text` / `assistant_text` / `none`; an adapter's `signal_coverage()` wins over inference), the headline sentence and the `signals` / `signalsByRuntime` snapshot slices |
-| `clawmetry/detector_money.py` | ~130 | `spend_at_risk_usd` and the ranking. Only a measured basis may promote a warning to `critical` |
-| `clawmetry/git_outcomes.py` | ~660 | **Read-only** Git reader (REQ-OBS-CEA-022) — commits, merge state by default-branch reachability, pull-request state via `gh` when present, line survival for rework, and session↔commit correlation with a recorded confidence. Every subprocess passes one chokepoint that rejects anything outside an allowlist of read-only plumbing subcommands |
-| `clawmetry/interceptor.py` | ~630 | Zero-config HTTP monkey-patching for LLM cost tracking (patches httpx/requests) |
-| `clawmetry/providers_pricing.py` | ~430 | Multi-provider pricing table (Anthropic, OpenAI, Google, OpenRouter, etc.) |
-| `clawmetry/config.py` | ~200 | Configuration dataclass |
-| `clawmetry/extensions.py` | ~300 | Plugin/hook system |
-| `clawmetry/track.py` | ~60 | Zero-config interceptor shorthand |
-| `clawmetry/providers/` | — | Pluggable data provider layer (LocalDataProvider, TursoDataProvider) |
+130 modules, listed in full in `docs/MODULE_MAP.md`.
+
+| File | Purpose |
+|------|---------|
+| `clawmetry/cli.py` | CLI entry point — `clawmetry`, `connect`, `sync`, `status`, `license`, `hook`, `update` |
+| `clawmetry/sync.py` | Cloud sync daemon — ingests into DuckDB, owns the writer lock, runs the detectors and Guard policies, streams the E2E-encrypted (AES-256-GCM) snapshot to `ingest.clawmetry.com`. Holds `_FAMILY_ADAPTER_SPECS` (the adapters that actually load) and `_CHANNEL_DIRS` |
+| `clawmetry/local_store.py` | **DuckDB store** — the single data layer features read and write (the daemon holds the writer lock). Schema v15 |
+| `clawmetry/local_server.py` | Daemon-hosted localhost query server (`/local/query`, discovered through `~/.clawmetry/local_query.json`) so the dashboard reads DuckDB without grabbing the writer lock |
+| `clawmetry/query_contract.py` | The declared node query surface (`q/1`), rendered to `docs/QUERY_CONTRACT.md`. Additive-only inside a version |
+| `clawmetry/entitlements.py` | Single source of truth for tiers, `FREE_RUNTIMES` / `PAID_RUNTIMES`, `ALL_CHANNELS` and every capacity limit. GRACE by default |
+| `clawmetry/license.py` | Offline Ed25519 verification of self-hosted license keys |
+| `clawmetry/proxy.py` | Enforcement proxy — budget limits, loop detection, model routing (port 4100) |
+| `clawmetry/detectors.py` | Event normalization, the four **trajectory** detectors (is it stuck?), the registry, `run_all` and `session_profile`. Re-exports the modules below, so `clawmetry.detectors` stays the single import |
+| `clawmetry/detector_behaviour.py` | The four **behavioural** detectors (is it doing something it does not normally do?): `file_blast_radius`, `credential_access`, `network_egress`, `privilege_change`, with their pattern tables |
+| `clawmetry/detector_surface.py` | What a tool call touched (paths, command, hosts, heredoc bodies stripped) and what a finding may repeat back |
+| `clawmetry/detector_calibration.py` | Where a threshold comes from: module defaults → `RUNTIME_PROFILES` → the cohort's learned baseline → a per-runtime env override. `resolve_thresholds` reports which layer set each value |
+| `clawmetry/detector_money.py` | `spend_at_risk_usd` and the ranking. Only a measured basis may promote a warning to `critical` |
+| `clawmetry/policy_engine.py` | **Pure** Guard policy evaluator — detector incident + policies → at most one enforcement decision per session, including the escalation ladder |
+| `clawmetry/guard_actuator.py` | The one place a decision becomes a signal. Both the manual and the automatic path go through it |
+| `clawmetry/process_control.py` | Signal actuators — pause (SIGSTOP / `NtSuspendProcess`), stop (SIGINT / a console Ctrl+C), kill (SIGTERM→SIGKILL tree / `taskkill /T`), pid-reuse guarded. Owns `runtime_control_support()` |
+| `clawmetry/resume_hints.py` | A verified resume command per runtime, with its native session id. Coverage is CI-enforced |
+| `clawmetry/approvals.py` | Approval queue and audit table; an approval denial can end a session |
+| `clawmetry/hook_ownership.py` | Hook install and removal at **hook** granularity, so ClawMetry never deletes a hook it did not write |
+| `clawmetry/behaviour_signals.py` | Six preset judge-free signals over every transcript in the store, persisted to `signal_turns` / `signal_matches` (never the matched text) |
+| `clawmetry/git_outcomes.py` | **Read-only** Git reader — commits, merge state, pull-request state via `gh`, line survival, session↔commit correlation. Every subprocess passes one allowlist chokepoint |
+| `clawmetry/interceptor.py` | Zero-config HTTP monkey-patching for LLM cost tracking (patches httpx/requests) |
+| `clawmetry/providers_pricing.py` | Multi-provider pricing table (Anthropic, OpenAI, Google, OpenRouter, etc.) |
+| `clawmetry/runtime_probe.py` | Which runtimes are actually installed on this machine |
+| `clawmetry/config.py` | Configuration dataclass |
+| `clawmetry/extensions.py` | Plugin/hook system — the `clawmetry.extensions` entry point `clawmetry-pro` registers through |
+| `clawmetry/track.py` | Zero-config interceptor shorthand |
+| `clawmetry/adapters/` | The FREE runtime adapters (OpenClaw, NemoClaw, Goose) plus the adapter base SDK the paid ones build on |
+| `clawmetry/providers/` | Pluggable data provider layer (LocalDataProvider, TursoDataProvider) |
 
 ### Config & Build
 | File | Purpose |
 |------|---------|
-| `setup.py` | PyPI package definition (entry point: `clawmetry` CLI) |
+| `setup.py` | PyPI package definition (entry point: `clawmetry` CLI). Derives the PyPI summary from `clawmetry/entitlements.py`, so the advertised runtime count cannot drift |
 | `requirements.txt` | pip dependencies |
 | `Dockerfile` | Docker image (Python 3.11-slim base) |
-| `Makefile` | Dev commands: `make dev`, `make test`, `make lint` |
+| `Makefile` | Dev commands: `make dev`, `make test`, `make lint` (which runs every `lint-*` guard) |
 | `install.sh` | One-liner installer script |
+| `desktop/` | The thin-shell desktop app (`.dmg` / `.exe` / `.deb` / `.AppImage`) that pip-installs clawmetry |
+| `scripts/` | The drift guards CI runs: `scripts/sync_runtime_count.py`, `scripts/gen_module_map.py`, `scripts/gen_query_contract_doc.py`, `scripts/check_ac_coverage.py`, `scripts/check_product_record.py`, `scripts/lint_daemon_allowlist.py` |
 
 ### Documentation
 | File | Purpose |
 |------|---------|
-| `ARCHITECTURE.md` | Detailed architecture guide with diagrams |
-| `CHANGELOG.md` | Version history (~11,600 lines) |
+| `ARCHITECTURE.md` | Architecture deep dive with C4 diagrams: the five intervention surfaces, the ingest paths, the store, Guard |
+| `docs/MODULE_MAP.md` | **Generated** inventory of every module, blueprint and URL prefix (`scripts/gen_module_map.py`) |
+| `docs/QUERY_CONTRACT.md` | **Generated** node query surface (`clawmetry/query_contract.py`) |
+| `docs/ENTITLEMENTS.md` | Open-core split: FREE runtimes/features, paid tiers, GRACE mode, `/api/entitlement` shape, `clawmetry license` CLI |
+| `docs/EGRESS.md` | Every outbound destination, what it carries, and how to verify it on the wire |
+| `docs/HOOK_COEXISTENCE.md` | How ClawMetry shares a runtime's hook config with other writers |
+| `docs/CUSTOM_RUNTIME_INGEST.md` | The HTTP ingest API for a runtime with no adapter |
+| `docs/EVENT_RETENTION.md` | Store growth and trimming |
+| `CHANGELOG.md` | Version history |
 | `CONTRIBUTING.md` | Contribution guidelines |
 | `SECURITY.md` | Security posture |
 | `CLOUD_EXTENSION_DESIGN.md` | Cloud feature design |
-| `docs/ENTITLEMENTS.md` | Open-core split: FREE runtimes/features, paid tiers, GRACE mode, `/api/entitlement` shape, `clawmetry license` CLI |
 
 ## How it works
 The **sync daemon** (`clawmetry/sync.py`) ingests these sources into the local **DuckDB** store; the Flask app reads DuckDB (via `routes/local_query.py`) to serve the UI:
-1. Session transcripts from `~/.openclaw/agents/main/sessions/*.jsonl`
-2. Chat-channel transcripts from `~/.openclaw/<channel>/*.jsonl` —
+1. OpenClaw session transcripts from `~/.openclaw/agents/main/sessions/*.jsonl`
+2. Every other runtime's own store, read by its adapter and loaded from the
+   hardcoded `sync._FAMILY_ADAPTER_SPECS` tuple (Claude Code under
+   `~/.claude/projects/<slug>/*.jsonl`, Codex, Cursor, Goose, …). There is no
+   dynamic discovery: an adapter absent from that tuple never loads.
+3. Chat-channel transcripts from `~/.openclaw/<channel>/*.jsonl` —
    one directory per adapter (`telegram/`, `signal/`, `whatsapp/`,
-   `discord/`, `slack/`, `irc/`, `imessage/`, `webchat/`, …). The 21
+   `discord/`, `slack/`, `irc/`, `imessage/`, `webchat/`, …). The 23
    adapter directories match the routes in `routes/channels.py`. New
-   adapter? Add its dir name to `_CHANNEL_DIRS` in `clawmetry/sync.py`.
-3. OpenClaw gateway via WebSocket (JSON-RPC, port 18789) for live data
-4. Optional OpenTelemetry metrics/traces/logs on `/v1/metrics`, `/v1/traces`, and `/v1/logs`
+   adapter? Add its dir name to `_CHANNEL_DIRS` in `clawmetry/sync.py`
+   (`tests/test_entitlement_channel_catalog.py` pins it to `ALL_CHANNELS`).
+4. OpenClaw gateway via WebSocket (JSON-RPC, port 18789) for live data
+5. Optional OpenTelemetry metrics/traces/logs on `/v1/metrics`, `/v1/traces`, and `/v1/logs`
+6. Runtime hooks (`clawmetry hook <runtime>`), the only path that sees a tool
+   call *before* it runs, and the HTTP ingest API (`/api/v1/runs/*`) for a
+   runtime with no adapter
 
-The daemon owns the DuckDB writer lock and runs a localhost query server so the dashboard reads through it. The dashboard serves the UI at `http://localhost:8900`; for cloud, the daemon also pushes an E2E-encrypted snapshot to `ingest.clawmetry.com` (decrypted client-side in the browser).
+Cadence: the daemon's main loop runs every 15s (`sync.POLL_INTERVAL`), family
+runtimes and the system snapshot every 60s.
+
+The daemon owns the DuckDB writer lock and runs a localhost query server so the dashboard reads through it. The dashboard serves the UI at `http://127.0.0.1:8900` (loopback by default; `--host` widens it deliberately); for cloud, the daemon also pushes an E2E-encrypted snapshot to `ingest.clawmetry.com` (decrypted client-side in the browser).
 
 ## API Endpoints (key ones)
+The complete surface is generated at `/openapi.json` and browsable at `/api/docs`; `docs/MODULE_MAP.md` maps each URL prefix to the module that owns it.
+
 - `/api/overview` — Main dashboard data (sessions, tokens, crons, health)
 - `/api/sessions` — Active session list
 - `/api/subagents` — Sub-agent tracker with status and costs
@@ -116,6 +165,10 @@ The daemon owns the DuckDB writer lock and runs a localhost query server so the 
 - `/api/budget/*` — Budget monitoring and alerts
 - `/api/alerts/*` — Custom alert rules (incl. the `signal_rate_above` rule type: a behaviour signal's rate over a window with a minimum sample)
 - `/api/signals` — Behaviour signal rates per window (`1d|7d|30d`) and `?runtime=`, with coverage and headline; `/api/signals/<name>/sessions` lists matching sessions, never phrases
+- `/api/guard/sessions` — What is running, what a detector thinks has gone off track, and whether each session can be controlled at all; `/api/guard/control` is the Pause / Stop / Kill button and `/api/guard/policies` the autonomous rules
+- `/api/entitlement` — The resolved entitlement (tier, allowed runtimes, features, capacity). GRACE mode answers "allowed" for everything until the announced enforce date
+- `/api/local/*` — The DuckDB read API, proxied to the daemon. The method set is declared in `clawmetry/query_contract.py`; `make lint-daemon-allowlist` fails when a route calls one the daemon does not serve
+- `/v1/metrics`, `/v1/traces`, `/v1/logs` — OTLP receiver (binds `127.0.0.1` by default)
 
 ## Dependencies
 Minimal by design, and this list had drifted — `setup.py` is the source of truth:
@@ -126,7 +179,9 @@ Minimal by design, and this list had drifted — `setup.py` is the source of tru
 - **websocket-client** (>=1.6) — cloud cold-data relay tunnel
 - **truststore** (>=0.8, 3.10+ only) — OS trust store, so corporate TLS-interception root CAs work
 - **certifi** (>=2024.2.2) — CA bundle; the trust-store fallback on 3.8/3.9 and on any interpreter whose OpenSSL has no CA store. Without one, every outbound HTTPS call fails `CERTIFICATE_VERIFY_FAILED`, and for the fire-and-forget pings that failure is silent
-- **Optional**: `opentelemetry-proto` for OTLP support (`pip install clawmetry[otel]`)
+- **cffi** (`<2` below 3.10, `>=2` on 3.10+) — not a direct import; it is what sets the `cryptography` ceiling above. The `<2` half exists because cffi 2.0.0 has a Python 3.9 finalizer SIGSEGV and cffi 2.1+ ships no cp39 wheels
+- **Optional**: `opentelemetry-proto` + `protobuf` for OTLP (`pip install clawmetry[otel]`), `deepeval` for the eval bridge (`clawmetry[deepeval]`, 3.10+)
+- `python_requires=">=3.8"`
 
 ## Running locally
 ```bash
@@ -152,25 +207,32 @@ make test-api
 # E2E browser tests (Playwright)
 make test-e2e
 
-# Syntax + lint check
+# Syntax + every drift guard (runtime/channel counts, module map,
+# daemon allowlist, py3.9 annotations, AC coverage, JS parse)
 make lint
 ```
 
 Tests use `CLAWMETRY_URL` and `CLAWMETRY_TOKEN` env vars. Test matrix in CI: 3 OS (Ubuntu, macOS, Windows) x 2 Python versions (3.9, 3.11).
 
+**CI runs explicit FILE LISTS, not `pytest tests/`.** A new test file that is not named in a workflow step runs in no job at all, which has shipped guards that never once executed. Add yours to `.github/workflows/ci.yml` in the same PR.
+
 ## Deploy
 - **PyPI**: `pip install clawmetry && clawmetry`
 - **Docker**: `docker build -t clawmetry . && docker run -p 8900:8900 -v ~/.openclaw:/root/.openclaw:ro clawmetry`
-- **Current version**: `0.12.650` (in `dashboard.py` `__version__`)
+- **Version**: `__version__` in `dashboard.py`. Don't hand-edit it and don't trust it as "what is released": `release-on-merge.yml` computes `max(PyPI, file) + 1` on a `[RELEASE]` merge, and the write-back bump PR often goes unmerged, so `main` legitimately lags PyPI by tens of releases. `https://pypi.org/pypi/clawmetry/json` is the released number.
 
 ## CI/CD (GitHub Actions)
-- `.github/workflows/ci.yml` — Lint + test matrix on push/PR
+36 workflows; the ones you will actually touch:
+- `.github/workflows/ci.yml` — Lint + drift guards + test matrix on push/PR
+- `.github/workflows/e2e-gate.yml` — The aggregating merge gate (`E2E Gate (required)`), which counts Drift Bot as a leg
+- `.github/workflows/release-on-merge.yml` — Publishes when a `[RELEASE]` PR merges (see FLYWHEEL.md §5)
 - `.github/workflows/publish.yml` — PyPI publish on git tag `v*`
-- `.github/workflows/release-on-merge.yml` — Auto-release when version bumped on main
 - `.github/workflows/sync-test.yml` — Cloud sync daemon tests
 - `.github/workflows/install-test.yml` — Cross-platform pip install smoke tests
+- `.github/workflows/product-record-gate.yml` — Fails a PR touching product code whose body cites no Factory record or `No-PRD:` line
 - `.github/workflows/auto-deploy-cloud.yml` — Cloud deployment
 - `.github/workflows/browserstack.yml` — Cross-browser E2E testing
+- `.github/workflows/queue-priority.yml` — Cancels queued non-main runs when main moves, so releases are not stuck behind PR jobs
 
 ## Environment Variables
 ```bash
@@ -193,12 +255,29 @@ CLAWMETRY_GIT_MAX_BLAME_FILES=40       # Files blamed for line survival (rework)
 CLAWMETRY_GIT_BLAME_BUDGET=10          # Seconds the whole blame pass may take
 CLAWMETRY_GIT_REPO_BUDGET=25           # Seconds one repository's whole scan may take
 CLAWMETRY_SIGNALS=1                    # Behaviour Signals tick on/off; CLAWMETRY_SIGNALS_EVENTS_PER_TICK (2000) and CLAWMETRY_SIGNALS_SCAN_CHARS (2000) bound each pass
+
+# Guard / enforcement. Every one of these defaults to the safe side.
+CLAWMETRY_DETECTORS=1                  # Trajectory + behavioural detectors on/off
+CLAWMETRY_GUARD_POLICIES=1             # Evaluate Guard policies at all (0 = skip the pass entirely)
+CLAWMETRY_POLICY_ENFORCE=0             # Let a policy actually signal a process. Default 0 = dry run; this one env var disables every policy on the node
+CLAWMETRY_GUARD_CRITICAL_USD=...       # Spend-at-risk above which a warning becomes critical
+CLAWMETRY_NOPROG_TOOLS__<RUNTIME>=40   # Per-runtime threshold override (highest layer in resolve_thresholds)
+CLAWMETRY_ENFORCE=1                    # Turn entitlement enforcement on (default: GRACE, everything allowed)
+
+# Resource budget (FLYWHEEL.md 1e: the daemon must stay near-invisible)
+CLAWMETRY_DUCKDB_THREADS=2             # DuckDB defaults to every core; never ship an uncapped connection
+CLAWMETRY_DUCKDB_MEMORY_LIMIT=...      # Ceiling; derived from store size when unset
+CLAWMETRY_AGG_CACHE_TTL=20             # Seconds a hot rollup is reused instead of re-scanned
+CLAWMETRY_AUTO_COMPACT=0               # Kill switch for startup compaction
+
+# Egress
+CLAWMETRY_OFFLINE=1                    # Air-gapped: no install ping, no version check. See docs/EGRESS.md
 DEBUG=1                                # Enable debug logging
 ```
 
 ## Conventions
 - **Product record before code (FLYWHEEL.md section 0c).** 8090 Software Factory is the product reviewer, not a lint gate. Write the requirement first -- problem, who is hurt, non-goals, alternatives rejected, risk accepted -- then the blueprint, then the code. A requirement written after the fact reviews nothing, and `scripts/check_product_record.py` gates PRs on citing one (or an explicit `No-PRD: <reason>`).
-- **Per-feature route modules** — new endpoints live in `routes/<feature>.py`, registered on a feature Blueprint that `dashboard.py` imports and registers. This replaces the old "single file" rule, which became counterproductive at ~33K lines (illegible to humans, constant PR conflicts on a single anchor point). Helpers and shared state stay in `dashboard.py` for now and are accessed from route modules via late `import dashboard as _d` to avoid circular imports.
+- **Per-feature route modules** — new endpoints live in `routes/<feature>.py`, registered on a feature Blueprint that `dashboard.py` imports and registers. This replaces the old "single file" rule, which became counterproductive at ~33K lines (illegible to humans, constant PR conflicts on a single anchor point). Helpers are migrating into `helpers/` (gateway RPC, log discovery, pricing, system stats, the OpenAPI spec); the ones still in `dashboard.py` are reached from route modules via late `import dashboard as _d` to avoid circular imports. `docs/MODULE_MAP.md` is the generated index of where everything currently lives.
 - **Embedded frontend, no build step** — the live UI is served from `clawmetry/static/` (`clawmetry/static/css/dashboard.css`, `clawmetry/static/js/app.js`) + `clawmetry/templates/tabs/*.html`. (`dashboard.py` defines `DASHBOARD_HTML` twice; the **second** wins and loads the static/template files — the earlier inline `<style>`/HTML is dead, so edit the static/template files.) No npm, no webpack.
 - **Minimal dependencies** — Flask + waitress + cryptography. Don't add heavy libraries.
 - **Control plane that defaults to observation** — ClawMetry is NOT read-only, and hasn't been for a long time. It already kills, pauses, blocks and reroutes running agents through five surfaces: approval denial → session kill (`clawmetry/approvals.py`), POSIX signals across the agent's descendant tree (`clawmetry/process_control.py`), HITL pause → proxy `503` (`routes/hitl.py`), the enforcement proxy's budget block / loop detection / model routing (`clawmetry/proxy.py`), and cron CRUD via gateway RPC (`routes/crons.py`). Do NOT reject a feature because "we're read-only" — that rule is retired.

--- a/FLYWHEEL.md
+++ b/FLYWHEEL.md
@@ -119,7 +119,7 @@ ClawMetry is open-core. There are **four repos**, each with a clear remit; agent
 
 | Repo | Visibility | Holds |
 |---|---|---|
-| **clawmetry** (this repo) | **Public OSS** | The FREE runtime adapters (OpenClaw, NemoClaw, **Goose**) + NeMo governance + 21 chat-channel adapters + entitlement gate (`clawmetry/entitlements.py`) + license client (`clawmetry/license.py`) + **hook points / stubs** for every gated feature. |
+| **clawmetry** (this repo) | **Public OSS** | The FREE runtime adapters (OpenClaw, NemoClaw, **Goose**) + NeMo governance + 23 chat-channel adapters + entitlement gate (`clawmetry/entitlements.py`) + license client (`clawmetry/license.py`) + **hook points / stubs** for every gated feature. |
 | **clawmetry-pro** | **Private** (not on public PyPI; served only to activated installs by the license server) | The gated runtime adapters (Claude Code, Codex, Cursor, Aider, opencode, Qwen Code, Hermes, PicoClaw, NanoClaw, …) and the Pro paid CLI / analytical features. Plugs into OSS via the `clawmetry.extensions` entry point. |
 | **clawmetry-cloud** | Private | Cloud SaaS server + license server (`/api/license/*`) + Stripe + admin + heartbeat-relay + the closed-wheel hosting (`wheels/` baked into the Cloud Run image). Business + revenue + funnel docs (private). |
 | **clawmetry-landing** | Private repo, public site `clawmetry.com` | Marketing + pricing page + public Buy buttons + installer script. Storefront only; no gated code. |

--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ moat-check:
 moat-check-drive:
 	@python3 scripts/accuracy_harness/keystone_e2e.py
 
-lint: lint-py lint-py39 lint-js lint-daemon-allowlist lint-runtime-count lint-ac-coverage
+lint: lint-py lint-py39 lint-js lint-daemon-allowlist lint-runtime-count lint-ac-coverage lint-module-map
 
 # Issue #1267: every `local_store_via_daemon("X")` / `_ls_call("X")` call
 # in routes/ must reference a method that's in the daemon's allowlist
@@ -134,6 +134,12 @@ ac-baseline:
 
 lint-runtime-count:
 	@python3 scripts/sync_runtime_count.py --check
+
+# docs/MODULE_MAP.md is generated from the source tree. CLAUDE.md's route
+# table listed 17 of 70 route modules before this existed.
+# Fix drift with: python3 scripts/gen_module_map.py
+lint-module-map:
+	@python3 scripts/gen_module_map.py --check
 
 lint-py:
 	python3 -c "import ast; ast.parse(open('dashboard.py').read()); print('Python syntax OK')"

--- a/PRD.md
+++ b/PRD.md
@@ -126,7 +126,7 @@ CLI auto-detects NemoClaw sandboxes during `connect` and registers a separate da
 
 ### 4.4 Channel adapters
 
-ClawMetry observes (and in most cases sends to) **22 chat channels** through `routes/channels.py`. Each adapter is a Flask blueprint that:
+ClawMetry observes (and in most cases sends to) **23 chat channels** through `routes/channels.py`. Each adapter is a Flask blueprint that:
 - Parses inbound messages from the channel into Brain events
 - Optionally implements an outbound `send` (for replying through the agent)
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Two questions worth answering before you trust any agent-comparison tool.
 A utilization percentage is only as honest as what it divides by. ClawMetry
 sizes the window per provider from [a table you can read and
 PR](clawmetry/context_windows.py), covering Anthropic, OpenAI, Google, xAI,
-DeepSeek, Kimi, Qwen, Mistral, Llama and GLM. It does not measure all 26
+DeepSeek, Kimi, Qwen, Mistral, Llama and GLM. It does not measure all 30
 runtimes with one vendor's ruler. That matters: a 300K GPT-5 turn scored
 against Anthropic's 200K reads ">100%, blown" when it is really at 75% of
 GPT-5's 400K. The same ruler hides a genuinely overflowed 130K DeepSeek turn

--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -19395,7 +19395,7 @@ def channel_catalog() -> list[dict]:
     channel axis. One row per id in :data:`ALL_CHANNELS`, sorted
     alphabetically so a pricing UI can render a stable table across
     releases. Every row is unlocked -- there is no paid-channel tier --
-    which lets a pricing page render "all 21 chat channels included in
+    which lets a pricing page render "all 23 chat channels included in
     every plan" off a single call instead of hard-coding the adapter list
     client-side.
 

--- a/docs/MODULE_MAP.md
+++ b/docs/MODULE_MAP.md
@@ -1,0 +1,293 @@
+# ClawMetry module map
+
+> GENERATED FILE, do not edit by hand. Regenerate with
+> `python3 scripts/gen_module_map.py` (CI fails on drift via
+> `tests/test_module_map_drift.py`).
+
+226 modules, 81 Flask blueprints. `CLAUDE.md` carries a short curated table of the ones you reach for most often; this is the whole list.
+
+Size bands are deliberately coarse so this file does not churn on every PR: **small** is under 200 lines, **medium** under 1k, **large** under 5k, **huge** is 5k and up.
+
+The **Serves** column is the URL space a module owns, collapsed to two path segments. A blank one means the module registers no routes of its own (it is a library, or its rules are built dynamically).
+
+## Top level
+
+The Flask app itself plus the optional SQLite time-series companion.
+
+| Module | Size | Purpose |
+|---|---|---|
+| `dashboard.py` | huge | ClawMetry - See your agent think 🦞 |
+| `history.py` | medium | ClawMetry History - Time-series data collection and storage. |
+
+## HTTP routes (`routes/`)
+
+One module per feature, each owning one or more Flask blueprints. New endpoints go here, never in `dashboard.py`.
+
+| Module | Size | Blueprints | Serves | Purpose |
+|---|---|---|---|---|
+| `routes/_dedupe.py` | small |  |  | sibling-dedupe helper for v3 event sums (issue #1451). |
+| `routes/advisor.py` | medium | `bp_advisor` | `/api/advisor` | ClawMetry Advisor: natural-language Q&A over your agent. |
+| `routes/agents.py` | medium | `bp_agents` | `/api/agents` | Multi-agent adapter endpoints. |
+| `routes/alerts.py` | large | `bp_alerts`, `bp_budget` | `/api/_harness`, `/api/agents`, `/api/alert-channels`, `/api/alerts`, `/api/budget`, `/api/emergency-stop` | Budget + Alerts endpoints. |
+| `routes/approval_routing.py` | small | `bp_approval_routing` | `/a`, `/a/decide`, `/api/approvals` | OSS stub after the impl moved to clawmetry-pro. |
+| `routes/assets.py` | small | `bp_assets` | `/api/assets` | OSS asset registry API. |
+| `routes/attention.py` | medium | `bp_attention` | `/api/attention`, `/api/hooks` | "which of my agents needs me right now". |
+| `routes/audit.py` | small | `bp_audit` | `/api/audit-log` | Enterprise audit-log query endpoint. |
+| `routes/autonomy.py` | medium | `bp_autonomy` | `/api/autonomy` | Autonomy Score endpoint. |
+| `routes/bench.py` | medium | `bp_bench` | `/api/bench` | Harness Engineering tab endpoints (Blueprint: Harness Benchmarks & |
+| `routes/bootstrap.py` | small | `bp_bootstrap` | `/api/bootstrap` | "First Contact" bootstrap artifact endpoints. |
+| `routes/brain.py` | large | `bp_brain` | `/api/brain`, `/api/brain-history`, `/api/brain-stream`, `/api/llm-call-timeline` | Brain event feed endpoints. |
+| `routes/channels.py` | large | `bp_channels` | `/api/channel`, `/api/channel-delivery-health`, `/api/channels` | Per-channel adapter endpoints. |
+| `routes/cohort.py` | medium | `bp_cohort` | `/api/cohort-compare`, `/api/sessions` | Cohort compare and similar runs (WO-60; requirement "Cohort compare and |
+| `routes/compliance.py` | small | `bp_compliance` | `/api/compliance` | OSS stub after the impl lives in clawmetry-pro. |
+| `routes/components.py` | large | `bp_components` | `/api/component` | Per-panel component detail endpoints. |
+| `routes/context_economics.py` | small | `bp_context_economics` | `/api/context-coverage`, `/api/context-economics` | context-window economics (PRD P1-2). |
+| `routes/crons.py` | large | `bp_crons` | `/api/agent-intentions`, `/api/cron`, `/api/cron-health`, `/api/cron-run-log`, `/api/crons` | Cron CRUD + health + run-log endpoints. |
+| `routes/delegated.py` | small | `bp_delegated` | `/api/cursor`, `/api/delegated-usage` | Connect a Cursor account from the dashboard, and read delegated usage. |
+| `routes/device.py` | medium | `bp_device` | `/api/device`, `/device-preview` | Device snapshot — a compact, screen-sized JSON for hardware companions. |
+| `routes/dives.py` | medium | `bp_dives` | `/api/dives` | ClawMetry Dives: NL-to-SQL-to-chart over the local DuckDB store. |
+| `routes/entitlement.py` | huge | `bp_entitlement` | `/api/entitlement`, `/api/features`, `/api/license`, `/api/paywall`, `/api/runtimes`, `/api/tiers` | ``bp_entitlement``. |
+| `routes/evals.py` | medium | `bp_evals` | `/api/evals`, `/api/evaluators` | Eval (LLM-as-judge) endpoints. |
+| `routes/extensions.py` | small | `bp_extensions` | `/api/extensions` | diagnostic introspection for the entry-point plugin loader. |
+| `routes/fleet_history.py` | medium | `bp_fleet` | `/api/nodes`, `/fleet` | Multi-node fleet endpoints. |
+| `routes/govern.py` | small | `bp_govern` | `/api/govern` | agent identity: a principal you can attach things to. |
+| `routes/guard.py` | medium | `bp_guard` | `/api/guard` | Guard — live session control and enforcement policies. |
+| `routes/harness.py` | small | `bp_harness` | `/api/harness` | ``bp_harness`` — the per-harness custom-tab API. |
+| `routes/health.py` | large | `bp_health` | `/api/_internal`, `/api/agent-presence`, `/api/authority-violations`, `/api/backups`, `/api/config-diagnostics`, `/api/diagnostics`, `/api/doctor-findings`, `/api/gateway-health`, `/api/handler-latency`, `/api/health`, `/api/health-stream`, `/api/heartbeat-ping`, `/api/heartbeat-status`, `/api/heatmap`, `/api/loop-detection`, `/api/loop-signals`, `/api/mcp-stats`, `/api/rate-limits`, `/api/reliability`, `/api/sandbox-status`, `/api/security-threats`, `/api/service-status`, `/api/system-health`, `/api/version-health`, `/healthz` | Health / reliability / diagnostics / rate-limits endpoints. |
+| `routes/heartbeat.py` | medium | `bp_heartbeat` | `/api/heartbeat`, `/api/heartbeat-loops` | Heartbeat liveness panel API endpoint (#686). |
+| `routes/hitl.py` | medium | `bp_hitl` | `/api/hitl` | Human-in-the-loop (HITL) pause API. |
+| `routes/hooks.py` | large | `bp_hooks` | `/api/hooks`, `/api/lifecycle`, `/api/sessions` | local receiver for runtime pre-tool hooks. |
+| `routes/infra.py` | large | `bp_config`, `bp_logs`, `bp_memory`, `bp_security` | `/api/automation-analysis`, `/api/context-anatomy`, `/api/cost-optimization`, `/api/cost-optimizer`, `/api/file`, `/api/flow`, `/api/flow-events`, `/api/llmfit`, `/api/logs`, `/api/logs-stream`, `/api/memory`, `/api/memory-access`, `/api/memory-analytics`, `/api/memory-files`, `/api/memory-rag`, `/api/numbat`, `/api/security` | Infrastructure / security / config / logs endpoints. |
+| `routes/insights.py` | medium | `bp_insights` | `/api/insights`, `/insights` | Weekly Insights Digest endpoints. |
+| `routes/inventory.py` | medium | `bp_inventory` | `/api/inventory` | Agent Inventory tab API. |
+| `routes/local_query.py` | large | `bp_local_query` | `/__local_query__`, `/api/local` | coherent local query API over the DuckDB store. |
+| `routes/meta.py` | large | `bp_auth`, `bp_cloud_relay`, `bp_gateway`, `bp_otel`, `bp_otlp_traces`, `bp_version`, `bp_version_impact` | `/.well-known/security.txt`, `/api/anon-auth-fail-ping`, `/api/auth`, `/api/cloud`, `/api/export`, `/api/gw`, `/api/install-age`, `/api/otel`, `/api/otel-status`, `/api/update`, `/api/version`, `/api/version-impact`, `/auth`, `/v1/logs`, `/v1/metrics`, `/v1/traces` | Auth / gateway / OTLP / version / version-impact. |
+| `routes/nemoclaw.py` | small | `bp_nemoclaw` | `/api/nemoclaw` | OSS stub after the impl moved to clawmetry-pro. |
+| `routes/onboarding.py` | medium | `bp_onboarding` | `/api/account`, `/api/onboarding` | the first-run onboarding gate state machine. |
+| `routes/org_analytics.py` | small | `bp_org_analytics` | `/api/org-analytics` | OSS stub after the impl lives in clawmetry-pro. |
+| `routes/otel_export.py` | medium | `bp_otel_export` | `/api/otel` | Pro+ OTel/OTLP export. |
+| `routes/overview.py` | large | `bp_overview` | `/api/activity-heatmap`, `/api/channels`, `/api/cloud-cta`, `/api/cloud-proxy`, `/api/device`, `/api/health-timeline`, `/api/overview`, `/api/prompt-errors`, `/api/sync`, `/api/timeline` | Main-dashboard endpoints. |
+| `routes/plugins.py` | medium | `bp_plugins` | `/api/plugins` | Plugin registry: unified view of installed plugins (#692). |
+| `routes/policy.py` | medium | `bp_policy` | `/api/approvals`, `/api/approvals-audit`, `/api/policy`, `/api/tool-policy` | tool-policy + sandbox + exec-approval audit (PRD P1-1). |
+| `routes/quality.py` | medium | `bp_quality` | `/api/quality` | the Quality tab endpoint. |
+| `routes/readiness.py` | small | `bp_readiness` | `/api/repo-readiness` | ``bp_readiness`` — repo AI-readiness. |
+| `routes/reasoning.py` | medium | `bp_reasoning` | `/api/reasoning` | Reasoning chain viewer endpoint. |
+| `routes/reports.py` | medium | `bp_reports` | `/api/reports`, `/reports`, `/reports/export.csv` | ClawMetry Reports: markdown + embedded DuckDB SQL. |
+| `routes/review.py` | medium | `bp_review` | `/api/review` | decision sampling review surface (issue #1615). |
+| `routes/rules.py` | small | `bp_rules` | `/api/v2` | Rule Builder backend endpoints. |
+| `routes/runtime_ingest.py` | small | `bp_runtime_ingest` | `/api/v1` | OSS stub after the impl moved to clawmetry-pro. |
+| `routes/runtime_memory.py` | small | `bp_runtime_memory` | `/api/runtimes` | Per-runtime Memory & Skills browser API. |
+| `routes/scheduler.py` | small | `bp_scheduler` | `/api/run-ledger` | OpenClaw run-ledger + queue-lane endpoints. |
+| `routes/selfconfig.py` | medium | `bp_selfconfig` | `/api/selfconfig` | Self-configuration diff viewer endpoints. |
+| `routes/selfdiag.py` | small | `bp_selfdiag` | `/api/self-reports` | Agent self-diagnostics read API (WO-59). |
+| `routes/selfevolve.py` | small | `bp_selfevolve` | `/api/selfevolve` | OSS stub after the impl moved to clawmetry-pro. |
+| `routes/selfhosted_ingest.py` | medium | `bp_selfhosted` | `/api/approvals`, `/api/cloud`, `/api/export`, `/api/ingest`, `/api/register`, `/api/selfhosted`, `/auth`, `/ingest/autonomy`, `/ingest/cache`, `/ingest/events`, `/ingest/heartbeat`, `/ingest/logs`, `/ingest/memory`, `/ingest/sessions`, `/ingest/stream`, `/ingest/system-snapshot`, `/selfhosted` | ClawMetry Enterprise self-hosted ingest API. |
+| `routes/sessions.py` | huge | `bp_sessions` | `/api/agents`, `/api/authority`, `/api/compactions`, `/api/cost-split`, `/api/delegation-tree`, `/api/error-triage`, `/api/export`, `/api/fallbacks`, `/api/live-sessions`, `/api/orchestration`, `/api/orchestration-summary`, `/api/outcomes`, `/api/replay-tree`, `/api/run-compare`, `/api/session-errors`, `/api/session-governance`, `/api/session-insight`, `/api/session-lineage`, `/api/session-model-journey`, `/api/session-orchestration`, `/api/session-tools`, `/api/sessions`, `/api/spans`, `/api/subagents`, `/api/task-runs`, `/api/transcript`, `/api/transcript-events`, `/api/transcript-page`, `/api/transcripts`, `/api/waste-summary` | Session / transcript / sub-agent API endpoints. |
+| `routes/signals.py` | medium | `bp_signals` | `/api/briefs`, `/api/signals` | Behaviour Signals read API (WO-58). |
+| `routes/skills.py` | medium | `bp_skills` | `/api/skills` | Skills fidelity telemetry endpoints (GH #687). |
+| `routes/sla.py` | small | `bp_sla` | `/api/sla` | SLA policy CRUD + compliance-status endpoints. |
+| `routes/spend_flow.py` | small | `bp_spend_flow` | `/api/spend-flow` | node-wide AI spend flow (the "where does the |
+| `routes/tool_catalog.py` | medium | `bp_tool_catalog` | `/api/mcp-servers`, `/api/tool-catalog` | interactive tool catalog + provenance (PRD P1-3). |
+| `routes/tracing.py` | large | `bp_tracing` | `/api/trace`, `/api/traces` | Phoenix/Arize-style tracing endpoints. |
+| `routes/trail.py` | small | `bp_trail` | `/api/trail` | decision-trail coverage, declared per runtime. |
+| `routes/trial.py` | medium | `bp_trial` | `/api/trial` | Local free-trial activation. |
+| `routes/turn_anatomy.py` | medium | `bp_turn_anatomy` | `/api/turn-anatomy` | per-turn anatomy waterfall (PRD P0-3). |
+| `routes/update_check.py` | large | `bp_update_check` | `/api/update-check` | Auto-update checker with changelog notification. |
+| `routes/usage.py` | huge | `bp_usage` | `/api/activity-today`, `/api/anomalies`, `/api/efficiency`, `/api/forward-progress`, `/api/model-attribution`, `/api/nemo-cap-status`, `/api/runtime-summary`, `/api/sessions`, `/api/skill-attribution`, `/api/skills`, `/api/token-attribution`, `/api/token-velocity`, `/api/usage` | Usage / analytics / anomaly / attribution endpoints. |
+| `routes/workspaces.py` | small | `bp_workspaces` | `/api/workspaces` | Multi-profile OpenClaw workspace discovery + switcher. |
+
+## Shared helpers (`helpers/`)
+
+Helpers extracted out of `dashboard.py`. Route modules still reach the ones that have not moved yet via a late `import dashboard as _d`.
+
+| Module | Size | Blueprints | Serves | Purpose |
+|---|---|---|---|---|
+| `helpers/gateway.py` | medium |  |  | OpenClaw gateway WebSocket RPC + HTTP invoke client. |
+| `helpers/hardware.py` | small |  |  | Real host hardware detection (CPU / cores / RAM / backend). |
+| `helpers/logs.py` | medium |  |  | Filesystem helpers for OpenClaw log discovery + tail + grep. |
+| `helpers/openapi.py` | medium | `bp_openapi` | `/api/docs`, `/openapi.json` | auto-generate an OpenAPI 3.1 spec from Flask routes. |
+| `helpers/pricing.py` | small |  |  | Pure helpers for mapping model names to providers. |
+| `helpers/streams.py` | small |  |  | Bounded SSE client accounting. |
+| `helpers/system.py` | medium |  |  | Portable system uptime helpers. |
+
+## Package (`clawmetry/`)
+
+The pip-installable package: CLI, sync daemon, DuckDB store, detectors, enforcement and the free runtime adapters.
+
+| Module | Size | Purpose |
+|---|---|---|
+| `clawmetry/_gate.py` | medium | Shared 402 ``upgrade_required`` decorator for entitlement-gated routes. |
+| `clawmetry/_paywall.py` | medium | Shared 402 ``upgrade_required`` body builder for OSS stub blueprints. |
+| `clawmetry/_paywall_events.py` | large | In-process rolling store for ``POST /api/paywall/event`` client beacons. |
+| `clawmetry/alert_evaluator.py` | large | Local alert-rule evaluator — pure logic, no I/O (PRD #779 PR-D part 2). |
+| `clawmetry/approval_events.py` | small | The public seam between approvals and whoever delivers them. |
+| `clawmetry/approvals.py` | large | cloud-mediated approval policy engine. |
+| `clawmetry/attention_hook.py` | small | the `clawmetry hook attention` client. |
+| `clawmetry/audit.py` | medium | append-only audit log. |
+| `clawmetry/behaviour_signals.py` | large | Behaviour Signals: what people and agents *say* about a run (WO-58). |
+| `clawmetry/brain_dedupe.py` | medium | Shared collapse for duplicate Brain-feed events. |
+| `clawmetry/briefs.py` | medium | Briefs (WO-62): a saved question, a schedule, and a destination channel. |
+| `clawmetry/ccr.py` | small | CCR — reversible event-payload compression for the DuckDB store (#2843). |
+| `clawmetry/claude_code_gate.py` | medium | Claude Code pre-tool gate: policy-driven PreToolUse hook, local-first. |
+| `clawmetry/cli.py` | huge |  |
+| `clawmetry/cohort_compare.py` | medium | Cohort compare and similar runs: pure math, no I/O (WO-60). |
+| `clawmetry/cohort_queries.py` | medium | Store reads behind cohort compare and similar runs (WO-60). |
+| `clawmetry/config.py` | medium | ClawMetry configuration dataclass. |
+| `clawmetry/connector_health.py` | small | Connector liveness — turn the daemon's ``connector.health`` signal |
+| `clawmetry/context_coverage.py` | small | Which context-blowout signals we can actually see, per runtime. |
+| `clawmetry/context_windows.py` | medium | Context-window sizing across every runtime ClawMetry ingests. |
+| `clawmetry/cost_windows.py` | small | One definition of "today", "this week" and "this month" for every cost surface. |
+| `clawmetry/cursor_connector.py` | medium | Opt-in pull of Cursor cloud-agent usage, with the operator's own key. |
+| `clawmetry/daemon_registration.py` | medium | one place that knows how to make the |
+| `clawmetry/deepeval_bridge.py` | medium | optional DeepEval metric engine (local-first). |
+| `clawmetry/delegated_usage.py` | medium | Usage for work a runtime handed to another vendor's agent. |
+| `clawmetry/detector_behaviour.py` | medium | Is this agent doing something it does not normally do? |
+| `clawmetry/detector_calibration.py` | medium | How a detector decides what "too many" means, for THIS runtime and THIS team. |
+| `clawmetry/detector_money.py` | small | What a finding costs, and therefore what to look at first. |
+| `clawmetry/detector_surface.py` | medium | What a tool call actually touched, and what a finding may repeat back. |
+| `clawmetry/detectors.py` | large | research-backed, judge-free, CPU-cheap trajectory |
+| `clawmetry/deterministic_evaluators.py` | medium | cheap, code-based checks on sessions. |
+| `clawmetry/distinfo_cleanup.py` | small | prune stale dist-info left by partial upgrades. |
+| `clawmetry/dives_prompt.py` | medium | prompt template + schema descriptor for Dives. |
+| `clawmetry/dives_sql_safety.py` | medium | SQL safety validator for ClawMetry Dives (AI SQL -> chart over local DuckDB). |
+| `clawmetry/doctor.py` | medium | clawmetry doctor — enterprise network connectivity diagnostics. |
+| `clawmetry/efficiency.py` | medium | Efficiency grade + measured savings (pure math). |
+| `clawmetry/endpoints.py` | small | clawmetry.endpoints — single source of truth for cloud endpoint resolution. |
+| `clawmetry/entitlements.py` | huge | open-core entitlement resolution. |
+| `clawmetry/error_signal.py` | small | OSS delegating shim after the impl moved to clawmetry-pro. |
+| `clawmetry/eval_regression_replay.py` | medium | Phase 3 evals: regression-replay. |
+| `clawmetry/eval_runner.py` | large | Local-first LLM-as-judge scoring of completed sessions. |
+| `clawmetry/eval_suite_runner.py` | medium | Phase 2 evals: golden test sets + CLI runner. |
+| `clawmetry/evaluators.py` | medium | the named evaluator CATALOGUE (single source of truth). |
+| `clawmetry/event_shape.py` | small | ONE normalizer for every stored event shape. |
+| `clawmetry/event_shape_classify.py` | medium | Event-shape classifier implementation (private to :mod:`clawmetry.event_shape`). |
+| `clawmetry/extensions.py` | medium | ClawMetry extension/plugin system. |
+| `clawmetry/flow_trace.py` | medium | Flow trace assembly for the Harness Engineering tab (REQ-HB-006). |
+| `clawmetry/gateway_protocol.py` | small | the single source of the OpenClaw gateway |
+| `clawmetry/gateway_tap.py` | medium | live OpenClaw gateway WebSocket subscriber. |
+| `clawmetry/git_outcomes.py` | medium | Read a repository and say whether the agent's work shipped (REQ-OBS-CEA-022). |
+| `clawmetry/guard_actuator.py` | medium | Guard actuator — the ONE path from a decision to a process. |
+| `clawmetry/harness_bench.py` | medium | Harness Engineering bench: pure scoring math, no I/O. |
+| `clawmetry/harness_templates.py` | medium | Per-harness custom-tab template registry. |
+| `clawmetry/hook_ownership.py` | medium | Ownership-aware editing of a shared hooks array. |
+| `clawmetry/hooks.py` | medium | Hook lifecycle manager — install manifest and atomic install/uninstall API. |
+| `clawmetry/hooks_claude_code.py` | large | Claude Code hooks → ClawMetry: pre-execution approval gate + phone pushes. |
+| `clawmetry/incident_alerts.py` | medium | deliver a detector incident to a human. |
+| `clawmetry/insights.py` | medium | Weekly Insights Digest — LLM-over-DuckDB summary of the last 7 days. |
+| `clawmetry/installs.py` | medium | Install census — find every clawmetry copy on this machine and flag stale ones. |
+| `clawmetry/instrument.py` | medium | ``clawmetry instrument <runtime>`` — switch a runtime's own OpenTelemetry |
+| `clawmetry/interceptor.py` | medium | Zero-config HTTP interceptor for LLM API cost tracking. |
+| `clawmetry/latency_tracker.py` | small | Per-endpoint p50/p95 handler-latency tracker (in-memory rolling window). |
+| `clawmetry/license.py` | huge | self-hosted Pro/Enterprise license client. |
+| `clawmetry/lifecycle_coverage.py` | medium | Which lifecycle facts each runtime can put on a session's trail. |
+| `clawmetry/local_server.py` | medium | HTTP query server hosted INSIDE the sync daemon process. |
+| `clawmetry/local_store.py` | huge | Local DuckDB event store — Phase 1 of the local-first refactor (#964). |
+| `clawmetry/mcp_install.py` | medium | Register the ClawMetry MCP server with each runtime's MCP configuration |
+| `clawmetry/mcp_server.py` | medium | ClawMetry MCP server — exposes local telemetry as MCP tools (stdio transport). |
+| `clawmetry/narrator.py` | small | LLM-narrated alert enrichment (issue #1412, Feature C). |
+| `clawmetry/net.py` | medium | clawmetry.net — outbound TLS + proxy bootstrap for enterprise networks. |
+| `clawmetry/numbat_ingest.py` | medium | map Perplexity numbat NDJSON records into ClawMetry rows. |
+| `clawmetry/onboarding_state.py` | small | the ONE writer for the first-run gate's |
+| `clawmetry/org_key.py` | small | The organisation key: one secret, shared by the people in one organisation. |
+| `clawmetry/otel_exporter.py` | medium | Outbound OTLP trace exporter for ClawMetry. |
+| `clawmetry/otel_profiles.py` | small | OTel runtime profiles — the seam between the generic OTLP receiver and |
+| `clawmetry/otel_push.py` | small | OSS delegating shim after the impl moved to clawmetry-pro. |
+| `clawmetry/otlp_json.py` | medium | stdlib OTLP/JSON decoder (issue #4781). |
+| `clawmetry/outcome_classifier.py` | large | Auto-label every session with an outcome. |
+| `clawmetry/policy_engine.py` | medium | Guard policies — turn a detector incident into an enforcement decision. |
+| `clawmetry/process_control.py` | large | host-side process control for runaway agents. |
+| `clawmetry/provenance.py` | medium | Every number says how it was obtained. |
+| `clawmetry/providers_pricing.py` | medium | ClawMetry provider detection and pricing table. |
+| `clawmetry/proxy.py` | large | ClawMetry Proxy — opt-in enforcement layer between OpenClaw and LLM providers. |
+| `clawmetry/published_benchmarks.py` | small | Published (harness, model) benchmark pairs for the Harness Engineering tab. |
+| `clawmetry/quality.py` | medium | the Quality tab's plain-English layer. |
+| `clawmetry/quality_signals.py` | medium | evidence-bearing quality signals. |
+| `clawmetry/quality_thresholds.py` | small | per-runtime threshold calibration. |
+| `clawmetry/query_contract.py` | medium | the declared q/1 query contract registry. |
+| `clawmetry/question_sets.py` | medium | Question-set approvals — decisions beyond yes/no (WO-52, phase 1). |
+| `clawmetry/redaction.py` | medium | Defense-in-depth secret redaction for the daemon ingest path. |
+| `clawmetry/relay.py` | small | DEPRECATED stub. |
+| `clawmetry/replay_schema.py` | small | Canonical replay-event schema. |
+| `clawmetry/repo_readiness.py` | medium | how legible is this repo to an agent? |
+| `clawmetry/resume_hints.py` | medium | How a human restarts a session ClawMetry can no longer control. |
+| `clawmetry/retention.py` | small | How long this node keeps event data — one answer, with its reason. |
+| `clawmetry/risk.py` | medium | Hallucination Risk Indicator (issue #567). |
+| `clawmetry/runtime_gates.py` | medium | Pre-tool gates for Cursor and GitHub Copilot CLI — "block before it runs". |
+| `clawmetry/runtime_memory.py` | large | Per-runtime Memory & Skills file browser. |
+| `clawmetry/runtime_probe.py` | medium | zero-dependency presence probes for every |
+| `clawmetry/runtime_records.py` | medium | What each runtime actually records — so a surface can say "not recorded" |
+| `clawmetry/secure.py` | medium | clawmetry secure — one-command numbat (Perplexity agent-EDR) setup. |
+| `clawmetry/security_posture.py` | large | Runtime-aware security posture registry. |
+| `clawmetry/self_diagnostics.py` | medium | Agent self-diagnostics: reports an agent files about its own trouble, and |
+| `clawmetry/selfhosted.py` | small | clawmetry.selfhosted — ClawMetry Enterprise single-tenant server mode. |
+| `clawmetry/session_context.py` | medium | Inputs & context: what the agent was actually given, per session. |
+| `clawmetry/session_titles.py` | medium | ChatGPT-style session titles from the first real user prompt. |
+| `clawmetry/siem.py` | small | OSS delegating shim after the impl moved to clawmetry-pro. |
+| `clawmetry/signal_shifts.py` | medium | Signal shifts (WO-62): notice when a behaviour-signal rate moves, explain |
+| `clawmetry/span_reconstruct.py` | medium | Runtime-agnostic span reconstruction for family runtimes (Agent Graph WS-A). |
+| `clawmetry/spend_flow.py` | medium | node-wide AI spend flow (pure math). |
+| `clawmetry/sync.py` | huge | Cloud sync daemon for clawmetry connect. |
+| `clawmetry/telemetry.py` | medium | anonymous, opt-out, install-lifecycle pings. |
+| `clawmetry/token_confidence.py` | medium | Token Probability Visualizer (issue #563). |
+| `clawmetry/tool_risk.py` | medium | deterministic call-level risk classification. |
+| `clawmetry/trace.py` | medium | clawmetry.trace — Dependency-free Python tracing SDK for AI applications. |
+| `clawmetry/trace_auto.py` | medium | Automatic PR tracing: capture, publish and comment, with no command. |
+| `clawmetry/trace_capture.py` | medium | Build a PR trace bundle from local session data (PRD-pr-trace.md §4b). |
+| `clawmetry/trace_stamp.py` | medium | Stamp agent-authored commits with the ClawMetry session that produced them. |
+| `clawmetry/trace_viewer.py` | medium | Render a trace bundle to a self-contained HTML page (PRD-pr-trace.md §4g). |
+| `clawmetry/track.py` | small | clawmetry.track — Zero-config HTTP interceptor for LLM cost tracking. |
+| `clawmetry/trail_store.py` | medium | Trail store methods: session intent, typed-event back-fill, per-session git join. |
+| `clawmetry/trial_enforcement.py` | medium | Trial-end hard-block layer. |
+| `clawmetry/update_guard.py` | small | Crash-loop rollback guard for daemon self-update (firmware-OTA style). |
+| `clawmetry/update_respawn.py` | medium | Windows out-of-process updater. |
+| `clawmetry/waste_flags.py` | small | OSS delegating shim after the impl moved to clawmetry-pro. |
+| `clawmetry/watchdog.py` | medium | macOS "app-vanished" watchdog. |
+| `clawmetry/winconsole.py` | small | clawmetry.winconsole — stop Windows console windows flashing. |
+| `clawmetry/workload_profiles.py` | small | Workload profiling for the Harness Engineering tab (REQ-HB-004). |
+
+## Free runtime adapters (`clawmetry/adapters/`)
+
+The runtime adapters that ship in open source. The paid ones live in `clawmetry-pro` and register over the `clawmetry.extensions` entry point; see `sync._FAMILY_ADAPTER_SPECS` for the load order.
+
+| Module | Size | Purpose |
+|---|---|---|
+| `clawmetry/adapters/base.py` | medium | Adapter base class + unified schemas. |
+| `clawmetry/adapters/cost.py` | small | Shared cost-derivation helper for the bundled runtime adapters. |
+| `clawmetry/adapters/goose.py` | medium | GooseAdapter — read Goose (Block / block/goose) sessions from its SQLite store. |
+| `clawmetry/adapters/nemo.py` | large | NeMoAdapter — push-mode telemetry exporter for NVIDIA's NeMo Agent Toolkit. |
+| `clawmetry/adapters/openclaw.py` | large | This adapter does NOT re-implement OpenClaw session parsing. It delegates |
+| `clawmetry/adapters/phase.py` | medium | The session phase model: one state machine, every runtime. |
+| `clawmetry/adapters/registry.py` | small | Process-wide adapter registry. |
+
+## Data providers (`clawmetry/providers/`)
+
+The pluggable data-provider layer behind `CLAWMETRY_PROVIDER`.
+
+| Module | Size | Purpose |
+|---|---|---|
+| `clawmetry/providers/base.py` | small | Abstract data provider interface for ClawMetry. |
+| `clawmetry/providers/local.py` | medium | Local filesystem data provider — reads directly from ~/.openclaw files. |
+| `clawmetry/providers/turso.py` | small | Turso cloud data provider for ClawMetry cloud dashboard. |
+
+## CLI subcommands (`clawmetry/cli_cmds/`)
+
+Subcommands dispatched by `clawmetry/cli.py`.
+
+| Module | Size | Purpose |
+|---|---|---|
+| `clawmetry/cli_cmds/_common.py` | medium | Shared plumbing for the agent-facing read CLI. |
+| `clawmetry/cli_cmds/activity.py` | small | `clawmetry activity` — the Brain event feed from the terminal. |
+| `clawmetry/cli_cmds/progress.py` | small | `clawmetry progress` — is the agent actually getting anywhere? |
+| `clawmetry/cli_cmds/selfevolve.py` | small | `clawmetry selfevolve` — OSS 402 stub for the Pro self-improvement engine. |
+| `clawmetry/cli_cmds/sessions.py` | medium | `clawmetry sessions` — list sessions; drill into one with facets. |
+| `clawmetry/cli_cmds/usage.py` | small | `clawmetry usage` — token/cost analytics from the terminal. |
+| `clawmetry/cli_cmds/waste.py` | small | `clawmetry waste` — the re-read tax, from the terminal. |
+
+## v2 API (`clawmetry/v2/`)
+
+The versioned public API surface.
+
+| Module | Size | Blueprints | Serves | Purpose |
+|---|---|---|---|---|
+| `clawmetry/v2/route_map.py` | small |  |  | Canonical tab-name mapping between v1 and v2 URL schemes. |
+| `clawmetry/v2/routes.py` | medium | `bp_v2` | `/api/v2` | ClawMetry v2 Flask blueprint. |

--- a/docs/i18n/es-419/README.md
+++ b/docs/i18n/es-419/README.md
@@ -61,7 +61,7 @@ Dos preguntas que vale la pena responder antes de confiar en cualquier herramien
 Un porcentaje de utilización es tan honesto como aquello por lo que divide. ClawMetry
 dimensiona la ventana por proveedor a partir de [una tabla que puedes leer y
 enviar como PR](clawmetry/context_windows.py), que cubre Anthropic, OpenAI, Google, xAI,
-DeepSeek, Kimi, Qwen, Mistral, Llama y GLM. No mide los 26
+DeepSeek, Kimi, Qwen, Mistral, Llama y GLM. No mide los 30
 runtimes con la regla de un solo proveedor. Eso importa: un turno de 300K de GPT-5
 medido con la regla de Anthropic de 200K se lee como ">100%, desbordado" cuando en
 realidad está al 75% de los 400K de GPT-5. La misma regla oculta un turno de DeepSeek

--- a/docs/i18n/pt-PT/README.md
+++ b/docs/i18n/pt-PT/README.md
@@ -61,7 +61,7 @@ Duas perguntas que vale a pena responder antes de confiar em qualquer ferramenta
 Uma percentagem de utilização só é tão honesta quanto o valor pelo qual divide. O ClawMetry
 dimensiona a janela por fornecedor a partir de [uma tabela que pode ler e
 propor via PR](clawmetry/context_windows.py), cobrindo Anthropic, OpenAI, Google, xAI,
-DeepSeek, Kimi, Qwen, Mistral, Llama e GLM. Não mede os 26
+DeepSeek, Kimi, Qwen, Mistral, Llama e GLM. Não mede os 30
 runtimes com a régua de um único fornecedor. Isso importa: um turno de 300K do GPT-5
 avaliado com a régua de 200K da Anthropic lê-se como ">100%, estourado" quando está
 na realidade a 75% dos 400K do GPT-5. A mesma régua esconde um turno de 130K da

--- a/scripts/gen_module_map.py
+++ b/scripts/gen_module_map.py
@@ -1,0 +1,329 @@
+#!/usr/bin/env python3
+"""Generate docs/MODULE_MAP.md — the full inventory of this repo's modules.
+
+WHY THIS EXISTS
+===============
+``CLAUDE.md`` and ``ARCHITECTURE.md`` used to carry hand-written tables of
+"the route modules" and "the package modules". They drifted, badly: on
+2026-09-05 the route table listed 17 of the 70 modules under ``routes/`` and
+none of the 82 blueprints the app registers, and both files quoted line
+counts thousands of lines out of date. An agent reading them looked for a
+feature in ``dashboard.py`` that had lived in its own module for months.
+
+A hand-maintained inventory of a repo this size is not maintainable, so this
+one is generated. The curated tables in ``CLAUDE.md`` stay small on purpose
+(the modules you reach for most often) and point here for the rest.
+
+Two deliberate choices keep the committed file stable enough to gate CI on:
+
+* **No exact line counts.** A byte-accurate size column would change on
+  almost every PR, so every unrelated PR would go red until someone
+  regenerated the doc. Sizes are reported as coarse bands instead, which
+  move perhaps twice a year.
+* **Structure, not prose.** Module path, the blueprints it defines, the URL
+  rules it registers, and the first line of its docstring. All of that is
+  read out of the source with ``ast``; nothing is imported, so this runs
+  without Flask, DuckDB or any optional dependency installed.
+
+Usage::
+
+    python3 scripts/gen_module_map.py            # rewrite the doc
+    python3 scripts/gen_module_map.py --check    # exit 1 on drift
+
+``tests/test_module_map_drift.py`` calls :func:`check` so CI fails on drift,
+and ``make lint-module-map`` runs the same check locally.
+"""
+from __future__ import annotations
+
+import argparse
+import ast
+import pathlib
+import sys
+
+REPO = pathlib.Path(__file__).resolve().parents[1]
+DOC_PATH = REPO / "docs" / "MODULE_MAP.md"
+
+# (directory, heading, blurb). Order is the order of the sections in the doc.
+SECTIONS: list[tuple[str, str, str]] = [
+    (
+        ".",
+        "Top level",
+        "The Flask app itself plus the optional SQLite time-series companion.",
+    ),
+    (
+        "routes",
+        "HTTP routes (`routes/`)",
+        "One module per feature, each owning one or more Flask blueprints. "
+        "New endpoints go here, never in `dashboard.py`.",
+    ),
+    (
+        "helpers",
+        "Shared helpers (`helpers/`)",
+        "Helpers extracted out of `dashboard.py`. Route modules still reach "
+        "the ones that have not moved yet via a late `import dashboard as _d`.",
+    ),
+    (
+        "clawmetry",
+        "Package (`clawmetry/`)",
+        "The pip-installable package: CLI, sync daemon, DuckDB store, "
+        "detectors, enforcement and the free runtime adapters.",
+    ),
+    (
+        "clawmetry/adapters",
+        "Free runtime adapters (`clawmetry/adapters/`)",
+        "The runtime adapters that ship in open source. The paid ones live in "
+        "`clawmetry-pro` and register over the `clawmetry.extensions` entry "
+        "point; see `sync._FAMILY_ADAPTER_SPECS` for the load order.",
+    ),
+    (
+        "clawmetry/providers",
+        "Data providers (`clawmetry/providers/`)",
+        "The pluggable data-provider layer behind `CLAWMETRY_PROVIDER`.",
+    ),
+    (
+        "clawmetry/cli_cmds",
+        "CLI subcommands (`clawmetry/cli_cmds/`)",
+        "Subcommands dispatched by `clawmetry/cli.py`.",
+    ),
+    (
+        "clawmetry/v2",
+        "v2 API (`clawmetry/v2/`)",
+        "The versioned public API surface.",
+    ),
+]
+
+# Files that are packaging plumbing rather than product code.
+SKIP_NAMES = {"__init__.py", "__main__.py", "setup.py", "conftest.py"}
+
+# Line-count bands. Coarse on purpose: see the module docstring.
+BANDS: list[tuple[int, str]] = [
+    (200, "small"),
+    (1_000, "medium"),
+    (5_000, "large"),
+]
+BAND_HUGE = "huge"
+
+_BAND_LEGEND = (
+    "Size bands are deliberately coarse so this file does not churn on every "
+    "PR: **small** is under 200 lines, **medium** under 1k, **large** under "
+    "5k, **huge** is 5k and up."
+)
+
+
+def band(lines: int) -> str:
+    """Return the coarse size band for a line count."""
+    for ceiling, name in BANDS:
+        if lines < ceiling:
+            return name
+    return BAND_HUGE
+
+
+def _summary(tree: ast.Module) -> str:
+    """First sentence-ish line of the module docstring, one line, no pipes."""
+    doc = ast.get_docstring(tree) or ""
+    first = ""
+    for raw in doc.splitlines():
+        if raw.strip():
+            first = raw.strip()
+            break
+    # Most docstrings open by restating the module path ("routes/alerts.py --
+    # Budget + Alerts endpoints"). The path is already the first column, so
+    # drop the restatement rather than printing it twice.
+    for sep in (" -- ", " — ", ": ", " - "):
+        head, found, tail = first.partition(sep)
+        if found and head.endswith(".py") and tail.strip():
+            first = tail.strip()
+            break
+    # A `|` would break the markdown table; a backslash-escape renders badly
+    # in some viewers, so use a comma, which is what the prose means anyway.
+    return first.replace("|", ",").strip()
+
+
+def _blueprints_and_rules(tree: ast.Module) -> tuple[list[str], list[str]]:
+    """Blueprint variable names defined here, and the URL rules on them."""
+    blueprints: list[str] = []
+    rules: list[str] = []
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign):
+            call = node.value
+            if (
+                isinstance(call, ast.Call)
+                and isinstance(call.func, ast.Name)
+                and call.func.id == "Blueprint"
+            ):
+                for target in node.targets:
+                    if isinstance(target, ast.Name):
+                        blueprints.append(target.id)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            for dec in node.decorator_list:
+                if not isinstance(dec, ast.Call):
+                    continue
+                func = dec.func
+                if not isinstance(func, ast.Attribute) or func.attr not in (
+                    "route",
+                    "get",
+                    "post",
+                ):
+                    continue
+                if not dec.args:
+                    continue
+                first = dec.args[0]
+                if isinstance(first, ast.Constant) and isinstance(first.value, str):
+                    rules.append(first.value)
+
+    return sorted(set(blueprints)), sorted(set(rules))
+
+
+def _rule_prefixes(rules: list[str]) -> str:
+    """Collapse URL rules to their distinct two-segment prefixes.
+
+    Listing every rule would put thousands of lines in the doc and would
+    churn constantly. The prefix is what a reader actually needs: which part
+    of the URL space this module owns.
+    """
+    prefixes: set[str] = set()
+    for rule in rules:
+        parts = [p for p in rule.split("/") if p and not p.startswith("<")]
+        if not parts:
+            continue
+        prefixes.add("/" + "/".join(parts[:2]))
+    return ", ".join(f"`{p}`" for p in sorted(prefixes))
+
+
+def _scan(directory: str) -> list[dict]:
+    """Collect one record per module in ``directory`` (non-recursive)."""
+    base = REPO / directory if directory != "." else REPO
+    if not base.is_dir():
+        return []
+
+    out: list[dict] = []
+    for path in sorted(base.glob("*.py")):
+        if path.name in SKIP_NAMES:
+            continue
+        rel = path.relative_to(REPO).as_posix()
+        text = path.read_text(encoding="utf-8", errors="replace")
+        try:
+            tree = ast.parse(text)
+        except SyntaxError:
+            # Never crash on bad input: report the module, skip the detail.
+            out.append(
+                {
+                    "path": rel,
+                    "band": band(text.count("\n") + 1),
+                    "blueprints": [],
+                    "prefixes": "",
+                    "summary": "(unparseable)",
+                }
+            )
+            continue
+        blueprints, rules = _blueprints_and_rules(tree)
+        out.append(
+            {
+                "path": rel,
+                "band": band(text.count("\n") + 1),
+                "blueprints": blueprints,
+                "prefixes": _rule_prefixes(rules),
+                "summary": _summary(tree),
+            }
+        )
+    return out
+
+
+def render() -> str:
+    """Render the whole document."""
+    sections = [(d, h, b, _scan(d)) for d, h, b in SECTIONS]
+    module_total = sum(len(rows) for _, _, _, rows in sections)
+    blueprint_total = len(
+        {
+            bp
+            for _, _, _, rows in sections
+            for row in rows
+            for bp in row["blueprints"]
+        }
+    )
+
+    lines = [
+        "# ClawMetry module map",
+        "",
+        "> GENERATED FILE, do not edit by hand. Regenerate with",
+        "> `python3 scripts/gen_module_map.py` (CI fails on drift via",
+        "> `tests/test_module_map_drift.py`).",
+        "",
+        f"{module_total} modules, {blueprint_total} Flask blueprints. "
+        "`CLAUDE.md` carries a short curated table of the ones you reach for "
+        "most often; this is the whole list.",
+        "",
+        _BAND_LEGEND,
+        "",
+        "The **Serves** column is the URL space a module owns, collapsed to "
+        "two path segments. A blank one means the module registers no routes "
+        "of its own (it is a library, or its rules are built dynamically).",
+        "",
+    ]
+
+    for directory, heading, blurb, rows in sections:
+        if not rows:
+            continue
+        lines += [f"## {heading}", "", blurb, ""]
+        has_bp = any(row["blueprints"] for row in rows)
+        if has_bp:
+            lines += [
+                "| Module | Size | Blueprints | Serves | Purpose |",
+                "|---|---|---|---|---|",
+            ]
+        else:
+            lines += ["| Module | Size | Purpose |", "|---|---|---|"]
+        for row in rows:
+            if has_bp:
+                bps = ", ".join(f"`{b}`" for b in row["blueprints"])
+                lines.append(
+                    f"| `{row['path']}` | {row['band']} | {bps} | "
+                    f"{row['prefixes']} | {row['summary']} |"
+                )
+            else:
+                lines.append(
+                    f"| `{row['path']}` | {row['band']} | {row['summary']} |"
+                )
+        lines.append("")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def check() -> int:
+    """Return 0 when the committed doc matches what we would render."""
+    want = render()
+    if not DOC_PATH.exists():
+        print(f"{DOC_PATH.relative_to(REPO)} is missing; run scripts/gen_module_map.py")
+        return 1
+    have = DOC_PATH.read_text(encoding="utf-8")
+    if have == want:
+        print(f"module map in sync ({DOC_PATH.relative_to(REPO)})")
+        return 0
+    print(
+        f"{DOC_PATH.relative_to(REPO)} is out of date.\n"
+        "Regenerate it with: python3 scripts/gen_module_map.py"
+    )
+    return 1
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="report drift and exit 1 instead of rewriting the doc",
+    )
+    args = parser.parse_args()
+
+    if args.check:
+        return check()
+
+    DOC_PATH.parent.mkdir(parents=True, exist_ok=True)
+    DOC_PATH.write_text(render(), encoding="utf-8")
+    print(f"wrote {DOC_PATH.relative_to(REPO)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/sync_runtime_count.py
+++ b/scripts/sync_runtime_count.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Keep the advertised runtime count in sync with the entitlement catalogue.
+"""Keep advertised counts in sync with the entitlement catalogue.
 
 ``clawmetry/entitlements.py`` is the source of truth: the supported runtime
 count is ``len(FREE_RUNTIMES | PAID_RUNTIMES)``. That number also appears in
@@ -20,6 +20,13 @@ that surface cannot go stale at all.
 When a number here is legitimately *not* the supported-runtime count (a tier
 bullet counting free runtimes, a dated changelog line, a capacity estimate),
 add it to :data:`EXEMPT` with the reason rather than reshaping the prose.
+
+The same script also checks the **chat-channel** count against
+``ALL_CHANNELS``, which drifted the same way and for the same reason
+(2026-09-05: ``ALL_CHANNELS`` had 23, CLAUDE.md / FLYWHEEL.md / AGENTS.md
+said 21 and PRD.md said 22). That half is report-only, with its own
+:data:`CHANNEL_EXEMPT`: the phrasing varies too much across surfaces
+("21 chat channels", "21 chat-channel adapters") to rewrite unattended.
 """
 from __future__ import annotations
 
@@ -32,6 +39,28 @@ REPO = Path(__file__).resolve().parent.parent
 
 # "14 runtimes", "12 AI agent runtimes", "14+ runtimes", "20 agent runtimes".
 COUNT_RE = re.compile(r"\b(\d{1,3})(\+?) ((?:AI )?(?:agent )?runtimes)\b")
+
+# The same phrase with the line wrapped between the number and the noun.
+# Hand-wrapped markdown does this constantly and the line-by-line scan below
+# cannot see it: README.md carried "all 26\nruntimes" from 2026-08-25 (#5202)
+# to 2026-09-05 while --check reported the count in sync at 30, and two
+# translations inherited it. Applied to PROSE_SUFFIXES only,
+# because in Python a newline between a number and the word `runtimes` is
+# usually two unrelated statements ("open_count = 0\n    runtimes = ...").
+WRAPPED_COUNT_RE = re.compile(
+    r"\b(\d{1,3})(\+?)\n([ \t]*)((?:AI )?(?:agent )?runtimes)\b"
+)
+PROSE_SUFFIXES = {".md", ".html"}
+
+# "21 chat channels", "21 chat-channel adapters". Same drift class as the
+# runtime count, against clawmetry/entitlements.py:ALL_CHANNELS.
+CHANNEL_COUNT_RE = re.compile(r"\b(\d{1,3}) chat[- ]channels?\b")
+
+# Same shape as EXEMPT: counts that are legitimately not the catalogue size.
+CHANNEL_EXEMPT: list[tuple[str, str, str]] = [
+    ("routes/channels.py", "6 chat channels", "per-tier capacity example"),
+    ("routes/entitlement.py", "6 chat channels", "per-tier capacity example"),
+]
 
 # Directories that legitimately carry historic or unrelated numbers.
 SKIP_DIRS = {
@@ -66,6 +95,11 @@ MORE_RE = re.compile(r"& \d{1,3} more\b")
 # reported by --check instead of rewritten, so a human updates them knowingly.
 MORE_RE_I18N = re.compile(r"[^\s]{1,3} ?\d{1,3} ?(?:more|más|mais|autres|ακόμα|weitere|более|أخرى|अन्य)\b")
 
+# The tagline names four runtimes and leaves the product names untranslated,
+# so this string is on that line in all 35 locales and almost nowhere else.
+# It is what keeps MORE_RE_I18N off unrelated prose.
+TAGLINE_ANCHOR = "Codex"
+
 
 def catalogue_count() -> int:
     """Supported runtime count, parsed (not imported) from entitlements.py."""
@@ -82,6 +116,55 @@ def catalogue_count() -> int:
     if total < 2:
         raise SystemExit("parsed an implausible runtime count from entitlements.py")
     return total
+
+
+def channel_count() -> int:
+    """Chat-channel count, parsed (not imported) from entitlements.py.
+
+    ``ALL_CHANNELS`` and ``sync._CHANNEL_DIRS`` are kept 1:1 by
+    ``tests/test_entitlement_channel_catalog.py``; this reads the catalogue for
+    the same reason :func:`catalogue_count` does, so the check runs without
+    importing a module that pulls in Flask and DuckDB.
+    """
+    src = (REPO / "clawmetry" / "entitlements.py").read_text(encoding="utf-8")
+    m = re.search(r"ALL_CHANNELS: tuple\[str, \.\.\.\] = \((.*?)\)", src, re.S)
+    if not m:
+        raise SystemExit("could not parse ALL_CHANNELS from entitlements.py")
+    total = len(re.findall(r'"[a-z0-9_]+"', m.group(1)))
+    if total < 2:
+        raise SystemExit("parsed an implausible channel count from entitlements.py")
+    return total
+
+
+def check_channel_count(expected: int | None = None) -> list[tuple[str, int, str, str]]:
+    """Return [(relpath, lineno, found, line)] for every stale channel count.
+
+    Same failure as the runtime count, one catalogue over: CLAUDE.md,
+    FLYWHEEL.md and AGENTS.md all said "21 chat-channel adapters" while
+    ``ALL_CHANNELS`` had grown to 23. Markdown, HTML and Python are scanned;
+    there is no fixer, because the phrasing varies too much to rewrite
+    safely ("21 chat channels", "21 chat-channel adapters").
+    """
+    expected = channel_count() if expected is None else expected
+    drift = []
+    for path in _files():
+        if path.suffix not in PROSE_SUFFIXES and path.suffix != ".py":
+            continue
+        rel = str(path.relative_to(REPO))
+        try:
+            lines = path.read_text(encoding="utf-8").splitlines()
+        except UnicodeDecodeError:
+            continue
+        for n, line in enumerate(lines, 1):
+            if any(
+                rel.endswith(suffix) and needle in line
+                for suffix, needle, _ in CHANNEL_EXEMPT
+            ):
+                continue
+            for m in CHANNEL_COUNT_RE.finditer(line):
+                if int(m.group(1)) != expected:
+                    drift.append((rel, n, m.group(0), line.strip()))
+    return drift
 
 
 def _is_exempt(rel: str, line: str) -> bool:
@@ -119,6 +202,17 @@ def check(expected: int | None = None) -> list[tuple[str, int, str, str]]:
                 for m in MORE_RE.finditer(line):
                     if m.group(0) != f"& {expected - NAMED_IN_TAGLINE} more":
                         drift.append((rel, n, m.group(0), line.strip()))
+
+        if path.suffix in PROSE_SUFFIXES:
+            text = "\n".join(lines)
+            for m in WRAPPED_COUNT_RE.finditer(text):
+                if int(m.group(1)) == expected:
+                    continue
+                n = text[: m.start()].count("\n") + 1
+                if _is_exempt(rel, lines[n - 1]):
+                    continue
+                found = m.group(0).replace("\n", " ")
+                drift.append((rel, n, found, lines[n - 1].strip()))
     return drift
 
 
@@ -135,6 +229,13 @@ def check_translated_taglines(expected: int | None = None) -> list[tuple[str, in
     for path in sorted((REPO / "docs" / "i18n").rglob("README.md")):
         rel = str(path.relative_to(REPO))
         for n, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+            # Only the tagline line. MORE_RE_I18N is loose by necessity (it
+            # spans 35 languages), so on ordinary prose it fires on things
+            # like "2 mais difíceis" -- pt-BR was reported stale for months
+            # while its tagline was correct, which is how a warning stops
+            # being read. TAGLINE_ANCHOR is untranslated in every locale.
+            if TAGLINE_ANCHOR not in line:
+                continue
             for m in MORE_RE_I18N.finditer(line):
                 if str(want) not in m.group(0):
                     stale.append((rel, n, m.group(0).strip()))
@@ -162,8 +263,20 @@ def fix(expected: int | None = None) -> list[str]:
                 new = MORE_RE.sub(f"& {expected - NAMED_IN_TAGLINE} more", new)
             changed |= new != line
             out.append(new)
+        joined = "".join(out)
+        if path.suffix in PROSE_SUFFIXES:
+
+            def _rewrap(m, _text=joined):
+                line = _text[: m.start()].rsplit("\n", 1)[-1] + m.group(0)
+                if _is_exempt(rel, line):
+                    return m.group(0)
+                return f"{expected}{m.group(2)}\n{m.group(3)}{m.group(4)}"
+
+            rewrapped = WRAPPED_COUNT_RE.sub(_rewrap, joined)
+            changed |= rewrapped != joined
+            joined = rewrapped
         if changed:
-            path.write_text("".join(out), encoding="utf-8")
+            path.write_text(joined, encoding="utf-8")
             touched.append(rel)
     return touched
 
@@ -184,18 +297,34 @@ def main() -> int:
             for rel, n, found in stale:
                 print(f"  {rel}:{n}: {found}")
 
+    channels = channel_count()
+
+    def _report_channels() -> int:
+        """Chat-channel drift. Reported, never rewritten: see the docstring."""
+        stale = check_channel_count(channels)
+        if not stale:
+            print(f"chat-channel count in sync at {channels}")
+            return 0
+        print(f"\nchat-channel count drift (ALL_CHANNELS has {channels}):\n")
+        for rel, n, found, line in stale:
+            print(f"  {rel}:{n}: {found!r}\n      {line}")
+        print(f"\n{len(stale)} stale mention(s). Edit the prose to say {channels}.")
+        return 1
+
     if args.check:
         drift = check(expected)
+        rc = 0
         if not drift:
             print(f"runtime count in sync at {expected} across every surface")
-            _report_translations()
-            return 0
-        print(f"runtime count drift (catalogue says {expected}):\n")
-        for rel, n, found, line in drift:
-            print(f"  {rel}:{n}: {found!r}\n      {line}")
-        print(f"\n{len(drift)} stale mention(s). Fix with: python3 {Path(__file__).relative_to(REPO)}")
+        else:
+            print(f"runtime count drift (catalogue says {expected}):\n")
+            for rel, n, found, line in drift:
+                print(f"  {rel}:{n}: {found!r}\n      {line}")
+            print(f"\n{len(drift)} stale mention(s). Fix with: python3 {Path(__file__).relative_to(REPO)}")
+            rc = 1
+        rc |= _report_channels()
         _report_translations()
-        return 1
+        return rc
 
     touched = fix(expected)
     if not touched:

--- a/tests/test_module_map_drift.py
+++ b/tests/test_module_map_drift.py
@@ -1,0 +1,107 @@
+"""CI guard against module-inventory drift in the architecture docs.
+
+``docs/MODULE_MAP.md`` is generator output (``scripts/gen_module_map.py``).
+This fails when the committed file no longer matches the source tree, and
+when the curated tables in ``CLAUDE.md`` name a module that has moved or been
+deleted.
+
+Burned 2026-09-05: ``CLAUDE.md``'s route table listed 17 of the 70 modules
+under ``routes/`` and none of the 82 blueprints the app registers, and
+``ARCHITECTURE.md`` described a 13-blueprint app that had not existed for
+months. Both files were hand-maintained, so nothing caught it.
+
+Sibling of ``test_query_contract_drift.py`` (generated doc must match its
+source) and ``test_runtime_count_copy_sync.py`` (numbers in prose must match
+the catalogue).
+"""
+from __future__ import annotations
+
+import importlib.util
+import re
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+SCRIPT = REPO / "scripts" / "gen_module_map.py"
+
+
+def _load_generator():
+    spec = importlib.util.spec_from_file_location("gen_module_map", SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+GEN = _load_generator()
+
+
+def test_committed_module_map_matches_the_source_tree():
+    """docs/MODULE_MAP.md is exactly what the generator emits today."""
+    assert GEN.DOC_PATH.exists(), (
+        "docs/MODULE_MAP.md is missing. Generate it with "
+        "`python3 scripts/gen_module_map.py`."
+    )
+    assert GEN.DOC_PATH.read_text(encoding="utf-8") == GEN.render(), (
+        "docs/MODULE_MAP.md is stale. A module was added, removed, renamed, "
+        "crossed a size band, or changed its docstring or its URL prefixes. "
+        "Regenerate it with `python3 scripts/gen_module_map.py` and commit "
+        "the result."
+    )
+
+
+def test_check_mode_agrees_with_the_committed_file():
+    """``--check`` is the contract `make lint-module-map` runs on."""
+    assert GEN.check() == 0
+
+
+def test_every_blueprint_the_app_registers_is_in_the_map():
+    """A blueprint registered in dashboard.py must be findable in the doc.
+
+    This is the half the generator cannot check on its own: it reads the
+    modules, not the registration list, so a blueprint defined in a file the
+    generator does not scan would be invisible in both places.
+    """
+    source = (REPO / "dashboard.py").read_text(encoding="utf-8")
+    # `from routes.meta import bp_otel as _bp_otel` registers under the alias;
+    # the map knows the blueprint by its real name.
+    aliases = dict(
+        (alias, real)
+        for real, alias in re.findall(r"import\s+(\w+)\s+as\s+(\w+)", source)
+    )
+    registered = {
+        aliases.get(name, name)
+        for name in re.findall(r"app\.register_blueprint\(\s*(\w+)", source)
+    }
+    assert registered, "no register_blueprint calls found; the regex is stale"
+
+    doc = GEN.DOC_PATH.read_text(encoding="utf-8")
+    missing = sorted(bp for bp in registered if f"`{bp}`" not in doc)
+    assert not missing, (
+        "dashboard.py registers blueprints that docs/MODULE_MAP.md does not "
+        f"list: {missing}. Either the defining module lives outside the "
+        "directories in gen_module_map.SECTIONS (add it there), or the map "
+        "needs regenerating."
+    )
+
+
+# Modules named in the curated CLAUDE.md tables. The tables are short on
+# purpose; this only asserts that what they DO name still exists, which is
+# how they went stale last time (files split out of dashboard.py and the
+# table kept pointing at the old home).
+_CODE_REF = re.compile(
+    r"`((?:routes|clawmetry|helpers|scripts|tests)/[\w./]+\.py|\w+\.py)`"
+)
+
+
+@pytest.mark.parametrize("doc_name", ["CLAUDE.md", "ARCHITECTURE.md"])
+def test_docs_do_not_name_modules_that_no_longer_exist(doc_name):
+    text = (REPO / doc_name).read_text(encoding="utf-8")
+    referenced = sorted(set(_CODE_REF.findall(text)))
+    assert referenced, f"{doc_name} names no modules; the regex is stale"
+
+    missing = [ref for ref in referenced if not (REPO / ref).exists()]
+    assert not missing, (
+        f"{doc_name} points at modules that do not exist: {missing}. "
+        "Update the prose, or the file moved and the reference did not."
+    )


### PR DESCRIPTION
`ARCHITECTURE.md` and `CLAUDE.md` had drifted far enough to mislead an agent reading them. Everything below was verified against `origin/main`, not remembered.

No-PRD: documentation and CI guards only, no product code or behaviour change. The two files the gate flags are a Makefile lint target and a comment in `entitlements.py`.

## What was wrong

**ARCHITECTURE.md described a different product.**

| Claim in the doc | Reality |
|---|---|
| "ClawMetry is a **read-only observer** ... It never modifies your agents" (repeated under Security) | Five intervention surfaces ship today. `CLAUDE.md` Conventions has said so since Guard landed; ARCHITECTURE.md never got the memo |
| "No external calls, your data never leaves your machine" | Contradicted by our own `docs/EGRESS.md`, which documents the install ping, the PyPI version check, and the opt-in encrypted snapshot |
| "Binds to `0.0.0.0:8900`" | `--host` defaults to `127.0.0.1` |
| "**Disk**: Zero", "**CPU**: negligible, no polling loops except health" | The DuckDB store grows with history, and the daemon has an explicit CPU budget with a thread cap and a rollup cache (FLYWHEEL.md §1e) |
| Gateway logs at `/tmp/moltbot/` | `~/.openclaw/logs/` since OpenClaw 2026.4; `/tmp` is the legacy fallback |
| The data-flow example reads `sessions.json` and each `.jsonl` inside the handler | That is precisely the violation FLYWHEEL.md §1 exists to prevent; it returns empty in cloud |
| Paid runtimes listed as ten, with Goose among them | 27 paid, and Goose has been free in OSS for a while |
| "a small core plus a `routes/` package (sessions, channels, ... nemoclaw)" | 13 of the 70 modules |

**CLAUDE.md** opened with "real-time observability dashboard for OpenClaw AI agents" on a 30-runtime product, which FLYWHEEL.md's multi-runtime rule calls a bug in so many words. Its route table listed 17 of 70 modules and none of the 82 registered blueprints, so anything that moved out of `dashboard.py` in the last few months was unfindable from the docs. Line counts were off by thousands (`dashboard.py` ~17,300 vs 21,306; `sync.py` ~20,200 vs 26,457), `routes/entitlement.py` (47,661 lines, the largest file in the repo) was absent entirely, `helpers/` was described as future work when it already exists, and the pinned version `0.12.650` disagreed with `dashboard.py`'s own `__version__` (`0.12.748`), which in turn trails PyPI (`0.12.820`) because the write-back bump PRs go unmerged. The doc now points at the source and says which number actually means "released", instead of carrying a third one.

**AGENTS.md** said "the 10 gated runtime adapters" and routed every non-OpenClaw adapter to `clawmetry-pro`, which stopped being the rule when open-source runtimes started landing in OSS.

## What changed

`ARCHITECTURE.md` is largely rewritten: the five surfaces and the three locks up front, the ingest paths (five, not three: hooks and the HTTP ingest API were missing), the writer-lock and localhost-query-server design, the durability contract, Guard and Behaviour Signals (neither was mentioned), cloud sync, and honest performance and security sections. The C4 diagrams now show the actuator path and the real free/paid split.

`CLAUDE.md`'s tables are now a short curated index with the line counts removed, because they went stale within weeks every single time they were written down. What replaced them:

**1. `docs/MODULE_MAP.md` is generated.** `scripts/gen_module_map.py` reads the tree with `ast` (no imports, so it runs without Flask or DuckDB) and emits every module, the blueprints it defines, the URL prefixes it owns, and its docstring summary. Sizes are coarse bands rather than exact counts, deliberately: a byte-accurate size column would go red on almost every PR and teach people to regenerate without reading.

**2. `tests/test_module_map_drift.py`** asserts the committed map matches the tree, that every blueprint `dashboard.py` registers appears in it (resolving `import ... as _alias`), and that neither doc names a module that no longer exists. Wired into `ci.yml` **by name**, because this repo runs file lists rather than `pytest tests/` and a guard not named in a workflow runs in no job at all.

**3. `scripts/sync_runtime_count.py` got two gaps closed**, and both were hiding real drift:

* It scanned line by line, so a count wrapped across a newline was invisible. `README.md` has said "It does not measure all 26\nruntimes with one vendor's ruler" since #5202 on 2026-08-25, with `--check` reporting "in sync at 30" the whole time. Two translations inherited it. Fixed in the three files.
* It never checked the chat-channel count. `ALL_CHANNELS` has 23; `CLAUDE.md`, `FLYWHEEL.md` and `AGENTS.md` said 21 and `PRD.md` said 22. Report-only with its own exempt list, since the phrasing varies too much to rewrite unattended.

Also stopped the i18n tagline warning firing on unrelated Portuguese prose ("2 mais difíceis"), which had been reporting pt-BR's tagline stale for months while it was correct. A warning nobody can act on is how the real ones get ignored.

## Verification

Each guard was proved to go red on the unfixed tree before being trusted:

* Appending one bogus row to `docs/MODULE_MAP.md` → 2 of 5 tests fail; restoring → 5 pass.
* The wrapped-count check flagged all three stale `26 runtimes` on first run, exit 1; after the fix, exit 0.
* The channel check flagged all five stale mentions plus two legitimate per-tier examples, which are now in `CHANNEL_EXEMPT` with reasons.

```
$ python3 scripts/sync_runtime_count.py --check
runtime count in sync at 30 across every surface
chat-channel count in sync at 23

$ make lint-module-map
module map in sync (docs/MODULE_MAP.md)

$ python3 -m pytest tests/test_module_map_drift.py tests/test_runtime_count_copy_sync.py \
    tests/test_entitlement_channel_catalog.py tests/test_advertised_runtimes_match_catalogue.py \
    tests/test_workflow_yaml_valid.py -q
238 passed, 2 skipped
```

Every module path, endpoint, environment variable and referenced doc named in the new text was checked to exist. `make lint-py` is red on this branch exactly as it is on `main` (231 pre-existing ruff findings in `dashboard.py`, which this PR does not touch); CI's lint step runs the advisory `ruff` invocation, not that target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WjTv3RQVBy8JbGZkFLWuWU
