### PR TITLE
Harden CI: requeue reads drift-bot from the status API, so parked PRs restart

### DIFF
--- a/.github/workflows/queue-priority.yml
+++ b/.github/workflows/queue-priority.yml
@@ -9,7 +9,8 @@
 #      in-progress) runs on non-main refs so main's jobs take the runners next.
 #   2. requeue      — once main is quiet again (Auto-deploy Cloud completed, or
 #      the half-hourly sweep finds main idle), re-run the latest cancelled run
-#      of each workflow for every open PR whose drift-bot check is green.
+#      of each workflow for every open PR whose drift-bot commit status is
+#      green, or which never receives one (frontend-only npm bumps).
 #      Red-drift PRs stay parked until their drift is fixed and re-reported.
 #
 # No third-party actions on purpose: every step is `gh api` against
@@ -78,11 +79,15 @@ jobs:
     if: github.event_name == 'workflow_run' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    # actions: re-run parked runs; checks: read drift-bot's conclusion;
+    # actions: re-run parked runs; statuses: read drift-bot's commit status;
     # pull-requests: list the open PRs to consider.
+    #
+    # `statuses: read` rather than `checks: read`: drift-bot is a commit
+    # status, not a check run (see the step below), and the two surfaces are
+    # governed by different scopes. Nothing here reads /check-runs any more.
     permissions:
       actions: write
-      checks: read
+      statuses: read
       pull-requests: read
     steps:
       - name: Skip while main still has queued or running jobs
@@ -111,9 +116,28 @@ jobs:
           gh api "/repos/$REPO/pulls?state=open&per_page=100" --paginate \
             --jq '.[] | select(.head.repo.full_name == env.REPO) | "\(.number)\t\(.head.ref)\t\(.head.sha)"' |
           while IFS=$'\t' read -r pr branch sha; do
-            drift=$(gh api "/repos/$REPO/commits/$sha/check-runs?check_name=drift-bot&per_page=10" \
-                      --jq '[.check_runs[] | .conclusion] | first // "missing"')
-            [ "$drift" = "success" ] || { echo "PR #$pr: drift=$drift, parked"; continue; }
+            # drift-bot is a COMMIT STATUS posted by the 8090-software-factory
+            # App, not an Actions check run. It never appears in /check-runs --
+            # scripts/e2e_gate.py grew list_commit_statuses() for exactly this
+            # reason. Reading the wrong surface returned "missing" for every
+            # PR, so the guard below rejected all of them and this job has
+            # re-run nothing since it landed: every run clear-queue cancelled
+            # stayed cancelled. /commits/<sha>/status already collapses to the
+            # latest status per context.
+            drift=$(gh api "/repos/$REPO/commits/$sha/status" \
+                      --jq '[.statuses[] | select(.context == "drift-bot") | .state]
+                            | first // "unreported"')
+            # Mirrors the E2E Gate's skip_if_unreported for the same spec: the
+            # App only posts on PRs touching Python or product-record files, so
+            # a frontend-only Dependabot npm bump never receives a status at
+            # all. Parking on "unreported" would strand precisely the security
+            # updates this workflow cancels -- #5376 (esbuild/vite, high
+            # severity) sat cancelled for days. A real failure, or an analysis
+            # still pending, still parks.
+            case "$drift" in
+              success|unreported) ;;
+              *) echo "PR #$pr: drift=$drift, parked"; continue ;;
+            esac
             # Latest run per workflow on this head branch; re-run it only if it
             # ended cancelled (i.e. we parked it) and recently.
             gh api "/repos/$REPO/actions/runs?branch=$branch&event=pull_request&per_page=100" \

--- a/.github/workflows/queue-priority.yml
+++ b/.github/workflows/queue-priority.yml
@@ -10,8 +10,8 @@
 #   2. requeue      — once main is quiet again (Auto-deploy Cloud completed, or
 #      the half-hourly sweep finds main idle), re-run the latest cancelled run
 #      of each workflow for every open PR whose drift-bot commit status is
-#      green, or which never receives one (frontend-only npm bumps).
-#      Red-drift PRs stay parked until their drift is fixed and re-reported.
+#      green. Red-drift PRs stay parked until their drift is fixed and
+#      re-reported.
 #
 # No third-party actions on purpose: every step is `gh api` against
 # GITHUB_TOKEN, so there is nothing to SHA-pin and no checkout needed.
@@ -127,17 +127,15 @@ jobs:
             drift=$(gh api "/repos/$REPO/commits/$sha/status" \
                       --jq '[.statuses[] | select(.context == "drift-bot") | .state]
                             | first // "unreported"')
-            # Mirrors the E2E Gate's skip_if_unreported for the same spec: the
-            # App only posts on PRs touching Python or product-record files, so
-            # a frontend-only Dependabot npm bump never receives a status at
-            # all. Parking on "unreported" would strand precisely the security
-            # updates this workflow cancels -- #5376 (esbuild/vite, high
-            # severity) sat cancelled for days. A real failure, or an analysis
-            # still pending, still parks.
-            case "$drift" in
-              success|unreported) ;;
-              *) echo "PR #$pr: drift=$drift, parked"; continue ;;
-            esac
+            # Success-only, exactly as the Main-First Runner Queue Priority
+            # requirement states. "unreported" is its own case and is NOT
+            # treated as green here: the App only posts on PRs touching Python
+            # or product-record files, so a frontend-only Dependabot npm bump
+            # never receives a status and stays parked. Widening the condition
+            # to cover it is a change to the requirement, not to this file --
+            # see the PR discussion. Kept distinct from "missing" only so the
+            # log says which of the two happened.
+            [ "$drift" = "success" ] || { echo "PR #$pr: drift=$drift, parked"; continue; }
             # Latest run per workflow on this head branch; re-run it only if it
             # ended cancelled (i.e. we parked it) and recently.
             gh api "/repos/$REPO/actions/runs?branch=$branch&event=pull_request&per_page=100" \

--- a/tests/test_workflow_yaml_valid.py
+++ b/tests/test_workflow_yaml_valid.py
@@ -363,10 +363,10 @@ def test_drift_bot_is_read_from_the_commit_status_api(entry) -> None:
 
     queue-priority.yml's ``requeue`` job did not: it asked
     ``/commits/<sha>/check-runs?check_name=drift-bot``, which returns an empty
-    list for every commit. The verdict defaulted to "missing", the green-drift
-    guard rejected every PR, and the job re-ran nothing for as long as it
-    existed -- so every run its sibling ``clear-queue`` cancelled stayed
-    cancelled. Dependabot's npm security bumps were the visible casualty.
+    list for every commit. The verdict defaulted to "missing", so the
+    green-drift guard rejected every PR -- including PRs whose drift-bot
+    status was in fact green -- and the job re-ran nothing for as long as it
+    existed. Every run its sibling ``clear-queue`` cancelled stayed cancelled.
 
     Auto-discovered over every run block, so any future consumer that reaches
     for the wrong surface is caught here rather than by silence.

--- a/tests/test_workflow_yaml_valid.py
+++ b/tests/test_workflow_yaml_valid.py
@@ -335,3 +335,70 @@ def test_every_job_declares_runs_on(path: str) -> None:
         assert "runs-on" in job, (
             f"{os.path.basename(path)}: job {job_id!r} has no 'runs-on'."
         )
+
+
+def _run_steps():
+    """(workflow, job_id, job, script) for every step with a `run:` block."""
+    out = []
+    for path in _workflow_files():
+        doc = _load_or_skip(path)
+        for job_id, job in (doc.get("jobs") or {}).items():
+            if not isinstance(job, dict):
+                continue
+            for step in job.get("steps") or []:
+                if isinstance(step, dict) and isinstance(step.get("run"), str):
+                    out.append((os.path.basename(path), job_id, job, step["run"]))
+    return out
+
+
+@pytest.mark.parametrize(
+    "entry", _run_steps(), ids=lambda e: f"{e[0]}::{e[1]}"
+)
+def test_drift_bot_is_read_from_the_commit_status_api(entry) -> None:
+    """drift-bot is a commit status, so /check-runs can never see it.
+
+    The 8090-software-factory App posts ``drift-bot`` as a COMMIT STATUS, not
+    as an Actions check run. ``scripts/e2e_gate.py`` grew
+    ``list_commit_statuses()`` for exactly this reason, and says so.
+
+    queue-priority.yml's ``requeue`` job did not: it asked
+    ``/commits/<sha>/check-runs?check_name=drift-bot``, which returns an empty
+    list for every commit. The verdict defaulted to "missing", the green-drift
+    guard rejected every PR, and the job re-ran nothing for as long as it
+    existed -- so every run its sibling ``clear-queue`` cancelled stayed
+    cancelled. Dependabot's npm security bumps were the visible casualty.
+
+    Auto-discovered over every run block, so any future consumer that reaches
+    for the wrong surface is caught here rather than by silence.
+    """
+    workflow, job_id, _job, script = entry
+    assert "check_name=drift-bot" not in script, (
+        f"{workflow} job {job_id!r} reads drift-bot from the check-runs API, "
+        "where it never appears (it is a commit status). Query "
+        "/commits/<sha>/status and filter on .context == \"drift-bot\"."
+    )
+
+
+@pytest.mark.parametrize(
+    "entry", _run_steps(), ids=lambda e: f"{e[0]}::{e[1]}"
+)
+def test_commit_status_readers_declare_statuses_read(entry) -> None:
+    """Reading commit statuses needs `statuses:`, which `checks:` does not grant.
+
+    The two surfaces are governed by different scopes. A job that switches
+    from check runs to commit statuses without moving its permission gets an
+    empty list from a token that simply cannot see them -- the same silent
+    "no verdict" this file's sibling test exists to prevent.
+    """
+    workflow, job_id, job, script = entry
+    if "/status" not in script.replace("/statuses", ""):
+        pytest.skip("does not read the commit-status API")
+    if "commits/" not in script:
+        pytest.skip("not a commit-status read")
+    perms = job.get("permissions")
+    if perms is None:
+        pytest.skip("job inherits workflow-level permissions")
+    assert isinstance(perms, dict) and perms.get("statuses") == "read", (
+        f"{workflow} job {job_id!r} reads /commits/<sha>/status but does not "
+        "declare `statuses: read`, so the token cannot see commit statuses."
+    )


### PR DESCRIPTION
## The problem

`queue-priority.yml` has two halves. `clear-queue` cancels every queued run on a non-main ref whenever main moves, so main's jobs take the runners next. `requeue` is meant to put those runs back once main goes idle, for each open PR whose drift-bot verdict is green.

The second half has never worked. It asked:

```
/repos/<repo>/commits/<sha>/check-runs?check_name=drift-bot
```

But drift-bot is a **commit status** posted by the `8090-software-factory` App, not an Actions check run — it never appears in `/check-runs` at all. The query returns an empty list for every commit, the verdict falls through to `"missing"`, and the green-drift guard therefore rejects **every** PR, including those whose drift-bot status is genuinely green.

So the workflow parks runs and never brings them back. This repo already knew the distinction: `scripts/e2e_gate.py` grew `list_commit_statuses()` for this exact reason and documents it in a comment. The two consumers of the same signal simply disagreed about where it lives.

## The fix

One defect, one change: read the verdict from `/commits/<sha>/status` and filter on `.context == "drift-bot"`. That endpoint already collapses to the latest status per context, so no de-duplication is needed.

The guard itself is unchanged — still `[ "$drift" = "success" ]`.

| drift-bot state | Before | After |
|---|---|---|
| green | parked (bug) | **requeued** |
| red | parked | parked |
| no status posted | parked | parked |

## Permissions

`checks: read` → `statuses: read`. Check runs and commit statuses are governed by different scopes; `checks: read` would leave the new call unable to see anything, reintroducing the same silent "no verdict" through a different door. `actions: write` and `pull-requests: read` are unchanged, and the workflow keeps its empty top-level `permissions: {}` with each scope granted per job.

## What this deliberately does not do

An earlier revision of this PR also treated an **absent** drift-bot status as eligible. Drift Bot correctly flagged that against [Main-First Runner Queue Priority](https://factory.8090.ai/project/b415065f-ab2f-4f53-8864-0c009fd098cb/requirements/b7c0af6c-e262-4a17-a342-093e94db3014), which specifies success. That has been reverted — it is a change to the requirement, not to this file, and the record comes first here.

The underlying problem is real and worth a decision, but separately: the App only posts on PRs touching Python or product-record files, so a frontend-only Dependabot npm bump never receives a status and stays parked indefinitely. See the comment below.

## Verification

- Both jq filters run against the real API payload shapes: green requeues, red parks, absent parks, and the old filter returns `missing` against a `/check-runs` response — which is the bug.
- Two auto-discovered guards added to `tests/test_workflow_yaml_valid.py`, which `ci.yml:159` already runs, so they execute rather than sitting in no job:
  - no `run:` block may read drift-bot from the check-runs API;
  - a job reading `/commits/<sha>/status` must declare `statuses: read`.
- Both guards **fail against the pre-fix workflow and pass after** — verified by reverting the file and re-running, on this repo's principle that a gate which cannot fail is worse than no gate.
- `tests/test_workflow_yaml_valid.py` — 504 passed, 310 skipped. `tests/test_ci_workflow_invocations_are_real.py` — 5 passed. `ruff` (CI's ruleset) clean. `bash -n` clean on both run blocks. All 36 workflow files parse under `yaml.safe_load`.

## Scope

Touches only `.github/` and `tests/`, both exempt paths, so this needs no Factory record; the opt-out line is belt-and-braces.

No-PRD: CI workflow logic under .github/ and tests/, no product-visible change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015fREELscGXoGNa8Lp83Kku