### PR TITLE
fix: use OpenAI cache counter semantics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,7 +163,7 @@ jobs:
         run: python3 -m pytest tests/test_workflow_yaml_valid.py -q
 
       - name: Published provider pricing and cache accounting
-        run: python3 -m pytest tests/test_providers_pricing.py tests/test_pricing_accuracy.py -q
+        run: python3 -m pytest tests/test_providers_pricing.py tests/test_pricing_accuracy.py tests/test_session_cost_intel.py -q
 
       # Named explicitly because this repo's CI runs FILE LISTS, not
       # `pytest tests/`: a guard added without a line here runs in no job at

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -14590,9 +14590,18 @@ def _session_cost_intel(s) -> dict:
             "input": in_t, "output": out_t,
             "cacheRead": cr, "cacheWrite": cw, "reasoning": rt,
         }
-        # Cache-hit %: share of read context served from cache (cheaper).
-        if (in_t + cr) > 0:
-            out["cacheHitPct"] = round(cr / (in_t + cr) * 100, 1)
+        # OpenAI includes cached tokens in input_tokens; Anthropic and unknown
+        # providers report cache reads as an additional counter.
+        from clawmetry.providers_pricing import provider_for_model
+        cached = max(0, cr)
+        input_total = max(0, in_t)
+        denominator = (
+            input_total
+            if provider_for_model(model) == "openai"
+            else input_total + cached
+        )
+        if denominator > 0:
+            out["cacheHitPct"] = round(min(cached, denominator) / denominator * 100, 1)
         # Reasoning-tax $: reasoning tokens priced at the model's output rate.
         if model and rt > 0:
             try:

--- a/tests/test_session_cost_intel.py
+++ b/tests/test_session_cost_intel.py
@@ -27,7 +27,21 @@ def test_cloud_model_reasoning_and_cache():
     )
     assert intel["tokenSplit"]["reasoning"] == 5000
     assert intel["reasoningCostUsd"] > 0  # reasoning billed at the output rate
+    assert intel["cacheHitPct"] == 80.0
+
+
+def test_anthropic_cache_reads_remain_additive():
+    intel = _session_cost_intel(
+        _FakeSession(input=100000, cache_read=80000, model="claude-opus-4-8")
+    )
     assert intel["cacheHitPct"] == round(80000 / 180000 * 100, 1)
+
+
+def test_openai_cache_hit_never_exceeds_one_hundred_percent():
+    intel = _session_cost_intel(
+        _FakeSession(input=100, cache_read=1000, model="gpt-5.4")
+    )
+    assert intel["cacheHitPct"] == 100.0
 
 
 def test_local_model_reasoning_is_real_zero():


### PR DESCRIPTION
## What This PR Does

Fixes #5609. OpenAI reports cached tokens as a subset of input tokens, so session intelligence now divides cache reads by total input for OpenAI models. Anthropic and unknown providers keep the existing additive calculation. Impossible OpenAI counters are clamped to 100%.

The change reuses the existing provider resolver from `providers_pricing.py`. The DuckDB snapshot and browser surfaces already consume the resulting `cacheHitPct` field, so no parallel calculation was added.

No-PRD: focused correction to an already documented provider counter semantic, with no new product behavior or surface.

## Testing

- Regression proven red on the previous calculation: expected 80.0%, received 44.4%
- 54 focused pricing and session intelligence tests pass
- Python syntax compilation passes
- Added the existing session intelligence test file to the explicit CI test list

🤖 Generated with OpenAI Codex