### PR TITLE
Harden: declare the non-security digests as non-security

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,6 +172,14 @@ jobs:
       - name: Architecture docs name modules that exist
         run: python3 -m pytest tests/test_module_map_drift.py -q
 
+      # Non-security digests (dedup ids, trace ids, change-detection hashes)
+      # must go through clawmetry.nonsecret_hash. A bare hashlib.md5/sha1
+      # raises ValueError -- not a weak digest, an exception -- on a host whose
+      # crypto provider allows only approved algorithms, which turns an ingest
+      # pass into a crash. Named explicitly because this job runs FILE LISTS.
+      - name: Non-security digests declare themselves
+        run: python3 -m pytest tests/test_nonsecret_hash.py -q
+
       # The declared product surface must match reality: every cell names a
       # verifier that exists, and nothing claims to be "gated" while sitting
       # behind a path-filtered workflow that stays silent on most PRs.

--- a/clawmetry/detectors.py
+++ b/clawmetry/detectors.py
@@ -63,13 +63,13 @@ by env so the daemon can tune them without a code change.
 """
 from __future__ import annotations
 
-import hashlib
 import json
 import os
 from typing import Any, Iterable, Optional
 
 # New in this change, each in its own module so the whole of the new capability
 # is readable in one place and this file keeps its shape.
+from clawmetry import nonsecret_hash as _nsh
 from clawmetry.detector_calibration import (  # noqa: F401
     BASELINE_CEIL_RATIO, BASELINE_FLOOR_RATIO, BASELINE_MIN_SESSIONS,
     BASELINE_SIGMA, BLAST_RADIUS_FILES, EGRESS_HOST_FANOUT, RUNTIME_PROFILES,
@@ -217,7 +217,7 @@ def _args_hash(args: Any) -> str:
             norm = str(args)
         except Exception:
             return ""
-    return hashlib.sha1(norm.encode("utf-8", "replace")).hexdigest()[:16]
+    return _nsh.sha1(norm.encode("utf-8", "replace")).hexdigest()[:16]
 
 
 def _iter_tool_calls_from_data(et: str, data: dict) -> list[dict]:

--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -47,6 +47,7 @@ import subprocess
 import sys
 from clawmetry import ccr as _ccr  # reversible event-payload compression (#2843)
 from clawmetry import event_shape as _event_shape  # v15 typed event columns
+from clawmetry import nonsecret_hash as _nsh
 from clawmetry.trail_store import TrailStoreMixin  # intent / back-fill / git join
 import threading
 import time
@@ -13887,11 +13888,10 @@ class LocalStore(TrailStoreMixin):
         Idempotent on a stable id derived from provider+kind+ts so re-tailing
         the log (after a rotation/truncation rescan) never double-counts.
         """
-        import hashlib
         prov = (provider or "").lower().strip()
         if not prov or not kind or not ts_iso:
             return
-        ev_id = "connhealth-" + hashlib.sha1(
+        ev_id = "connhealth-" + _nsh.sha1(
             f"{prov}|{kind}|{ts_iso}|{(raw or '')[:80]}".encode("utf-8")
         ).hexdigest()[:24]
         payload = json.dumps({
@@ -13947,7 +13947,7 @@ class LocalStore(TrailStoreMixin):
         """
         if not event_type or not ts_iso:
             return
-        ev_id = "talk-" + hashlib.sha1(
+        ev_id = "talk-" + _nsh.sha1(
             f"{session_id or ''}|{event_type}|{ts_iso}|{(raw or '')[:80]}".encode("utf-8")
         ).hexdigest()[:24]
         payload = json.dumps({

--- a/clawmetry/nonsecret_hash.py
+++ b/clawmetry/nonsecret_hash.py
@@ -32,28 +32,47 @@ signatures, tokens, or integrity checks over untrusted content. Those want
 SHA-256 (or the ``cryptography`` package, which the cloud-sync path already
 depends on), not a documented-as-non-security MD5.
 
-Why the two scanners are told to stand down *here* and nowhere else
-------------------------------------------------------------------
+What the two scanners say about this page
+----------------------------------------
 
 Collecting the calls into this module is what makes the risk acceptance
 reviewable: there are exactly four ``hashlib`` constructor calls in the
 package now, all of them on this page, instead of fifteen scattered ones.
-That same collection is why both scanners fire here.
+That same collection is why both scanners point here.
 
 * **bandit B324** flags a weak digest built without ``usedforsecurity``.
-  Only the two 3.8 fallbacks qualify, and they carry ``# nosec B324``.
+  Only the two 3.8 fallbacks qualify, and ``# nosec B324`` clears them.
+  That marker works: bandit reports zero B324 for this file.
 * **CodeQL ``py/weak-sensitive-data-hashing``** flags all four, because it
   tracks the *caller's* value into the sink: a ``session_id``, ``job_id`` or
   ``trace_id`` reaching a weak digest reads as sensitive data being hashed.
-  Unlike bandit, it does not treat ``usedforsecurity=False`` as an answer,
-  so the declaration alone does not clear it. The values concerned are
-  identifiers ClawMetry itself minted and already stores in plaintext beside
-  the digest -- the digest is a shorter name for a row, not a way of
-  protecting it -- so there is nothing here for a collision or a preimage to
-  win. That is a judgement about *these* four lines; it is not a licence to
-  add a fifth. ``tests/test_nonsecret_hash.py`` holds both halves: the
-  ratchet that keeps new call sites out, and a check that these annotations
-  stay attached to the calls they excuse.
+  It does not treat ``usedforsecurity=False`` as an answer, so the
+  declaration does not clear it.
+
+  **There is no in-code way to clear it either, and that was measured, not
+  assumed.** An ``# codeql[py/weak-sensitive-data-hashing]`` comment was put
+  on all four calls and pushed; CodeQL re-ran and reported the same four
+  high-severity alerts, merely renumbered (977-980 became 981-984, because
+  moving the lines mints new alert identities). This repository runs code
+  scanning through **default setup** -- there is no
+  ``.github/workflows/codeql.yml`` and no ``.github/codeql/`` config -- so
+  there is no query filter to add, and inline suppression comments are a
+  CodeQL *CLI* feature that default setup does not honour. The annotations
+  were removed again rather than left as decoration that reads like a fix.
+
+  So those four alerts clear **only** by being dismissed in the
+  repository's Security tab, or by moving these digests off MD5/SHA-1 --
+  which rewrites bytes that are already persisted (event dedup keys, trace
+  ids, cron change hashes) and so needs its own migration. That choice
+  belongs to a maintainer, not to this docstring.
+
+On the substance: the values concerned are identifiers ClawMetry itself
+minted and already stores in plaintext beside the digest -- the digest is a
+shorter name for a row, not a way of protecting it -- so there is nothing
+here for a collision or a preimage to win. That is a judgement about
+*these* four lines; it is not a licence to add a fifth, and
+``tests/test_nonsecret_hash.py`` holds the ratchet that keeps new call
+sites out.
 """
 
 import hashlib
@@ -72,9 +91,9 @@ def md5(data=b""):
     ``.update()`` on the returned object.
     """
     if _ACCEPTS_USEDFORSECURITY:
-        return hashlib.md5(data, usedforsecurity=False)  # codeql[py/weak-sensitive-data-hashing]
+        return hashlib.md5(data, usedforsecurity=False)
     # py3.8 has no usedforsecurity kwarg; see module docstring.
-    return hashlib.md5(data)  # codeql[py/weak-sensitive-data-hashing]  # nosec B324
+    return hashlib.md5(data)  # nosec B324
 
 
 def sha1(data=b""):
@@ -83,6 +102,6 @@ def sha1(data=b""):
     Signature matches ``hashlib.sha1``.
     """
     if _ACCEPTS_USEDFORSECURITY:
-        return hashlib.sha1(data, usedforsecurity=False)  # codeql[py/weak-sensitive-data-hashing]
+        return hashlib.sha1(data, usedforsecurity=False)
     # py3.8 has no usedforsecurity kwarg; see module docstring.
-    return hashlib.sha1(data)  # codeql[py/weak-sensitive-data-hashing]  # nosec B324
+    return hashlib.sha1(data)  # nosec B324

--- a/clawmetry/nonsecret_hash.py
+++ b/clawmetry/nonsecret_hash.py
@@ -1,0 +1,65 @@
+"""MD5/SHA-1 digests that are *not* being used as a security primitive.
+
+ClawMetry hashes a lot of things that have nothing to do with secrecy: a
+dedup id for an ingested event, a change-detection hash over a cron file, a
+fingerprint over a tool call's arguments, a trace/span id derived from a
+session id. Every one of those wants a cheap, stable, short digest. None of
+them is defending against an adversary who gets to choose the input, so the
+collision weakness that retired MD5 and SHA-1 for signatures does not apply.
+
+Two things go wrong when those call sites reach for ``hashlib`` directly:
+
+1. **A restricted crypto provider refuses them.** When the interpreter's
+   OpenSSL is built or configured to allow only approved algorithms (a
+   FIPS-mode host, which is the normal build on several enterprise Linux
+   distributions), ``hashlib.md5(b"...")`` does not return a weak digest --
+   it raises ``ValueError``. The daemon's cron ingest, memory-file ingest and
+   event dedup would all fail on such a host, and none of them is doing
+   cryptography. ``usedforsecurity=False`` is the documented way to say so,
+   and it is what keeps a non-security digest available where the provider
+   restricts the algorithm.
+
+2. **The keyword cannot simply be passed everywhere.** ``usedforsecurity=``
+   reached hashlib's constructors in CPython 3.9, and ``setup.py`` still
+   declares ``python_requires=">=3.8"``. On 3.8 passing it is a
+   ``TypeError``, not a no-op -- so a bare kwarg trades one crash for
+   another. The version check lives here, once, instead of at fifteen call
+   sites.
+
+Use these for identifiers, dedup keys, fingerprints and change detection.
+Do **not** use them for anything an attacker is trying to forge: passwords,
+signatures, tokens, or integrity checks over untrusted content. Those want
+SHA-256 (or the ``cryptography`` package, which the cloud-sync path already
+depends on), not a documented-as-non-security MD5.
+"""
+
+import hashlib
+import sys
+
+#: CPython gained ``usedforsecurity=`` on the hashlib constructors in 3.9.
+#: Below that the keyword raises TypeError, so it has to be omitted rather
+#: than passed and ignored.
+_ACCEPTS_USEDFORSECURITY = sys.version_info >= (3, 9)
+
+
+def md5(data=b""):
+    """An MD5 digest object declared as not-for-security.
+
+    Signature matches ``hashlib.md5``: pass the bytes up front, or call
+    ``.update()`` on the returned object.
+    """
+    if _ACCEPTS_USEDFORSECURITY:
+        return hashlib.md5(data, usedforsecurity=False)
+    # nosec B324 - py3.8 has no usedforsecurity kwarg; see module docstring.
+    return hashlib.md5(data)  # nosec B324
+
+
+def sha1(data=b""):
+    """A SHA-1 digest object declared as not-for-security.
+
+    Signature matches ``hashlib.sha1``.
+    """
+    if _ACCEPTS_USEDFORSECURITY:
+        return hashlib.sha1(data, usedforsecurity=False)
+    # nosec B324 - py3.8 has no usedforsecurity kwarg; see module docstring.
+    return hashlib.sha1(data)  # nosec B324

--- a/clawmetry/nonsecret_hash.py
+++ b/clawmetry/nonsecret_hash.py
@@ -31,6 +31,29 @@ Do **not** use them for anything an attacker is trying to forge: passwords,
 signatures, tokens, or integrity checks over untrusted content. Those want
 SHA-256 (or the ``cryptography`` package, which the cloud-sync path already
 depends on), not a documented-as-non-security MD5.
+
+Why the two scanners are told to stand down *here* and nowhere else
+------------------------------------------------------------------
+
+Collecting the calls into this module is what makes the risk acceptance
+reviewable: there are exactly four ``hashlib`` constructor calls in the
+package now, all of them on this page, instead of fifteen scattered ones.
+That same collection is why both scanners fire here.
+
+* **bandit B324** flags a weak digest built without ``usedforsecurity``.
+  Only the two 3.8 fallbacks qualify, and they carry ``# nosec B324``.
+* **CodeQL ``py/weak-sensitive-data-hashing``** flags all four, because it
+  tracks the *caller's* value into the sink: a ``session_id``, ``job_id`` or
+  ``trace_id`` reaching a weak digest reads as sensitive data being hashed.
+  Unlike bandit, it does not treat ``usedforsecurity=False`` as an answer,
+  so the declaration alone does not clear it. The values concerned are
+  identifiers ClawMetry itself minted and already stores in plaintext beside
+  the digest -- the digest is a shorter name for a row, not a way of
+  protecting it -- so there is nothing here for a collision or a preimage to
+  win. That is a judgement about *these* four lines; it is not a licence to
+  add a fifth. ``tests/test_nonsecret_hash.py`` holds both halves: the
+  ratchet that keeps new call sites out, and a check that these annotations
+  stay attached to the calls they excuse.
 """
 
 import hashlib
@@ -49,9 +72,9 @@ def md5(data=b""):
     ``.update()`` on the returned object.
     """
     if _ACCEPTS_USEDFORSECURITY:
-        return hashlib.md5(data, usedforsecurity=False)
-    # nosec B324 - py3.8 has no usedforsecurity kwarg; see module docstring.
-    return hashlib.md5(data)  # nosec B324
+        return hashlib.md5(data, usedforsecurity=False)  # codeql[py/weak-sensitive-data-hashing]
+    # py3.8 has no usedforsecurity kwarg; see module docstring.
+    return hashlib.md5(data)  # codeql[py/weak-sensitive-data-hashing]  # nosec B324
 
 
 def sha1(data=b""):
@@ -60,6 +83,6 @@ def sha1(data=b""):
     Signature matches ``hashlib.sha1``.
     """
     if _ACCEPTS_USEDFORSECURITY:
-        return hashlib.sha1(data, usedforsecurity=False)
-    # nosec B324 - py3.8 has no usedforsecurity kwarg; see module docstring.
-    return hashlib.sha1(data)  # nosec B324
+        return hashlib.sha1(data, usedforsecurity=False)  # codeql[py/weak-sensitive-data-hashing]
+    # py3.8 has no usedforsecurity kwarg; see module docstring.
+    return hashlib.sha1(data)  # codeql[py/weak-sensitive-data-hashing]  # nosec B324

--- a/clawmetry/span_reconstruct.py
+++ b/clawmetry/span_reconstruct.py
@@ -54,9 +54,10 @@ they're the edges the feature exists for.
 """
 from __future__ import annotations
 
-import hashlib
 import time
 from typing import Any
+
+from clawmetry import nonsecret_hash as _nsh
 
 __all__ = [
     "build_family_spans",
@@ -79,7 +80,7 @@ _SPAWN_TOOL_NAMES = ("task",)
 
 def _sha1_hex(*parts: Any) -> str:
     joined = "|".join("" if p is None else str(p) for p in parts)
-    return hashlib.sha1(joined.encode("utf-8", "replace")).hexdigest()
+    return _nsh.sha1(joined.encode("utf-8", "replace")).hexdigest()
 
 
 def _span_id(*parts: Any) -> str:

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -31,6 +31,7 @@ from typing import Any
 
 # Leaf module (typing-only deps) — safe to import at package load, no cycle.
 from clawmetry import error_signal as _error_signal
+from clawmetry import nonsecret_hash as _nsh
 from clawmetry import session_titles as _session_titles
 from clawmetry.adapters import phase as _phase
 # The ONE actuator both the Guard tab and the policy pass call. A leaf
@@ -4836,7 +4837,6 @@ def _canonical_event_id(
     # to parentId, etc.) doesn't change the digest. The keys we keep are
     # everything except the small set of wrapper/cross-ref fields that
     # differ per-path.
-    import hashlib
     skip_keys = {
         "_claude_session_id",
         "_openclaw_session_id",
@@ -4855,7 +4855,7 @@ def _canonical_event_id(
         body = json.dumps(canonical, sort_keys=True, separators=(",", ":"), default=str)
     except Exception:
         body = repr(sorted(canonical.items()))
-    digest = hashlib.md5(body.encode("utf-8", errors="replace")).hexdigest()[:16]
+    digest = _nsh.md5(body.encode("utf-8", errors="replace")).hexdigest()[:16]
     ts = obj.get("timestamp") or obj.get("ts") or "?"
     evt_type = obj.get("type") or "unknown"
     return f"cc-derived:{session_id}:{ts}:{evt_type}:{digest}"
@@ -12268,13 +12268,12 @@ def sync_crons(config: dict, state: dict, paths: dict) -> int:
             return 0
 
     try:
-        import hashlib
         if _sqlite_jobs is not None:
             jobs = _sqlite_jobs
             h, file_unchanged = "", False
         else:
             raw = open(cron_file, "rb").read()
-            h = hashlib.md5(raw).hexdigest()
+            h = _nsh.md5(raw).hexdigest()
             file_unchanged = h == last_hash
             data = json.loads(raw)
             jobs = data.get("jobs", []) if isinstance(data, dict) else data
@@ -12337,7 +12336,7 @@ def sync_crons(config: dict, state: dict, paths: dict) -> int:
 
             # Dedup: sha1 over the full event payload with sorted keys so the
             # hash is stable across poll iterations when nothing changed.
-            job_hash = hashlib.sha1(
+            job_hash = _nsh.sha1(
                 json.dumps(event_data, sort_keys=True).encode("utf-8")
             ).hexdigest()
             prev = job_dedup.get(job_id) or [None, 0.0]
@@ -13706,7 +13705,6 @@ def sync_memory(config: dict, state: dict, paths: dict) -> int:
 
     # Check for changes via content hash; always send all file contents so the
     # Memory tab can display any file, not just files changed in the last cycle.
-    import hashlib
 
     changed_files = []
     all_file_contents = []
@@ -13714,7 +13712,7 @@ def sync_memory(config: dict, state: dict, paths: dict) -> int:
     for name, path in memory_files:
         try:
             content_bytes = open(path, "rb").read()
-            h = hashlib.md5(content_bytes).hexdigest()
+            h = _nsh.md5(content_bytes).hexdigest()
             text = content_bytes.decode("utf-8", errors="replace")
             file_list.append(
                 {
@@ -14212,8 +14210,7 @@ def sync_vm_usage_log(config: dict, state: dict, paths: dict) -> int:
                 continue
             sess = str(line.get("session") or "").strip() or "unknown"
             ns_sess = "%s:vmusage:%s" % (runtime, sess)
-            import hashlib
-            digest = hashlib.sha1(("%s:%s" % (
+            digest = _nsh.sha1(("%s:%s" % (
                 st.st_ino, raw.decode("utf-8", "replace"))).encode()
             ).hexdigest()[:24]
             ts_iso = (_epoch_to_iso(line.get("ts"))

--- a/docs/MODULE_MAP.md
+++ b/docs/MODULE_MAP.md
@@ -4,7 +4,7 @@
 > `python3 scripts/gen_module_map.py` (CI fails on drift via
 > `tests/test_module_map_drift.py`).
 
-227 modules, 81 Flask blueprints. `CLAUDE.md` carries a short curated table of the ones you reach for most often; this is the whole list.
+228 modules, 81 Flask blueprints. `CLAUDE.md` carries a short curated table of the ones you reach for most often; this is the whole list.
 
 Size bands are deliberately coarse so this file does not churn on every PR: **small** is under 200 lines, **medium** under 1k, **large** under 5k, **huge** is 5k and up.
 
@@ -187,6 +187,7 @@ The pip-installable package: CLI, sync daemon, DuckDB store, detectors, enforcem
 | `clawmetry/mcp_server.py` | medium | ClawMetry MCP server — exposes local telemetry as MCP tools (stdio transport). |
 | `clawmetry/narrator.py` | small | LLM-narrated alert enrichment (issue #1412, Feature C). |
 | `clawmetry/net.py` | medium | clawmetry.net — outbound TLS + proxy bootstrap for enterprise networks. |
+| `clawmetry/nonsecret_hash.py` | small | MD5/SHA-1 digests that are *not* being used as a security primitive. |
 | `clawmetry/numbat_ingest.py` | medium | map Perplexity numbat NDJSON records into ClawMetry rows. |
 | `clawmetry/onboarding_state.py` | small | the ONE writer for the first-run gate's |
 | `clawmetry/org_key.py` | small | The organisation key: one secret, shared by the people in one organisation. |

--- a/routes/health.py
+++ b/routes/health.py
@@ -38,7 +38,6 @@ Module-level helpers (``_history_db``, ``AgentReliabilityScorer``,
 
 from __future__ import annotations
 
-import hashlib
 import json
 import os
 import re
@@ -50,6 +49,7 @@ from datetime import datetime, timedelta, timezone
 
 from flask import Blueprint, Response, jsonify, request
 from clawmetry.config import is_local_store_read_enabled
+from clawmetry import nonsecret_hash as _nsh
 
 bp_health = Blueprint('health', __name__)
 
@@ -2800,7 +2800,7 @@ def _detect_loops_in_sessions(sessions_dir, max_sessions=20, window=10, min_repe
                             continue
                         inp = blk.get("input") or {}
                         raw_args = json.dumps(inp, sort_keys=True, default=str)[:500]
-                        fp = hashlib.md5(raw_args.encode()).hexdigest()[:8]
+                        fp = _nsh.md5(raw_args.encode()).hexdigest()[:8]
                         tool_seq.append((name, fp, ts))
         except Exception:
             continue
@@ -2888,7 +2888,7 @@ def _try_local_store_loop_detection(window: int, min_repeats: int):
             raw_args = json.dumps(inp, sort_keys=True, default=str)[:500]
         except Exception:
             raw_args = str(inp)[:500]
-        fp = hashlib.md5(raw_args.encode()).hexdigest()[:8]
+        fp = _nsh.md5(raw_args.encode()).hexdigest()[:8]
         by_session.setdefault(sid, []).append((name, fp, r.get("ts") or ""))
 
     if not by_session:

--- a/routes/hooks.py
+++ b/routes/hooks.py
@@ -37,12 +37,13 @@ would surface as "no opinion" anyway), an unentitled node gets an explicit
 """
 from __future__ import annotations
 
-import hashlib
 import json
 import os
 import sys
 import time
 import uuid
+
+from clawmetry import nonsecret_hash as _nsh
 
 from flask import Blueprint, jsonify, request
 
@@ -141,7 +142,7 @@ def _ls_read(method_name: str, **kwargs):
 
 
 def _input_hash(tool_input: dict) -> str:
-    return hashlib.md5(
+    return _nsh.md5(
         json.dumps(tool_input, sort_keys=True, default=str).encode()
     ).hexdigest()
 

--- a/routes/meta.py
+++ b/routes/meta.py
@@ -48,6 +48,7 @@ from datetime import datetime, timezone
 
 from flask import Blueprint, jsonify, make_response, render_template_string, request
 from clawmetry.config import is_local_store_read_enabled
+from clawmetry import nonsecret_hash as _nsh
 from clawmetry.otlp_json import OtlpProtobufUnavailable
 
 bp_version = Blueprint('version', __name__)
@@ -211,7 +212,7 @@ def _sessions_to_otlp_fallback(sessions: list, version: str) -> dict:
     spans = []
     for s in sessions:
         sid = s.get("session_id") or ""
-        trace_id = _pad_tid(hashlib.md5(sid.encode(), usedforsecurity=False).hexdigest())
+        trace_id = _pad_tid(_nsh.md5(sid.encode()).hexdigest())
         start_ns = _ts_to_ns(s.get("started_at") or s.get("last_active_at"))
         end_ns = _ts_to_ns(s.get("last_active_at") or s.get("ended_at"))
         if not end_ns or end_ns <= start_ns:

--- a/routes/sessions.py
+++ b/routes/sessions.py
@@ -3863,7 +3863,7 @@ def api_export_otlp():
     Compatible with Grafana Tempo, Jaeger, and any OTLP-capable backend.
     """
     import dashboard as _d
-    import hashlib
+    from clawmetry import nonsecret_hash as _nsh
 
     sessions_dir = _d._get_sessions_dir()
     index_path = os.path.join(sessions_dir, "sessions.json")
@@ -3889,7 +3889,7 @@ def api_export_otlp():
         is_subagent = ":subagent:" in key
         agent_type = "subagent" if is_subagent else "main"
         session_id = val.get("sessionId", key.split(":")[-1])
-        trace_id = hashlib.md5(session_id.encode()).hexdigest()
+        trace_id = _nsh.md5(session_id.encode()).hexdigest()
         span_id = trace_id[:16]
         total_tokens = int(val.get("totalTokens") or 0)
 

--- a/tests/test_nonsecret_hash.py
+++ b/tests/test_nonsecret_hash.py
@@ -16,6 +16,7 @@ Two things are being pinned here:
    in-repo ratchet so it cannot come back between audit runs.
 """
 
+import ast
 import hashlib
 import io
 import os
@@ -65,6 +66,49 @@ def test_declares_not_for_security_where_the_runtime_accepts_it():
     ).read()
     assert "hashlib.md5(data, usedforsecurity=False)" in src
     assert "hashlib.sha1(data, usedforsecurity=False)" in src
+
+
+def test_every_hashlib_call_here_carries_its_scanner_annotation():
+    """The four excused calls stay excused, and a fifth cannot sneak in.
+
+    Both scanners read source, so their annotations live on the call line and
+    are silently lost by a reformat or a copy-paste. Losing the CodeQL one
+    puts four high-severity alerts back on a public repository's security
+    tab; losing the bandit one re-raises B324. Neither failure shows up in a
+    test run, so this is the test run.
+    """
+    path = os.path.join(REPO, "clawmetry", "nonsecret_hash.py")
+    src = io.open(path, encoding="utf-8").read()
+    lines = src.splitlines()
+
+    # Parsed, not grepped: the module docstring quotes `hashlib.md5(...)`
+    # while explaining itself, and prose must not count as a call site.
+    calls = []
+    for node in ast.walk(ast.parse(src)):
+        if not isinstance(node, ast.Call):
+            continue
+        fn = node.func
+        if (isinstance(fn, ast.Attribute) and fn.attr in ("md5", "sha1")
+                and isinstance(fn.value, ast.Name) and fn.value.id == "hashlib"):
+            calls.append((node.lineno, lines[node.lineno - 1]))
+    calls.sort()
+
+    assert len(calls) == 4, (
+        "expected exactly the two md5 and two sha1 constructor calls, got:\n  "
+        + "\n  ".join("%d: %s" % (n, ln.strip()) for n, ln in calls)
+    )
+
+    for n, ln in calls:
+        assert "codeql[py/weak-sensitive-data-hashing]" in ln, (
+            "nonsecret_hash.py:%d builds a weak digest with no CodeQL "
+            "suppression -- read the docstring before adding one:\n  %s"
+            % (n, ln.strip())
+        )
+        if "usedforsecurity" not in ln:
+            assert "nosec B324" in ln, (
+                "nonsecret_hash.py:%d omits usedforsecurity= and so needs "
+                "bandit's B324 marker too:\n  %s" % (n, ln.strip())
+            )
 
 
 def test_helper_is_importable_on_py38_syntax():

--- a/tests/test_nonsecret_hash.py
+++ b/tests/test_nonsecret_hash.py
@@ -1,0 +1,160 @@
+"""The non-security digest helper, and the ratchet that keeps it used.
+
+Two things are being pinned here:
+
+1. ``nonsecret_hash.md5``/``sha1`` return the SAME digest as ``hashlib``.
+   That is not a nicety -- the call sites this helper replaced produce
+   persisted ids (event dedup keys in DuckDB, trace/span ids, cron
+   change-detection hashes). If ``usedforsecurity=False`` changed the bytes,
+   the switch would silently re-ingest every already-stored event. It does
+   not, and this test is what says so out loud.
+
+2. No runtime module reaches for ``hashlib.md5``/``hashlib.sha1`` directly
+   again. A bare constructor raises ``ValueError`` on a host whose crypto
+   provider allows only approved algorithms, which turns a dedup key into a
+   crashed ingest pass. Bandit reports this as B324; this test is the
+   in-repo ratchet so it cannot come back between audit runs.
+"""
+
+import hashlib
+import io
+import os
+import re
+import subprocess
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from clawmetry import nonsecret_hash  # noqa: E402
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+@pytest.mark.parametrize("payload", [
+    b"",
+    b"hello",
+    "cron|2026-09-06T00:00:00Z|job-1".encode("utf-8"),
+    bytes(range(256)),
+])
+def test_digests_match_hashlib(payload):
+    """The helper must not change any already-persisted id."""
+    assert nonsecret_hash.md5(payload).hexdigest() == hashlib.md5(payload).hexdigest()
+    assert nonsecret_hash.sha1(payload).hexdigest() == hashlib.sha1(payload).hexdigest()
+
+
+def test_update_is_supported():
+    """Callers may build a digest incrementally, as with hashlib."""
+    h = nonsecret_hash.sha1()
+    h.update(b"ab")
+    h.update(b"cd")
+    assert h.hexdigest() == hashlib.sha1(b"abcd").hexdigest()
+
+
+def test_declares_not_for_security_where_the_runtime_accepts_it():
+    """On 3.9+ the kwarg must actually be passed, not merely available."""
+    if sys.version_info < (3, 9):
+        pytest.skip("usedforsecurity= reached hashlib in CPython 3.9")
+    assert nonsecret_hash._ACCEPTS_USEDFORSECURITY is True
+    # A digest object built with the flag reports it the only way it can:
+    # by being constructible at all under a restricted provider. Assert the
+    # call shape instead, so this stays meaningful off a FIPS host.
+    src = io.open(
+        os.path.join(REPO, "clawmetry", "nonsecret_hash.py"), encoding="utf-8"
+    ).read()
+    assert "hashlib.md5(data, usedforsecurity=False)" in src
+    assert "hashlib.sha1(data, usedforsecurity=False)" in src
+
+
+def test_helper_is_importable_on_py38_syntax():
+    """The helper is imported by modules that still have to load on 3.8."""
+    src = io.open(
+        os.path.join(REPO, "clawmetry", "nonsecret_hash.py"), encoding="utf-8"
+    ).read()
+    compile(src, "nonsecret_hash.py", "exec")
+    assert "sys.version_info >= (3, 9)" in src, "the 3.8 fallback must stay"
+
+
+# --------------------------------------------------------------------------
+# The ratchet.
+# --------------------------------------------------------------------------
+
+#: Directly-constructed MD5/SHA-1 that does NOT declare usedforsecurity.
+_BARE = re.compile(r"hashlib\.(?:md5|sha1)\s*\((?![^)]*usedforsecurity)")
+
+#: Scanned trees. `scripts/` is deliberately absent: those are standalone CI
+#: harnesses run as `python3 scripts/...`, so the package is not on their
+#: sys.path and they cannot import this helper.
+_SCANNED = ("clawmetry", "routes", "helpers")
+
+_EXEMPT = {
+    # The helper itself owns the one guarded fallback call, for 3.8.
+    os.path.join("clawmetry", "nonsecret_hash.py"),
+}
+
+
+def _python_files():
+    for tree in _SCANNED:
+        base = os.path.join(REPO, tree)
+        if not os.path.isdir(base):
+            continue
+        for dirpath, dirnames, filenames in os.walk(base):
+            dirnames[:] = [d for d in dirnames if d not in ("__pycache__", "node_modules")]
+            for name in filenames:
+                if name.endswith(".py"):
+                    yield os.path.join(dirpath, name)
+    top = os.path.join(REPO, "dashboard.py")
+    if os.path.isfile(top):
+        yield top
+
+
+def test_no_bare_md5_or_sha1_in_runtime_code():
+    offenders = []
+    for path in _python_files():
+        rel = os.path.relpath(path, REPO)
+        if rel in _EXEMPT:
+            continue
+        try:
+            src = io.open(path, encoding="utf-8", errors="replace").read()
+        except OSError:
+            continue
+        for lineno, line in enumerate(src.splitlines(), 1):
+            if _BARE.search(line):
+                offenders.append("%s:%d: %s" % (rel, lineno, line.strip()))
+    assert not offenders, (
+        "Use clawmetry.nonsecret_hash.md5 / .sha1 for non-security digests -- a "
+        "bare constructor raises on a host with a restricted crypto provider:\n  "
+        + "\n  ".join(offenders)
+    )
+
+
+def test_ratchet_would_catch_a_regression():
+    """The guard above is worthless if its pattern does not actually bite."""
+    assert _BARE.search("h = hashlib.md5(raw).hexdigest()")
+    assert _BARE.search('x = hashlib.sha1(b"a")')
+    assert not _BARE.search("hashlib.md5(data, usedforsecurity=False)")
+    assert not _BARE.search("hashlib.sha256(raw)")
+
+
+def test_every_rewritten_call_site_still_imports_the_helper():
+    """Catches a merge that keeps `_nsh.md5(...)` but drops the import."""
+    missing = []
+    for path in _python_files():
+        src = io.open(path, encoding="utf-8", errors="replace").read()
+        if "_nsh." not in src:
+            continue
+        if "nonsecret_hash as _nsh" not in src:
+            missing.append(os.path.relpath(path, REPO))
+    assert not missing, "uses _nsh without importing it: %s" % missing
+
+
+def test_package_imports_cleanly_in_a_fresh_interpreter():
+    """The new module must not introduce an import cycle."""
+    out = subprocess.run(
+        [sys.executable, "-c",
+         "import clawmetry.nonsecret_hash as m; print(m.md5(b'x').hexdigest())"],
+        cwd=REPO, capture_output=True, text=True,
+    )
+    assert out.returncode == 0, out.stderr
+    assert out.stdout.strip() == hashlib.md5(b"x").hexdigest()

--- a/tests/test_nonsecret_hash.py
+++ b/tests/test_nonsecret_hash.py
@@ -68,14 +68,19 @@ def test_declares_not_for_security_where_the_runtime_accepts_it():
     assert "hashlib.sha1(data, usedforsecurity=False)" in src
 
 
-def test_every_hashlib_call_here_carries_its_scanner_annotation():
-    """The four excused calls stay excused, and a fifth cannot sneak in.
+def test_the_weak_digest_calls_stay_contained_and_marked():
+    """Exactly four ``hashlib`` calls live here, and the 3.8 pair keeps B324.
 
-    Both scanners read source, so their annotations live on the call line and
-    are silently lost by a reformat or a copy-paste. Losing the CodeQL one
-    puts four high-severity alerts back on a public repository's security
-    tab; losing the bandit one re-raises B324. Neither failure shows up in a
-    test run, so this is the test run.
+    The bandit marker lives on the call line and is silently lost by a
+    reformat or a copy-paste, which re-raises B324 without failing any test
+    run -- so this is the test run.
+
+    There is deliberately no CodeQL annotation to assert. An
+    ``# codeql[py/weak-sensitive-data-hashing]`` comment was tried on all
+    four calls and measured: CodeQL re-ran and reported the same four
+    alerts, renumbered 977-980 -> 981-984. Default setup does not honour
+    inline suppression, so such a comment is decoration that reads like a
+    fix. This asserts it does not come back.
     """
     path = os.path.join(REPO, "clawmetry", "nonsecret_hash.py")
     src = io.open(path, encoding="utf-8").read()
@@ -99,9 +104,11 @@ def test_every_hashlib_call_here_carries_its_scanner_annotation():
     )
 
     for n, ln in calls:
-        assert "codeql[py/weak-sensitive-data-hashing]" in ln, (
-            "nonsecret_hash.py:%d builds a weak digest with no CodeQL "
-            "suppression -- read the docstring before adding one:\n  %s"
+        assert "codeql[" not in ln, (
+            "nonsecret_hash.py:%d carries an inline CodeQL suppression. "
+            "Default setup does not honour those -- it was measured on this "
+            "very file -- so the comment silences nothing and reads like a "
+            "fix. Dismiss the alert in the Security tab instead:\n  %s"
             % (n, ln.strip())
         )
         if "usedforsecurity" not in ln:


### PR DESCRIPTION
No-PRD: security hardening of existing digest call sites; no product surface, no API, and no stored value changes.

**Risk:** Low, and the one thing that could have bitten is explicitly tested. Several of the rewritten call sites produce **persisted** ids — event dedup keys in DuckDB, trace/span ids, cron change-detection hashes. If the digests had changed, the daemon would have silently re-ingested every already-stored event. `usedforsecurity=False` does not alter the output, and `test_digests_match_hashlib` asserts that byte-for-byte against `hashlib` for four payloads including the empty string and all 256 byte values. Nothing else changes: no schema, no endpoint, no config. Undone by reverting the commit — there is no migration and no retroactive data change.

---

## Summary

- ClawMetry hashes plenty of things that are not secrets: dedup ids for ingested events, the change-detection hash over a cron file, a fingerprint over a tool call's arguments, trace/span ids derived from a session id. Fourteen of those call sites reached for `hashlib.md5` / `hashlib.sha1` directly. On a host whose crypto provider is configured to allow only approved algorithms — the normal build on several enterprise Linux distributions — those constructors don't return a weak digest, they **raise `ValueError`**. That turns the daemon's cron ingest, its memory-file ingest, event dedup, the detector fingerprints and the Tracing tab's span ids into crashes, and not one of them is doing cryptography. `usedforsecurity=False` is the documented way to say so, and it's what keeps a non-security digest available where the provider restricts the algorithm.
- The keyword can't just be sprinkled on. It reached hashlib's constructors in CPython 3.9 and `setup.py` still declares `python_requires=">=3.8"`, where passing it is a `TypeError` rather than a no-op. `routes/meta.py` already carried a bare `usedforsecurity=False`, so that one line was already broken on any 3.8 install — CI covers 3.9 and 3.11 only, so nothing had eyes on it. The version check now lives in one new short module, `clawmetry/nonsecret_hash.py` (per CLAUDE.md's "new short module, not 300 lines into a 20k-line file"), and all fifteen call sites go through it.
- `tests/test_nonsecret_hash.py` carries a **ratchet** that fails if a bare `md5`/`sha1` reappears anywhere under `clawmetry/`, `routes/` or `helpers/`, so this can't quietly come back between audit runs. It's wired into `ci.yml` in this PR, because this repo runs FILE LISTS and a test named in no workflow step runs in no job at all.
- `scripts/harness/audit.py` keeps its own bare `sha1` deliberately, and is excluded from the ratchet's scanned trees with the reason written down: it's a standalone CI harness invoked as `python3 scripts/harness/audit.py`, so the package isn't on its `sys.path` and it can't import the helper.

## Test plan

- [x] `bandit` B324 findings go **14 → 1** (the harness script above, excluded on purpose)
- [x] 11 new tests in `tests/test_nonsecret_hash.py` pass
- [x] **The ratchet was verified to bite** — reintroduced one bare `hashlib.sha1(` in `clawmetry/detectors.py` and `test_no_bare_md5_or_sha1_in_runtime_code` failed naming that exact line; `test_ratchet_would_catch_a_regression` pins the pattern itself
- [x] Digests are unchanged vs `hashlib` for `b""`, `b"hello"`, a realistic dedup key, and `bytes(range(256))` — so no persisted id moves
- [x] Every workflow file parses under `yaml.safe_load`; `tests/test_workflow_yaml_valid.py` → 507 passed
- [x] The repo's own `ast.parse` gate passes over all 1329 `.py` files
- [x] `lint-py39`, `lint-js`, `lint-daemon-allowlist`, `lint-runtime-count`, `lint-ac-coverage`, `lint-module-map` all pass; `docs/MODULE_MAP.md` regenerated and in sync
- [x] `ruff check dashboard.py clawmetry/` reports **231** findings — the exact pre-existing count on clean `main`, so this adds no lint debt. Getting there meant removing five `import hashlib` statements left dead by the rewrite (four of them function-local); each was confirmed dead by walking its enclosing function's AST first
- [x] `dashboard`, `clawmetry.sync`, `clawmetry.local_store`, `clawmetry.detectors`, `clawmetry.span_reconstruct` and the four touched route modules all import cleanly in a fresh interpreter
- [x] Known-unrelated: `tests/test_detectors_behavioural.py` and `tests/test_event_id_unification_and_dedup.py` have six DuckDB connection-configuration failures. They **reproduce identically on clean `main`** and are untouched by this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QHxWYV4ayn5pp3UcsK6xPr

---
_Generated by [Claude Code](https://claude.ai/code/session_01QHxWYV4ayn5pp3UcsK6xPr)_