### PR TITLE
Harden CI: clear the visual-diff bot's Playwright SSL-verification advisory

### DIFF
--- a/.github/scripts/package-lock.json
+++ b/.github/scripts/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "pixelmatch": "5.3.0",
-        "playwright": "1.49.0",
+        "playwright": "1.59.1",
         "pngjs": "7.0.0"
       }
     },
@@ -50,12 +50,12 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.49.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.49.0.tgz",
-      "integrity": "sha512-eKpmys0UFDnfNb3vfsf8Vx2LEOtflgRebl0Im2eQQnYMA4Aqd+Zw8bEOB+7ZKvN76901mRnqdsiOGKxzVTbi7A==",
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.49.0"
+        "playwright-core": "1.59.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -68,9 +68,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.49.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.49.0.tgz",
-      "integrity": "sha512-R+3KKTQF3npy5GTiKH/T+kdhoJfJojjHESR1YEWhYuEKRVfVaxH3+4+GvXE5xyCngCxhxnykk0Vlah9v8fs3jA==",
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"

--- a/.github/scripts/package.json
+++ b/.github/scripts/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "dependencies": {
     "pixelmatch": "5.3.0",
-    "playwright": "1.49.0",
+    "playwright": "1.59.1",
     "pngjs": "7.0.0"
   }
 }


### PR DESCRIPTION
**Product record:** No-PRD: CI-only dependency bump confined to `.github/scripts/`, a PRD-exempt path. No runtime code, no workflow file, and nothing that ships in the clawmetry wheel changes.

**Risk:** Low. One pin moves, in a bot that is already non-blocking by design. Undone by reverting one commit.

## What this fixes

The PR visual-diff bot's lockfile landed today (#5583) pinning `playwright` **1.49.0**. That version sits inside **[GHSA-7mvr-c777-76hp](https://github.com/advisories/GHSA-7mvr-c777-76hp) (high)** — Playwright's browser-download step does not verify the authenticity of the server's SSL certificate, so the Chromium build `npx playwright install` pulls is fetched over a connection whose identity is never checked.

That step runs in a job holding `contents: write` and `pull-requests: write`, so whatever gets installed there runs with those scopes. It is the same reasoning that motivated committing the lockfile in the first place: make what executes in CI a deliberate, verified choice rather than whatever the network happened to return.

## The change

`playwright` **1.49.0 → 1.59.1**, and the regenerated lock.

The advisory's fixed boundary is 1.55.1, so several versions would clear it. 1.59.1 is chosen because it is **the line the rest of the repository is already on** — both `.github/ci-node/auth-bootstrap` and `tests/e2e` pin exactly 1.59.1. That is deliberate rather than incidental: `.github/dependabot.yml` asks for these Playwright pins to be kept in step, because two different lines mean CI downloads two browser builds for no reason. npm's own suggestion was 1.63.0; 1.59.1 clears the advisory just as completely, matches what CI already downloads, and is the smaller move.

`pixelmatch` 5.3.0 and `pngjs` 7.0.0 are untouched. No workflow file is edited.

## Verification

- [x] `npm audit` in `.github/scripts` — **1 high → 0 findings of any severity**
- [x] Every package in the regenerated lock still carries an `integrity` hash **and** a `resolved` URL (lockfileVersion 3) — the property the committed lock exists for
- [x] `npm ci` in a clean directory laid out as `head/.github/scripts/` exits 0 and installs playwright 1.59.1, pixelmatch 5.3.0, pngjs 7.0.0
- [x] All three bare specifiers `visual-diff.mjs` imports (`playwright`, `pixelmatch`, `pngjs`) resolve from its real location under ESM — the resolution constraint #5583 documents
- [x] All 36 workflow files parse under `yaml.safe_load`; `scripts/check_action_refs.py` exits 0
- [x] Diff is exactly 2 files, 9 insertions / 9 deletions (8/8 in the lock, 1/1 in the manifest)
- [x] **Post-push:** CI green on `ed8c1ab` — all 37 checks pass, including `E2E Gate (required)` and `visual-diff` itself

## On the visual-diff comment below

The bot flagged 46 of 74 comparisons. That is its known capture noise, not an effect of this change, and the job concluded **success**.

`pr-screenshots.yml` runs a single `npm ci` + `npx playwright install --with-deps chromium` in `head/.github/scripts` and takes **both** the before and after captures with that one browser. The Playwright version is therefore constant within a run and cannot produce a before/after difference. For reference, five earlier runs against byte-identical code flagged 37 → 40 → 14 → 40 → 42 of 66, with individual pages swinging between 0.00% and 100.00%.

That the bot completed at all is the useful signal here: it is the real consumer of this dependency, and on 1.59.1 it installed from the regenerated lock, launched Chromium, and drove 74 page captures.

## Note for reviewers

Found by a scheduled security sweep running `npm audit` across every committed lockfile. The same sweep found **1 critical + 6 high** advisories in `.github/actions/setup-openclaw/package-lock.json` (also added today, #5575). That one is **deliberately not touched here**: its only fix is a bump past `openclaw@2026.5.12`, which `.github/dependabot.yml` documents at length as taking the live E2E suites red until the daemon can read OpenClaw's SQLite transcripts. It needs its own change and a decision, not a drive-by bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014rKe6WrcjgbKSzgxp8vTWE

---
_Generated by [Claude Code](https://claude.ai/code/session_014rKe6WrcjgbKSzgxp8vTWE)_