### PR TITLE
Harden deps: clear the setup-openclaw advisories that don't need the pin to move

### DIFF
--- a/.github/actions/setup-openclaw/package-lock.json
+++ b/.github/actions/setup-openclaw/package-lock.json
@@ -1471,23 +1471,6 @@
         "tar": "7.5.13"
       }
     },
-    "node_modules/@openclaw/fs-safe/node_modules/tar": {
-      "version": "7.5.13",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
-      "integrity": "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==",
-      "license": "BlueOak-1.0.0",
-      "optional": true,
-      "dependencies": {
-        "@isaacs/fs-minipass": "^4.0.0",
-        "chownr": "^3.0.0",
-        "minipass": "^7.1.2",
-        "minizlib": "^3.1.0",
-        "yallist": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@opentelemetry/semantic-conventions": {
       "version": "1.43.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.43.0.tgz",
@@ -5232,9 +5215,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.15",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.15.tgz",
-      "integrity": "sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ==",
+      "version": "7.5.22",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+      "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
@@ -5434,9 +5417,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-8.2.0.tgz",
-      "integrity": "sha512-Z+4Hx9GE26Lh9Upwfnc8C7SsrpBPGaM/Gm6kMFtiG7c+5IvQKlXi/t+9x9DrrCh29cww5TSP9YdVaBcnLDs5fQ==",
+      "version": "8.10.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.2.tgz",
+      "integrity": "sha512-/y4/bH9YNU5hi9NIrpOuvGXFcxrj3CMrV+/AYpowAYTpHn8gX/XPFjNy766FPoYY0miQhdW977JFWKGNhBdwyQ==",
       "license": "MIT",
       "engines": {
         "node": ">=22.19.0"
@@ -5623,9 +5606,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/.github/actions/setup-openclaw/package.json
+++ b/.github/actions/setup-openclaw/package.json
@@ -4,7 +4,43 @@
   "private": true,
   "description": "Pinned OpenClaw CLI for the setup-openclaw composite action. CI-only: nothing here ships in the clawmetry wheel or is imported by the dashboard.",
   "license": "UNLICENSED",
+  "//overrides": [
+    "The openclaw pin cannot move: see the note on this directory's Dependabot",
+    "entry in .github/dependabot.yml. 2026.5.12 is the last release that still",
+    "writes per-session agents/main/sessions/*.jsonl, which is the only shape",
+    "clawmetry/sync.py globs. So `npm audit fix` -- which resolves every finding",
+    "here by bumping openclaw to 2026.6.34 -- is not available to us.",
+    "",
+    "These overrides take the subset of that fix that does NOT require moving",
+    "openclaw: each is a patch/minor bump inside the major the tree already",
+    "resolves, so no consumer sees a new API surface. Keys are range-scoped",
+    "(name@major) deliberately -- a bare `undici` key would also rewrite the",
+    "undici@7.29.1 that @earendil-works/pi-ai resolves, which IS a major bump.",
+    "",
+    "  tar@7    7.5.15 / 7.5.13 -> 7.5.22  clears GHSA-23hp-3jrh-7fpw (critical),",
+    "                                      GHSA-8x88-c5mf-7j5w, GHSA-r292-9mhp-454m,",
+    "                                      GHSA-vmf3-w455-68vh, GHSA-w8wr-v893-vjvp,",
+    "                                      GHSA-gvwx-54wh-qm9j",
+    "  undici@8 8.2.0 -> 8.10.2            clears GHSA-vmh5-mc38-953g and the ten",
+    "                                      other 8.x advisories",
+    "  ws@8     8.20.0 -> 8.21.3           clears GHSA-96hv-2xvq-fx4p, GHSA-58qx-3vcg-4xpx",
+    "",
+    "What these deliberately do NOT cover, because no override can:",
+    "  extract-zip      GHSA-jmr9-qjv8-65gv has no fixed release; 2.0.1 is latest",
+    "                   and is itself in range.",
+    "  pdfjs-dist       fix is 6.2.108, a major bump from the 5.7.284 in tree.",
+    "  markdown-it      fix is 15.x, a major bump from 14.1.1.",
+    "  pi-coding-agent  fix is 0.79.0, which arrives with the openclaw bump.",
+    "  openclaw itself  its own advisories are fixed only by the version bump.",
+    "Those stay open against the pin, and close when the daemon can read the",
+    "OpenClaw SQLite transcript and the pin can finally move."
+  ],
   "dependencies": {
     "openclaw": "2026.5.12"
+  },
+  "overrides": {
+    "tar@7": "7.5.22",
+    "undici@8": "8.10.2",
+    "ws@8": "8.21.3"
   }
 }


### PR DESCRIPTION
No-PRD: CI-only supply-chain fix. Both files are under `.github/` and are a dependency manifest and its lockfile — doubly exempt under `scripts/check_product_record.py` (`EXEMPT_PREFIXES` and the lockfile basename rule). What justifies it is the advisory set, not a requirement written first.

**Risk:** Confined to CI. Nothing here ships in the clawmetry wheel or is imported by the dashboard — this directory exists only so `setup-openclaw` can `npm ci` a pinned OpenClaw for E2E jobs. The real risk is that an override supersedes a version OpenClaw pinned exactly, so a caller could meet an API it did not expect; each bump is patch/minor inside the major already in tree, and the three modules were exercised directly (below). Undone by reverting the `overrides` block and regenerating the lockfile. Nothing retroactive, no migration, no in-flight collision — no other open PR touches this directory.

---

## Summary

- `.github/actions/setup-openclaw` carried **9 advisories: 1 critical, 6 high, 2 moderate**. `npm audit fix` resolves every one of them the same way — bump `openclaw` to 2026.6.34 — and that is the one move this repository cannot make. 2026.5.12 is the last release still writing per-session `agents/main/sessions/*.jsonl`, which is the only shape `clawmetry/sync.py` globs, so the bump takes the live E2E suites red until the daemon can read the OpenClaw SQLite transcript. That constraint is already written down on this directory's Dependabot entry in `.github/dependabot.yml`; this PR respects it rather than re-litigating it.
- So take the part of the fix that leaves the pin alone. Three range-scoped overrides, each a patch/minor bump inside the major already resolved:

  | override | before | after |
  |---|---|---|
  | `tar@7` | 7.5.15 / 7.5.13 | 7.5.22 |
  | `undici@8` | 8.2.0 | 8.10.2 |
  | `ws@8` | 8.20.0 | 8.21.3 |

- **Result: 1 critical + 6 high + 2 moderate → 0 critical + 4 high + 1 moderate.** `openclaw` stays 2026.5.12.
- Keys are scoped by major deliberately. A bare `undici` key would also rewrite the `undici@7.29.1` that `@earendil-works/pi-ai` resolves — a major bump for that consumer, and not something an advisory fix should smuggle in. Verified it stays 7.29.1.
- The remaining five are not reachable by any override: one has no fixed release published at all, two would need major bumps, and the rest are fixed only by the `openclaw` bump itself. They close when the pin can move. The `//overrides` block in `package.json` records which is which, so the next person does not re-derive it.

## Test plan

- [x] `npm audit` before: `{critical: 1, high: 6, moderate: 2, total: 9}`
- [x] `npm audit` after: `{critical: 0, high: 4, moderate: 1, total: 5}`
- [x] Lockfile resolves as intended — `tar` 7.5.22, `undici` 8.10.2, `ws` 8.21.3, `openclaw` **still 2026.5.12**, nested `@earendil-works/pi-ai` `undici` **still 7.29.1**
- [x] `npm ci --no-audit --no-fund` from the regenerated lockfile — 427 packages, clean (this is the exact command the composite action runs)
- [x] `openclaw --version` → `OpenClaw 2026.5.12 (f066dd2)`, and `openclaw --help` renders — the action's own verify step
- [x] `ws` exercised on the gateway's shape: `WebSocketServer` + client JSON-RPC round-trip on a local port, echoed correctly
- [x] `undici` exercised: `request()` over HTTPS returned 200
- [x] `tar` exercised: gzip create + extract round-trip, content matched
- [x] `require()` of all three overridden modules succeeds at the forced versions
- [x] Node 22 (the major `setup-openclaw` pins via `node-version: "22"`)

Full E2E against a live OpenClaw is CI's to run — the suites that consume this action are the check that matters for the `ws` bump, and they run on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YAULS1C7kJ2fAAT7EpHZ9f

---
_Generated by [Claude Code](https://claude.ai/code/session_01YAULS1C7kJ2fAAT7EpHZ9f)_