### PR TITLE
Let the gate be answered for free, and forward the paywall beacons

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -291,6 +291,14 @@ jobs:
       - name: Desktop bootstrap resilience
         run: python3 -m pytest tests/test_desktop_bootstrap_resilience.py -q
 
+      # The conversion funnel's two blind spots, both silent by construction:
+      # the onboarding gate's free-runtimes escape (markup + handler +
+      # endpoint must agree or it is a dead link) and the paywall beacons
+      # that reach the cloud only while app.js keeps posting the exact event
+      # names the forwarder maps. Both regress with nothing turning red.
+      - name: Paywall funnel telemetry + gate free escape
+        run: python3 -m pytest tests/test_paywall_funnel_telemetry.py -q
+
   # ── API tests across all 3 platforms ─────────────────────────────────────────────────────────────────────────────────────────
   api-tests:
     name: API Tests (${{ matrix.os }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,7 +149,11 @@ jobs:
       # running the guards there means they are exercised on the interpreter
       # 0.12.753 broke on.
       - name: Install verification test deps
-        run: pip install pytest pyyaml requests
+        # flask: the guards in this job that exercise a Blueprint through a
+        # Flask test client (paywall funnel telemetry + the gate's free
+        # escape) cannot even be COLLECTED without it, and a collection
+        # error fails the whole step, not just that file.
+        run: pip install pytest pyyaml requests flask
 
       # A malformed workflow fails at STARTUP, before any step runs, and shows
       # up named after its own file path. c6-schedule-heal.yml carried two such

--- a/clawmetry/static/js/onboarding.js
+++ b/clawmetry/static/js/onboarding.js
@@ -1,4 +1,5 @@
-// onboarding.js — first-run onboarding gate (hard gate, no skip).
+// onboarding.js — first-run onboarding gate (hard gate; the only way
+// past it without an account is the free-runtimes escape, _startFreeOnly).
 //
 // Shows templates/partials/onboarding-modal.html when
 // GET /api/onboarding/state says {required:true}. The gate itself is just
@@ -59,6 +60,36 @@
       }
     }).catch(function () {
       if (onFail) onFail('Network error. Try again.');
+    });
+  }
+
+  // ── Free-runtimes escape ─────────────────────────────────────────────
+  // The two cards above both demand an identity before the dashboard opens,
+  // and prod says that is where the installs go: 798 first launches to 38
+  // completed choices in the 30 days to 2026-09-06. OpenClaw, NVIDIA
+  // NemoClaw and Goose are FREE_RUNTIMES, free forever with no account, so
+  // for someone who only runs those the gate was asking for a signup that
+  // buys them nothing. This posts to a dedicated endpoint (not /complete,
+  // which deliberately refuses to record selfhost_free) that flips free-only
+  // mode on and writes the nocloud marker before recording the choice.
+  function _startFreeOnly() {
+    var b = $('obg-free-btn');
+    _err('obg-free-err', '');
+    if (b) { b.disabled = true; }
+    fetch('/api/onboarding/free-only', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+    }).then(function (r) { return r.json(); }).then(function (d) {
+      if (d && d.ok) {
+        _hide();
+        location.reload();
+        return;
+      }
+      if (b) { b.disabled = false; }
+      _err('obg-free-err', (d && d.error) || 'Could not save your choice. Try again.');
+    }).catch(function () {
+      if (b) { b.disabled = false; }
+      _err('obg-free-err', 'Network error. Try again.');
     });
   }
 
@@ -499,6 +530,8 @@
         if (m) m.addEventListener('click', _startManaged);
         var s = $('obg-selfhost-btn');
         if (s) s.addEventListener('click', window.openSelfhostModal);
+        var f = $('obg-free-btn');
+        if (f) f.addEventListener('click', _startFreeOnly);
         _fillDetection();
         _show();
       })

--- a/clawmetry/templates/partials/onboarding-modal.html
+++ b/clawmetry/templates/partials/onboarding-modal.html
@@ -53,6 +53,11 @@
         </div>
       </div>
     </div>
+    <button type="button" class="obg-alt" id="obg-free-btn"
+            style="background:none;border:none;cursor:pointer;width:100%;padding:0;font:inherit;">
+      I just want OpenClaw, NVIDIA NemoClaw and Goose, free and with no account
+    </button>
+    <div class="obg-err" id="obg-free-err"></div>
     <p class="obg-foot">Read-only by design: ClawMetry watches your agents, it never changes them.<br>
     You can switch between cloud and self-host any time from Settings.</p>
   </div>

--- a/docs/TRIAL_ENFORCEMENT.md
+++ b/docs/TRIAL_ENFORCEMENT.md
@@ -196,6 +196,57 @@ blocked by this scaffold.
 2. **Regression sweep**: existing paying customer with valid signed
    license on disk sees NO block whether flag is on or off.
 
+## Paywall funnel telemetry
+
+The hard-block overlay posts two beacons to `POST /api/paywall/event`:
+
+| Beacon (app.js) | Forwarded as | Meaning |
+|---|---|---|
+| `hard_block_view` | `paywall_view` | the overlay was rendered to a user |
+| `hard_block_checkout_click` | `paywall_checkout_click` | that user clicked through to pay |
+
+Both were local-only until 0.12.821: `/api/paywall/event` wrote to an
+in-process rolling store (`clawmetry/_paywall_events.py`, read back by
+`/api/paywall/events/*`) and nothing left the machine. Cloud analytics
+therefore held zero rows for either beacon, ever, and the funnel could not
+separate "saw the paywall and declined" from "never reached it" — the one
+question a pricing decision actually turns on.
+
+`routes/entitlement.py::_ping_paywall_lifecycle` now mirrors exactly these
+two into `clawmetry/telemetry.py`, the same anonymous lifecycle channel as
+`install` / `update` / `onboarded` / `gate_shown`. That is deliberate: it
+inherits the existing privacy contract with no new surface. An anonymous
+install id, no account, no email, no hostname, no workspace path and no
+runtime data; every opt-out already honoured (`CLAWMETRY_NO_TELEMETRY`,
+`DO_NOT_TRACK`, `~/.clawmetry/notelemetry`). `ping_once` dedups on disk, so
+an overlay that re-renders on every background poll still sends one row per
+install. The cloud must allowlist both names in
+`routes/install.py::_ALLOWED_EVENTS` or they are dropped with no insert and
+no error.
+
+The mapping is a silent-failure point: rename a beacon in `app.js` and the
+telemetry stops with nothing turning red. `tests/test_paywall_funnel_telemetry.py`
+asserts the forwarder still covers every `hard_block_*` beacon `app.js` posts.
+
+## The gate's free-runtimes escape
+
+`POST /api/onboarding/free-only` records `selfhost_free`: the user keeps
+OpenClaw, NVIDIA NemoClaw and Goose (the `FREE_RUNTIMES`, free forever) and
+takes no account, no cloud and no trial. It flips free-only mode on
+(`trial_enforcement.set_free_only_mode`, the same marker the expired-trial
+paywall writes) and writes the nocloud marker **before** recording the
+choice, so the recorded state is backed by real local configuration. Undo
+from Settings or `POST /api/trial/exit-free`.
+
+This is **not** the deferred gate ("Look First, Choose Later", REQ-OGV-DG-*),
+which remains unbuilt and is a different design: there, free runtimes render
+with *no choice on record* and the gate is deferred to a later trigger. Here
+the gate is still hard and still answered immediately — the change is only
+that one of the answers no longer costs a signup. `selfhost_free` stays out
+of `onboarding_state.CHOICES`, so it is not postable through the generic
+`/api/onboarding/complete`; this dedicated endpoint is the only flow that
+may claim it.
+
 ## Related code
 
 | File | What lives there |

--- a/docs/TRIAL_ENFORCEMENT.md
+++ b/docs/TRIAL_ENFORCEMENT.md
@@ -198,6 +198,10 @@ blocked by this scaffold.
 
 ## Paywall funnel telemetry
 
+> Spec: REQ "Free Answer at the Gate, and a Visible Paywall"
+> (`cd0b3dc3-ca5c-49ad-a4c0-dec01f122d12`), AC-FREE-002 and AC-FREE-001.
+
+
 The hard-block overlay posts two beacons to `POST /api/paywall/event`:
 
 | Beacon (app.js) | Forwarded as | Meaning |

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -23598,7 +23598,52 @@ def api_paywall_event():
         _pe.record_event(body)
     except Exception as exc:
         logger.debug("api_paywall_event: store swallowed error: %s", exc)
+    _ping_paywall_lifecycle(body)
     return "", 204
+
+
+# The overlay's two beacons, mapped to the lifecycle event names the cloud
+# funnel understands. Anything else stays local-only.
+_PAYWALL_LIFECYCLE_EVENTS = {
+    "hard_block_view": "paywall_view",
+    "hard_block_checkout_click": "paywall_checkout_click",
+}
+
+
+def _ping_paywall_lifecycle(body: dict) -> None:
+    """Mirror the two paywall beacons into the anonymous lifecycle ping.
+
+    Why: until now ``POST /api/paywall/event`` wrote ONLY to an in-process
+    rolling store on the user's own machine, so the highest-intent surface we
+    ship had no telemetry anywhere we can read. Checked on 2026-09-06:
+    ``hard_block_view`` and ``hard_block_checkout_click`` had zero rows in
+    cloud analytics, ever, which is why "do people see the paywall and
+    decline, or never reach it?" could not be answered, and why a pricing
+    change would have been made blind.
+
+    Rides ``clawmetry.telemetry`` rather than a new channel so it inherits
+    the existing privacy contract unchanged: an anonymous install id, no
+    account, no email, no hostname, no runtime data, and every opt-out
+    (``CLAWMETRY_NO_TELEMETRY``, ``DO_NOT_TRACK``, ``~/.clawmetry/notelemetry``)
+    already honoured. ``ping_once`` dedups on disk, so an overlay that
+    re-renders on every background poll still sends one row per install.
+
+    Never raises: a telemetry failure must not change the 204 the beacon
+    already returns.
+    """
+    try:
+        event = _PAYWALL_LIFECYCLE_EVENTS.get(str((body or {}).get("event", "")))
+        if not event:
+            return
+        from clawmetry import telemetry as _telemetry
+
+        try:
+            from dashboard import __version__ as _ver
+        except Exception:
+            _ver = "unknown"
+        _telemetry.ping_once(event, _ver)
+    except Exception as exc:
+        logger.debug("api_paywall_event: lifecycle ping skipped: %s", exc)
 
 
 @bp_entitlement.route("/api/paywall/events/summary")

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -23613,6 +23613,9 @@ _PAYWALL_LIFECYCLE_EVENTS = {
 def _ping_paywall_lifecycle(body: dict) -> None:
     """Mirror the two paywall beacons into the anonymous lifecycle ping.
 
+    Spec: REQ "Free Answer at the Gate, and a Visible Paywall"
+    (cd0b3dc3-ca5c-49ad-a4c0-dec01f122d12), AC-FREE-002.
+
     Why: until now ``POST /api/paywall/event`` wrote ONLY to an in-process
     rolling store on the user's own machine, so the highest-intent surface we
     ship had no telemetry anywhere we can read. Checked on 2026-09-06:

--- a/routes/onboarding.py
+++ b/routes/onboarding.py
@@ -469,6 +469,9 @@ def api_onboarding_complete():
 def api_onboarding_free_only():
     """Record the gate's free-runtimes escape: no account, no cloud, no trial.
 
+    Spec: REQ "Free Answer at the Gate, and a Visible Paywall"
+    (cd0b3dc3-ca5c-49ad-a4c0-dec01f122d12), AC-FREE-001.
+
     Why this exists: both cards on the gate demand an identity before the
     dashboard opens, and the funnel says that is where the installs go. In
     the 30 days to 2026-09-06 prod saw 798 first launches and 38 completed

--- a/routes/onboarding.py
+++ b/routes/onboarding.py
@@ -465,6 +465,57 @@ def api_onboarding_complete():
     return jsonify({"ok": True, "state": choice})
 
 
+@bp_onboarding.route("/api/onboarding/free-only", methods=["POST"])
+def api_onboarding_free_only():
+    """Record the gate's free-runtimes escape: no account, no cloud, no trial.
+
+    Why this exists: both cards on the gate demand an identity before the
+    dashboard opens, and the funnel says that is where the installs go. In
+    the 30 days to 2026-09-06 prod saw 798 first launches and 38 completed
+    choices — 4.8%. A user who only runs OpenClaw, NVIDIA NemoClaw or Goose
+    owes us no account at all (those three are FREE_RUNTIMES, free forever
+    by design), so making them sign in to see their own free data is a wall
+    with nothing behind it.
+
+    ``selfhost_free`` was already a RECORDED choice (the CLI wizard's
+    no-account branch writes it) but deliberately not postable through
+    ``/api/onboarding/complete``, because a generic POST could claim it with
+    no flow behind it and skip the gate. That reasoning still holds; this
+    endpoint is the flow. It does the two things the CLI branch does — flip
+    free-only mode on and write the nocloud marker — so the recorded state
+    is backed by real local configuration, exactly like every other choice
+    the gate accepts.
+
+    Free-only mode is the same marker the expired-trial paywall writes
+    (``trial_enforcement.set_free_only_mode``): free runtimes keep working,
+    paid ones stay locked until the user upgrades. Reversible from Settings
+    and by ``POST /api/trial/exit-free``.
+    """
+    try:
+        from clawmetry import trial_enforcement as _te
+
+        _te.set_free_only_mode(True)
+    except Exception as exc:
+        # A marker we could not write means paid runtimes would stay
+        # blocked-by-default with no record of why. Fail loudly rather than
+        # record a choice the install cannot honour.
+        log.warning("onboarding: free-only marker failed: %s", exc)
+        return jsonify({"ok": False,
+                        "error": "Could not save your choice. Try again."}), 500
+
+    _write_choice_file("selfhost_free")
+    _apply_marker_semantics("selfhost_free")
+    _ensure_daemon_for_choice("selfhost_free")
+    _ping_onboarded("selfhost_free")
+    try:
+        from clawmetry import entitlements as _ent
+
+        _ent.invalidate()
+    except Exception:
+        pass
+    return jsonify({"ok": True, "state": "selfhost_free"})
+
+
 @bp_onboarding.route("/api/onboarding/activate-license", methods=["POST"])
 def api_onboarding_activate_license():
     data = request.get_json(silent=True) or {}

--- a/routes/onboarding.py
+++ b/routes/onboarding.py
@@ -490,6 +490,15 @@ def api_onboarding_free_only():
     (``trial_enforcement.set_free_only_mode``): free runtimes keep working,
     paid ones stay locked until the user upgrades. Reversible from Settings
     and by ``POST /api/trial/exit-free``.
+
+    NOT the deferred gate. "Look First, Choose Later" (REQ-OGV-DG-*) is a
+    different, still-unbuilt design in which free runtimes render with **no
+    choice on record** and the gate is deferred to a later trigger (a locked
+    card click, a paid feature, 3 loads or 24h). This endpoint leaves the
+    hard gate exactly as it is, answered immediately and recorded
+    immediately, and only makes one of its answers free of a signup. Whoever
+    builds the deferred gate should treat this as an existing answer to
+    carry over, not as a partial implementation of that requirement.
     """
     try:
         from clawmetry import trial_enforcement as _te

--- a/tests/test_paywall_funnel_telemetry.py
+++ b/tests/test_paywall_funnel_telemetry.py
@@ -1,0 +1,178 @@
+"""The two conversion surfaces we were blind on, and the escape from the gate.
+
+Both changes here exist because of one prod pull on 2026-09-06:
+
+  * 798 first launches in 30 days produced 38 completed onboarding choices
+    (4.8%). Both cards on the gate demand an identity, including from users
+    whose only runtimes are the three that are free forever.
+  * ``hard_block_view`` / ``hard_block_checkout_click`` had ZERO rows in
+    cloud analytics, ever. The overlay wrote them to an in-process store on
+    the user's own machine and nothing forwarded them, so the one surface
+    where a user looks straight at a price reported nothing at all.
+
+The regressions these guard are all silent: a renamed JS beacon, a gate
+button nobody wired, a choice the recorder refuses. None of them would turn
+anything red without a test.
+"""
+from __future__ import annotations
+
+import importlib
+import json
+import os
+import re
+import sys
+
+import pytest
+from flask import Flask
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+# ── the gate's free-runtimes escape ──────────────────────────────────────────
+
+@pytest.fixture
+def ob(monkeypatch, tmp_path):
+    import routes.onboarding as mod
+    importlib.reload(mod)
+    monkeypatch.setattr(mod, "_STATE_PATH", str(tmp_path / "onboarding.json"))
+    monkeypatch.setattr(mod, "_ping_onboarded", lambda choice: None)
+    monkeypatch.setattr(mod, "_apply_marker_semantics", lambda choice: None)
+    # Never register or spawn a real background daemon from a unit test.
+    monkeypatch.setattr(mod, "_ensure_daemon_for_choice", lambda choice: None)
+    return mod
+
+
+@pytest.fixture
+def client(ob):
+    app = Flask(__name__)
+    app.register_blueprint(ob.bp_onboarding)
+    return app.test_client()
+
+
+def test_free_only_records_the_choice_and_flips_free_mode(ob, client, monkeypatch, tmp_path):
+    from clawmetry import trial_enforcement as te
+    marker = tmp_path / "free_only.marker"
+    monkeypatch.setattr(te, "_FREE_ONLY_MARKER", str(marker))
+
+    r = client.post("/api/onboarding/free-only")
+    assert r.status_code == 200
+    assert r.get_json() == {"ok": True, "state": "selfhost_free"}
+
+    # Free-only mode is what actually keeps OpenClaw/NemoClaw/Goose working
+    # while paid runtimes stay locked. Without the marker the choice would be
+    # a recorded preference with nothing enforcing it.
+    assert marker.is_file()
+    assert te.free_only_mode_enabled() is True
+
+    recorded = json.loads((tmp_path / "onboarding.json").read_text())
+    assert recorded["choice"] == "selfhost_free"
+
+
+def test_free_only_closes_the_gate(ob, client, monkeypatch, tmp_path):
+    """The whole point: after choosing free, the gate must stop asking."""
+    from clawmetry import trial_enforcement as te
+    monkeypatch.setattr(te, "_FREE_ONLY_MARKER", str(tmp_path / "free_only.marker"))
+    monkeypatch.setattr(ob, "_license_state", lambda: "")
+    monkeypatch.setattr(ob, "_cloud_connected", lambda: False)
+    monkeypatch.setattr(ob, "_paid_entitlement_state", lambda: "")
+    monkeypatch.setattr(ob, "_ping_gate_shown", lambda: None)
+    _shell = tmp_path / "shell"
+    _shell.mkdir()
+    monkeypatch.setattr(ob, "_desktop_shell_runtime_dir", lambda: _shell)
+    for k in ("CLAWMETRY_CLOUD", "CLAWMETRY_SKIP_ONBOARDING", "CI",
+              "GITHUB_ACTIONS", "GITLAB_CI", "CIRCLECI", "TRAVIS", "BUILDKITE",
+              "JENKINS_URL", "TEAMCITY_VERSION", "BITBUCKET_BUILD_NUMBER",
+              "CODEBUILD_BUILD_ID", "DRONE", "AGENT_NAME"):
+        monkeypatch.delenv(k, raising=False)
+
+    assert client.get("/api/onboarding/state").get_json()["required"] is True
+    client.post("/api/onboarding/free-only")
+    assert client.get("/api/onboarding/state").get_json()["required"] is False
+
+
+def test_selfhost_free_is_recordable_but_still_not_postable_to_complete(ob, client):
+    """The dedicated endpoint is the flow; /complete must stay closed.
+
+    ``selfhost_free`` is deliberately absent from the generic POST body
+    allowlist so a caller cannot claim it with no local configuration behind
+    it. Adding the escape must not have widened that hole.
+    """
+    from clawmetry import onboarding_state as obs
+    assert "selfhost_free" in obs.RECORDED_CHOICES
+    assert "selfhost_free" not in obs.CHOICES
+    r = client.post("/api/onboarding/complete", json={"choice": "selfhost_free"})
+    assert r.status_code == 400
+
+
+def test_gate_offers_the_free_escape_and_wires_it():
+    """Markup + handler + endpoint must agree; any one alone is a dead link."""
+    html = open(os.path.join(_ROOT, "clawmetry/templates/partials/onboarding-modal.html"),
+                encoding="utf-8").read()
+    js = open(os.path.join(_ROOT, "clawmetry/static/js/onboarding.js"),
+              encoding="utf-8").read()
+    assert 'id="obg-free-btn"' in html
+    # The three free runtimes are the offer; naming them is the whole reason
+    # a user takes this path instead of bouncing.
+    for name in ("OpenClaw", "NemoClaw", "Goose"):
+        assert name in html, name
+    assert "obg-free-btn" in js
+    assert "/api/onboarding/free-only" in js
+
+
+# ── paywall beacons reaching the cloud funnel ────────────────────────────────
+
+def test_paywall_beacons_are_forwarded_as_lifecycle_events(monkeypatch):
+    import routes.entitlement as ent
+    sent = []
+    import clawmetry.telemetry as telemetry
+    monkeypatch.setattr(telemetry, "ping_once",
+                        lambda event, version="unknown", extra=None: sent.append(event))
+
+    ent._ping_paywall_lifecycle({"event": "hard_block_view"})
+    ent._ping_paywall_lifecycle({"event": "hard_block_checkout_click"})
+    assert sent == ["paywall_view", "paywall_checkout_click"]
+
+
+def test_unrelated_paywall_events_are_not_forwarded(monkeypatch):
+    """Only the two funnel beacons leave the machine; nothing else does."""
+    import routes.entitlement as ent
+    sent = []
+    import clawmetry.telemetry as telemetry
+    monkeypatch.setattr(telemetry, "ping_once",
+                        lambda event, version="unknown", extra=None: sent.append(event))
+
+    for body in ({"event": "some_other_beacon"}, {}, {"event": ""}, {"harness": "cursor"}):
+        ent._ping_paywall_lifecycle(body)
+    assert sent == []
+
+
+def test_beacon_names_match_what_the_overlay_actually_posts():
+    """The silent-failure guard.
+
+    The forwarder keys off the literal ``event`` strings app.js posts. Rename
+    one there and the telemetry stops with no error anywhere, which is
+    precisely how these two beacons came to have zero rows in the first
+    place.
+    """
+    import routes.entitlement as ent
+    js = open(os.path.join(_ROOT, "clawmetry/static/js/app.js"), encoding="utf-8").read()
+    posted = set(re.findall(r"event:\s*'(hard_block_[a-z_]+)'", js))
+    assert posted, "app.js no longer posts any hard_block_* paywall beacon"
+    assert posted <= set(ent._PAYWALL_LIFECYCLE_EVENTS), (
+        "app.js posts paywall beacons the forwarder does not map: "
+        f"{sorted(posted - set(ent._PAYWALL_LIFECYCLE_EVENTS))}"
+    )
+
+
+def test_forwarding_never_breaks_the_beacon(monkeypatch):
+    """A telemetry failure must not change the 204 the beacon returns."""
+    import routes.entitlement as ent
+    import clawmetry.telemetry as telemetry
+
+    def _boom(*a, **k):
+        raise RuntimeError("network down")
+
+    monkeypatch.setattr(telemetry, "ping_once", _boom)
+    ent._ping_paywall_lifecycle({"event": "hard_block_view"})  # must not raise


### PR DESCRIPTION
Requirements: [Free Answer at the Gate, and a Visible Paywall](https://factory.8090.ai/project/b415065f-ab2f-4f53-8864-0c009fd098cb/requirements/cd0b3dc3-ca5c-49ad-a4c0-dec01f122d12) — AC-FREE-001 the escape, AC-FREE-002 the beacons, AC-FREE-003 the guards.

## What the funnel actually said

| Measurement (prod, 30d to 2026-09-06) | Value |
|---|---|
| `installs` first launches, non-CI | **798** |
| completed onboarding choices | **38 (4.8%)** |
| real Pro trials | 72 (2.4/day) |
| `hard_block_view` rows in cloud analytics | **0, ever** |
| `hard_block_checkout_click` rows in cloud analytics | **0, ever** |

Checkout itself is healthy. Driving it live as a lapsed trial mints the correct Stripe session for all four combinations ($9/mo, $90/yr, $19/mo, $190/yr), promo codes on, annual device perk stamped. Nobody is declining a price. Most people never reach one.

## 1. The gate had no free answer

Both cards demand an identity before the dashboard opens. OpenClaw, NVIDIA NemoClaw and Goose are `FREE_RUNTIMES`, free forever with no account, so for someone running only those the gate was charging a signup for data we give away.

`selfhost_free` was already a **recorded** choice (the CLI wizard's no-account branch writes it) but deliberately **not postable** through `/api/onboarding/complete`, so a bare POST could not claim it with no local configuration behind it. That reasoning still holds and `/complete` stays closed, guarded by a test. `POST /api/onboarding/free-only` is the flow it was missing: it flips free-only mode on and writes the nocloud marker **before** recording the choice, so the recorded state is backed by real configuration exactly like every other answer. Reversible from Settings and via `POST /api/trial/exit-free`.

> I just want OpenClaw, NVIDIA NemoClaw and Goose, free and with no account

## 2. The paywall reported nothing

The overlay's two beacons were POSTed to `/api/paywall/event` and written **only** to an in-process store on the user's own machine. So on the one surface where someone looks straight at a price, we could not tell "saw it and declined" from "never got there".

They now ride `clawmetry/telemetry`, inheriting its privacy contract unchanged: anonymous install id, no account, no email, no hostname, no runtime data, every existing opt-out (`CLAWMETRY_NO_TELEMETRY`, `DO_NOT_TRACK`, `~/.clawmetry/notelemetry`) honoured. `ping_once` dedups on disk, so an overlay re-rendering on each background poll still sends one row.

## Guards

Both regressions are silent by construction, so both get tests, **named explicitly in `ci.yml`** (a test file nobody lists runs in no job). The sharpest one asserts the forwarder's map still covers every `hard_block_*` beacon `app.js` actually posts: rename one there and the telemetry stops with no error anywhere, which is how these came to have zero rows in the first place.

- 8 new tests pass; **7 of 8 fail on `origin/main`** (the eighth is the `/complete`-stays-closed invariant, correctly green on both).
- 100 existing onboarding + paywall tests still pass.

## Ships with

vivekchand/clawmetry-cloud#2305 allowlists the two events, the `selfhost_free` state, and the `cloud_route_policy` entry for the new route. **Merge the cloud PR first or at the same time** — an OSS route with no policy entry is a `SystemExit` in `apply_policy` and the cloud will not boot when the pin advances.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CtZ1FEUNx4hLhTFdrZ2Txz