### PR TITLE
Stop blaming a 32-bit interpreter's pip failure on Python age in desktop bootstrap

### DIFF
--- a/desktop/app.py
+++ b/desktop/app.py
@@ -691,13 +691,21 @@ def _bootstrap_python(cache_file: Optional[Path] = None) -> Optional[str]:
     # — a dead end this probe must reject up front. venv+ensurepip is
     # all the BASE interpreter needs (the venv seeds its own pip);
     # requiring `import pip` here rejected perfectly usable pythons.
-    # The probe also prints "major.minor" so the winner's version rides
-    # along in the cache — the field-failure report wants to say WHICH
-    # Python a bootstrap died on (the 2026-08-29 cffi failure was
-    # invisible precisely because nothing recorded "3.14").
+    # The probe also prints "major.minor bits" so the winner's version
+    # (and word size) rides along in the cache — the field-failure report
+    # wants to say WHICH Python a bootstrap died on (the 2026-08-29 cffi
+    # failure was invisible precisely because nothing recorded "3.14"),
+    # and a 32-bit interpreter is the one other thing this probe can
+    # cheaply rule in or out: PyPI stopped shipping win32 wheels for
+    # duckdb/cryptography years ago, so a 32-bit Python satisfies this
+    # version floor and still hits "no matching distribution" on every
+    # pip run — a failure the old hint blamed on Python being "too old",
+    # which cannot be true of an interpreter this same probe already
+    # accepted.
     probe = (
         "import sys, venv, ensurepip; "
-        "print('%d.%d' % sys.version_info[:2]); "
+        "print('%d.%d %d' % (sys.version_info[0], sys.version_info[1], "
+        "64 if sys.maxsize > 2**32 else 32)); "
         "sys.exit(0 if sys.version_info >= (3, 9) else 3)"
     )
     for p in paths:
@@ -716,10 +724,11 @@ def _bootstrap_python(cache_file: Optional[Path] = None) -> Optional[str]:
             if r.returncode == 0:
                 if cache_file is not None:
                     try:
-                        cache_file.write_text(json.dumps({
-                            "python": p,
-                            "version": (r.stdout or "").strip()[:8],
-                        }))
+                        parts = (r.stdout or "").strip().split()
+                        payload = {"python": p, "version": parts[0][:8] if parts else ""}
+                        if len(parts) > 1 and parts[1] in ("32", "64"):
+                            payload["bits"] = int(parts[1])
+                        cache_file.write_text(json.dumps(payload))
                     except OSError:
                         pass
                 return p
@@ -738,6 +747,19 @@ def _bootstrap_python_version(cache_file: Optional[Path]) -> str:
         return v if re.fullmatch(r"\d+\.\d+", v) else ""
     except Exception:
         return ""
+
+
+def _bootstrap_python_bits(cache_file: Optional[Path]) -> int:
+    """32 or 64, the word size of the cached bootstrap interpreter, or 0
+    when unknown (no probe has succeeded yet, or the cache predates the
+    bits field)."""
+    if cache_file is None:
+        return 0
+    try:
+        b = json.loads(cache_file.read_text()).get("bits")
+        return b if b in (32, 64) else 0
+    except Exception:
+        return 0
 
 
 def _winget_install_python(log: Callable[[str], None]) -> None:
@@ -789,8 +811,12 @@ _PIP_FAILURE_HINTS = {
         "python.org Python 3.12/3.13 and relaunch."
     ),
     "no_distribution": (
-        "Python too old or PyPI unreachable — "
-        "install python.org Python 3.11+ and relaunch."
+        "PyPI has no matching package build for this Python — "
+        "install 64-bit python.org Python 3.11+ and relaunch."
+    ),
+    "arch_32bit": (
+        "This Python is 32-bit, but ClawMetry's dependencies only ship "
+        "64-bit builds — install 64-bit python.org Python 3.11+ and relaunch."
     ),
     "tls_intercepted": (
         "A firewall or proxy is intercepting TLS to pypi.org — "
@@ -1105,6 +1131,7 @@ class RuntimeSupervisor:
         # valid and a stale value can never outlive the attempt.
         self.failure_class: Optional[str] = None
         self.bootstrap_python_version: str = ""
+        self.bootstrap_python_bits: int = 0
         if self._venv_clawmetry().exists():
             # The exe stub existing is NOT the package existing. A pip
             # upgrade that dies between uninstall and install (live field
@@ -1141,6 +1168,7 @@ class RuntimeSupervisor:
             self.failure_class = "no_python"
             return False
         self.bootstrap_python_version = _bootstrap_python_version(cache)
+        self.bootstrap_python_bits = _bootstrap_python_bits(cache)
         self._log(f"bootstrap python: {py}")
 
         # Health check, not existence check: we only get here with no
@@ -1166,6 +1194,7 @@ class RuntimeSupervisor:
                     self.failure_class = "venv_setup_failed"
                     return False
                 self.bootstrap_python_version = _bootstrap_python_version(cache)
+                self.bootstrap_python_bits = _bootstrap_python_bits(cache)
 
         self.on_status("Installing ClawMetry from PyPI")
         rc, out = self._pip_install_clawmetry()
@@ -1178,6 +1207,16 @@ class RuntimeSupervisor:
                 rc, out = self._pip_install_clawmetry()
         if rc != 0:
             self.failure_class = self._classify_pip_failure(out)
+            # A 32-bit interpreter satisfies the >=3.9 floor `_bootstrap_
+            # python` probes for and still hits "no matching distribution"
+            # on every run, because PyPI stopped shipping win32 wheels for
+            # duckdb/cryptography years ago. The generic hint blamed
+            # Python being "too old", which cannot be true of an
+            # interpreter this same probe already accepted (field failure
+            # 2026-09-07: no_distribution on a probed, floor-satisfying
+            # Windows py3.11).
+            if self.failure_class == "no_distribution" and self.bootstrap_python_bits == 32:
+                self.failure_class = "arch_32bit"
             hint = _PIP_FAILURE_HINTS[self.failure_class]
             self.on_status(f"Install failed: {hint} Log: {self.log_file}")
             return False

--- a/tests/test_desktop_bootstrap_resilience.py
+++ b/tests/test_desktop_bootstrap_resilience.py
@@ -26,6 +26,7 @@ Properties under test:
 """
 from __future__ import annotations
 
+import json
 import subprocess
 import sys
 import threading
@@ -378,6 +379,75 @@ def test_version_reader_tolerates_legacy_cache(tmp_path):
     cache.write_text('{"python": "/usr/bin/python3"}')
     assert dapp._bootstrap_python_version(cache) == ""
     assert dapp._bootstrap_python_version(None) == ""
+
+
+# ── 6b. a 32-bit interpreter is not "Python too old" (#5628) ─────────────
+#
+# Field failure 2026-09-07: `no_distribution` on Windows py3.11. But
+# `_bootstrap_python` only ever returns an interpreter that already passed
+# its own `sys.version_info >= (3, 9)` probe, so "Python too old" cannot be
+# the real cause of a no_distribution failure reached through bootstrap() —
+# and telling a user who already has 3.11 to "install Python 3.11+" fixes
+# nothing. The actual, checkable cause PyPI hits this way is a 32-bit
+# interpreter: duckdb/cryptography stopped shipping win32 wheels years ago,
+# so a 32-bit Python satisfies the floor and still gets "no matching
+# distribution" on every relaunch.
+
+
+def test_bootstrap_python_bits_reads_the_probed_word_size(tmp_path):
+    cache = tmp_path / "bootstrap-python.json"
+    py = dapp._bootstrap_python(cache)
+    assert py
+    bits = dapp._bootstrap_python_bits(cache)
+    assert bits in (32, 64), f"probe must record a word size, got {bits!r}"
+
+
+def test_bootstrap_python_bits_tolerates_legacy_cache(tmp_path):
+    cache = tmp_path / "bootstrap-python.json"
+    cache.write_text('{"python": "/usr/bin/python3", "version": "3.11"}')
+    assert dapp._bootstrap_python_bits(cache) == 0
+    assert dapp._bootstrap_python_bits(None) == 0
+
+
+def test_no_distribution_on_a_32bit_interpreter_blames_the_architecture(
+        tmp_path, monkeypatch):
+    """Reproduction of #5628: a floor-satisfying but 32-bit interpreter
+    hits no_distribution, and the surfaced hint must say so instead of
+    claiming the already-adequate Python is too old."""
+    sup = _sup(tmp_path)
+    py = dapp._bootstrap_python()
+    assert py
+    assert sup._create_venv(py)
+    # Simulate the probe having found a 32-bit Python 3.11: this sandbox's
+    # own interpreter is 64-bit, so the fact is forged into the same cache
+    # file `bootstrap()` reads, rather than requiring an actual 32-bit
+    # install. `_bootstrap_python` short-circuits on a cached path that
+    # still exists on disk, so the forged version/bits survive untouched.
+    cache = sup.runtime / "bootstrap-python.json"
+    cache.write_text(json.dumps({"python": py, "version": "3.11", "bits": 32}))
+    monkeypatch.setattr(
+        sup, "_pip_install_clawmetry",
+        lambda: (1, "ERROR: No matching distribution found for duckdb"))
+    assert sup.bootstrap() is False
+    assert sup.failure_class == "arch_32bit"
+    status = sup.statuses[-1]
+    assert "32-bit" in status
+    assert "too old" not in status.lower()
+
+
+def test_no_distribution_on_a_64bit_interpreter_keeps_the_generic_hint(
+        tmp_path, monkeypatch):
+    sup = _sup(tmp_path)
+    py = dapp._bootstrap_python()
+    assert py
+    assert sup._create_venv(py)
+    cache = sup.runtime / "bootstrap-python.json"
+    cache.write_text(json.dumps({"python": py, "version": "3.11", "bits": 64}))
+    monkeypatch.setattr(
+        sup, "_pip_install_clawmetry",
+        lambda: (1, "ERROR: No matching distribution found for clawmetry"))
+    assert sup.bootstrap() is False
+    assert sup.failure_class == "no_distribution"
 
 
 # ── 7. an exe stub is not an install (package-corpse recovery) ───────────


### PR DESCRIPTION
**Product record:**

No-PRD: fix of field-reported bug #5628

**Risk:** None. Additive: a new `bits` key in the existing bootstrap-python cache JSON (old caches without it just read back `0`/unknown), a new `arch_32bit` entry in the closed `_PIP_FAILURE_HINTS`/failure-class enum, and a corrected string for the existing `no_distribution` hint. No change to control flow, no data migration, nothing reversible-only-with-effort. A legacy cache file without `bits` behaves exactly as before (falls through to the generic `no_distribution` hint).

---

## Summary

- Repro (issue #5628, "no_distribution on Windows (py 3.11)"): `_bootstrap_python()` only ever returns an interpreter that already passed its own `sys.version_info >= (3, 9)` probe, so a `no_distribution` pip failure reached through `bootstrap()` can never actually mean "Python too old" — yet that's exactly what the old hint said, telling a user who already has 3.11 to go install 3.11+, which fixes nothing. The realistic, checkable cause PyPI surfaces this way on a floor-satisfying interpreter is a 32-bit Python: `duckdb`/`cryptography` no longer publish win32 wheels, so a 32-bit interpreter passes the version probe and then fails every `pip install` with "no matching distribution".
- Fix: the interpreter probe in `desktop/app.py::_bootstrap_python` now also reports its word size (`sys.maxsize > 2**32`), cached alongside the version it already recorded. A new `_bootstrap_python_bits()` reader mirrors the existing `_bootstrap_python_version()`. When a pip failure classifies as `no_distribution` and the probed interpreter is 32-bit, `bootstrap()` now reports it as `arch_32bit` with an accurate, actionable hint ("This Python is 32-bit... install 64-bit python.org Python 3.11+"). The generic `no_distribution` hint is also corrected to stop asserting "Python too old" as a cause, since the interpreter that reaches this code path is never too old by construction.

## Test plan

- [x] Added `test_bootstrap_python_bits_reads_the_probed_word_size` / `test_bootstrap_python_bits_tolerates_legacy_cache` — the new cache reader over a real probe and over a legacy (no `bits` key) cache.
- [x] Added `test_no_distribution_on_a_32bit_interpreter_blames_the_architecture` — reproduces #5628 end-to-end through `bootstrap()` (forging a floor-satisfying, 32-bit interpreter into the bootstrap cache, since this sandbox's own Python is 64-bit) and asserts the surfaced status names the architecture and never says "too old".
- [x] Added `test_no_distribution_on_a_64bit_interpreter_keeps_the_generic_hint` — same failure text on a 64-bit interpreter still classifies as plain `no_distribution`.
- [x] Red-before-green: stashed the `desktop/app.py` fix and reran the suite — the 3 new tests fail (`AttributeError: no attribute '_bootstrap_python_bits'`, then `'no_distribution' == 'arch_32bit'` assertion) exactly as expected; restored the fix and all 39 tests in `tests/test_desktop_bootstrap_resilience.py` pass.
- [x] `tests/test_desktop_bootstrap_resilience.py` is already wired into `.github/workflows/ci.yml` (`python3 -m pytest tests/test_desktop_bootstrap_resilience.py -q`), so no CI file-list change needed.
- [x] `python3 -m py_compile desktop/app.py tests/test_desktop_bootstrap_resilience.py` — no syntax errors.

Closes #5628

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011E8zKv7PHzobVfiYC56Z6t

---
_Generated by [Claude Code](https://claude.ai/code/session_011E8zKv7PHzobVfiYC56Z6t)_