### PR TITLE
feat(openclaw): surface OOM-victim events for local model servers (#5548)

### DIFF
--- a/clawmetry/adapters/openclaw.py
+++ b/clawmetry/adapters/openclaw.py
@@ -801,6 +801,50 @@ def _gateway_migration_warning(events: list) -> Optional[str]:
         return None
 
 
+def _gateway_oom_victim(events: list) -> dict:
+    """Return OOM-victim metadata when a local model server was killed under memory pressure.
+
+    OpenClaw 2026.9.1+ ("A Gateway that stays up") lowers the gateway's own OOM
+    score so the kernel preferentially kills local model server processes (e.g.
+    an Ollama-backed sandbox) rather than the gateway itself.  When that happens
+    the gateway logs a structured entry whose ``msg`` mentions ``"oom"`` or
+    ``"out of memory"``, or whose ``msg`` mentions ``"killed"`` alongside a
+    model-server keyword (``"model"``, ``"ollama"``, ``"sandbox"``, or
+    ``"server"``).
+
+    Accepts the already-fetched events list (no extra I/O).  Returns a dict with
+    ``oomVictimDetected=True``, ``oomVictimMsg``, and optionally ``oomVictimTs``
+    on the first matching entry; returns ``{}`` when no OOM event is found.
+    Never raises (closes #5548).
+    """
+    try:
+        if not events:
+            return {}
+        for evt in events:
+            if not isinstance(evt, dict):
+                continue
+            raw_msg = evt.get("msg", "")
+            msg = str(raw_msg).lower()
+            if not msg:
+                continue
+            is_oom = "oom" in msg or "out of memory" in msg
+            is_model_kill = "killed" in msg and any(
+                kw in msg for kw in ("model", "ollama", "sandbox", "server")
+            )
+            if is_oom or is_model_kill:
+                result: dict = {
+                    "oomVictimDetected": True,
+                    "oomVictimMsg": str(raw_msg),
+                }
+                ts = evt.get("ts")
+                if ts is not None:
+                    result["oomVictimTs"] = ts
+                return result
+        return {}
+    except Exception:
+        return {}
+
+
 def _openshell_sandbox_logs(name: str, count: int = 20) -> list:
     """Retrieve OCSF JSON audit log lines for a NemoClaw sandbox.
 
@@ -2593,6 +2637,14 @@ class OpenClawAdapter(AgentAdapter):
             if _mig_warn is not None:
                 meta["gatewayDegraded"] = True
                 meta["gatewayMigrationWarning"] = _mig_warn
+            # OOM-victim detection (#5548): OpenClaw 2026.9.1 lowers its own OOM
+            # score so the kernel preferentially kills local model servers (e.g.
+            # Ollama) under memory pressure.  Scan the already-fetched events so
+            # there is no extra I/O; surface oomVictimDetected so the dashboard
+            # can explain an otherwise-silent sandbox outage.
+            _oom = _gateway_oom_victim(_gw_events)
+            if _oom:
+                meta.update(_oom)
             # Skill Workshop approval-policy (#3992): surfaces
             # skills.workshop.approvalPolicy from openclaw.json so cloud-synced
             # fleet views know whether autonomous skill actions are gated by

--- a/tests/test_obs_gap_openclaw_oom_victim_5548.py
+++ b/tests/test_obs_gap_openclaw_oom_victim_5548.py
@@ -1,0 +1,183 @@
+"""Tests for #5548 — OOM-victim preference for local model servers not tracked.
+
+OpenClaw 2026.9.1+ ("A Gateway that stays up") lowers the gateway's own OOM
+score so the kernel preferentially kills local model servers (e.g. Ollama)
+under memory pressure.  Without this fix the kill shows up only as an
+unexplained sandbox/model outage.
+
+Fix: ``_gateway_oom_victim(events)`` scans the already-read gateway log events
+for entries whose ``msg`` contains "oom" / "out of memory", or "killed"
+alongside a model-server keyword.  ``detect()`` merges the result dict
+(``oomVictimDetected``, ``oomVictimMsg``, optionally ``oomVictimTs``) into
+``meta`` when a match is found.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+def _fn():
+    from clawmetry.adapters.openclaw import _gateway_oom_victim
+    return _gateway_oom_victim
+
+
+# ---------------------------------------------------------------------------
+# Empty / no-match cases
+# ---------------------------------------------------------------------------
+
+def test_empty_events_returns_empty_dict():
+    """No events → {} (no OOM state)."""
+    assert _fn()([]) == {}
+
+
+def test_none_input_returns_empty_dict():
+    """Passing None instead of a list doesn't raise."""
+    assert _fn()(None) == {}  # type: ignore[arg-type]
+
+
+def test_unrelated_warn_returns_empty_dict():
+    """A warn about disk I/O is not an OOM event."""
+    events = [{"level": "warn", "msg": "slow disk I/O detected"}]
+    assert _fn()(events) == {}
+
+
+def test_killed_without_model_context_returns_empty_dict():
+    """'killed' alone (no model/ollama/sandbox/server context) is not matched."""
+    events = [{"level": "warn", "msg": "process killed by user"}]
+    assert _fn()(events) == {}
+
+
+def test_error_without_oom_returns_empty_dict():
+    """An error entry unrelated to OOM is not matched."""
+    events = [{"level": "error", "msg": "connection refused"}]
+    assert _fn()(events) == {}
+
+
+# ---------------------------------------------------------------------------
+# Positive: "oom" keyword
+# ---------------------------------------------------------------------------
+
+def test_oom_in_msg_detected():
+    """msg containing 'oom' is detected as an OOM victim event."""
+    events = [{"msg": "oom kill: ollama process terminated", "ts": "2026-09-05T10:00:00Z"}]
+    result = _fn()(events)
+    assert result["oomVictimDetected"] is True
+    assert "oom" in result["oomVictimMsg"].lower()
+    assert result["oomVictimTs"] == "2026-09-05T10:00:00Z"
+
+
+def test_oom_case_insensitive():
+    """'OOM' (uppercase) is matched case-insensitively."""
+    events = [{"msg": "OOM-kill: local model server stopped"}]
+    result = _fn()(events)
+    assert result["oomVictimDetected"] is True
+
+
+def test_out_of_memory_phrase_detected():
+    """'out of memory' phrase triggers the match."""
+    events = [{"msg": "out of memory: ollama sandbox evicted"}]
+    result = _fn()(events)
+    assert result["oomVictimDetected"] is True
+
+
+# ---------------------------------------------------------------------------
+# Positive: "killed" + model-server keyword
+# ---------------------------------------------------------------------------
+
+def test_killed_with_model_keyword():
+    """'killed' + 'model' in msg is detected."""
+    events = [{"msg": "local model server killed by kernel"}]
+    result = _fn()(events)
+    assert result["oomVictimDetected"] is True
+
+
+def test_killed_with_ollama_keyword():
+    """'killed' + 'ollama' in msg is detected."""
+    events = [{"msg": "ollama process killed unexpectedly"}]
+    result = _fn()(events)
+    assert result["oomVictimDetected"] is True
+
+
+def test_killed_with_sandbox_keyword():
+    """'killed' + 'sandbox' in msg is detected."""
+    events = [{"msg": "sandbox inference server killed by OS"}]
+    result = _fn()(events)
+    assert result["oomVictimDetected"] is True
+
+
+def test_killed_with_server_keyword():
+    """'killed' + 'server' in msg is detected."""
+    events = [{"msg": "inference server killed, gateway survived"}]
+    result = _fn()(events)
+    assert result["oomVictimDetected"] is True
+
+
+# ---------------------------------------------------------------------------
+# First-match semantics
+# ---------------------------------------------------------------------------
+
+def test_returns_first_matching_event():
+    """When multiple OOM events exist, the first (newest-first list) is returned."""
+    msg_first = "oom kill: ollama evicted (first)"
+    msg_second = "oom kill: sandbox evicted (second)"
+    events = [{"msg": msg_first}, {"msg": msg_second}]
+    result = _fn()(events)
+    assert result["oomVictimMsg"] == msg_first
+
+
+def test_skips_non_matching_before_match():
+    """Non-matching entries before an OOM entry don't block the result."""
+    msg = "oom kill: model server sacrificed to keep gateway alive"
+    events = [
+        {"msg": "disk space low"},
+        {"msg": "slow query on db"},
+        {"msg": msg},
+    ]
+    result = _fn()(events)
+    assert result["oomVictimDetected"] is True
+    assert result["oomVictimMsg"] == msg
+
+
+# ---------------------------------------------------------------------------
+# Timestamp handling
+# ---------------------------------------------------------------------------
+
+def test_ts_included_when_present():
+    """oomVictimTs is set when the event carries a 'ts' field."""
+    events = [{"msg": "oom kill: ollama stopped", "ts": "2026-09-05T12:34:56Z"}]
+    result = _fn()(events)
+    assert result["oomVictimTs"] == "2026-09-05T12:34:56Z"
+
+
+def test_ts_absent_when_not_in_event():
+    """oomVictimTs is not present when the event has no 'ts' field."""
+    events = [{"msg": "oom kill: model server evicted"}]
+    result = _fn()(events)
+    assert "oomVictimTs" not in result
+
+
+# ---------------------------------------------------------------------------
+# Robustness
+# ---------------------------------------------------------------------------
+
+def test_malformed_non_dict_entries_skipped():
+    """Non-dict entries are silently skipped; the real entry is still found."""
+    events = [None, "bad", 42, {"msg": "oom kill: ollama died"}]
+    result = _fn()(events)
+    assert result["oomVictimDetected"] is True
+
+
+def test_missing_msg_key_does_not_raise():
+    """Entries missing 'msg' are treated as non-matching; never raises."""
+    events = [{"level": "warn", "ts": "2026-09-05"}, {"msg": "oom kill: server gone"}]
+    result = _fn()(events)
+    assert result["oomVictimDetected"] is True
+
+
+def test_exception_in_events_returns_empty_dict():
+    """An object whose iteration raises is handled gracefully."""
+    class _Bad:
+        def __iter__(self):
+            raise RuntimeError("boom")
+
+    assert _fn()(_Bad()) == {}  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary

OpenClaw 2026.9.1 ("A Gateway that stays up") lowers the gateway's own OOM score so the kernel preferentially kills local model servers (e.g. Ollama-backed sandboxes) under memory pressure. Previously this kill showed up only as an unexplained sandbox/model outage — ClawMetry had no way to distinguish it from a clean shutdown. This PR adds first-class detection of that event so the dashboard can surface a meaningful explanation.

No-PRD: Automated harness-observability gap filed by scripts/harness/audit.py — additive-only event detection, no new spec beyond the harness fingerprint (hgap-7a3b74d59a).

## Changes

- **`clawmetry/adapters/openclaw.py`** — adds `_gateway_oom_victim(events)`, a zero-extra-I/O helper that scans the already-fetched gateway log events for OOM markers (`"oom"`, `"out of memory"`, or `"killed"` + model-server keyword). Returns `{"oomVictimDetected": True, "oomVictimMsg": ..., "oomVictimTs": ...}` on the first match, `{}` otherwise. Follows the identical pattern established by `_gateway_migration_warning` (#5547). Wired into `detect()` so `meta["oomVictimDetected"]` is populated when a matching event is present.
- **`tests/test_obs_gap_openclaw_oom_victim_5548.py`** — 19 unit tests covering empty input, each positive keyword variant, first-match semantics, timestamp presence/absence, and robustness against malformed entries.

## Test plan

- [ ] `python3 -m pytest tests/test_obs_gap_openclaw_oom_victim_5548.py -v` — all 19 pass locally
- [ ] `python3 -c 'import ast; ast.parse(open("clawmetry/adapters/openclaw.py").read())'` — syntax clean
- [ ] On a machine with OpenClaw 2026.9.1+: induce memory pressure and verify `GET /api/runtimes` (or the detect endpoint) returns `oomVictimDetected: true`

## Bot meta

<!-- bot-autofix -->
Draft PR opened autonomously based on the plan in #5548. Marked draft for human review — mark Ready for Review once happy.

Closes #5548

https://claude.ai/code/session_01VR3XfTkHCBnFAwfZmZcsnA