### PR TITLE
[RELEASE] fix(accuracy): restore full event shape in sessions clusters (tool_count regression from #5524)

### DIFF
--- a/routes/usage.py
+++ b/routes/usage.py
@@ -2567,7 +2567,10 @@ def _try_local_store_sessions_clusters(days: int):
     if not sessions:
         return None
     # One bulk events fetch; group by session_id (avoids N+1 daemon hops).
-    events = _scan_events_slim(since=cutoff_iso, limit=20000) or []
+    # Must use the full event shape (not _scan_events_slim) because the cluster
+    # analysis reads data.tool_calls via _extract_tool_plugins — a key stripped
+    # by the slim projection — and blob-searches data for cron/subagent signals.
+    events = _ls_call("query_events", since=cutoff_iso, limit=20000) or []
     # Issue #1451: sibling-dedupe so the per-session token fallback below
     # doesn't double-count assistant + model.completed pairs on v3 installs.
     bucket_max = build_sibling_bucket_max(events)


### PR DESCRIPTION
## Summary

PR #5524 (`perf(cost): ship slim event rows`) switched all `_ls_call("query_events", ...)` calls to `_scan_events_slim(...)`. The Cost tab endpoints (21 per page load) were the right target; however `_try_local_store_sessions_clusters` was also switched, and that function reads `data.tool_calls` — a key **stripped by the slim projection** (`_SLIM_DROP_KEYS = ("content", "tool_calls")`).

### What breaks

In `_try_local_store_sessions_clusters`:

1. **`tool_counts` under-counts** — `_extract_tool_plugins(data)` reads `data.tool_calls` to find OpenAI-style tool call arrays. With slim events `data.tool_calls` is always absent, so any tool calls stored there are silently dropped. `top_tool` and `total_tools` are wrong for sessions where tools are recorded in `data.tool_calls`.

2. **`has_cron` / `has_subagent` detection loses signal** — the function blob-searches `json.dumps(data).lower()` for `"cron"`, `"scheduled"`, `"subagent"`, `"spawned"`. With slim data, `data.content` and `data.tool_calls` are absent, so any of those keywords appearing only in those fields are missed, mis-classifying sessions in the cluster view.

### Fix

Revert the clusters fetch to `_ls_call("query_events", ...)` (full shape). The clusters endpoint is a single one-shot call per page load — unlike the Cost tab, which fired 21 event queries per request. The 38 MB savings that motivated the slim scan don't apply here.

### Verification

Harness reproducer (requires live workspace):
```bash
python3 scripts/accuracy_harness/tokens.py
```

Static verification: inspect `_extract_tool_plugins` in `dashboard.py` — it reads `obj.get("tool_calls")` from the top-level `data` dict, which confirms the key must be present for correct results.

`OPENCLAW_BIN_AVAILABLE` is not set in the cloud sandbox so automated harness verification is not available; human verification on a live instance is recommended before merge.

No-PRD: accuracy regression fix from a recent perf refactor, single-line correctness fix.

---
🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01VdBDmPvEBARUCPpWi5tPxf

---
_Generated by [Claude Code](https://claude.ai/code/session_01VdBDmPvEBARUCPpWi5tPxf)_