### PR TITLE
Harden CI: install the visual-diff bot's Node deps from a lockfile

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -139,3 +139,20 @@ updates:
       - "dependencies"
     cooldown:
       default-days: 7
+
+  # npm — the PR visual-diff bot's Playwright/pixelmatch/pngjs
+  # (.github/scripts/, driven by pr-screenshots.yml). The other half of that
+  # pin: the lockfile makes the install reproducible and integrity-checked,
+  # and this entry is what keeps it moving. Without it the bot would sit on
+  # one Playwright forever, which is the frozen end of the same problem the
+  # unpinned install was at the other end of.
+  - package-ecosystem: "npm"
+    directory: "/.github/scripts"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+    cooldown:
+      default-days: 7

--- a/.github/scripts/package-lock.json
+++ b/.github/scripts/package-lock.json
@@ -1,0 +1,92 @@
+{
+  "name": "clawmetry-pr-screenshots",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "clawmetry-pr-screenshots",
+      "version": "0.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "pixelmatch": "5.3.0",
+        "playwright": "1.49.0",
+        "pngjs": "7.0.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/pixelmatch": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/pixelmatch/-/pixelmatch-5.3.0.tgz",
+      "integrity": "sha512-o8mkY4E/+LNUf6LzX96ht6k6CEDi65k9G2rjMtBe9Oo+VPKSvl+0GKHuH/AlG+GA5LPG/i5hrekkxUc3s2HU+Q==",
+      "license": "ISC",
+      "dependencies": {
+        "pngjs": "^6.0.0"
+      },
+      "bin": {
+        "pixelmatch": "bin/pixelmatch"
+      }
+    },
+    "node_modules/pixelmatch/node_modules/pngjs": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-6.0.0.tgz",
+      "integrity": "sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.13.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.49.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.49.0.tgz",
+      "integrity": "sha512-eKpmys0UFDnfNb3vfsf8Vx2LEOtflgRebl0Im2eQQnYMA4Aqd+Zw8bEOB+7ZKvN76901mRnqdsiOGKxzVTbi7A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.49.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.49.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.49.0.tgz",
+      "integrity": "sha512-R+3KKTQF3npy5GTiKH/T+kdhoJfJojjHESR1YEWhYuEKRVfVaxH3+4+GvXE5xyCngCxhxnykk0Vlah9v8fs3jA==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/pngjs": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-7.0.0.tgz",
+      "integrity": "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.19.0"
+      }
+    }
+  }
+}

--- a/.github/scripts/package.json
+++ b/.github/scripts/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "clawmetry-pr-screenshots",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Pinned deps for the PR visual-diff bot (.github/scripts/visual-diff.mjs). Installed with `npm ci` so every tarball is integrity-checked.",
+  "license": "MIT",
+  "dependencies": {
+    "pixelmatch": "5.3.0",
+    "playwright": "1.49.0",
+    "pngjs": "7.0.0"
+  }
+}

--- a/.github/workflows/pr-screenshots.yml
+++ b/.github/workflows/pr-screenshots.yml
@@ -24,6 +24,8 @@ on:
       - ".github/workflows/pr-screenshots.yml"
       - ".github/scripts/visual-diff.mjs"
       - ".github/scripts/post-visual-diff.mjs"
+      - ".github/scripts/package.json"
+      - ".github/scripts/package-lock.json"
 
 permissions:
   contents: read
@@ -109,15 +111,23 @@ jobs:
           pip install duckdb requests
 
       # -- 5. Node deps (Playwright + pixelmatch + pngjs) ----------------------
+      # `npm ci` against the committed .github/scripts/package-lock.json, not a
+      # bare `npm install`. The versions were already pinned, but without a lock
+      # every TRANSITIVE dependency still re-resolved on each run and no tarball
+      # was checked against an integrity hash -- and this job holds
+      # `contents: write` and `pull-requests: write`, so anything that resolves
+      # here runs with those. The lock records the whole tree and npm verifies
+      # every sha512 before it unpacks.
+      #
+      # node_modules must land in the same directory as the scripts that import
+      # it: `visual-diff.mjs` imports `playwright`/`pixelmatch`/`pngjs` as bare
+      # specifiers, which Node resolves by walking up from the importing file.
+      # head/.github/scripts/node_modules is the first directory it checks.
       - name: Install Node deps
-        working-directory: head
+        working-directory: head/.github/scripts
         run: |
-          npm init -y >/dev/null
-          npm install --no-audit --no-fund --silent \
-            playwright@1.49.0 \
-            pixelmatch@5.3.0 \
-            pngjs@7.0.0
-          npx --yes playwright install --with-deps chromium
+          npm ci --no-audit --no-fund
+          npx playwright install --with-deps chromium
 
       # -- 5b. Install OpenClaw + export gateway token -------------------------
       # continue-on-error: true so a transient npm registry miss does not


### PR DESCRIPTION
`No-PRD:` CI-only change. Every file is under `.github/`, which is exempt from the product-record gate.

## What this changes

`pr-screenshots.yml` built its Node environment with `npm init -y` followed by a bare `npm install`:

```yaml
working-directory: head
run: |
  npm init -y >/dev/null
  npm install --no-audit --no-fund --silent \
    playwright@1.49.0 pixelmatch@5.3.0 pngjs@7.0.0
```

The three direct versions were already pinned, so this is not about them. Without a lockfile every **transitive** dependency still re-resolved against the registry on each run, and no tarball was checked against an integrity hash. zizmor reports it as `adhoc-packages` — one of the two left on this repository's workflows.

The step runs in a job holding `contents: write` and `pull-requests: write`, so whatever resolves there runs with those scopes. Same reasoning as the equivalent fixes already merged in `clawmetry-pro` and `clawmetry-cloud`, and as the SHA pinning applied to every `uses:` reference: make an upgrade deliberate rather than a side effect of when the job happened to run.

Now:

```yaml
working-directory: head/.github/scripts
run: |
  npm ci --no-audit --no-fund
  npx playwright install --with-deps chromium
```

Same three versions — this changes **how** they are installed, not what.

## Why the manifest lives in `.github/scripts/`

`visual-diff.mjs` imports `playwright`, `pixelmatch` and `pngjs` as bare specifiers, which Node resolves by walking up from the importing file. `head/.github/scripts/node_modules` is the first directory it checks. A manifest in a directory of its own would install somewhere those imports never look.

## Dependabot

Paired with a new npm entry for `/.github/scripts`, so the lock keeps moving instead of freezing — the same pin/updater pairing that file already documents for the SHA pins and the other four Node manifests. **Appended at the end of the file** so it does not collide with the entry #5575 adds mid-file.

## Verification

- `npm ci` in a clean directory laid out as `head/.github/scripts/` exits 0; every package in the lock carries an integrity hash
- all three bare specifiers resolve from `visual-diff.mjs`'s real location (checked with `createRequire` against that exact path)
- zizmor `adhoc-packages` on `pr-screenshots.yml`: 1 → 0, no new finding introduced (52 → 51 total; the remainder is the `setup-openclaw` one #5575 fixes)
- all 38 workflow, composite-action and `dependabot.yml` files parse under `yaml.safe_load`
- `scripts/check_action_refs.py` still exits 0

## One transitional note for the reviewer

The manifest is read from the PR **head** checkout, consistent with how this workflow already consumes head (`./head/.github/actions/setup-openclaw`, `head/.github/scripts/post-visual-diff.mjs`). A PR branched before this merges will not have the manifest in its head, so its install step will fail until it picks up main. The bot is non-blocking by design — it is not among the 12 checks `E2E Gate (required)` aggregates — so this costs a screenshot comment, not a merge. Flagging it rather than burying it; happy to add a trusted-checkout step instead if you would rather it not depend on head at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019xu7MkNCbNQuZMJRw7SJpT

---
_Generated by [Claude Code](https://claude.ai/code/session_019xu7MkNCbNQuZMJRw7SJpT)_