### PR TITLE
feat(nemoclaw): resolve vLLM sandbox provider distinctly in _sandbox_inference_configs (#5579)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -497,6 +497,7 @@ jobs:
             tests/test_live_sessions_all_runtimes.py \
             tests/test_needs_you_ui_contract.py \
             tests/test_overview_claims_are_evidenced.py \
+            tests/test_obs_gap_nemoclaw_vllm_5579.py \
             -q
 
   # ── Entitlement API test suite (~2700+ hermetic tests) ─────────────────────────────────────────────

--- a/clawmetry/adapters/openclaw.py
+++ b/clawmetry/adapters/openclaw.py
@@ -398,6 +398,15 @@ def _resolve_lmstudio_base_url() -> str:
     return val or "http://localhost:1234/v1"
 
 
+def _resolve_vllm_base_url() -> str:
+    """Return the active vLLM server base URL from env var or the default.
+
+    VLLM_HOST overrides; falls back to vLLM's default port.
+    """
+    val = os.environ.get("VLLM_HOST", "").strip()
+    return val or "http://localhost:8000/v1"
+
+
 def _list_ollama_models(host: str) -> list:
     """Return available Ollama model names. Never raises; returns [] on failure.
 
@@ -1215,6 +1224,11 @@ def _sandbox_inference_configs() -> list:
                 provider_key = "lmstudio"
                 primary = f"lmstudio/{model}" if model else ""
                 base_url = _resolve_lmstudio_base_url()
+                compat = "openai"
+            elif provider in ("vllm", "vllm-server"):
+                provider_key = "vllm"
+                primary = f"vllm/{model}" if model else ""
+                base_url = _resolve_vllm_base_url()
                 compat = "openai"
             else:
                 provider_key = _MANAGED

--- a/tests/test_obs_gap_nemoclaw_vllm_5579.py
+++ b/tests/test_obs_gap_nemoclaw_vllm_5579.py
@@ -1,0 +1,122 @@
+"""Tests for vLLM sandbox detection in _sandbox_inference_configs() (#5579).
+
+Covers:
+- _resolve_vllm_base_url() priority: VLLM_HOST > default http://localhost:8000/v1
+- vLLM sandbox gets providerKey='vllm', correct primaryModelRef, inferenceBaseUrl
+- provider strings "vllm" and "vllm-server" both match the new branch
+- Non-vLLM sandboxes are unaffected by the new branch
+"""
+import json
+
+import pytest
+
+from clawmetry.adapters.openclaw import (
+    _resolve_vllm_base_url,
+    _sandbox_inference_configs,
+)
+
+
+# ---------------------------------------------------------------------------
+# _resolve_vllm_base_url
+# ---------------------------------------------------------------------------
+
+def test_resolve_vllm_base_url_default(monkeypatch):
+    monkeypatch.delenv("VLLM_HOST", raising=False)
+    assert _resolve_vllm_base_url() == "http://localhost:8000/v1"
+
+
+def test_resolve_vllm_base_url_from_env(monkeypatch):
+    monkeypatch.setenv("VLLM_HOST", "http://192.168.1.10:8000/v1")
+    assert _resolve_vllm_base_url() == "http://192.168.1.10:8000/v1"
+
+
+def test_resolve_vllm_base_url_strips_whitespace(monkeypatch):
+    monkeypatch.setenv("VLLM_HOST", "  http://my-vllm:8000/v1  ")
+    assert _resolve_vllm_base_url() == "http://my-vllm:8000/v1"
+
+
+def test_resolve_vllm_base_url_empty_env_falls_back(monkeypatch):
+    monkeypatch.setenv("VLLM_HOST", "")
+    assert _resolve_vllm_base_url() == "http://localhost:8000/v1"
+
+
+# ---------------------------------------------------------------------------
+# _sandbox_inference_configs — vLLM sandbox
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def nemoclaw_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    (tmp_path / ".nemoclaw").mkdir()
+    return tmp_path
+
+
+def _write_sandboxes(home, sandboxes, default=None):
+    payload = {"sandboxes": sandboxes}
+    if default:
+        payload["defaultSandbox"] = default
+    (home / ".nemoclaw" / "sandboxes.json").write_text(json.dumps(payload))
+
+
+def test_vllm_sandbox_gets_correct_provider_key(nemoclaw_home, monkeypatch):
+    _write_sandboxes(nemoclaw_home, {"local": {"provider": "vllm", "model": "mistral-7b"}})
+    monkeypatch.delenv("VLLM_HOST", raising=False)
+
+    configs = {c["sandbox"]: c for c in _sandbox_inference_configs()}
+    assert "local" in configs
+    c = configs["local"]
+    assert c["providerKey"] == "vllm"
+    assert c["primaryModelRef"] == "vllm/mistral-7b"
+    assert c["inferenceCompat"] == "openai"
+    assert c["inferenceBaseUrl"] == "http://localhost:8000/v1"
+
+
+def test_vllm_server_provider_string_also_matches(nemoclaw_home, monkeypatch):
+    """The 'vllm-server' alias is also recognised (#5579)."""
+    _write_sandboxes(nemoclaw_home, {"srv": {"provider": "vllm-server", "model": "llama3"}})
+    monkeypatch.delenv("VLLM_HOST", raising=False)
+
+    configs = {c["sandbox"]: c for c in _sandbox_inference_configs()}
+    assert configs["srv"]["providerKey"] == "vllm"
+    assert configs["srv"]["primaryModelRef"] == "vllm/llama3"
+
+
+def test_vllm_sandbox_base_url_from_env(nemoclaw_home, monkeypatch):
+    _write_sandboxes(nemoclaw_home, {"gpu": {"provider": "vllm", "model": "qwen"}})
+    monkeypatch.setenv("VLLM_HOST", "http://gpu-node:8000/v1")
+
+    configs = {c["sandbox"]: c for c in _sandbox_inference_configs()}
+    assert configs["gpu"]["inferenceBaseUrl"] == "http://gpu-node:8000/v1"
+
+
+def test_vllm_sandbox_no_model_gives_empty_primary_ref(nemoclaw_home, monkeypatch):
+    _write_sandboxes(nemoclaw_home, {"bare": {"provider": "vllm"}})
+    monkeypatch.delenv("VLLM_HOST", raising=False)
+
+    configs = {c["sandbox"]: c for c in _sandbox_inference_configs()}
+    assert configs["bare"]["primaryModelRef"] == ""
+
+
+def test_vllm_sandbox_is_default(nemoclaw_home, monkeypatch):
+    _write_sandboxes(
+        nemoclaw_home,
+        {"local": {"provider": "vllm", "model": "phi3"}},
+        default="local",
+    )
+    monkeypatch.delenv("VLLM_HOST", raising=False)
+    configs = {c["sandbox"]: c for c in _sandbox_inference_configs()}
+    assert configs["local"]["isDefault"] is True
+
+
+def test_non_vllm_sandboxes_unaffected(nemoclaw_home, monkeypatch):
+    _write_sandboxes(nemoclaw_home, {
+        "oai": {"provider": "openai-api", "model": "gpt-4o"},
+        "anth": {"provider": "anthropic-prod", "model": "claude-x"},
+        "managed": {"provider": "some-future-thing", "model": "m"},
+    })
+    configs = {c["sandbox"]: c for c in _sandbox_inference_configs()}
+    assert configs["oai"]["providerKey"] == "openai"
+    assert configs["anth"]["providerKey"] == "anthropic"
+    assert configs["managed"]["providerKey"] == "inference"
+    for key in ("oai", "anth", "managed"):
+        assert configs[key]["providerKey"] != "vllm"


### PR DESCRIPTION
No-PRD: automated harness-observability gap fill; adds a missing elif branch to an existing provider chain with no new product requirement

## Summary

vLLM-backed NeMoClaw sandboxes fell through to the generic `"inference"` else-branch in `_sandbox_inference_configs()`, making their real base URL, model ref, and provider identity indistinguishable from managed cloud providers in the dashboard. This adds a distinct `vllm` branch following the exact same pattern used by ollama, llama.cpp, lmstudio, and minimax.

## Changes

- **`clawmetry/adapters/openclaw.py`**: Add `_resolve_vllm_base_url()` (checks `VLLM_HOST` env var, falls back to `http://localhost:8000/v1`) and add `elif provider in ("vllm", "vllm-server"):` branch before the generic `else` in `_sandbox_inference_configs()`. The `"vllm"` provider string is already recognised in `sync.py` and `providers_pricing.py`; this aligns the adapter layer with them.
- **`tests/test_obs_gap_nemoclaw_vllm_5579.py`**: 10 tests covering resolver env-var priority, whitespace stripping, both provider string aliases, env-var URL override, empty model ref, isDefault flag, and that non-vLLM sandboxes remain unaffected. Modelled on `tests/test_obs_gap_nemoclaw_ollama_3201.py`.

## Test plan

- [ ] `python3 -m pytest tests/test_obs_gap_nemoclaw_vllm_5579.py -v` — all 10 tests pass
- [ ] `python3 -c "import ast; ast.parse(open('clawmetry/adapters/openclaw.py').read())"` — syntax clean
- [ ] A sandbox with `provider: "vllm"` in `~/.nemoclaw/sandboxes.json` now shows `providerKey: "vllm"` and the correct base URL in the NeMoClaw sandbox panel

## Bot meta

<!-- bot-autofix -->
Draft PR opened autonomously based on the plan in #5579. Marked draft for human review — mark Ready for Review once happy.

Closes #5579

https://claude.ai/code/session_01Tq6J2ct37Q66ejqKHnvy5a