### PR TITLE
Move the paywall forwarder out of a 47,700-line file

### DIFF
--- a/docs/MODULE_MAP.md
+++ b/docs/MODULE_MAP.md
@@ -4,7 +4,7 @@
 > `python3 scripts/gen_module_map.py` (CI fails on drift via
 > `tests/test_module_map_drift.py`).
 
-226 modules, 81 Flask blueprints. `CLAUDE.md` carries a short curated table of the ones you reach for most often; this is the whole list.
+227 modules, 81 Flask blueprints. `CLAUDE.md` carries a short curated table of the ones you reach for most often; this is the whole list.
 
 Size bands are deliberately coarse so this file does not churn on every PR: **small** is under 200 lines, **medium** under 1k, **large** under 5k, **huge** is 5k and up.
 
@@ -67,6 +67,7 @@ One module per feature, each owning one or more Flask blueprints. New endpoints 
 | `routes/org_analytics.py` | small | `bp_org_analytics` | `/api/org-analytics` | OSS stub after the impl lives in clawmetry-pro. |
 | `routes/otel_export.py` | medium | `bp_otel_export` | `/api/otel` | Pro+ OTel/OTLP export. |
 | `routes/overview.py` | large | `bp_overview` | `/api/activity-heatmap`, `/api/channels`, `/api/cloud-cta`, `/api/cloud-proxy`, `/api/device`, `/api/health-timeline`, `/api/overview`, `/api/prompt-errors`, `/api/sync`, `/api/timeline` | Main-dashboard endpoints. |
+| `routes/paywall_lifecycle.py` | small |  |  | the paywall beacons that reach the funnel. |
 | `routes/plugins.py` | medium | `bp_plugins` | `/api/plugins` | Plugin registry: unified view of installed plugins (#692). |
 | `routes/policy.py` | medium | `bp_policy` | `/api/approvals`, `/api/approvals-audit`, `/api/policy`, `/api/tool-policy` | tool-policy + sandbox + exec-approval audit (PRD P1-1). |
 | `routes/quality.py` | medium | `bp_quality` | `/api/quality` | the Quality tab endpoint. |

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -23602,51 +23602,17 @@ def api_paywall_event():
     return "", 204
 
 
-# The overlay's two beacons, mapped to the lifecycle event names the cloud
-# funnel understands. Anything else stays local-only.
-_PAYWALL_LIFECYCLE_EVENTS = {
-    "hard_block_view": "paywall_view",
-    "hard_block_checkout_click": "paywall_checkout_click",
-}
-
-
-def _ping_paywall_lifecycle(body: dict) -> None:
-    """Mirror the two paywall beacons into the anonymous lifecycle ping.
-
-    Spec: REQ "Free Answer at the Gate, and a Visible Paywall"
-    (cd0b3dc3-ca5c-49ad-a4c0-dec01f122d12), AC-FREE-002.
-
-    Why: until now ``POST /api/paywall/event`` wrote ONLY to an in-process
-    rolling store on the user's own machine, so the highest-intent surface we
-    ship had no telemetry anywhere we can read. Checked on 2026-09-06:
-    ``hard_block_view`` and ``hard_block_checkout_click`` had zero rows in
-    cloud analytics, ever, which is why "do people see the paywall and
-    decline, or never reach it?" could not be answered, and why a pricing
-    change would have been made blind.
-
-    Rides ``clawmetry.telemetry`` rather than a new channel so it inherits
-    the existing privacy contract unchanged: an anonymous install id, no
-    account, no email, no hostname, no runtime data, and every opt-out
-    (``CLAWMETRY_NO_TELEMETRY``, ``DO_NOT_TRACK``, ``~/.clawmetry/notelemetry``)
-    already honoured. ``ping_once`` dedups on disk, so an overlay that
-    re-renders on every background poll still sends one row per install.
-
-    Never raises: a telemetry failure must not change the 204 the beacon
-    already returns.
-    """
-    try:
-        event = _PAYWALL_LIFECYCLE_EVENTS.get(str((body or {}).get("event", "")))
-        if not event:
-            return
-        from clawmetry import telemetry as _telemetry
-
-        try:
-            from dashboard import __version__ as _ver
-        except Exception:
-            _ver = "unknown"
-        _telemetry.ping_once(event, _ver)
-    except Exception as exc:
-        logger.debug("api_paywall_event: lifecycle ping skipped: %s", exc)
+# The forwarder that mirrors the overlay's two beacons into the anonymous
+# lifecycle ping lives in its own module (routes/paywall_lifecycle.py).
+# It is 60 lines of concern that three separate readers need to find, and
+# this file is ~47,700 lines: written inline here, every tool that samples
+# the head of a file reported the function as absent and this whole module
+# as missing from the repository. Re-exported under the original private
+# names so existing callers and tests keep working.
+from routes.paywall_lifecycle import (  # noqa: E402
+    PAYWALL_LIFECYCLE_EVENTS as _PAYWALL_LIFECYCLE_EVENTS,
+    ping_paywall_lifecycle as _ping_paywall_lifecycle,
+)
 
 
 @bp_entitlement.route("/api/paywall/events/summary")

--- a/routes/paywall_lifecycle.py
+++ b/routes/paywall_lifecycle.py
@@ -1,0 +1,76 @@
+"""routes/paywall_lifecycle.py — the paywall beacons that reach the funnel.
+
+The trial hard-block overlay (``clawmetry/static/js/app.js``) posts two
+beacons to ``POST /api/paywall/event``:
+
+    hard_block_view            the overlay was rendered to a user
+    hard_block_checkout_click  that user clicked through to pay
+
+Until 0.12.821 both were written ONLY to an in-process rolling store on the
+user's own machine (``clawmetry/_paywall_events.py``, read back by
+``/api/paywall/events/*``) and forwarded nowhere. Checked against cloud
+analytics on 2026-09-06: zero rows for either, ever. So on the one surface
+where somebody is looking straight at a price, we recorded nothing, and the
+funnel could not separate "saw a price and declined" from "never reached
+one" — the only question a pricing decision actually turns on.
+
+This module is deliberately tiny and deliberately its OWN file. It was
+first written inline in ``routes/entitlement.py``, which is ~47,700 lines;
+every automated reader that samples the head of a file (Drift Bot among
+them) concluded the function did not exist and reported the whole module as
+missing from the repository. A 60-line concern that three different tools
+need to find is a module, not a footnote in the largest file we ship.
+
+Spec: REQ "Free Answer at the Gate, and a Visible Paywall"
+(cd0b3dc3-ca5c-49ad-a4c0-dec01f122d12), AC-FREE-002; blueprint component
+``#PaywallBeaconForwarder``.
+"""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+# The overlay's two beacons, mapped to the lifecycle event names the cloud
+# funnel understands. This is an ALLOWLIST, not a passthrough: the local
+# rolling store keeps receiving every beacon, and only these two leave the
+# machine. The cloud must carry the same two names in
+# ``routes/install.py::_ALLOWED_EVENTS`` or they are dropped with no insert
+# and no error.
+PAYWALL_LIFECYCLE_EVENTS = {
+    "hard_block_view": "paywall_view",
+    "hard_block_checkout_click": "paywall_checkout_click",
+}
+
+
+def ping_paywall_lifecycle(body: dict) -> None:
+    """Mirror the two paywall beacons into the anonymous lifecycle ping.
+
+    Rides ``clawmetry.telemetry`` rather than a new channel so it inherits
+    the existing privacy contract unchanged: an anonymous install id, no
+    account, no email, no hostname, no workspace path, no runtime data, and
+    every opt-out already honoured (``CLAWMETRY_NO_TELEMETRY``,
+    ``DO_NOT_TRACK``, ``~/.clawmetry/notelemetry``). ``ping_once`` dedups on
+    disk, so an overlay that re-renders on every background poll still sends
+    one row per install — the funnel wants installs, not renders.
+
+    Never raises: a telemetry failure must not change the 204 the beacon
+    endpoint already returns.
+    """
+    try:
+        event = PAYWALL_LIFECYCLE_EVENTS.get(str((body or {}).get("event", "")))
+        if not event:
+            return
+        from clawmetry import telemetry as _telemetry
+
+        try:
+            from dashboard import __version__ as _ver
+        except Exception:
+            _ver = "unknown"
+        _telemetry.ping_once(event, _ver)
+    except Exception as exc:
+        logger.debug("paywall_lifecycle: ping skipped: %s", exc)
+
+
+__all__ = ["PAYWALL_LIFECYCLE_EVENTS", "ping_paywall_lifecycle"]

--- a/tests/test_paywall_funnel_telemetry.py
+++ b/tests/test_paywall_funnel_telemetry.py
@@ -176,3 +176,29 @@ def test_forwarding_never_breaks_the_beacon(monkeypatch):
 
     monkeypatch.setattr(telemetry, "ping_once", _boom)
     ent._ping_paywall_lifecycle({"event": "hard_block_view"})  # must not raise
+
+
+def test_forwarder_lives_in_its_own_module_and_is_re_exported():
+    """The forwarder must stay findable, by tools as well as people.
+
+    Written inline in routes/entitlement.py (~47,700 lines) it was invisible
+    to every reader that samples the head of a file: Drift Bot reported the
+    function as undefined and the whole module as missing from the
+    repository. Keeping it in a small module of its own is what makes it
+    readable; keeping the re-export is what keeps existing callers working.
+    """
+    import routes.paywall_lifecycle as pl
+    import routes.entitlement as ent
+
+    assert pl.PAYWALL_LIFECYCLE_EVENTS == {
+        "hard_block_view": "paywall_view",
+        "hard_block_checkout_click": "paywall_checkout_click",
+    }
+    # Same objects, not copies: a future edit to one cannot silently leave
+    # the other behind.
+    assert ent._PAYWALL_LIFECYCLE_EVENTS is pl.PAYWALL_LIFECYCLE_EVENTS
+    assert ent._ping_paywall_lifecycle is pl.ping_paywall_lifecycle
+
+    src = open(os.path.join(_ROOT, "routes/paywall_lifecycle.py"), encoding="utf-8").read()
+    assert len(src.splitlines()) < 200, "keep this module small enough to be read whole"
+


### PR DESCRIPTION
Requirements: [Free Answer at the Gate, and a Visible Paywall](https://factory.8090.ai/project/b415065f-ab2f-4f53-8864-0c009fd098cb/requirements/cd0b3dc3-ca5c-49ad-a4c0-dec01f122d12) — AC-FREE-002, blueprint component `#PaywallBeaconForwarder`.

## The findings were false, and I checked before acting

Drift Bot raised three findings on the release PR: `routes/entitlement.py` "is completely missing from the repository", `_ping_paywall_lifecycle` "is not defined anywhere in the codebase", and dashboard.py's import "will fail at runtime, preventing the dashboard from starting".

Verified against merged main (`9b13b4d7f`):

```
$ git ls-tree origin/main routes/entitlement.py
100644 blob 9089445b09a7d84489a7b6c45bccdad75ddbbe63  routes/entitlement.py
$ git show origin/main:routes/entitlement.py | wc -l
47709
$ python -c "import routes.entitlement as e; print(e._PAYWALL_LIFECYCLE_EVENTS)"
{'hard_block_view': 'paywall_view', 'hard_block_checkout_click': 'paywall_checkout_click'}
```

Nothing is broken. No production impact, and the dashboard boots.

## But the signal about the file is fair

Automated readers sample the head of a file. At **47,709 lines** a function near the tail may as well not exist — and this one has three separate readers: the beacon endpoint that calls it, the guard test that pins its mapping, and anyone auditing what leaves a user's machine. That last one matters most: code deciding what gets sent off a user's device should be findable in seconds, not buried at line 23,613 of the largest file we ship.

## What changed

`routes/paywall_lifecycle.py` (76 lines) holds `PAYWALL_LIFECYCLE_EVENTS` and `ping_paywall_lifecycle`. `routes/entitlement.py` imports and re-exports them under the original private names, so every existing caller and test keeps working.

**No behaviour change.** 43 paywall tests pass unchanged. One new test pins that `entitlement._PAYWALL_LIFECYCLE_EVENTS is paywall_lifecycle.PAYWALL_LIFECYCLE_EVENTS` — the same objects, not copies that could drift apart — and that the new module stays under 200 lines, i.e. small enough to be read whole.

No new route, so no `cloud_route_policy` entry needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CtZ1FEUNx4hLhTFdrZ2Txz