### PR TITLE
fix: correct OpenAI rates and inclusive prompt-cache accounting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,6 +162,9 @@ jobs:
       - name: Every workflow file must parse
         run: python3 -m pytest tests/test_workflow_yaml_valid.py -q
 
+      - name: Published provider pricing and cache accounting
+        run: python3 -m pytest tests/test_providers_pricing.py tests/test_pricing_accuracy.py -q
+
       # Named explicitly because this repo's CI runs FILE LISTS, not
       # `pytest tests/`: a guard added without a line here runs in no job at
       # all. Covers the half `gen_module_map.py --check` cannot: every

--- a/clawmetry/providers_pricing.py
+++ b/clawmetry/providers_pricing.py
@@ -108,6 +108,43 @@ PROVIDER_MAP: dict[str, dict] = {
     },
 }
 
+# OpenAI standard text-token rates, USD per million: input, output, cache read,
+# cache write. None means no published rate for that cache operation.
+# Verified 2026-09-07 against https://developers.openai.com/api/docs/models/<id>
+# and https://developers.openai.com/api/docs/guides/prompt-caching.
+# These are short-context estimates, not historical or service-tier invoices.
+# GPT-5.6 is the Sol alias; its promotional rates last at least to 2026-11-21.
+_OPENAI_PRICES = {
+    "gpt-4o": (2.50, 10.00, 1.25, None),
+    "gpt-4o-mini": (0.15, 0.60, 0.075, None),
+    "gpt-4.1": (2.00, 8.00, 0.50, None),
+    "gpt-4.1-mini": (0.40, 1.60, 0.10, None),
+    "gpt-4.1-nano": (0.10, 0.40, 0.025, None),
+    "gpt-5": (1.25, 10.00, 0.125, None),
+    "gpt-5-mini": (0.25, 2.00, 0.025, None),
+    "gpt-5-nano": (0.05, 0.40, 0.005, None),
+    "gpt-5.1": (1.25, 10.00, 0.125, None),
+    "gpt-5.2": (1.75, 14.00, 0.175, None),
+    "gpt-5.3-codex": (1.75, 14.00, 0.175, None),
+    "gpt-5.4": (2.50, 15.00, 0.25, None),
+    "gpt-5.4-mini": (0.75, 4.50, 0.075, None),
+    "gpt-5.4-nano": (0.20, 1.25, 0.02, None),
+    "gpt-5.4-pro": (30.00, 180.00, None, None),
+    "gpt-5.5": (5.00, 30.00, 0.50, None),
+    "gpt-5.6": (4.00, 20.00, 0.40, 5.00),
+    "gpt-5.6-sol": (4.00, 20.00, 0.40, 5.00),
+    "gpt-5.6-terra": (2.00, 12.00, 0.20, 2.50),
+    "gpt-5.6-luna": (0.20, 1.20, 0.02, 0.25),
+}
+
+
+def _openai_prices(model: str):
+    """Match a documented model or dated snapshot, never an invented variant."""
+    name = (model or "").lower().split("/", 1)[-1]
+    name = re.sub(r"-\d{4}-\d{2}-\d{2}$", "", name)
+    return _OPENAI_PRICES.get(name)
+
+
 # Model-specific overrides (provider, model_prefix) -> (input_per_1m, output_per_1m)
 MODEL_OVERRIDES: dict[tuple[str, str], tuple[float, float]] = {
     ("anthropic", "claude-3-5-haiku"): (0.80, 4.00),
@@ -142,11 +179,6 @@ MODEL_OVERRIDES: dict[tuple[str, str], tuple[float, float]] = {
     ("openai", "o1-mini"): (3.00, 12.00),
     ("openai", "o1"): (15.00, 60.00),
     ("openai", "o3-mini"): (1.10, 4.40),
-    # GPT-5 family (gpt-5.4, gpt-5.6, …). Official prices not yet published —
-    # $10/$40 per 1M is a best-effort estimate; update once OpenAI confirms.
-    # gpt-5.6 entry beats the broad prefix via longest-prefix matching in _get_rates.
-    ("openai", "gpt-5"): (10.00, 40.00),
-    ("openai", "gpt-5.6"): (10.00, 40.00),
     ("gemini", "gemini-2.0-flash"): (0.10, 0.40),
     ("gemini", "gemini-1.5-pro"): (1.25, 5.00),
     ("gemini", "gemini-1.5-flash"): (0.075, 0.30),
@@ -241,6 +273,11 @@ def _get_rates(provider: str, model: str) -> tuple[float, float]:
     # the lookup matches. Compare case-insensitively too (callers vary).
     if prov_lower == "google":
         prov_lower = "gemini"
+
+    if prov_lower == "openai":
+        prices = _openai_prices(model)
+        if prices is not None:
+            return prices[0], prices[1]
 
     if model:
         # Strip a leading provider namespace so OpenRouter ids
@@ -486,13 +523,14 @@ def estimate_event_cost_usd(
 
     Infers the provider from the model when not supplied — important because
     ``_get_rates`` needs the right provider (an empty provider falls through to
-    the conservative unknown default and mis-prices). Prices prompt-cache read
-    and write on top of input+output using Anthropic's documented multipliers
-    (only applied for the anthropic provider, where the split is well-defined).
+    the conservative unknown default and mis-prices). Anthropic cache counts
+    are additional to input_tokens. OpenAI cache counts are INCLUDED in total
+    input_tokens, so replace their ordinary input charge with the published
+    cache rate. Unknown OpenAI models retain the provider baseline estimate.
     Local / self-hosted models resolve to 0. Never raises.
     """
     try:
-        prov = provider or provider_for_model(model)
+        prov = (provider or provider_for_model(model)).lower()
         input_rate, output_rate = _get_rates(prov, model)
         if input_rate == 0 and output_rate == 0:
             return 0.0
@@ -503,6 +541,16 @@ def estimate_event_cost_usd(
         if prov == "anthropic":
             cost += (max(0, int(cache_read_tokens)) / 1_000_000) * input_rate * _CACHE_READ_MULT
             cost += (max(0, int(cache_write_tokens)) / 1_000_000) * input_rate * _CACHE_WRITE_MULT
+        elif prov == "openai":
+            prices = _openai_prices(model)
+            if prices is not None:
+                total_input = max(0, int(input_tokens))
+                cached = min(total_input, max(0, int(cache_read_tokens)))
+                written = min(total_input - cached, max(0, int(cache_write_tokens)))
+                if prices[2] is not None:
+                    cost += cached / 1_000_000 * (prices[2] - input_rate)
+                if prices[3] is not None:
+                    cost += written / 1_000_000 * (prices[3] - input_rate)
         return round(cost, 8)
     except Exception:
         return 0.0

--- a/tests/test_providers_pricing.py
+++ b/tests/test_providers_pricing.py
@@ -2,6 +2,7 @@
 cost source used across the app (cost-intel, out-loop attribution, budgets)."""
 import os
 import sys
+import pytest
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
@@ -68,10 +69,71 @@ def test_local_models_are_free():
     assert _get_rates("", "ollama/llama3.2") == (0.0, 0.0)
 
 
-def test_gpt5_6_priced_explicitly():
-    # GPT-5.x must not fall through to the gpt-4o baseline ($2.50/$10). #3502
-    assert _get_rates("openai", "gpt-5.6") == (10.00, 40.00)
-    assert _get_rates("openai", "gpt-5.4") == (10.00, 40.00)
-    assert _get_rates("openai", "gpt-5") == (10.00, 40.00)
-    # gpt-5.6 prefix wins over the broader gpt-5 prefix
-    assert _get_rates("openai", "gpt-5.6-turbo") == (10.00, 40.00)
+@pytest.mark.parametrize("model,rates", [
+    ("gpt-4.1", (2.0, 8.0)),
+    ("gpt-4.1-mini", (0.4, 1.6)),
+    ("gpt-4.1-nano", (0.1, 0.4)),
+    ("gpt-5", (1.25, 10.0)),
+    ("gpt-5-mini", (0.25, 2.0)),
+    ("gpt-5-nano", (0.05, 0.4)),
+    ("gpt-5.1", (1.25, 10.0)),
+    ("gpt-5.2", (1.75, 14.0)),
+    ("gpt-5.3-codex", (1.75, 14.0)),
+    ("gpt-5.4", (2.5, 15.0)),
+    ("gpt-5.4-mini", (0.75, 4.5)),
+    ("gpt-5.4-nano", (0.2, 1.25)),
+    ("gpt-5.4-pro", (30.0, 180.0)),
+    ("gpt-5.5", (5.0, 30.0)),
+    ("gpt-5.6", (4.0, 20.0)),
+    ("gpt-5.6-sol", (4.0, 20.0)),
+    ("gpt-5.6-terra", (2.0, 12.0)),
+    ("gpt-5.6-luna", (0.2, 1.2)),
+])
+def test_openai_standard_rates_match_published_model_pages(model, rates):
+    # https://developers.openai.com/api/docs/models/<model>, 2026-09-07.
+    assert _get_rates("openai", model) == rates
+    assert _get_rates("openai", "openai/" + model) == rates
+
+
+@pytest.mark.parametrize("model,expected", [
+    ("gpt-4o", 1.375),
+    ("gpt-4o-mini", 0.0825),
+    ("gpt-4.1", 0.65),
+    ("gpt-5", 0.2375),
+    ("openai/gpt-5-2025-08-07", 0.2375),
+    ("gpt-5.6-sol", 0.76),
+])
+def test_openai_cache_reads_are_a_discounted_subset_of_input(model, expected):
+    # One million TOTAL input tokens, of which 900k were cache hits.
+    assert estimate_event_cost_usd(
+        model, input_tokens=1_000_000, cache_read_tokens=900_000,
+    ) == pytest.approx(expected)
+
+
+def test_openai_cache_writes_replace_ordinary_input_tokens():
+    # GPT-5.6: input $4, read $0.40, write $5, output $20 per million.
+    assert estimate_event_cost_usd(
+        "gpt-5.6", input_tokens=1000, output_tokens=100,
+        cache_read_tokens=600, cache_write_tokens=200,
+    ) == pytest.approx(0.00404)
+
+
+def test_openai_cache_counters_are_bounded_by_total_input():
+    assert estimate_event_cost_usd(
+        "gpt-4o", input_tokens=100, cache_read_tokens=1000,
+    ) == pytest.approx(0.000125)
+    assert estimate_event_cost_usd(
+        "gpt-4o", input_tokens=100, cache_read_tokens=-50,
+    ) == pytest.approx(0.00025)
+
+
+def test_openai_unknown_variants_do_not_inherit_a_published_cache_discount():
+    assert _get_rates("openai", "gpt-5.6-turbo") == (2.5, 10.0)
+    assert estimate_event_cost_usd(
+        "unknown-openai-model", input_tokens=100, cache_read_tokens=100,
+        provider="OPENAI",
+    ) == pytest.approx(0.00025)
+    # This model's published pricing has no cached-input rate.
+    assert estimate_event_cost_usd(
+        "gpt-5.4-pro", input_tokens=100, cache_read_tokens=100,
+    ) == pytest.approx(0.003)


### PR DESCRIPTION
**Product record:** https://factory.8090.ai/project/b415065f-ab2f-4f53-8864-0c009fd098cb/requirements/43d6b27c-0e37-45dc-9fdd-df4200844c29

Bug-fix rationale: restore the existing scoped-cost and evidence requirements AC-OBS-CEA-001.1/.2. Reproduction and acceptance details: #5605. No new product capability or billing guarantee is introduced.

**Risk:** Derived historical session estimates may change when recomputed. These are standard short-context text-token estimates, not service-tier or historical invoices. No schema changes. Revert this commit to undo the estimator change.

## Summary

Fixes #5605.

- Replace the guessed GPT-5 $10/$40 family fallback with documented model-specific rates and exact documented/snapshot matching.
- Apply OpenAI cached-input discounts and published cache-write rates to subsets of total input; preserve Anthropic's additive cache accounting and native-cost precedence in callers.
- Explicitly run the pricing regression files in the required Syntax & Lint CI job.

Primary sources checked 2026-09-07: [GPT-5](https://developers.openai.com/api/docs/models/gpt-5), [GPT-4o](https://developers.openai.com/api/docs/models/gpt-4o), [GPT-5.6 Sol](https://developers.openai.com/api/docs/models/gpt-5.6-sol), [prompt caching](https://developers.openai.com/api/docs/guides/prompt-caching). Other rate-table entries were checked against their corresponding official model pages. GPT-5.6 promotional rates require revalidation after the published promotional period.

Concrete regression: one million GPT-5 input tokens, 900,000 cached, changes from $10.00 to $0.2375 at the documented standard rate. This synthetic example is arithmetic, not a customer invoice.

## Test plan

- [x] 27 regression cases failed on the original estimator before implementation.
- [x] `python3 -m pytest tests/test_providers_pricing.py tests/test_pricing_accuracy.py tests/test_session_cost_intel.py -q --tb=short`: 52 passed.
- [x] The same selection plus `tests/test_workflow_yaml_valid.py`: 563 passed, 317 non-applicable workflow cases skipped.
- [x] Cross-repo Codex/orchestration/cost conformance tests against this OSS worktree: 57 passed.
- [x] `git diff --check`.
- [ ] Required hosted CI and drift check.

An expanded diagnostic run also found nine failures in the existing `tests/test_interceptor.py`. Repeating that file with the unmodified baseline pricing module reproduced the same nine failures; they concern token-dict shape, opt-in persistence/activation, and an existing unknown-model expectation. They are not hidden or disabled by this PR.

## Release and documentation boundary

This is a fix PR, not a release PR. No version/tag changes. PyPI release, cloud dependency roll, and live verification remain later flywheel steps. Cache-hit percentage and long-context/service-tier estimation remain separate gaps.

The existing hosted [Cost and Efficiency Analytics Blueprint](https://factory.8090.ai/project/b415065f-ab2f-4f53-8864-0c009fd098cb/blueprints/9cf653c2-5ca4-490c-b0a4-875ae631eb47) was updated and read back at v26 using the repository's documented API client. It now covers documented-rate lookup, inclusive/additive provider cache semantics, model-attributed usage and runtime-scoped hosted rows. The private cloud audit branch also carries the source contract record. Require green drift review before merge; production delivery is still pending.

Prepared with Codex.
