### PR TITLE
fix(approvals): make an approval request legible, and stop the preset that paused everything

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -303,6 +303,15 @@ jobs:
       - name: Paywall funnel telemetry + gate free escape
         run: python3 -m pytest tests/test_paywall_funnel_telemetry.py -q
 
+      # An approval card must say WHAT ran, WHERE and under WHICH rule. All
+      # three defects behind the 2026-09-06 "58 approvals I cannot read"
+      # report are silent: an empty arg object stringified to "{}", a queue
+      # row carried no runtime/policy/cwd, and the risk_high preset lost its
+      # min_risk in cloud storage and started pausing every tool call. Named
+      # here because this job runs FILE LISTS.
+      - name: Approval card legibility + preset risk floor
+        run: python3 -m pytest tests/test_approval_card_legibility.py -q
+
   # ── API tests across all 3 platforms ─────────────────────────────────────────────────────────────────────────────────────────
   api-tests:
     name: API Tests (${{ matrix.os }})

--- a/clawmetry/approvals.py
+++ b/clawmetry/approvals.py
@@ -319,6 +319,27 @@ def _yaml_scalar(s: str):
     return s
 
 
+def action_label(tool_name: str, command: str) -> str:
+    """The one-line label an approval card leads with.
+
+    ``"<tool>: <command>"`` when we know the command, and a bare ``"<tool>"``
+    when we do not. The old unconditional join printed the empty preview
+    straight after the colon, so an operator read ``exec: {}`` -- a card that
+    names a tool and then shows punctuation where the command belongs. A
+    reader can tell "we did not record the command" from a bare tool name;
+    they cannot tell it from braces."""
+    tool = str(tool_name or "tool call").strip()
+    cmd = str(command or "").strip()
+    return f"{tool}: {cmd}" if cmd else tool
+
+
+# Minimum risk level implied by a shipped preset key, used to repair rows
+# whose ``min_risk`` did not survive a round trip through storage. Only
+# presets whose WHOLE definition is the risk gate belong here -- a preset
+# that matches on a command regex needs no entry.
+_PRESET_MIN_RISK: dict[str, str] = {"risk_high": "high"}
+
+
 def _compile_policy(p: dict) -> Optional[dict]:
     """Compile a single raw policy dict into a match-ready dict, or None."""
     match = p.get("match") or {}
@@ -334,6 +355,17 @@ def _compile_policy(p: dict) -> Optional[dict]:
     # rejected here so a typo ("hgih") can't silently disable the gate.
     min_risk = str(p.get("min_risk") or match.get("min_risk")
                    or "").strip().lower() or None
+    # Preset rows created through the cloud lost their min_risk on the way to
+    # the database (the cloud policies table had no such column until
+    # 2026-09-06), which turned the shipped "Require approval for high-risk
+    # actions" preset -- tool '', pattern '', min_risk 'high' -- into a rule
+    # with NO condition at all: it matched every tool call of every runtime
+    # and buried the operator in approvals for `git status`. A preset carries
+    # its own intent, so recover it from the key rather than trusting a row
+    # that lost a field. Explicit min_risk on the row always wins.
+    if min_risk is None:
+        min_risk = _PRESET_MIN_RISK.get(
+            str(p.get("preset_key") or "").strip().lower())
     if min_risk is not None:
         from clawmetry.tool_risk import RISK_RANK
         if min_risk not in RISK_RANK:
@@ -341,7 +373,7 @@ def _compile_policy(p: dict) -> Optional[dict]:
                         f"'{min_risk}' (want low/medium/high/critical)")
             return None
     try:
-        return {
+        compiled = {
             "name": p.get("name") or "(unnamed)",
             "tool": tool,
             # Optional per-runtime scoping ('' = applies to every runtime).
@@ -361,6 +393,19 @@ def _compile_policy(p: dict) -> Optional[dict]:
     except re.error as re_err:
         log.warning(f"policy '{p.get('name')}' has bad regex: {re_err}")
         return None
+    # A gating policy with no tool, no pattern and no risk floor has no
+    # condition: it pauses EVERY tool call on the node. That is a legal thing
+    # to ask for, but it is almost always a row that lost a field on the way
+    # here, so say so once, loudly, naming the policy -- an operator drowning
+    # in approvals should be able to find out why from the daemon log.
+    if compiled["action"] != "approve" and not (
+            compiled["tool"] or compiled["command_regex"]
+            or compiled["args_regex"] or compiled["min_risk"]):
+        log.warning("policy %r has no tool, no pattern and no min_risk: it "
+                    "will pause EVERY tool call on this node",
+                    compiled["name"])
+        compiled["matches_everything"] = True
+    return compiled
 
 
 # Fingerprint of the last policy set we announced, so a reload that changes
@@ -760,6 +805,42 @@ def _session_runtime(session_id: str) -> str:
         return "openclaw"
 
 
+# Working directory per session, memoised. An approval card that cannot say
+# WHERE the command would run is asking the operator to approve a `git push`
+# without telling them which checkout. Missing/unknown stays "" -- never a
+# guessed path.
+_session_cwd_cache: dict[str, str] = {}
+_SESSION_CWD_CACHE_MAX = 512
+
+
+def _session_cwd(session_id: str) -> str:
+    """Best-effort cwd for a session id, from the local store. Never raises."""
+    sid = session_id or ""
+    if not sid:
+        return ""
+    if sid in _session_cwd_cache:
+        return _session_cwd_cache[sid]
+    cwd = ""
+    try:
+        from clawmetry import local_store
+        store = local_store.get_store(read_only=True)
+        # Family runtimes are stored under the prefixed id, OpenClaw under the
+        # bare one; try what we were handed, then the other half.
+        for cand in (sid, sid.split(":", 1)[1] if ":" in sid else None):
+            if not cand:
+                continue
+            row = store.get_session_location(cand)
+            if row and row.get("cwd"):
+                cwd = str(row["cwd"])
+                break
+    except Exception as e:
+        log.debug("approval cwd lookup failed for %s: %s", sid, e)
+    if len(_session_cwd_cache) >= _SESSION_CWD_CACHE_MAX:
+        _session_cwd_cache.clear()
+    _session_cwd_cache[sid] = cwd
+    return cwd
+
+
 _hooks_marker_cache: tuple = (0.0, frozenset())
 _HOOKS_MARKER_TTL_S = 10.0
 _HOOKS_MARKER_PATH = Path.home() / ".clawmetry" / "hooks_installed.json"
@@ -971,6 +1052,19 @@ def process_tool_call(api_key: str, node_id: str, session_id: Optional[str],
     args_with_risk = dict(args) if isinstance(args, dict) else {"value": args}
     args_with_risk["_cm_risk"] = {"level": risk["level"],
                                   "reasons": risk["reasons"]}
+    # Same namespaced-key trick for the WHO/WHERE/WHY of the request. Without
+    # it a queue row carried the tool and the command and nothing else, so the
+    # inbox could only print the tail of a session id -- an operator looking at
+    # twenty of them had no way to tell which agent, in which checkout, tripped
+    # which rule. Everything here is already known at this point; none of it
+    # costs a second lookup except cwd, which is memoised per session.
+    args_with_risk["_cm_ctx"] = {
+        "tool": tool_name,
+        "runtime": _session_runtime(session_id or ""),
+        "session_id": session_id or "",
+        "policy": policy.get("name"),
+        "cwd": _session_cwd(session_id or ""),
+    }
     log.info(f"[approval] policy='{policy['name']}' tool={tool_name} "
              f"risk={risk['level']} cmd={cmd_preview!r} session={session_id}")
 
@@ -988,7 +1082,7 @@ def process_tool_call(api_key: str, node_id: str, session_id: Optional[str],
                 "id": approval_id,
                 "owner_hash": _hl.sha256((api_key or "").encode()).hexdigest(),
                 "requestor_session_id": session_id,
-                "action": f"{tool_name}: {cmd_preview}",
+                "action": action_label(tool_name, cmd_preview),
                 "args": args_with_risk,
                 "status": "auto_approved",
                 "decision_reason": (f"always-allow rule '{policy['name']}' "
@@ -1026,7 +1120,7 @@ def process_tool_call(api_key: str, node_id: str, session_id: Optional[str],
                 "id": approval_id,
                 "owner_hash": _hl.sha256((api_key or "").encode()).hexdigest(),
                 "requestor_session_id": session_id,
-                "action": f"{tool_name}: {cmd_preview}",
+                "action": action_label(tool_name, cmd_preview),
                 "args": args_with_risk,
                 "status": "simulated",
                 "decision_reason": (f"monitor mode: policy '{policy['name']}' "
@@ -1071,7 +1165,7 @@ def process_tool_call(api_key: str, node_id: str, session_id: Optional[str],
                 "id": approval_id,
                 "owner_hash": _hl.sha256((api_key or "").encode()).hexdigest(),
                 "requestor_session_id": session_id,
-                "action": f"{tool_name}: {cmd_preview}",
+                "action": action_label(tool_name, cmd_preview),
                 "args": args_with_risk,
                 "status": "auto_approved",
                 "decision_reason": "approved earlier this session "
@@ -1119,7 +1213,7 @@ def process_tool_call(api_key: str, node_id: str, session_id: Optional[str],
             "id": approval_id,
             "owner_hash": _hl.sha256((api_key or "").encode()).hexdigest(),
             "requestor_session_id": session_id,
-            "action": f"{tool_name}: {cmd_preview}",
+            "action": action_label(tool_name, cmd_preview),
             "args": args_with_risk,
             "status": "pending",
             "created_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),

--- a/clawmetry/tool_risk.py
+++ b/clawmetry/tool_risk.py
@@ -102,7 +102,15 @@ def extract_command(tool_name: str, args: Any) -> str:
                 return " ".join(str(x) for x in v)
             except Exception:
                 continue
-    # Fallback: stringify args
+    # Nothing recognised. An EMPTY arg object has no command to show, and
+    # stringifying it produced the literal "{}" that reached operators as
+    # ``exec: {}`` in the approval inbox -- a card that names a tool and then
+    # shows braces where the command should be. Say nothing instead; callers
+    # render "command not recorded" rather than punctuation.
+    if not args:
+        return ""
+    # Non-empty args we do not have a key for still carry information (a
+    # web query, a patch body), so stringify those.
     try:
         return json.dumps(args)[:500]
     except Exception:

--- a/routes/hooks.py
+++ b/routes/hooks.py
@@ -382,8 +382,8 @@ def _pretooluse_impl(runtime: str):
             "id": uuid.uuid4().hex,
             "requestor_session_id": f"{runtime}:{session_id}" if session_id
                                     else None,
-            "action": f"{tool_name}: "
-                      f"{ap._extract_command(tool_name, tool_input)[:140]}",
+            "action": ap.action_label(
+                tool_name, ap._extract_command(tool_name, tool_input)[:140]),
             "args": {"source": "pretooluse-hook", "runtime": runtime,
                      "tool_input": tool_input},
             "status": "simulated",
@@ -433,7 +433,7 @@ def _pretooluse_impl(runtime: str):
         "id": approval_id,
         "requestor_session_id": f"{runtime}:{session_id}" if session_id
                                 else None,
-        "action": f"{tool_name}: {cmd_preview}",
+        "action": ap.action_label(tool_name, cmd_preview),
         # Meta rides in the args blob so resume requests are stateless:
         # the row itself knows its policy window and timeout action.
         "args": {
@@ -930,7 +930,7 @@ def api_hook_claude_code_permissionrequest():
         "id": approval_id,
         "requestor_session_id": f"claude_code:{session_id}" if session_id
                                 else None,
-        "action": f"{tool_name}: {cmd_preview}",
+        "action": ap.action_label(tool_name, cmd_preview),
         "args": {
             "_cm_risk": mirror_risk,
             "source": "permissionrequest-hook",

--- a/routes/policy.py
+++ b/routes/policy.py
@@ -68,11 +68,43 @@ def _arg_preview(args) -> str:
                 return str(v)[:160]
         try:
             import json as _json
-            slim = {k: v for k, v in args.items() if k != "_cm_risk"}
+            slim = {k: v for k, v in args.items()
+                    if k not in ("_cm_risk", "_cm_ctx")}
+            if not slim:
+                return ""
             return _json.dumps(slim, separators=(",", ":"))[:160]
         except Exception:
             return str(args)[:160]
     return str(args)[:160]
+
+
+def _row_context(r) -> dict:
+    """WHO / WHERE / WHY for one approval row, from the namespaced keys the
+    producers stamp into ``args``.
+
+    Both producers are covered: the watcher writes ``_cm_ctx``; the pre-tool
+    hook receiver has always written ``runtime`` / ``cwd`` / ``policy`` /
+    ``tool_name`` at the top of its args blob. Missing fields are omitted, not
+    guessed -- a card that cannot say where a command would run must say
+    nothing rather than imply the wrong directory.
+    """
+    args = r.get("args")
+    if not isinstance(args, dict):
+        return {}
+    ctx = args.get("_cm_ctx")
+    if not isinstance(ctx, dict):
+        ctx = {}
+    sid = str(r.get("requestor_session_id") or ctx.get("session_id") or "")
+    runtime = str(ctx.get("runtime") or args.get("runtime") or "")
+    if not runtime and ":" in sid:
+        runtime = sid.split(":", 1)[0].lower()
+    out = {
+        "tool":    str(ctx.get("tool") or args.get("tool_name") or ""),
+        "runtime": runtime,
+        "policy":  str(ctx.get("policy") or args.get("policy") or ""),
+        "cwd":     str(ctx.get("cwd") or args.get("cwd") or ""),
+    }
+    return {k: v for k, v in out.items() if v}
 
 
 def _row_risk(r) -> "dict | None":
@@ -244,6 +276,10 @@ def api_approvals_queue():
             "requestor_session_id": r.get("requestor_session_id"),
             "args_preview":         _arg_preview(r.get("args")),
             "risk":                 _row_risk(r),
+            # WHO / WHERE / WHY. Without these a queue row could only be
+            # printed as a tool name and the tail of a session id, which is
+            # not enough for anyone to decide with.
+            "context":              _row_context(r),
             # "policy" (a protection rule fired) vs "permission_prompt"
             # (the runtime itself stopped to ask) — the UI says which,
             # because they mean different things to the person deciding.
@@ -604,8 +640,13 @@ def _row_tool_and_args(row) -> "tuple[str, dict]":
         raw = args.get("tool_input")
         return (str(args.get("tool_name") or ""),
                 raw if isinstance(raw, dict) else {})
-    tool = str(row.get("action") or "").split(": ", 1)[0].strip()
-    raw = {k: v for k, v in args.items() if k != "_cm_risk"}
+    # ``_cm_ctx`` records the tool name outright; fall back to the action
+    # prefix for rows written before it existed.
+    ctx = args.get("_cm_ctx") if isinstance(args.get("_cm_ctx"), dict) else {}
+    tool = str(ctx.get("tool") or "").strip() or \
+        str(row.get("action") or "").split(": ", 1)[0].strip()
+    raw = {k: v for k, v in args.items()
+           if k not in ("_cm_risk", "_cm_ctx")}
     return tool, raw
 
 

--- a/tests/test_approval_card_legibility.py
+++ b/tests/test_approval_card_legibility.py
@@ -1,0 +1,182 @@
+"""An approval card must say WHAT ran, WHERE, and WHY it was stopped.
+
+Founder report 2026-09-06 (58 pending approvals on app.clawmetry.com/cloud):
+every card read
+
+    exec: {}
+    {"_cm_risk":{"level":"medium","reasons":["shell command with side
+     effects unknown"]}}
+    session 7dd6106a - 7h ago
+
+which names a tool, shows punctuation where the command belongs, and
+identifies the agent by the tail of an opaque id. Three separate defects
+produced it, and each gets a test here:
+
+1.  ``extract_command`` stringified an EMPTY argument object, so the label
+    builder pasted the literal ``"{}"`` after the colon.
+2.  A queue row carried no runtime / policy / directory, so nothing
+    downstream could say which agent tripped which rule.
+3.  The shipped "Require approval for high-risk actions" preset lost its
+    ``min_risk`` on the way through cloud storage, which turned a rule that
+    should fire on high and critical calls into one with NO condition at
+    all -- it paused every tool call on the node. That is where 58 came
+    from, and it is the defect that actually causes approval fatigue.
+
+Revert-proof: undo any of the three and the matching test fails.
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+from clawmetry import approvals
+from clawmetry.tool_risk import extract_command
+
+
+# ── 1. No card ever reads "<tool>: {}" ────────────────────────────────────
+
+def test_empty_args_yield_no_command_string():
+    """An empty arg object has no command; it must not stringify to "{}"."""
+    assert extract_command("exec", {}) == ""
+    assert extract_command("Bash", {}) == ""
+
+
+def test_non_empty_unknown_args_still_stringify():
+    """Args we have no key for still carry information -- keep showing them."""
+    out = extract_command("exec", {"search_query": [{"q": "duckdb"}]})
+    assert "duckdb" in out
+
+
+def test_action_label_drops_the_empty_colon():
+    assert approvals.action_label("exec", "") == "exec"
+    assert approvals.action_label("exec", "git status") == "exec: git status"
+    # The exact string the founder saw must be unproducible.
+    assert approvals.action_label("exec", extract_command("exec", {})) != "exec: {}"
+
+
+# ── 2. A row says which agent, where, and under which rule ────────────────
+
+def test_row_context_reports_runtime_policy_and_cwd():
+    from routes.policy import _row_context
+    row = {
+        "requestor_session_id": "codex:01a07627-9daf-7cc2-93ae-6c1bb8618272",
+        "action": "exec: git push --force",
+        "args": {
+            "cmd": "git push --force",
+            "_cm_ctx": {"tool": "exec", "runtime": "codex",
+                        "policy": "Block force pushes",
+                        "cwd": "/Users/x/projects/clawmetry"},
+        },
+    }
+    ctx = _row_context(row)
+    assert ctx["runtime"] == "codex"
+    assert ctx["policy"] == "Block force pushes"
+    assert ctx["cwd"] == "/Users/x/projects/clawmetry"
+    assert ctx["tool"] == "exec"
+
+
+def test_row_context_covers_the_hook_producer_too():
+    """Pre-tool hook rows use a different args shape; both must resolve."""
+    from routes.policy import _row_context
+    row = {
+        "requestor_session_id": "claude_code:abc",
+        "args": {"source": "pretooluse-hook", "runtime": "claude_code",
+                 "tool_name": "Bash", "cwd": "/repo",
+                 "policy": "Block sudo / root commands",
+                 "tool_input": {"command": "sudo ls"}},
+    }
+    ctx = _row_context(row)
+    assert ctx["runtime"] == "claude_code"
+    assert ctx["tool"] == "Bash"
+    assert ctx["cwd"] == "/repo"
+
+
+def test_row_context_omits_what_it_does_not_know():
+    """Unknown location is absent, never an empty or guessed path."""
+    from routes.policy import _row_context
+    ctx = _row_context({"requestor_session_id": "codex:abc", "args": {}})
+    assert "cwd" not in ctx
+    assert ctx["runtime"] == "codex"   # derivable from the id prefix
+
+
+def test_arg_preview_hides_the_namespaced_keys():
+    """The preview line shows tool arguments, not ClawMetry's own metadata."""
+    from routes.policy import _arg_preview
+    assert _arg_preview({"_cm_risk": {"level": "medium"},
+                         "_cm_ctx": {"runtime": "codex"}}) == ""
+    assert _arg_preview({"cmd": "git status",
+                         "_cm_ctx": {"runtime": "codex"}}) == "git status"
+
+
+# ── 3. The risk_high preset gates on risk, not on everything ──────────────
+
+_RISK_HIGH_AS_STORED_BY_CLOUD = {
+    # Exactly the row shape the cloud policies table returns: the min_risk
+    # field the preset was authored with never had a column to live in.
+    "name": "Require approval for high-risk actions",
+    "tool": "",
+    "pattern_type": "command_regex",
+    "pattern": "",
+    "action": "require_approval",
+    "timeout": 604800,
+    "on_timeout": "deny",
+    "enabled": True,
+    "preset_key": "risk_high",
+}
+
+
+def test_risk_high_preset_recovers_its_risk_floor():
+    compiled = approvals._compile_policy(dict(_RISK_HIGH_AS_STORED_BY_CLOUD))
+    assert compiled is not None
+    assert compiled["min_risk"] == "high"
+
+
+def test_risk_high_preset_ignores_ordinary_work():
+    """`git status` and reading a file must not page a human."""
+    compiled = [approvals._compile_policy(dict(_RISK_HIGH_AS_STORED_BY_CLOUD))]
+    for tool, args in (
+        ("exec", {"cmd": "git status --short"}),
+        ("exec", {"cmd": "sed -n '1,40p' README.md"}),
+        ("read", {"path": "README.md"}),
+        ("exec", {}),
+        ("list_agents", {}),
+    ):
+        assert approvals.match_policy(compiled, tool, args) is None, (tool, args)
+
+
+def test_risk_high_preset_still_catches_high_risk_calls():
+    compiled = [approvals._compile_policy(dict(_RISK_HIGH_AS_STORED_BY_CLOUD))]
+    for tool, args in (
+        ("exec", {"cmd": "sudo rm -rf /var"}),
+        ("exec", {"cmd": "curl http://169.254.169.254/latest/meta-data/"}),
+    ):
+        assert approvals.match_policy(compiled, tool, args) is not None, args
+
+
+def test_explicit_min_risk_on_the_row_wins():
+    """Recovery is a repair for a lost field, not an override."""
+    row = dict(_RISK_HIGH_AS_STORED_BY_CLOUD, min_risk="critical")
+    assert approvals._compile_policy(row)["min_risk"] == "critical"
+
+
+def test_condition_less_policy_is_flagged_as_matching_everything():
+    """A rule with no tool, no pattern and no risk floor still works -- it is
+    a legal ask -- but it is marked so an operator can be told why every
+    call is pausing."""
+    compiled = approvals._compile_policy(
+        {"name": "no conditions", "tool": "", "pattern": "",
+         "action": "require_approval"})
+    assert compiled["matches_everything"] is True
+    assert approvals.match_policy([compiled], "read", {"path": "a"}) is not None
+
+
+def test_a_real_policy_is_not_flagged():
+    compiled = approvals._compile_policy(
+        {"name": "Block sudo / root commands", "tool": "exec",
+         "pattern_type": "command_regex", "pattern": r"\bsudo\s",
+         "action": "require_approval"})
+    assert "matches_everything" not in compiled


### PR DESCRIPTION
## The report

> "i'm unable to understand what this approval requests are — what session it was meant for — what it really tried running & they all seem to be duplicate — creates approval fatigue on not knowing what to approve"

58 pending approvals on the cloud inbox, every card identical:

```
exec: {}
{"_cm_risk":{"level":"medium","reasons":["shell command with side effects unknown"]}}
session 7dd6106a · 7h ago
```

Three separate defects. They are not duplicates — 280 distinct requests across 7 Codex sessions, all rendered the same way because the command never reached the store.

## 1. The volume — a preset with no condition

The shipped **"Require approval for high-risk actions"** preset is authored in `templates/tabs/approvals.html` as `tool:''`, `pattern:''`, **`min_risk:'high'`**. The cloud `approval_policies` table has **no `min_risk` column**, so the field is dropped on write and absent on read. `_compile_policy` then produces a rule with no tool, no regex and no risk floor — no condition at all — and `match_policy` returns it for every call:

```
exec {'cmd': 'git status'}  -> Require approval for high-risk actions
read {'path': 'README.md'}  -> Require approval for high-risk actions
list_agents {}              -> Require approval for high-risk actions
```

Measured on the reporter's own data: **280 approvals raised in 22 minutes**. Replaying the repaired preset over the same 244 Codex shell calls on disk pauses **0** of them. Every one was noise.

`_compile_policy` now recovers a preset's risk floor from its `preset_key` when the row lost it. An explicit `min_risk` on the row always wins — this is a repair for a dropped field, not an override. A policy that genuinely has no condition is logged and flagged `matches_everything` rather than silently behaving as a catch-all.

The cloud schema fix (so *new* policies persist their floor) is a separate PR in `clawmetry-cloud`; this change means existing nodes stop drowning without waiting for it.

## 2. The illegibility — `exec: {}`

`extract_command` fell through to `json.dumps(args)` for an **empty** argument object, producing the literal `"{}"`, which the label builder pasted straight after the colon. It now returns nothing for empty args, and the new `action_label` helper renders a bare tool name. A reader can tell "we did not record the command" from a bare tool name; they cannot tell it from braces. Non-empty args we have no key for still stringify — those carry real information.

*Why the args were empty for Codex at all* is fixed in `clawmetry-pro` (the adapter read only the legacy `arguments` field and stored `null` for every `custom_tool_call`). With both landed, the same rows read `exec: git diff --cached --stat -- clawmetry-landing`.

## 3. The identity — "session 7dd6106a"

A queue row carried a tool, a command and a session id, and nothing else, so the inbox could only print an id tail. The watcher now stamps `_cm_ctx` — tool, runtime, session, policy name, cwd — beside the existing `_cm_risk` (same namespaced-key trick, no schema migration). `/api/approvals` exposes it as `context`, and the pre-tool-hook producer's differently shaped rows resolve through the same reader.

Unknown fields are **omitted, never guessed**. `sessions.cwd` is not populated for family runtimes today (`Session` has no `cwd` field), so the directory is honestly absent there rather than blank. Noted as a non-goal in the requirement.

## Tests

`tests/test_approval_card_legibility.py` — 13 guards, **9 of which fail on unmodified `origin/main`** (verified against a clean `git archive` of main). Named explicitly in `ci.yml`, which runs file lists, not `pytest tests/`.

The two pre-existing failures in `test_approvals_duckdb_watcher.py` and `test_audit_producers.py` reproduce on unmodified main and are untouched by this change.

## Risk

Recovering the preset's risk floor **narrows** what an enabled policy pauses. An operator who had unknowingly been pausing every call will see approvals stop for ordinary work — that is the behaviour the preset's own description promises, but it is a live change to an enforcement rule and belongs in the release notes.

Requirement: https://factory.8090.ai/project/b415065f-ab2f-4f53-8864-0c009fd098cb/requirements/25f82b53-de8b-47ac-861c-0ff9d7c56fc7

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EKwipCEfKx8gSZDVtULC52
