### PR TITLE
[RELEASE] fix(usage): stop double-counting OpenAI cache_read in /api/token-attribution

### DIFF
--- a/routes/usage.py
+++ b/routes/usage.py
@@ -1909,6 +1909,16 @@ def _try_local_store_token_attribution(wanted_sid: str = "", limit: int = 100):
     except Exception:
         return None
 
+    try:
+        from clawmetry.providers_pricing import provider_for_model as _pfm
+    except Exception:
+        _pfm = None
+
+    # Tracks the true input-context denominator for cache_hit_ratio_pct.
+    # For Anthropic (additive schema) each row contributes input + cache_read;
+    # for OpenAI (inclusive schema) cache_read is already in input_tokens.
+    _real_input_context = 0
+
     for r in rows:
         if not isinstance(r, dict):
             continue
@@ -1930,7 +1940,16 @@ def _try_local_store_token_attribution(wanted_sid: str = "", limit: int = 100):
         output_tok = int(splits.get("output_tokens", 0) or 0)
         cache_read = int(splits.get("cache_read_tokens", 0) or 0)
         cache_write = int(splits.get("cache_write_tokens", 0) or 0)
-        total_tok = input_tok + output_tok + cache_read + cache_write
+        _row_prov = _pfm(r.get("model") or "") if _pfm else ""
+        if _row_prov == "openai":
+            # OpenAI inclusive schema: cache_read_tokens are already counted in
+            # input_tokens (total prompt tokens), so adding them again inflates total.
+            total_tok = input_tok + output_tok + cache_write
+            _real_input_context += input_tok
+        else:
+            # Anthropic (and others) additive schema: cache_read is additional context.
+            total_tok = input_tok + output_tok + cache_read + cache_write
+            _real_input_context += input_tok + cache_read
 
         # Fall back to the daemon-stamped scalar column when the data
         # blob splits are empty (e.g. slim ``model.completed`` rows that
@@ -1998,10 +2017,13 @@ def _try_local_store_token_attribution(wanted_sid: str = "", limit: int = 100):
 
         sid = r.get("session_id") or ""
         ts = r.get("ts") or ""
-        cache_hit_pct = (
-            round(cache_read / (input_tok + cache_read) * 100, 1)
-            if (input_tok + cache_read) > 0 else 0.0
-        )
+        if _row_prov == "openai":
+            cache_hit_pct = round(cache_read / input_tok * 100, 1) if input_tok > 0 else 0.0
+        else:
+            cache_hit_pct = (
+                round(cache_read / (input_tok + cache_read) * 100, 1)
+                if (input_tok + cache_read) > 0 else 0.0
+            )
         messages.append({
             "session_id": sid,
             "timestamp": ts,
@@ -2047,10 +2069,9 @@ def _try_local_store_token_attribution(wanted_sid: str = "", limit: int = 100):
     messages.sort(key=lambda m: m.get("timestamp") or "", reverse=True)
     messages = messages[:limit]
 
-    input_plus_cache = totals["input_tokens"] + totals["cache_read_tokens"]
     totals["cache_hit_ratio_pct"] = (
-        round(totals["cache_read_tokens"] / input_plus_cache * 100, 1)
-        if input_plus_cache else 0.0
+        round(totals["cache_read_tokens"] / _real_input_context * 100, 1)
+        if _real_input_context else 0.0
     )
 
     return {

--- a/tests/test_token_attribution_local_store_v3.py
+++ b/tests/test_token_attribution_local_store_v3.py
@@ -260,6 +260,50 @@ def test_session_id_filter_restricts_rows(app):
     assert msgs[0]["tokens"]["total"] == 1500
 
 
+def test_openai_inclusive_cache_no_double_count(app):
+    """OpenAI inclusive-cache schema: cache_read_tokens is a SUBSET of
+    input_tokens (total prompt tokens), not additional context.
+
+    Bug: before the provider-aware fix, total_tokens for a gpt-4o turn with
+    input=150 / cache_read=80 was computed as 150+40+80=270 instead of
+    150+40=190, and cache_hit_ratio_pct used 80/230 ≈ 34.8% instead of
+    80/150 ≈ 53.3%.
+    """
+    a, ls, usage_mod = app
+    store = ls.get_store()
+    sid = "sess-openai-cache"
+    now = time.time()
+
+    # OpenAI-style row: model=gpt-4o; input_tokens=150 (inclusive of 80 cached).
+    store.ingest(_assistant_row(
+        "e-oai", sid, _iso(now - 30),
+        input_t=150, output_t=40, cache_read=80, cache_write=0,
+        cost_total=0.001,
+        model="gpt-4o",
+    ))
+    _drain(store)
+
+    fast = usage_mod._try_local_store_token_attribution()
+    assert fast is not None
+    msgs = fast.get("messages") or []
+    assert len(msgs) == 1
+
+    row = msgs[0]
+    # total must NOT add cache_read again (inclusive schema)
+    assert row["tokens"]["total"] == 190, (
+        f"OpenAI inclusive double-count: expected 190, got {row['tokens']['total']}"
+    )
+    # cache_hit_ratio: 80 / 150 * 100 = 53.3 (numerator / inclusive input)
+    expected_hit = round(80 / 150 * 100, 1)
+    assert row["cache_hit_ratio"] == expected_hit, (
+        f"cache_hit_ratio wrong: expected {expected_hit}, got {row['cache_hit_ratio']}"
+    )
+
+    totals = fast.get("totals") or {}
+    assert totals["total_tokens"] == 190
+    assert totals["cache_hit_ratio_pct"] == expected_hit
+
+
 def test_slim_completed_without_sibling_still_surfaces(app):
     """A standalone ``model.completed`` row (no rich sibling within the
     ±1 s window) must still produce an attribution row via the scalar-


### PR DESCRIPTION
## Problem

`/api/token-attribution` (`_try_local_store_token_attribution` in `routes/usage.py`) inflated `total_tokens` and reported a falsely low `cache_hit_ratio_pct` for every OpenAI (gpt-4o, gpt-4-turbo, etc.) session.

**Root cause:** OpenAI uses an *inclusive* prompt-cache schema — `cache_read_tokens` is a **subset** of `input_tokens` (total prompt tokens already counted). The code treated it as Anthropic's *additive* schema and added `cache_read` a second time:

| Metric | Before (wrong) | After (correct) |
|---|---|---|
| `total_tokens` (input=150, output=40, cache_read=80) | 150+40+80 = **270** | 150+40 = **190** |
| `cache_hit_ratio_pct` | 80/(150+80)·100 = **34.8%** | 80/150·100 = **53.3%** |

The same wrong denominator propagated to the aggregate `cache_hit_ratio_pct` in `totals`.

## Fix

Detect the provider via `providers_pricing.provider_for_model(model)` and branch:

- **openai**: `total_tok = input + output + cache_write`; `cache_hit_pct = cache_read / input`; aggregate denominator = `input` only  
- **anthropic / others**: existing additive logic unchanged

## Files changed

| File | Change |
|---|---|
| `routes/usage.py` | Provider-aware total + cache_hit_ratio_pct in `_try_local_store_token_attribution` |
| `tests/test_token_attribution_local_store_v3.py` | New `test_openai_inclusive_cache_no_double_count` asserting correct totals for a gpt-4o row |

## Test

```
pytest tests/test_token_attribution_local_store_v3.py -v
# 6 passed (includes new openai test)
```

No-PRD: single-bug accuracy fix with < 50 LOC change, no new API surface.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01TuKnuEadi5ohf28GDr9TCD

---
_Generated by [Claude Code](https://claude.ai/code/session_01TuKnuEadi5ohf28GDr9TCD)_