### PR TITLE
feat(obs-gap): capture backup-outcome gateway events in OpenClaw adapter (#5618)

### DIFF
--- a/clawmetry/adapters/openclaw.py
+++ b/clawmetry/adapters/openclaw.py
@@ -863,13 +863,14 @@ def _backup_outcome_events(events: list) -> dict:
     A corrupt-archive rejection is a data-loss-adjacent event: the backup did
     not complete, but silently.  This scanner makes it visible in ClawMetry.
 
-    Scans the already-fetched events list (no extra I/O).  Matches entries whose
-    ``msg`` contains any of: ``"backup"``, ``"corrupt"``, ``"archive"``,
-    ``"integrity"``.  Returns a dict with ``backupOutcomeDetected=True``,
-    ``backupOutcomeMsg``, and optionally ``backupOutcomeTs`` and
-    ``backupCorruptArchiveRejected=True`` (when a corrupt-archive keyword is
-    present).  Returns ``{}`` when no backup event is found.  Never raises
-    (closes #5618).
+    Scans the already-fetched events list (no extra I/O).  Matches entries
+    whose ``msg`` contains ``"backup"`` (the match trigger).  Within a matching
+    entry, the additional keywords ``"corrupt"``, ``"integrity"``,
+    ``"reject"``, and ``"invalid"`` determine whether to set
+    ``backupCorruptArchiveRejected=True``.  Returns a dict with
+    ``backupOutcomeDetected=True``, ``backupOutcomeMsg``, and optionally
+    ``backupOutcomeTs`` and ``backupCorruptArchiveRejected=True``.  Returns
+    ``{}`` when no backup event is found.  Never raises (closes #5618).
     """
     try:
         if not events:

--- a/clawmetry/adapters/openclaw.py
+++ b/clawmetry/adapters/openclaw.py
@@ -854,6 +854,54 @@ def _gateway_oom_victim(events: list) -> dict:
         return {}
 
 
+def _backup_outcome_events(events: list) -> dict:
+    """Return backup-outcome metadata when the gateway logs a backup event.
+
+    OpenClaw 2026.9.2+ ("Backups that preserve your data") improved the backup
+    pipeline to reject corrupt archive headers instead of silently accepting an
+    incomplete backup, and to preserve NUL-containing text in Git backups.
+    A corrupt-archive rejection is a data-loss-adjacent event: the backup did
+    not complete, but silently.  This scanner makes it visible in ClawMetry.
+
+    Scans the already-fetched events list (no extra I/O).  Matches entries whose
+    ``msg`` contains any of: ``"backup"``, ``"corrupt"``, ``"archive"``,
+    ``"integrity"``.  Returns a dict with ``backupOutcomeDetected=True``,
+    ``backupOutcomeMsg``, and optionally ``backupOutcomeTs`` and
+    ``backupCorruptArchiveRejected=True`` (when a corrupt-archive keyword is
+    present).  Returns ``{}`` when no backup event is found.  Never raises
+    (closes #5618).
+    """
+    try:
+        if not events:
+            return {}
+        _BACKUP_KEYWORDS = ("backup",)
+        _CORRUPT_KEYWORDS = ("corrupt", "integrity", "reject", "invalid")
+        for evt in events:
+            if not isinstance(evt, dict):
+                continue
+            raw_msg = evt.get("msg", "")
+            msg = str(raw_msg).lower()
+            if not msg:
+                continue
+            is_backup = any(kw in msg for kw in _BACKUP_KEYWORDS)
+            if not is_backup:
+                continue
+            result: dict = {
+                "backupOutcomeDetected": True,
+                "backupOutcomeMsg": str(raw_msg),
+            }
+            ts = evt.get("ts")
+            if ts is not None:
+                result["backupOutcomeTs"] = ts
+            is_corrupt = any(kw in msg for kw in _CORRUPT_KEYWORDS)
+            if is_corrupt:
+                result["backupCorruptArchiveRejected"] = True
+            return result
+        return {}
+    except Exception:
+        return {}
+
+
 def _openshell_sandbox_logs(name: str, count: int = 20) -> list:
     """Retrieve OCSF JSON audit log lines for a NemoClaw sandbox.
 
@@ -2659,6 +2707,15 @@ class OpenClawAdapter(AgentAdapter):
             _oom = _gateway_oom_victim(_gw_events)
             if _oom:
                 meta.update(_oom)
+            # Backup-outcome detection (#5618): OpenClaw 2026.9.2 rejects corrupt
+            # archive headers instead of silently accepting an incomplete backup.
+            # A corrupt-archive rejection is data-loss-adjacent and was invisible
+            # to ClawMetry before this.  Scan the already-fetched events so there
+            # is no extra I/O; surface backupOutcomeDetected (and optionally
+            # backupCorruptArchiveRejected) so the dashboard can flag it.
+            _backup = _backup_outcome_events(_gw_events)
+            if _backup:
+                meta.update(_backup)
             # Skill Workshop approval-policy (#3992): surfaces
             # skills.workshop.approvalPolicy from openclaw.json so cloud-synced
             # fleet views know whether autonomous skill actions are gated by

--- a/tests/test_obs_gap_openclaw_backup_5618.py
+++ b/tests/test_obs_gap_openclaw_backup_5618.py
@@ -1,0 +1,101 @@
+"""Regression tests for the backup-outcome gateway event scanner.
+
+Closes: vivekchand/clawmetry#5618
+"""
+import pytest
+from clawmetry.adapters.openclaw import _backup_outcome_events
+
+
+# ---------------------------------------------------------------------------
+# corrupt-archive rejection
+# ---------------------------------------------------------------------------
+
+def test_corrupt_archive_rejection_detected():
+    events = [
+        {"msg": "backup rejected: corrupt archive header detected", "ts": "2026-09-07T01:00:00Z"},
+    ]
+    result = _backup_outcome_events(events)
+    assert result["backupOutcomeDetected"] is True
+    assert result["backupCorruptArchiveRejected"] is True
+    assert result["backupOutcomeTs"] == "2026-09-07T01:00:00Z"
+    assert "corrupt archive header" in result["backupOutcomeMsg"]
+
+
+def test_backup_integrity_failure_detected():
+    events = [
+        {"msg": "backup integrity check failed — archive is incomplete", "ts": "2026-09-07T02:00:00Z"},
+    ]
+    result = _backup_outcome_events(events)
+    assert result["backupOutcomeDetected"] is True
+    assert result["backupCorruptArchiveRejected"] is True
+
+
+# ---------------------------------------------------------------------------
+# plain backup failure (no corrupt keyword)
+# ---------------------------------------------------------------------------
+
+def test_plain_backup_failure_no_corrupt_flag():
+    events = [
+        {"msg": "backup failed: disk write error"},
+    ]
+    result = _backup_outcome_events(events)
+    assert result["backupOutcomeDetected"] is True
+    assert result.get("backupCorruptArchiveRejected") is None
+
+
+# ---------------------------------------------------------------------------
+# backup success
+# ---------------------------------------------------------------------------
+
+def test_backup_success_detected():
+    events = [
+        {"msg": "backup completed successfully", "ts": "2026-09-07T03:00:00Z"},
+    ]
+    result = _backup_outcome_events(events)
+    assert result["backupOutcomeDetected"] is True
+    assert result.get("backupCorruptArchiveRejected") is None
+
+
+# ---------------------------------------------------------------------------
+# no backup events → empty dict
+# ---------------------------------------------------------------------------
+
+def test_no_backup_events_returns_empty():
+    events = [
+        {"msg": "gateway started", "ts": "2026-09-07T00:00:00Z"},
+        {"msg": "oom: model server killed", "ts": "2026-09-07T00:01:00Z"},
+    ]
+    assert _backup_outcome_events(events) == {}
+
+
+def test_empty_events_list():
+    assert _backup_outcome_events([]) == {}
+
+
+def test_none_msg_skipped():
+    events = [{"msg": None}, {"msg": "backup done"}]
+    result = _backup_outcome_events(events)
+    assert result["backupOutcomeDetected"] is True
+
+
+# ---------------------------------------------------------------------------
+# exception safety
+# ---------------------------------------------------------------------------
+
+def test_exception_safety_returns_empty():
+    assert _backup_outcome_events(None) == {}  # type: ignore[arg-type]
+    assert _backup_outcome_events("not-a-list") == {}  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# first matching event wins
+# ---------------------------------------------------------------------------
+
+def test_first_backup_event_wins():
+    events = [
+        {"msg": "backup rejected: corrupt archive", "ts": "2026-09-07T01:00:00Z"},
+        {"msg": "backup completed", "ts": "2026-09-07T02:00:00Z"},
+    ]
+    result = _backup_outcome_events(events)
+    assert result["backupOutcomeTs"] == "2026-09-07T01:00:00Z"
+    assert result["backupCorruptArchiveRejected"] is True


### PR DESCRIPTION
No-PRD: automated harness-gap observability addition; reads a new signal from an already-fetched event stream, no product decision required.

**Risk:** None — additive only. `_backup_outcome_events` is a pure function over the already-fetched `_gw_events` list: zero extra I/O, zero schema changes, zero auth/billing/security paths. The three new keys (`backupOutcomeDetected`, `backupOutcomeMsg`, `backupCorruptArchiveRejected`) are set in `meta` only when a matching gateway event exists; otherwise `detect()` is unchanged. Revert is a two-function rollback.

---

## Summary

OpenClaw 2026.9.2 improved its backup pipeline to reject corrupt archive headers instead of silently accepting incomplete backups — but ClawMetry had no read path for backup outcomes at all. A corrupt-archive rejection (a data-loss-adjacent event) was completely invisible in the dashboard. This PR fixes that by adding a `_backup_outcome_events()` gateway event scanner following the exact established pattern (`_gateway_oom_victim` / `_gateway_migration_warning`).

## Changes

- **`clawmetry/adapters/openclaw.py`**: Adds `_backup_outcome_events(events: list) -> dict` — scans already-fetched gateway log events for backup-surface keywords (`"backup"`, `"corrupt"`, `"integrity"`, `"reject"`). Returns `backupOutcomeDetected=True` + `backupOutcomeMsg` on any backup event; also sets `backupCorruptArchiveRejected=True` when a corrupt-archive keyword is present. Returns `{}` on no match, never raises. Wired into `detect()` immediately after the `_gateway_oom_victim` block (same `if _x: meta.update(_x)` pattern).
- **`tests/test_obs_gap_openclaw_backup_5618.py`**: 9 tests covering corrupt-archive rejection, integrity failure, plain backup failure (no corrupt flag), backup success, no-backup-events case, empty list, `None` msg, exception safety, and first-event-wins ordering.

## Test plan

- [x] `python3 -c 'import ast; ast.parse(open("clawmetry/adapters/openclaw.py").read())'` — syntax clean
- [x] `python3 -m pytest tests/test_obs_gap_openclaw_backup_5618.py -q` — 9/9 passed
- [x] Red-before-green verified: removing `_backup_outcome_events` makes all 9 tests fail with `ImportError`; restoring it makes all 9 pass
- [ ] **Note for maintainer:** `tests/test_obs_gap_openclaw_backup_5618.py` needs to be added to the explicit file list in `.github/workflows/ci.yml` before CI will run it in the matrix (per CLAUDE.md convention)

## Bot meta
<!-- bot-autofix -->
Draft PR opened autonomously based on the plan in #5618. Marked draft for human review — mark Ready for Review once happy.

Closes #5618

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P7ywmqwtfr49eN4cenJrX5