### PR TITLE
[RELEASE] fix(accuracy): provider-aware cache_hit_ratio denominator in by_model cache-trends

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -491,6 +491,7 @@ jobs:
             tests/test_launchd_dashboard_runs_waitress.py \
             tests/test_scan_read_cache.py \
             tests/test_cache_push_gating.py \
+            tests/test_usage_cache_trends_local_store.py \
             tests/test_transcript_local_store.py \
             tests/test_moat_perf_benchmark.py \
             tests/test_runtime_detection_snapshot.py \

--- a/routes/usage.py
+++ b/routes/usage.py
@@ -3856,11 +3856,14 @@ def _empty_cache_bucket():
     }
 
 
-def _summarise_cache_bucket(label, b, key):
-    in_plus_cache = b["input_tokens"] + b["cache_read_tokens"]
+def _summarise_cache_bucket(label, b, key, *, openai_schema=False):
+    # OpenAI inclusive schema: cache_read is already counted inside input_tokens,
+    # so the effective context denominator is input_tokens alone.
+    # Anthropic (and others) additive schema: cache_read is on top of input_tokens.
+    in_context = b["input_tokens"] if openai_schema else b["input_tokens"] + b["cache_read_tokens"]
     cache_hit_pct = (
-        round(b["cache_read_tokens"] / in_plus_cache * 100, 1)
-        if in_plus_cache
+        round(b["cache_read_tokens"] / in_context * 100, 1)
+        if in_context
         else 0.0
     )
     # Anthropic prompt-cache reads cost ~10% of fresh input tokens, so the
@@ -3913,6 +3916,11 @@ def _try_local_store_cache_trends(days: int):
     if rows is None:
         return None
 
+    try:
+        from clawmetry.providers_pricing import provider_for_model as _pfm_ct
+    except Exception:
+        _pfm_ct = None
+
     daily: dict = {}
     by_model: dict = {}
     for r in rows:
@@ -3942,7 +3950,10 @@ def _try_local_store_cache_trends(days: int):
         )
 
     by_model_out = [
-        _summarise_cache_bucket(m, b, key="model")
+        _summarise_cache_bucket(
+            m, b, key="model",
+            openai_schema=(_pfm_ct(m) == "openai" if _pfm_ct else False),
+        )
         for m, b in sorted(by_model.items(), key=lambda kv: -kv[1]["total_cost"])
     ]
 

--- a/tests/test_usage_cache_trends_local_store.py
+++ b/tests/test_usage_cache_trends_local_store.py
@@ -246,6 +246,56 @@ def test_cache_trends_dedupes_v3_sibling_pairs(fast_path_app):
     assert abs(t["cache_hit_ratio_pct"] - 66.7) < 0.1, t
 
 
+# ── OpenAI inclusive-schema cache_hit_ratio in by_model ──────────────────
+
+
+def test_cache_trends_openai_inclusive_schema_by_model(fast_path_app):
+    """OpenAI uses an inclusive token schema: cache_read_tokens are already
+    counted inside input_tokens.  The by_model cache_hit_ratio_pct must
+    therefore use ``cache_read / input`` as its denominator, not the
+    Anthropic-style ``cache_read / (input + cache_read)``.
+
+    Regression guard for the fix in routes/usage.py:_summarise_cache_bucket
+    (openai_schema=True path).  With input=100k, cache_read=80k on gpt-4o:
+      * Wrong (Anthropic formula): 80 / (100+80) = 44.4 %
+      * Correct (OpenAI formula): 80 / 100        = 80.0 %
+    """
+    a, ls, _u = fast_path_app
+    store = ls.get_store()
+
+    # Ingest an OpenAI-style assistant event.  The Anthropic SDK envelope
+    # uses cache_read_input_tokens; OpenAI uses the same key (sync.py
+    # normalises both via _extract_usage_splits), so the fixture is identical
+    # except for the model name which drives provider_for_model().
+    _ingest_v3_assistant(
+        store,
+        sid="sess-openai-cache",
+        ts=_iso(time.time()),
+        ev_id="asst-openai-cache",
+        model="gpt-4o",
+        input_tokens=100_000,
+        output_tokens=5_000,
+        cache_read=80_000,
+        cache_write=0,
+        cost_total=0.10,
+    )
+    _wait_flush(store)
+
+    body = a.test_client().get("/api/usage/cache-trends?days=2").get_json()
+    assert body["_source"] == "local_store", body
+
+    by_model = {m["model"]: m for m in body["by_model"]}
+    assert "gpt-4o" in by_model, list(by_model.keys())
+    gpt = by_model["gpt-4o"]
+
+    # Correct OpenAI denominator: cache_read / input_tokens = 80000/100000 = 80.0%
+    assert abs(gpt["cache_hit_ratio_pct"] - 80.0) < 0.2, (
+        f"Expected ~80.0% for OpenAI inclusive schema, got {gpt['cache_hit_ratio_pct']}. "
+        "If this reads ~44.4%, the Anthropic-style denominator (input+cache_read) "
+        "is still being used."
+    )
+
+
 # ── gate: env flag OFF ────────────────────────────────────────────────────
 
 def test_cache_trends_falls_through_when_local_store_disabled(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

Same root cause as #5617 (token-attribution fast path) and #5613 (sync.py session-cost cache-hit %) — the OpenAI inclusive token schema was not accounted for in `_summarise_cache_bucket`, which drives the `/api/usage/cache-trends` by_model view.

**Bug**: For OpenAI models, `input_tokens` already includes `cache_read_tokens` (inclusive schema). The old code used the Anthropic-style additive formula for all providers:
```
cache_hit_pct = cache_read / (input + cache_read)   # wrong for OpenAI
```
With `input=100k, cache_read=80k` on `gpt-4o`, this gave **44.4%** instead of the correct **80.0%**.

**Fix**:
- `_summarise_cache_bucket` gains `openai_schema=False` keyword; uses `cache_read / input` when `True`
- `_try_local_store_cache_trends` derives provider via `provider_for_model()` for each model in the `by_model` aggregation and passes `openai_schema=True` for OpenAI models
- `daily` and `totals` buckets are left with the default Anthropic formula (they mix providers; tracking per-provider context in the aggregation layer is a separate, larger change)

**Harness reproducer** (requires live ClawMetry + OpenAI sessions):
```bash
# Confirm by_model cache_hit_ratio_pct is ~80% not ~44% for gpt-4o
# with 80% cache-read sessions
curl http://localhost:8900/api/usage/cache-trends | python3 -c \
  "import json,sys; d=json.load(sys.stdin); [print(m['model'], m['cache_hit_ratio_pct']) for m in d['by_model']]"
```

**Changes** (3 files, < 70 LOC):
- `routes/usage.py`: provider-aware denominator in `_summarise_cache_bucket` + `_try_local_store_cache_trends`
- `tests/test_usage_cache_trends_local_store.py`: new `test_cache_trends_openai_inclusive_schema_by_model` regression test
- `.github/workflows/ci.yml`: wire `test_usage_cache_trends_local_store.py` into the explicit CI file list (was never executed by any CI job)

No-PRD: single-cause accuracy regression, same root cause as already-shipped #5617 and #5613.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01DNJBvuZr6NCJFv9gRukGC4

---
_Generated by [Claude Code](https://claude.ai/code/session_01DNJBvuZr6NCJFv9gRukGC4)_