### PR TITLE
Harden CI: install the auth-bootstrap guard's Playwright from a lockfile

### DIFF
--- a/.github/ci-node/auth-bootstrap/package-lock.json
+++ b/.github/ci-node/auth-bootstrap/package-lock.json
@@ -1,0 +1,60 @@
+{
+  "name": "clawmetry-ci-auth-bootstrap",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "clawmetry-ci-auth-bootstrap",
+      "version": "1.0.0",
+      "license": "UNLICENSED",
+      "dependencies": {
+        "playwright": "1.59.1"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/.github/ci-node/auth-bootstrap/package.json
+++ b/.github/ci-node/auth-bootstrap/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "clawmetry-ci-auth-bootstrap",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Pinned Playwright for the Auth Bootstrap Guard workflow's smoke test. CI-only: nothing here ships in the clawmetry wheel or is imported by the dashboard.",
+  "license": "UNLICENSED",
+  "dependencies": {
+    "playwright": "1.59.1"
+  }
+}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -109,6 +109,23 @@ updates:
     cooldown:
       default-days: 7
 
+  # npm — the Playwright the Auth Bootstrap Guard workflow's smoke test runs
+  # on. It is the other half of that pin: the lockfile makes the install
+  # reproducible and integrity-checked, and this entry is what keeps it
+  # moving. Kept in step with /tests/e2e, which pins the same Playwright
+  # line; bumping one without the other means CI downloads two browser
+  # builds for no reason.
+  - package-ecosystem: "npm"
+    directory: "/.github/ci-node/auth-bootstrap"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+    cooldown:
+      default-days: 7
+
   # npm — the ClawHub/OpenClaw plugin, which is published to npm
   # (openclaw.release.publishToNpm). No lockfile, so Dependabot updates the
   # manifest ranges.

--- a/.github/workflows/auth-bootstrap-guard.yml
+++ b/.github/workflows/auth-bootstrap-guard.yml
@@ -5,6 +5,10 @@ on:
     paths:
       - "clawmetry/static/js/*.js"
       - ".github/workflows/auth-bootstrap-guard.yml"
+      # The pinned Playwright this job's smoke test runs on. Without this
+      # path a Dependabot bump of that lockfile would change what the guard
+      # executes while never running the guard.
+      - ".github/ci-node/auth-bootstrap/**"
 
 concurrency:
   group: abg-${{ github.event.pull_request.number || github.ref }}
@@ -50,9 +54,23 @@ jobs:
             node -e "const fs=require('fs'); const s=fs.readFileSync(0,'utf8'); if (/location\\.reload\\s*\\(/.test(s) || /window\\.location\\.reload\\s*\\(/.test(s)) { console.error('auth bootstrap IIFE must not call location.reload()'); process.exit(1); }"
 
       - name: Install runtime deps
+        run: pip install flask requests waitress cryptography
+
+      # `npm install playwright` resolved the registry's moving `latest` on
+      # every run, with no lockfile and so no integrity check on any tarball
+      # in the tree. It also ran at the repository root, where package.json
+      # is the landing-deploy manifest, so the install rewrote a tracked file
+      # as a side effect of a smoke test.
+      #
+      # `npm ci` against the committed lockfile in .github/ci-node/auth-bootstrap
+      # installs exactly the recorded tree and checks every tarball against its
+      # sha512 hash. Same pin/updater pairing the other CI Node installs here
+      # use: the lockfile makes an upgrade deliberate, the Dependabot entry in
+      # .github/dependabot.yml keeps it from freezing.
+      - name: Install Node deps (npm ci from the pinned lockfile)
+        working-directory: .github/ci-node/auth-bootstrap
         run: |
-          pip install flask requests waitress cryptography
-          npm install playwright
+          npm ci --no-audit --no-fund
           npx playwright install --with-deps chromium
 
       - name: Start dashboard
@@ -65,7 +83,12 @@ jobs:
           cat /tmp/clawmetry.log
           exit 1
 
+      # `require('playwright')` resolves from the step's working directory, and
+      # the install now lives beside its lockfile rather than at the repository
+      # root, so this step runs there. Nothing else in the script reads the
+      # working directory: it talks to the dashboard over 127.0.0.1:8900.
       - name: Smoke test zero-click bootstrap does not reload
+        working-directory: .github/ci-node/auth-bootstrap
         run: |
           node <<'NODE'
           const { chromium } = require('playwright');


### PR DESCRIPTION
**Product record:** No-PRD: CI-only supply-chain hardening under `.github/`. Closes a zizmor `adhoc-packages` finding by installing a CI-only browser driver from a committed lockfile. No product behaviour, endpoint, flag or default changes, and nothing here ships in the wheel.

**Risk:** Confined to the Auth Bootstrap Guard workflow, which runs only on PRs touching `clawmetry/static/js/*.js`. If the new install path were wrong the guard fails loudly on its own PR — it cannot fail open, and it gates nothing else. Undone by reverting the commit; no state, no migration, nothing in flight. The published wheel is untouched (`setup.py`/`MANIFEST.in` never read `.github/`), and the repository-root `package.json` is unchanged by this diff.

---

## Summary

- The guard installed its browser driver with `npm install playwright` — no version, no lockfile. That resolved the registry's moving `latest` on every run and verified nothing: the transitive tree was unpinned and no tarball was checked against an integrity hash. zizmor reports it as `adhoc-packages`.
- It also ran at the repository root, where `package.json` is the landing-deploy manifest. `npm install <pkg>` writes the dependency into that file, so a smoke test was rewriting a tracked file as a side effect.
- Playwright is now an ordinary dependency at an exact version in `.github/ci-node/auth-bootstrap/package.json`, with a committed `package-lock.json` carrying the resolved URL and sha512 integrity hash for all 3 packages in the tree. `npm ci` installs exactly that and re-resolves nothing.

The pin is **1.59.1**, which is what `/tests/e2e` already locks, so CI does not download a second browser build for this one job. This is the same pin/updater pairing the other CI Node installs here use: a new npm entry in `.github/dependabot.yml` keeps the lock moving rather than frozen, and the workflow's `paths:` filter now includes that directory — without it a Dependabot bump would change what the guard executes while never running the guard.

`require('playwright')` resolves from the step's working directory, so the install and the smoke step both run in that directory. Nothing else in the script reads the working directory; it talks to the dashboard over `127.0.0.1:8900`. The dashboard still starts from the repository root.

## Test plan

- [x] zizmor over the audit's own input set: **53 findings → 52**, and the one that went is this file's `adhoc-packages`. No new finding appears.
- [x] End to end with the real steps: `npm ci` exits 0 and installs playwright 1.59.1; the dashboard boots on `127.0.0.1:8900`; the smoke script run verbatim from the new working directory prints `auth bootstrap smoke passed` and exits 0.
- [x] `require('playwright')` resolves in that directory and does **not** resolve at the repository root — which is why the step carries `working-directory`.
- [x] The two guard steps this PR does not touch still pass at the repo root (`node --check`, the no-reload IIFE check).
- [x] All 36 workflows, both composite actions and `dependabot.yml` parse under `yaml.safe_load`; both new JSON files parse; every dependabot `directory` exists; all 157 action references remain SHA-pinned.
- [x] Repository-root `package.json` is unchanged by the diff.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wx2kBCychN5d2uf9y9oH8g

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wx2kBCychN5d2uf9y9oH8g)_