### PR TITLE
Show only the Security panels the hosted dashboard can actually fill

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -320,6 +320,16 @@ jobs:
       - name: Approval card legibility + preset risk floor
         run: python3 -m pytest tests/test_approval_card_legibility.py -q
 
+      # The hosted Security tab must show only the panels the snapshot can
+      # fill. Every scan on it (posture, signatures, policy, credentials,
+      # findings) reads the machine's own config and event history, which the
+      # cloud container does not have -- so on cloud they rendered dashes,
+      # 0/0/0/0 tiles and permanent "Scanning..." spinners. Silent by
+      # construction: nothing errors, the page just looks vibe-coded. Named
+      # here because this job runs FILE LISTS.
+      - name: Hosted Security tab shows only what it can fill
+        run: python3 -m pytest tests/test_security_tab_cloud_honesty.py -q
+
   # ── API tests across all 3 platforms ─────────────────────────────────────────────────────────────────────────────────────────
   api-tests:
     name: API Tests (${{ matrix.os }})

--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -11497,14 +11497,51 @@ async function saveRetentionSetting(usePlanDefault) {
   }
 }
 
+// Hosted dashboard: show only the parts of this tab that have real data.
+//
+// The cloud container has no ~/.openclaw config and no local DuckDB, so the
+// posture scan, the live signature scan, the policy/PII scan, the credential
+// scan and the recorded-findings feed have nothing to read. What a trial user
+// saw instead was a full Security page made of dashes, 0/0/0/0 tiles under a
+// heading promising threat detection, severity filters that filtered nothing,
+// and two panels stuck on "Scanning..." forever. That reads as broken
+// software, and the reading is fair: a control that claims a capability it
+// does not have costs more trust than the capability would have earned.
+// So on cloud those panels are removed outright, and #security-cloud-note
+// says in one line where those scans actually run. What survives is what the
+// snapshot really carries: the tamper-evident log, the plan's retention, and
+// governance activity when there is any (loadSecurityAudit hides its own
+// panel when there is none).
+var _CM_SECURITY_CLOUD_HIDDEN = [
+  'security-scan-btn',
+  'security-posture-panel',
+  'security-threat-heading',
+  'security-allclear',
+  'security-summary',
+  'security-filter-pills',
+  'security-threat-panel',
+  'security-findings-panel',
+  'policy-events-panel',
+  'credential-scan-panel',
+  'security-catalog-panel'
+];
+
+function _cmSecurityCloudTrim() {
+  if (!window.CLOUD_MODE) return;
+  _CM_SECURITY_CLOUD_HIDDEN.forEach(function(id) {
+    var el = document.getElementById(id);
+    if (el) el.style.display = 'none';
+  });
+  var note = document.getElementById('security-cloud-note');
+  if (note) note.style.display = '';
+}
+
 async function loadSecurityPosture() {
   if (window.CLOUD_MODE) {
-    // Trial-bug fix #23: posture scans the local OpenClaw config (no DuckDB in
-    // cloud) so it errored on the hosted dashboard. Show an honest state.
-    var _pb = document.getElementById('posture-score-badge');
-    if (_pb) _pb.textContent = '--';
-    var _pl = document.getElementById('posture-score-label');
-    if (_pl) _pl.textContent = t('app.local_dashboard_only', null, 'Local dashboard only');
+    // Posture scans the machine's agent config, which the cloud container does
+    // not have. It used to paint '--' + "Local dashboard only" into the panel,
+    // which is an empty score card claiming a scan happened. The panel goes.
+    _cmSecurityCloudTrim();
     return;
   }
   try {
@@ -11596,17 +11633,12 @@ async function loadSecurityPosture() {
 
 async function loadSecurityPage(silent) {
   if (window.CLOUD_MODE) {
-    // Trial-bug fix #24: threat scanning runs on the local node (no DuckDB in
-    // cloud); the early-return left "Scanning..." spinning forever. Render an
-    // honest state instead.
-    var _tl = document.getElementById('security-threat-list');
-    if (_tl) _tl.innerHTML = '<div style="color:var(--text-muted);padding:20px;font-size:13px;">' + t('app.security_threats_local_only', null, 'Threat detection runs on your local node. Open the local dashboard to scan for misconfigurations.') + '</div>';
-    // Integrity + audit DO ship in the snapshot; a cm-cloud interceptor will
-    // serve them. Until then these render an honest "local node" state rather
-    // than a silent blank (and become live once the interceptor lands).
+    // Threat/policy/credential scans read this machine's event history, which
+    // the cloud container does not have. Their panels go; integrity and the
+    // audit log DO ship in the snapshot (cm-cloud-security), so those load.
+    _cmSecurityCloudTrim();
     loadSecurityIntegrity();
     loadSecurityAudit();
-    loadSecurityFindings();
     return;
   }
   // The durable findings feed is loaded FIRST so the tiles and the all-clear
@@ -11777,14 +11809,12 @@ async function loadSecurityFindings() {
   var listEl = document.getElementById('security-findings-list');
   var countEl = document.getElementById('security-findings-count');
   if (!listEl) return;
-  // Cloud parity (FLYWHEEL gate 1): security_events is not in the snapshot,
-  // so the hosted dashboard has nothing to read. Say that plainly instead of
-  // leaving "Loading findings..." spinning forever, which is how a trial user
-  // learns to distrust the product.
+  // Cloud parity: security_events is not in the snapshot, so the hosted
+  // dashboard has nothing to read. An empty findings panel is a panel that
+  // says "we record findings" while showing none, so it is removed there
+  // rather than filled with an apology.
   if (window.CLOUD_MODE) {
-    listEl.innerHTML = '<div style="color:var(--text-muted);padding:12px;font-size:12px;">'
-      + t('security.findings_local_only', null, 'Findings are recorded on the machine your agent runs on. Open the dashboard there to read them.')
-      + '</div>';
+    _cmSecurityCloudTrim();
     if (countEl) countEl.textContent = '';
     return null;
   }
@@ -11926,7 +11956,11 @@ async function loadSecurityAudit() {
     if (countEl) countEl.textContent = rows.length ? (rows.length + (rows.length === 1 ? ' event' : ' events')) : '';
     if (!rows.length) {
       if (window.CLOUD_MODE) {
-        listEl.innerHTML = '<div style="color:var(--text-muted);padding:12px;">' + t('app.audit_local_only', null, 'Governance activity is recorded on your local node. Open the local dashboard to review it.') + '</div>';
+        // The snapshot's auditLog slice is real, so "no rows" here means there
+        // has been no governance activity to record -- nothing to show, and no
+        // reason to keep an empty box on the page.
+        var _ap = document.getElementById('security-audit-panel');
+        if (_ap) _ap.style.display = 'none';
       } else {
         listEl.innerHTML = '<div style="color:var(--text-muted);padding:12px;" data-i18n="security.audit_empty">' + t('security.audit_empty', null, 'No recorded activity yet. Approval decisions, budget changes, and pauses appear here.') + '</div>';
       }
@@ -11973,8 +12007,16 @@ async function loadSecurityAudit() {
       html += escHtml(when) + '</div>';
       html += '</div></div>';
     });
+    var _ap2 = document.getElementById('security-audit-panel');
+    if (_ap2) _ap2.style.display = '';
     listEl.innerHTML = html;
   } catch (e) {
+    if (window.CLOUD_MODE) {
+      // Same reasoning as the empty case: no feed, no box.
+      var _ap3 = document.getElementById('security-audit-panel');
+      if (_ap3) _ap3.style.display = 'none';
+      return;
+    }
     listEl.innerHTML = '<div style="color:var(--text-muted);padding:12px;font-size:11px;">' + t('app.audit_unavailable', null, 'Activity feed unavailable.') + '</div>';
   }
 }

--- a/clawmetry/static/locales/en.json
+++ b/clawmetry/static/locales/en.json
@@ -1140,6 +1140,7 @@
   "security.audit_empty": "No recorded activity yet. Approval decisions, budget changes, and pauses appear here.",
   "security.audit_sub": "(approvals, budgets, pauses)",
   "security.audit_title": "Recent activity",
+  "security.cloud_note": "Config posture checks and threat scans run on the machine your agent runs on: they read files and activity that stay on it. Open ClawMetry there (localhost:8900 \u2192 Security) to run them.",
   "security.clean_sessions": "Clean Sessions",
   "security.critical": "Critical",
   "security.failed": "Failed",

--- a/clawmetry/templates/tabs/security.html
+++ b/clawmetry/templates/tabs/security.html
@@ -4,7 +4,7 @@
       <span style="font-size:14px;font-weight:700;color:var(--text-primary);">🛡️ <span data-i18n="security.title">Security</span></span>
       <div style="display:flex;gap:8px;align-items:center;">
         <span id="security-scan-time" style="font-size:11px;color:var(--text-muted);"></span>
-        <button class="refresh-btn" onclick="loadSecurityPage();loadSecurityPosture();">↻ <span data-i18n="security.scan">Scan</span></button>
+        <button class="refresh-btn" id="security-scan-btn" onclick="loadSecurityPage();loadSecurityPosture();">↻ <span data-i18n="security.scan">Scan</span></button>
       </div>
     </div>
     <!-- Security Posture Score -->
@@ -115,8 +115,17 @@
       </div>
       <div id="retention-status" style="font-size:11px;color:var(--text-muted);width:100%;"></div>
     </div>
+    <!-- Hosted dashboard only. The posture scan reads the machine's agent
+         config, and the threat/policy/credential scans read its local event
+         history - neither of which exists in the cloud container, so those
+         panels rendered dashes, 0/0/0/0 tiles and permanent "Scanning..."
+         spinners here. They are hidden on cloud (_cmSecurityCloudTrim) and
+         this line says where they really run. -->
+    <div id="security-cloud-note" style="display:none;padding:12px 14px;background:var(--bg-secondary);border:1px solid var(--border);border-radius:8px;color:var(--text-secondary);font-size:12px;line-height:1.55;">
+      <span data-i18n="security.cloud_note">Config posture checks and threat scans run on the machine your agent runs on: they read files and activity that stay on it. Open ClawMetry there (localhost:8900 → Security) to run them.</span>
+    </div>
     <!-- Threat Detection -->
-    <div style="
+    <div id="security-threat-heading" style="
       font-size:13px;
       font-weight:700;
       color:var(--text-primary);
@@ -219,7 +228,7 @@
         font-weight:600;
         " data-i18n="security.low">Low</button>
     </div>
-    <div style="background:var(--bg-secondary);border:1px solid var(--border);border-radius:8px;padding:10px 14px;">
+    <div id="security-threat-panel" style="background:var(--bg-secondary);border:1px solid var(--border);border-radius:8px;padding:10px 14px;">
       <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:6px;">
         <span style="font-size:11px;color:var(--text-muted);" data-i18n="security.threat_timeline">Threat timeline (newest first)</span>
         <span id="sec-total-label" style="font-size:11px;color:var(--text-muted);"></span>
@@ -282,7 +291,7 @@
         <div style="color:var(--text-muted);padding:12px;">Scanning session events for leaked API keys...</div>
       </div>
     </div>
-    <div style="
+    <div id="security-catalog-panel" style="
       margin-top:14px;
       background:var(--bg-secondary);
       border:1px solid var(--border);

--- a/tests/test_security_tab_cloud_honesty.py
+++ b/tests/test_security_tab_cloud_honesty.py
@@ -1,0 +1,142 @@
+"""The hosted Security tab shows only the parts of itself that have data.
+
+Founder report 2026-09-06, hosted dashboard, runtime switcher on Codex: the
+Security tab rendered a posture score card of dashes, a "Threat Detection &
+Anomaly Alerts" heading over 0/0/0/0 tiles, severity filters that filtered
+nothing, and Policy Events + API Key Scan stuck on "Scanning..." forever.
+None of those can work there — the cloud container has no ~/.openclaw config
+and no local DuckDB, so every one of those scans has nothing to read. His
+words: *"if this security is not functional why to show it ... & make users
+feel it's a vibe coded software?"*
+
+The rule these tests pin (FLYWHEEL "minimal that works beats broad that
+half-works"): a panel that cannot be filled is REMOVED on cloud, not filled
+with dashes or an apology. What stays is what the encrypted snapshot really
+carries — the tamper-evident log (``securityIntegrity``), the plan's
+retention, and the audit log (``auditLog``) when it has entries — plus one
+line saying where the local-only scans actually run.
+"""
+import re
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+APP_JS = REPO / "clawmetry" / "static" / "js" / "app.js"
+SEC_HTML = REPO / "clawmetry" / "templates" / "tabs" / "security.html"
+EN_JSON = REPO / "clawmetry" / "static" / "locales" / "en.json"
+
+# Every panel on the tab whose data source does not exist in the cloud
+# container. Each one must be reachable by id, because hiding it is how the
+# hosted view stays honest.
+CLOUD_DEAD_PANEL_IDS = [
+    "security-scan-btn",         # nothing to scan
+    "security-posture-panel",    # reads the machine's agent config
+    "security-threat-heading",   # promises detection that does not run here
+    "security-allclear",
+    "security-summary",          # the 0/0/0/0 tiles
+    "security-filter-pills",     # filters over an empty list
+    "security-threat-panel",
+    "security-findings-panel",   # security_events is not in the snapshot
+    "policy-events-panel",       # was stuck on "Scanning..." forever
+    "credential-scan-panel",     # was stuck on "scanning..." forever
+    "security-catalog-panel",    # a catalogue of scans that do not run here
+]
+
+
+def _js():
+    return APP_JS.read_text(encoding="utf-8")
+
+
+def _html():
+    return SEC_HTML.read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize("panel_id", CLOUD_DEAD_PANEL_IDS)
+def test_every_local_only_panel_can_be_addressed_by_id(panel_id):
+    assert f'id="{panel_id}"' in _html(), (
+        f"{panel_id} has no id in security.html, so the hosted view cannot "
+        "hide it and it renders empty for every trial user"
+    )
+
+
+@pytest.mark.parametrize("panel_id", CLOUD_DEAD_PANEL_IDS)
+def test_the_cloud_trim_hides_every_local_only_panel(panel_id):
+    js = _js()
+    i = js.index("function _cmSecurityCloudTrim(")
+    lst = js[js.index("_CM_SECURITY_CLOUD_HIDDEN = ["):i]
+    assert f"'{panel_id}'" in lst, (
+        f"{panel_id} is not in _CM_SECURITY_CLOUD_HIDDEN, so it survives on "
+        "the hosted dashboard with nothing in it"
+    )
+
+
+def test_the_trim_only_fires_on_cloud():
+    js = _js()
+    i = js.index("function _cmSecurityCloudTrim(")
+    body = js[i:i + 700]
+    assert "if (!window.CLOUD_MODE) return;" in body, (
+        "the local dashboard runs these scans for real; the trim must never "
+        "touch it"
+    )
+    assert "security-cloud-note" in body, "the hosted view must say where the scans run"
+
+
+def test_posture_hides_its_card_instead_of_painting_dashes():
+    """'--' next to 'Security Posture' is an empty score card claiming a scan."""
+    js = _js()
+    i = js.index("async function loadSecurityPosture(")
+    branch = js[i:js.index("try {", i)]
+    assert "_cmSecurityCloudTrim()" in branch
+    code = "\n".join(l for l in branch.splitlines() if not l.strip().startswith("//"))
+    assert "'--'" not in code, "the hosted posture card must be gone, not blank"
+    assert "Local dashboard only" not in code
+
+
+def test_the_threat_page_keeps_only_the_slices_the_snapshot_carries():
+    js = _js()
+    i = js.index("async function loadSecurityPage(")
+    branch = js[i:i + 1200]
+    cloud = branch[branch.index("if (window.CLOUD_MODE) {"):branch.index("return;\n  }")]
+    assert "_cmSecurityCloudTrim()" in cloud
+    # securityIntegrity + auditLog are real snapshot slices (cm-cloud-security).
+    assert "loadSecurityIntegrity()" in cloud
+    assert "loadSecurityAudit()" in cloud
+    # security_events is not, so the findings feed must not be started here.
+    assert "loadSecurityFindings()" not in cloud
+
+
+def test_an_empty_hosted_audit_log_removes_its_panel():
+    """No governance activity recorded means nothing to show, not an empty box."""
+    js = _js()
+    i = js.index("async function loadSecurityAudit(")
+    body = js[i:js.index("function openDetailView(", i)]
+    empty = body[body.index("if (!rows.length) {"):body.index("} else {")]
+    assert "security-audit-panel" in empty
+    assert "'none'" in empty
+    # ...and it comes back when there is something to say.
+    assert "_ap2.style.display = ''" in body
+
+
+def test_the_hosted_note_is_hidden_by_default_and_i18n_keyed():
+    html = _html()
+    note = html[html.index('id="security-cloud-note"'):]
+    note = note[:note.index("</div>")]
+    assert "display:none" in note, (
+        "the local dashboard runs these scans, so it must not carry the "
+        "'they run elsewhere' line"
+    )
+    key = re.search(r'data-i18n="(security\.cloud_note)"', html)
+    assert key, "the hosted note must be translatable like the rest of the tab"
+    import json
+    assert key.group(1) in json.loads(EN_JSON.read_text(encoding="utf-8")), (
+        "a data-i18n key missing from en.json renders the raw key on screen"
+    )
+
+
+def test_the_note_names_no_raw_error_code_and_says_what_to_do():
+    import json
+    txt = json.loads(EN_JSON.read_text(encoding="utf-8"))["security.cloud_note"]
+    for code in ("forbidden", "500", "undefined", "null", "no_auth", "DuckDB"):
+        assert code not in txt, f"user-facing copy must not carry {code!r}"
+    assert "localhost:8900" in txt, "tell the reader where to go, not just what is missing"


### PR DESCRIPTION
## The report

Hosted dashboard, runtime switcher on Codex. The Security tab was a page of controls that cannot work there:

- **Security Posture** — badge `-`, "Local dashboard only", `-` / `-` / `-` for Passed / Warnings / Failed
- **Threat Detection & Anomaly Alerts** — a heading over `0` / `0` / `0` / `0` tiles, five severity pills filtering an empty list, and a timeline reading "Threat detection runs on your local node"
- **Recorded findings** — "Findings are recorded on the machine your agent runs on"
- **Policy Events (PII · Injection · Credential Leak)** — `-` / `-` / `-`, "Scanning..." forever (its loader is never called on cloud)
- **API Key Scan** — "scanning..." forever, same cause
- **Signature Catalog** — a catalogue of detections that do not run here

> *"if this security is not functional why to show it in codex & make users feel it's a vibe coded software?? let's only show & claim what we really do well"*

## Why none of it can work on cloud

The posture scan reads the machine's agent config (`~/.openclaw/openclaw.json`, `~/.codex/config.toml`, …). The threat, policy and credential scans and the findings feed read that machine's local DuckDB event history. The cloud container has neither, and neither is in the encrypted snapshot — all six endpoints are `oss-passthrough`, so the OSS handler runs against an empty container. `cm-cloud-security` intercepts only `/api/security/integrity` and `/api/security/audit`; `cm-cloud-security-posture` was deleted in cloud #1602 because the daemon never shipped the slice it read.

Nothing errors, so nothing turns red. The page just looks unfinished.

## The change

On cloud those panels are **removed**, not filled with dashes or an apology (`_cmSecurityCloudTrim()`), and one plain sentence says where the scans really run. What stays is what the snapshot actually carries:

- **Tamper-evident log** — real (236,144 chained events on the reporting node)
- **Data retention** — real, already read-only on cloud
- **Recent activity** — real (`auditLog`); when it has no entries it now hides its own panel instead of showing an empty box

The local dashboard is untouched — it runs all of these for real, per runtime.

## Verified

Local dashboard on this branch, Security tab:

| | before/local | after `CLOUD_MODE` |
|---|---|---|
| posture | `B` · 77.3% from `~/.openclaw/openclaw.json` (Codex: `C` · 65.4% from `~/.codex/config.toml`) | panel gone |
| threat heading + tiles + pills + timeline | visible | gone |
| findings / policy events / API key scan / catalogue | visible | gone |
| tamper-evident log · retention · recent activity | visible | visible, with real data |
| the "where these run" line | hidden | shown |

`node --check` on app.js, the served `/` and `/static/js/app.js` grep for the change, and `tests/test_security_tab_cloud_honesty.py` (28 assertions) — which **fails 20 of them on the pre-change files**, so the guard is real. It is named in `ci.yml`, because this job runs file lists.

https://factory.8090.ai/project/b415065f-ab2f-4f53-8864-0c009fd098cb/requirements/0d43a7e7-bea6-4bb4-8aee-c754682c4973

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2jYtu2HxBdgb58htLcDGv
