### PR TITLE
feat(openclaw): capture response_steered spans in the Tracing tab (#5578)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -434,6 +434,7 @@ jobs:
             tests/test_session_context_ingest.py \
             tests/test_session_context_route.py \
             tests/test_tracing_reasoning_spans.py \
+            tests/test_obs_gap_openclaw_response_steered_5578.py \
             tests/test_trail_coverage_route.py \
             tests/test_harness_bench.py \
             tests/test_bench_route.py \

--- a/clawmetry/adapters/openclaw.py
+++ b/clawmetry/adapters/openclaw.py
@@ -3986,6 +3986,46 @@ class OpenClawAdapter(AgentAdapter):
                     "attributes": wc_attrs,
                 })
 
+            elif t == "response_steered":
+                # OpenClaw CHANGELOG 2026.9.2 (#138046, #138434): when a
+                # response is steered mid-flight over a cached WebSocket during
+                # async tool execution, the harness writes a response_steered
+                # event. Without this branch the span builder silently drops it,
+                # leaving a gap in the Timeline/Brain stream (#5578).
+                _sc = (
+                    obj.get("steeringCount")
+                    or obj.get("steering_count")
+                    or obj.get("count")
+                )
+                _tid = (
+                    obj.get("asyncToolId")
+                    or obj.get("async_tool_id")
+                    or obj.get("toolCallId")
+                    or obj.get("tool_call_id")
+                )
+                _cid = obj.get("continuationId") or obj.get("continuation_id")
+                steer_attrs: dict = {"event.kind": "response_steered"}
+                if _sc is not None:
+                    try:
+                        steer_attrs["steering.count"] = int(_sc)
+                    except (TypeError, ValueError):
+                        pass
+                if isinstance(_tid, str) and _tid.strip():
+                    steer_attrs["steering.async_tool_id"] = _tid.strip()
+                if isinstance(_cid, str) and _cid.strip():
+                    steer_attrs["steering.continuation_id"] = _cid.strip()
+                spans.append({
+                    "span_id": _sid("response_steered", session_id, str(raw_ts)),
+                    "trace_id": trace_id,
+                    "parent_span_id": session_span_id,
+                    "name": "response.steered",
+                    "kind": "INTERNAL",
+                    "start_ts": ts,
+                    "session_id": session_id,
+                    "agent_type": agent_type,
+                    "attributes": steer_attrs,
+                })
+
         return spans
 
     def reconstruct_spans(self, jsonl_path: str) -> list:

--- a/tests/test_obs_gap_openclaw_response_steered_5578.py
+++ b/tests/test_obs_gap_openclaw_response_steered_5578.py
@@ -1,0 +1,84 @@
+"""Tests for #5578 — openclaw response_steered events produce spans in the Tracing tab.
+
+The harness emits a ``"response_steered"`` JSONL event (openclaw CHANGELOG 2026.9.2,
+#138046/#138434) when a running response is steered mid-flight over a cached WebSocket
+during async direct function-tool execution. Before this fix ``_build_spans_from_events``
+had no branch for the ``response_steered`` type, so every steering event fell through
+the loop silently, leaving the activity invisible in the Timeline and Brain stream tabs.
+"""
+from __future__ import annotations
+
+from clawmetry.adapters.openclaw import OpenClawAdapter
+
+
+def test_response_steered_produces_span_with_count_and_tool_id():
+    events = [
+        {"type": "session", "version": "1.0", "timestamp": "2026-09-06T00:00:00Z"},
+        {
+            "type": "response_steered",
+            "timestamp": "2026-09-06T00:00:01Z",
+            "steeringCount": 2,
+            "asyncToolId": "t_abc123",
+        },
+    ]
+    spans = OpenClawAdapter._build_spans_from_events(events, "s1")
+    by_name = {s["name"]: s for s in spans}
+    assert "response.steered" in by_name, "response_steered event must produce a span"
+    span = by_name["response.steered"]
+    assert span["kind"] == "INTERNAL"
+    assert span["parent_span_id"] == by_name["session"]["span_id"]
+    attrs = span["attributes"]
+    assert attrs["event.kind"] == "response_steered"
+    assert attrs["steering.count"] == 2
+    assert attrs["steering.async_tool_id"] == "t_abc123"
+
+
+def test_response_steered_accepts_snake_case_fields():
+    events = [
+        {
+            "type": "response_steered",
+            "timestamp": "2026-09-06T00:00:02Z",
+            "steering_count": 3,
+            "async_tool_id": "t_xyz",
+            "continuation_id": "cont_001",
+        },
+    ]
+    spans = OpenClawAdapter._build_spans_from_events(events, "s2")
+    assert len(spans) == 1
+    attrs = spans[0]["attributes"]
+    assert attrs["steering.count"] == 3
+    assert attrs["steering.async_tool_id"] == "t_xyz"
+    assert attrs["steering.continuation_id"] == "cont_001"
+
+
+def test_response_steered_accepts_camelcase_continuation():
+    events = [
+        {
+            "type": "response_steered",
+            "timestamp": "2026-09-06T00:00:03Z",
+            "steeringCount": 1,
+            "toolCallId": "tc_99",
+            "continuationId": "c_42",
+        },
+    ]
+    spans = OpenClawAdapter._build_spans_from_events(events, "s3")
+    assert len(spans) == 1
+    attrs = spans[0]["attributes"]
+    assert attrs["steering.count"] == 1
+    assert attrs["steering.async_tool_id"] == "tc_99"
+    assert attrs["steering.continuation_id"] == "c_42"
+
+
+def test_response_steered_minimal_payload_still_emits_span():
+    events = [{"type": "response_steered", "timestamp": "2026-09-06T00:00:04Z"}]
+    spans = OpenClawAdapter._build_spans_from_events(events, "s4")
+    assert len(spans) == 1
+    assert spans[0]["name"] == "response.steered"
+    assert spans[0]["attributes"] == {"event.kind": "response_steered"}
+
+
+def test_response_steered_span_ids_are_deterministic():
+    events = [{"type": "response_steered", "timestamp": "2026-09-06T00:00:05Z", "steeringCount": 1}]
+    a = OpenClawAdapter._build_spans_from_events(events, "s5")
+    b = OpenClawAdapter._build_spans_from_events(events, "s5")
+    assert a[0]["span_id"] == b[0]["span_id"]


### PR DESCRIPTION
## Summary

OpenClaw CHANGELOG 2026.9.2 (#138046/#138434) emits a `response_steered` event when a running response is steered mid-flight over a cached WebSocket during async tool execution. Before this fix `_build_spans_from_events` had no branch for this event type, so it fell through silently — the steering activity was invisible in the Timeline and Brain stream tabs.

This PR adds the missing handler, following the exact same INTERNAL-span pattern used by the `retry` (#3198) and `workspace.conflict` (#4148) handlers.

No-PRD: bot-autofix implementing harness-filed obs-gap issue #5578 (the issue itself is the requirement record, filed by `scripts/harness/audit.py`)

## Changes

- `clawmetry/adapters/openclaw.py` — add `elif t == "response_steered":` branch in `_build_spans_from_events` (between `workspace.conflict` and `return spans`). Extracts `steering.count`, `steering.async_tool_id`, and `steering.continuation_id` with camelCase/snake_case fallbacks, producing an INTERNAL span named `"response.steered"` parented to `session_span_id`.
- `tests/test_obs_gap_openclaw_response_steered_5578.py` — 5 hermetic tests covering full payload, snake_case fields, camelCase fields, minimal payload, and span-id determinism. Mirrors the pattern of `test_obs_gap_openclaw_retry_event_3198.py`.
- `.github/workflows/ci.yml` — adds the new test file to the MOAT verifier suite's explicit file list (per CLAUDE.md: CI uses file lists, not `pytest tests/`).

## Test plan

- [ ] `python3 -m pytest tests/test_obs_gap_openclaw_response_steered_5578.py -v` — 5/5 pass locally
- [ ] MOAT verifier job in CI (the new file is now listed there)
- [ ] Verify no regression: `python3 -m pytest tests/test_obs_gap_openclaw_retry_event_3198.py -v` still passes

## Bot meta
<!-- bot-autofix -->
Draft PR opened autonomously based on the plan in #5578. Marked draft for human review — mark Ready for Review once happy.

Closes #5578

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018R8xRKXcGm7sEE3aJTdSCP