### PR TITLE
Fix: per-repo agent memory never reached the cloud Memory tab (codex, cursor, opencode)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -294,6 +294,14 @@ jobs:
       - name: Trail page + session-first nav
         run: python3 -m pytest tests/test_trail_tab_template.py tests/test_trail_context_panel.py tests/test_beginner_nav_phase_a.py tests/test_transcript_layout_grid.py -q
 
+      # Memory & Skills catalog + its sync path. Both files existed and were
+      # green locally while running in NO job — and the catalog is exactly
+      # where a wrong root means a runtime's Memory tab is empty for every
+      # user (2026-09-06: Codex, whose memory is only per-repo AGENTS.md,
+      # synced nothing because the daemon's launchd workspace is "/").
+      - name: Runtime memory catalog
+        run: python3 -m pytest tests/test_runtime_memory_catalog.py -q
+
       # The desktop shell's first pip install must self-heal (broken-venv
       # rebuild, cold-cache retry, actionable failure hints) — the
       # 2026-08-29 Windows "PyPI install failed" brick. Runs here because

--- a/clawmetry/runtime_memory.py
+++ b/clawmetry/runtime_memory.py
@@ -52,6 +52,7 @@ import glob as _glob
 import json
 import os
 import re as _re
+import time as _time
 from dataclasses import dataclass, field
 from typing import Iterable, Optional
 
@@ -119,6 +120,15 @@ def _workspace_root() -> str:
 
     Uses the dashboard's resolved WORKSPACE when the module is imported in
     the Flask process, else the CWD. Never raises.
+
+    The CWD fallback has one trap worth naming: the sync daemon is started
+    by launchd/systemd, which sets ``cwd="/"``. A workspace of "/" makes
+    every project-scoped root a path no agent ever writes ("/AGENTS.md"),
+    and it used to make ``_expand_project_roots`` skip the runtime entirely
+    (burned 2026-09-06: Codex, whose memory is *only* per-repo AGENTS.md,
+    ingested zero memory files on cloud while the local dashboard — whose
+    workspace is a real dir — showed them). Fall back to the OpenClaw
+    workspace, then $HOME, before ever returning the filesystem root.
     """
     try:
         import dashboard as _d
@@ -127,7 +137,28 @@ def _workspace_root() -> str:
             return ws
     except Exception:
         pass
-    return os.getcwd()
+    try:
+        cwd = os.getcwd()
+    except OSError:          # cwd deleted out from under us
+        cwd = ""
+    if cwd and cwd != os.sep:
+        return cwd
+    oc_ws = os.path.join(_openclaw_home(), "workspace")
+    if os.path.isdir(oc_ws):
+        return oc_ws
+    return os.path.expanduser("~")
+
+
+def _is_within(path: str, base: str) -> bool:
+    """True when ``path`` is ``base`` or lives under it.
+
+    ``path.startswith(base + os.sep)`` is wrong for the filesystem root:
+    ``"/" + "/"`` is ``"//"``, which nothing starts with, so every path
+    tested against a root workspace answered False.
+    """
+    if path == base:
+        return True
+    return path.startswith(base.rstrip(os.sep) + os.sep)
 
 
 def _openclaw_home() -> str:
@@ -250,6 +281,56 @@ def _claude_registry_projects(limit: int = 8) -> list:
     return [p for p in cached if os.path.isdir(p)][:limit]
 
 
+# Codex keeps no project registry, but every rollout file opens with a
+# ``session_meta`` line carrying the cwd of the run — Codex's own answer to
+# "which repos did I work in". Scanning the newest N rollouts costs one
+# readline each, cached for a minute so a catalog build per request is free.
+_CODEX_CWD_CACHE: dict = {}
+_CODEX_CWD_TTL_SECS = 60.0
+_CODEX_ROLLOUT_SCAN = 40
+
+
+def _codex_project_dirs(limit: int = 6) -> list:
+    """Repos Codex actually ran in, newest first, from its own rollouts.
+
+    Codex stores memory *only* per repo (``AGENTS.md``), and a Codex-only
+    user has no ``~/.claude.json`` for the borrowed-registry path to read —
+    so without this their Memory tab is empty by construction. Mirrors the
+    adapter's discovery: ``$CODEX_HOME`` (default ``~/.codex``), both the
+    live ``sessions/`` and the ``archived_sessions/`` sibling. Never raises.
+    """
+    home = _env_root("CODEX_HOME", os.path.expanduser("~/.codex"))
+    cached = _CODEX_CWD_CACHE.get(home)
+    if cached and (_time.time() - cached[0]) < _CODEX_CWD_TTL_SECS:
+        return cached[1][:limit]
+    files: list = []
+    for sub in ("sessions", "archived_sessions"):
+        root = os.path.join(home, sub)
+        if not os.path.isdir(root):
+            continue
+        try:
+            # Rollout names embed an ISO timestamp under YYYY/MM/DD dirs, so
+            # a reverse lexicographic sort of the full path is newest-first.
+            files.extend(_glob.glob(
+                os.path.join(root, "**", "rollout-*.jsonl"), recursive=True))
+        except Exception:
+            continue
+    out: list = []
+    for f in sorted(files, reverse=True)[:_CODEX_ROLLOUT_SCAN]:
+        try:
+            with open(f, "r", encoding="utf-8", errors="replace") as fh:
+                meta = json.loads(fh.readline(65536) or "{}")
+        except Exception:
+            continue
+        cwd = (meta.get("payload") or {}).get("cwd") or meta.get("cwd")
+        if (isinstance(cwd, str) and os.path.isabs(cwd)
+                and cwd not in out and os.path.isdir(cwd)):
+            out.append(cwd)
+    _CODEX_CWD_CACHE.clear()
+    _CODEX_CWD_CACHE[home] = (_time.time(), out)
+    return out[:limit]
+
+
 def _candidate_project_dirs(ws: str, limit: int = 10) -> list:
     """Real project dirs to re-base project-scoped roots over.
 
@@ -276,6 +357,11 @@ def _candidate_project_dirs(ws: str, limit: int = 10) -> list:
     for p in (os.environ.get("AIDER_HISTORY_DIRS") or "").split(os.pathsep):
         if p.strip():
             add(os.path.expanduser(p.strip()))
+    # A runtime's own registry outranks a borrowed one: Codex's rollout cwds
+    # go in before Claude Code's project map, so a Codex-heavy laptop can
+    # never spend the whole `limit` on repos Codex has never opened.
+    for p in _codex_project_dirs():
+        add(p)
     for p in _claude_registry_projects():
         add(p)
     for p in _slug_project_dirs(os.path.expanduser("~/.qwen/projects")):
@@ -292,9 +378,9 @@ def _expand_project_roots(catalog: list, ws: str) -> list:
     exists — so runtimes the user never touched in a repo stay exactly as
     quiet as before, while real per-repo files finally surface.
     """
+    # No candidates still runs the dedup pass below — a duplicate root can
+    # come from the workspace spec alone, with no clone involved.
     candidates = _candidate_project_dirs(ws)
-    if not candidates:
-        return catalog
     ws_abs = os.path.abspath(ws)
     for entry in catalog:
         extra: list = []
@@ -302,7 +388,7 @@ def _expand_project_roots(catalog: list, ws: str) -> list:
             if spec.scope != "project":
                 continue
             root = os.path.abspath(spec.expanded_root())
-            if root != ws_abs and not root.startswith(ws_abs + os.sep):
+            if not _is_within(root, ws_abs):
                 continue
             rel = os.path.relpath(root, ws_abs)
             for cand in candidates:
@@ -317,6 +403,22 @@ def _expand_project_roots(catalog: list, ws: str) -> list:
                 ))
         if extra:
             entry.roots = tuple(entry.roots) + tuple(extra)
+        # One file, one row. A project spec can resolve to a path a global
+        # spec already covers (with the daemon's workspace at $HOME,
+        # "<ws>/.codex/config.toml" IS "~/.codex/config.toml"), and showing
+        # the same file twice under two labels reads as a bug to anyone
+        # opening the tab. Globs are part of the key: the same root scanned
+        # with different include patterns is two honest groups.
+        deduped: list = []
+        seen_roots: set = set()
+        for spec in entry.roots:
+            key = (spec.category, os.path.abspath(spec.expanded_root()),
+                   tuple(spec.include_globs or ()))
+            if key in seen_roots:
+                continue
+            seen_roots.add(key)
+            deduped.append(spec)
+        entry.roots = tuple(deduped)
     return catalog
 
 

--- a/tests/test_runtime_memory_catalog.py
+++ b/tests/test_runtime_memory_catalog.py
@@ -331,6 +331,75 @@ def test_project_roots_expand_over_claude_registry(fake_home, tmp_path):
     assert any(p == str(repo / "AGENTS.md") for p in codex_mem)
 
 
+def test_project_roots_expand_when_workspace_is_filesystem_root(
+        fake_home, tmp_path, monkeypatch):
+    """The sync daemon runs under launchd with cwd="/".
+
+    Burned 2026-09-06: with a workspace of "/", the containment test
+    ``root.startswith(ws + os.sep)`` compared against "//" and matched
+    nothing, so no project-scoped root was ever cloned. Codex keeps memory
+    only in per-repo AGENTS.md, so its Memory tab was empty on cloud (the
+    daemon's ingest) while the local dashboard (a real workspace) showed the
+    files — the exact "no memory files synced for codex" report.
+    """
+    home, _ = fake_home
+    repo = tmp_path / "rootws_repo"
+    _write(repo, "AGENTS.md")
+    (home / ".claude.json").write_text(json.dumps(
+        {"projects": {str(repo): {}}}))
+    import clawmetry.runtime_memory as rm_mod
+    monkeypatch.setattr(rm_mod, "_workspace_root", lambda: os.sep)
+    rm = _import_rm()
+    codex_mem = _files(rm, "codex", "memory")
+    assert any(p == str(repo / "AGENTS.md") for p in codex_mem), codex_mem
+
+
+def test_is_within_handles_the_filesystem_root(fake_home):
+    rm = _import_rm()
+    assert rm._is_within("/AGENTS.md", "/")
+    assert rm._is_within("/", "/")
+    assert rm._is_within("/a/b/AGENTS.md", "/a/b")
+    assert not rm._is_within("/ab/AGENTS.md", "/a")
+    assert not rm._is_within("/a/AGENTS.md", "/b")
+
+
+def test_workspace_root_never_returns_the_filesystem_root(
+        fake_home, monkeypatch):
+    """A workspace of "/" is never a real answer — prefer HOME."""
+    home, _ = fake_home
+    import clawmetry.runtime_memory as rm_mod
+    monkeypatch.undo()  # drop the fixture's _workspace_root patch
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("OPENCLAW_HOME", str(home / ".openclaw"))
+    monkeypatch.setattr(rm_mod.os, "getcwd", lambda: os.sep)
+    assert rm_mod._workspace_root() != os.sep
+
+
+def test_codex_project_dirs_come_from_its_own_rollouts(fake_home, tmp_path):
+    """A Codex-only laptop has no ~/.claude.json to borrow repos from.
+
+    Codex's rollout files open with a ``session_meta`` line carrying the cwd
+    of the run — its own registry of "repos I worked in" — and that is where
+    its AGENTS.md memory lives.
+    """
+    home, _ = fake_home
+    repo = tmp_path / "codexrepo"
+    _write(repo, "AGENTS.md")
+    roll = (home / ".codex" / "sessions" / "2026" / "09" / "06"
+            / "rollout-2026-09-06T11-58-22-abc.jsonl")
+    roll.parent.mkdir(parents=True, exist_ok=True)
+    roll.write_text(json.dumps({
+        "type": "session_meta",
+        "payload": {"session_id": "abc", "cwd": str(repo)},
+    }) + "\n")
+    assert not (home / ".claude.json").exists()
+    rm = _import_rm()
+    rm._CODEX_CWD_CACHE.clear()
+    assert str(repo) in rm._codex_project_dirs()
+    codex_mem = _files(rm, "codex", "memory")
+    assert any(p == str(repo / "AGENTS.md") for p in codex_mem), codex_mem
+
+
 def test_registry_repo_without_runtime_files_stays_quiet(fake_home, tmp_path):
     home, _ = fake_home
     repo = tmp_path / "plainrepo"


### PR DESCRIPTION
**Product record:** https://factory.8090.ai/project/b415065f-ab2f-4f53-8864-0c009fd098cb/requirements/3c72f3a9-29ca-431a-8f8d-ef97e95a91e7

## The report

Hosted dashboard → node → `?runtime=codex` → **Memory**: *"No memory files found for codex"*. On the same machine, at the same moment, the local dashboard on :8900 listed 2 Codex memory files.

## Root cause

`runtime_memory._expand_project_roots()` re-bases every project-scoped root (Codex `AGENTS.md`, Cursor rules, opencode, Copilot) over the repos the user really works in — but only for roots under the resolved workspace, tested as:

```python
if root != ws_abs and not root.startswith(ws_abs + os.sep):
    continue
```

The sync daemon is started by launchd/systemd with `cwd="/"`, and with no OpenClaw workspace `_workspace_root()` fell through to `os.getcwd()` → `"/"`. The test then compared against `"/" + "/"` == `"//"`, which no path starts with, so **no project-scoped root was ever cloned in the daemon**. Codex keeps memory *only* per repo, so its ingest wrote zero memory rows → nothing in the snapshot → empty cloud tab.

Measured on the reporter's laptop before the fix:

```
query_memory_blobs(agent_type='codex') -> 56 rows
Counter({'skills': 54, 'hooks': 2})     # zero 'memory'
```

The local dashboard escaped it because its workspace is a real directory — which is exactly why this looked like "cloud is broken" rather than a catalog bug. Cursor, opencode and Copilot were blind the same way for their per-repo half.

## Second, independent gap

Candidate repos came from **Claude Code's** `~/.claude.json` registry, Qwen's slug registry, and the cwd. A **Codex-only** user has none of those, so their per-repo `AGENTS.md` was invisible by construction. Codex has its own registry: every rollout file's first line is a `session_meta` carrying the run's `cwd`.

## The fix

1. **`_is_within(path, base)`** — containment that is correct at the filesystem root.
2. **`_workspace_root()` never returns `/`** — OpenClaw workspace, then `$HOME`. A workspace of `/` also made the tab display roots like `/AGENTS.md`, paths no agent ever writes.
3. **`_codex_project_dirs()`** — repos from Codex's own rollouts (`$CODEX_HOME`, both `sessions/` and `archived_sessions/`, newest 40, one `readline` each, 60s cache), ranked **ahead of** the borrowed Claude Code registry so a Codex-heavy laptop cannot spend the whole candidate budget on repos Codex never opened.
4. **Roots deduped** per `(category, abspath, include_globs)`. With the workspace at `$HOME`, `<ws>/.codex/config.toml` *is* `~/.codex/config.toml`; one file listed twice under two labels reads as a bug.

## Verification

Run under the daemon's exact conditions (`cwd="/"`, real `$HOME`), before → after:

| runtime | memory before | memory after |
|---|---|---|
| codex | 0 | 2 (`clawmetry/AGENTS.md`, `clawmetry-landing/AGENTS.md`) |
| cursor | 0 | 2 |
| opencode | 0 | 2 |
| claude_code | 656 | 656 (unchanged) |

Codex `hooks` goes 3 → 2: the dedup drops a duplicate `~/.codex/config.toml` that the workspace change would otherwise have listed twice.

## Tests

Four new regression tests in `tests/test_runtime_memory_catalog.py`, **each watched failing on unfixed code first** (the workspace-root one fails on its real assertion, `AssertionError: []`, not on a missing attribute):

- project roots expand when the workspace is `/`
- `_is_within` at the filesystem root
- `_workspace_root` never returns `/`
- Codex project dirs come from its own rollouts, with no `~/.claude.json` present

`tests/test_runtime_memory_catalog.py` **ran in no CI job** — the file-list trap this repo has been burned by before. It is now named in `ci.yml`.

30 passed locally.

**Pre-existing failure, not from this change:** `tests/test_runtime_memory_sync.py::test_unchanged_snapshot_is_not_repushed_every_heartbeat` fails identically on unmodified `origin/main` here (the fixture's rows carry no `sha256`, so the change-gate fingerprint is `None`; real rows do carry it). Left alone rather than folded into this fix.

## Not done yet

Per the "done" bar this is not finished until it is released, the cloud is pinned, and the tab is verified live in the browser. That follows this merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01482eRnWkmqaJuqGhk72PpQ