### PR TITLE
Run the red-team corpus in CI, and audit main on a schedule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -690,6 +690,52 @@ jobs:
       - name: Run compression/cache-safety eval suite
         run: python3 -m pytest tests/test_compression_safety_eval.py -q
 
+  # ── Red-team corpus (disclosed attacks we claim to catch) ────────────────────
+  # scripts/redteam/corpus/*.json holds one entry per publicly disclosed agent
+  # attack, each naming the detector that must fire and at what severity. The
+  # day GitSpawn stops being detected this job goes red, instead of a customer
+  # finding out. Proven to fail: dropping `core.fsmonitor` from
+  # `repo_scan._EXEC_KEYS` reds three cases (see the PR that added this job).
+  #
+  # Named explicitly because this repo's CI runs FILE LISTS: a test file nobody
+  # names runs in no job at all. That has bitten us before (five guard files in
+  # zero jobs), so if you add a red-team test file, add it here too.
+  #
+  # The audit re-runs the same corpus through scripts/redteam/audit.py to print
+  # the per-case verdicts into the job summary, and to hold the exit-code
+  # contract: 0 = clean, 1 = gaps (with --strict), 2 = a CONTROL failed or a
+  # payload executed. Exit 2 is not "gaps found" -- a control failure means the
+  # audit cannot vouch for any of its other verdicts that day.
+  redteam-corpus:
+    name: Red-team corpus (disclosed attacks)
+    needs: lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.11"
+          cache: pip
+      - name: Install dependencies
+        run: pip install flask waitress cryptography duckdb pytest requests psutil
+      - name: Run red-team corpus regression suite
+        run: python3 -m pytest tests/test_redteam_corpus.py -v --tb=short
+      - name: Replay the corpus through the audit (exit-code contract)
+        run: |
+          set +e
+          python3 scripts/redteam/audit.py --strict --summary "$GITHUB_STEP_SUMMARY"
+          code=$?
+          set -e
+          case "$code" in
+            0) echo "audit clean" ;;
+            2) echo "::error::Red-team audit CONTROL FAILURE (exit 2): a control case failed or a corpus payload executed. Every other verdict in this run is untrustworthy."; exit 1 ;;
+            1) echo "::error::Red-team audit found gaps (exit 1): a disclosed attack in the corpus is no longer detected."; exit 1 ;;
+            *) echo "::error::Red-team audit exited $code (unexpected)"; exit 1 ;;
+          esac
+
   # ── OTLP receiver (daemon-free intake path, WO-7) ────────────────────────────
   # The ONLY job that installs opentelemetry-proto. Without it every OTLP
   # protobuf test in this repo is importorskip'd, so the receiver an

--- a/.github/workflows/redteam-audit.yml
+++ b/.github/workflows/redteam-audit.yml
@@ -1,0 +1,114 @@
+name: Red-team detection audit (daily)
+
+# Every day: replay every publicly disclosed agent attack in
+# scripts/redteam/corpus/ against ClawMetry's own detectors and report what we
+# would MISS. The PR gate (ci.yml, "Red-team corpus") catches a regression a
+# change introduces; this catches the other direction -- a signature added to
+# the corpus, or a detector that drifts on main while nobody opens a PR.
+#
+# A MISS is filed as a `sec-gap` issue on the private tracker (product work on
+# closed detectors does not belong in the public repo). The script dedupes on a
+# fingerprint it prints into each issue body, so a standing gap is filed once,
+# not once a day.
+#
+# Safe to merge before REDTEAM_ISSUE_TOKEN exists: with no token the audit still
+# runs and the run is still red on a gap; only the filing step is skipped, and it
+# says so in the summary rather than failing silently.
+
+on:
+  schedule:
+    - cron: "0 5 * * *"   # daily 05:00 UTC (an hour before the harness audit)
+  workflow_dispatch:
+    inputs:
+      file_issues:
+        description: "Actually open sec-gap issues (false = dry-run)"
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: redteam-audit
+  cancel-in-progress: false
+
+jobs:
+  audit:
+    name: Replay the red-team corpus
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install dependencies
+        run: pip install flask waitress cryptography duckdb requests psutil
+
+      - name: Token visibility (presence only)
+        env:
+          REDTEAM_ISSUE_TOKEN: ${{ secrets.CLOUD_REPO_PAT }}
+        run: |
+          if [ -n "$REDTEAM_ISSUE_TOKEN" ]; then
+            echo "issue token: set (gaps will be filed to the private tracker)"
+          else
+            echo "::warning::CLOUD_REPO_PAT not set -- the audit runs and still fails on a gap, but no sec-gap issue is filed."
+          fi
+
+      # Exit-code contract (scripts/redteam/audit.py):
+      #   0 -- every case passes
+      #   1 -- gaps, only with --strict
+      #   2 -- a CONTROL failed, or a corpus payload actually executed
+      # Exit 2 is NOT "gaps found": a control failure means the audit cannot
+      # vouch for any of its other verdicts, so its whole report is worthless
+      # that day and the run must say so loudly.
+      - name: Run the audit
+        env:
+          # gh reads GH_TOKEN; the corpus gaps are filed cross-repo to the
+          # private tracker, which github.token cannot write to.
+          GH_TOKEN: ${{ secrets.CLOUD_REPO_PAT }}
+          REDTEAM_ISSUE_REPO: vivekchand/clawmetry-pro
+          # Dispatch inputs are untrusted text: bind to env, read as a quoted
+          # shell variable, never interpolate ${{ github.event.* }} into `run:`.
+          FILE_ISSUES: ${{ github.event.inputs.file_issues }}
+          HAS_TOKEN: ${{ secrets.CLOUD_REPO_PAT != '' }}
+        run: |
+          ARGS=(--strict --json redteam-report.json --summary "$GITHUB_STEP_SUMMARY")
+          if [ "$FILE_ISSUES" = "false" ] || [ "$HAS_TOKEN" != "true" ]; then
+            echo "dry-run (no issues will be filed)"
+          else
+            ARGS+=(--file-issues)
+          fi
+          set +e
+          python3 scripts/redteam/audit.py "${ARGS[@]}"
+          code=$?
+          set -e
+          case "$code" in
+            0) echo "audit clean" ;;
+            2)
+              echo "::error::CONTROL FAILURE (exit 2): a control case failed or a corpus payload executed. Today's verdicts are untrustworthy -- fix the harness before reading any other row."
+              {
+                echo ""
+                echo "> **Control failure.** The audit could not vouch for its own verdicts in this run."
+              } >> "$GITHUB_STEP_SUMMARY"
+              exit 1
+              ;;
+            1)
+              echo "::error::Detection gap (exit 1): a disclosed attack in the corpus is not detected. See the sec-gap issue on the private tracker."
+              exit 1
+              ;;
+            *) echo "::error::Audit exited $code (unexpected)"; exit 1 ;;
+          esac
+
+      - name: Upload the report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: redteam-report
+          path: redteam-report.json
+          if-no-files-found: warn

--- a/scripts/redteam/audit.py
+++ b/scripts/redteam/audit.py
@@ -284,6 +284,43 @@ def _file_issue(case: dict, result: dict, fp: str, dry: bool) -> None:
             print(f"    [error] could not file issue: {e2}")
 
 
+_VERDICT_ICON = {
+    "PASS": "ok",
+    "MISS": "MISS",
+    "FALSE-POSITIVE": "FALSE POSITIVE",
+    "UNDER-SEVERITY": "UNDER SEVERITY",
+    "UNSAFE-CORPUS": "UNSAFE CORPUS",
+}
+
+
+def _write_summary(path: str, results: list, misses: list, bad_controls: list) -> None:
+    """Append a markdown verdict table (one row per case) to ``path``.
+
+    Written for ``$GITHUB_STEP_SUMMARY`` so a scheduled run is readable from the
+    Actions tab without opening the log: every case, what fired, and the verdict.
+    A summary nobody can read is the same as no audit.
+    """
+    lines = ["## Red-team detection audit", ""]
+    ok = len(results) - len(misses) - len(bad_controls)
+    lines.append(f"**{ok}/{len(results)} pass** - "
+                 f"{len(misses)} gap(s), {len(bad_controls)} control failure(s)")
+    lines.append("")
+    lines.append("| Case | Surface | Verdict | Detectors that fired | Detail |")
+    lines.append("|---|---|---|---|---|")
+    for r in results:
+        name = r["id"] + (" (control)" if r.get("control") else "")
+        fired = ", ".join(f"`{d}`" for d in (r.get("fired") or [])) or "none"
+        detail = str(r.get("detail", "")).replace("|", "\\|")
+        lines.append(f"| {name} | {r.get('surface', '?')} | "
+                     f"{_VERDICT_ICON.get(r['verdict'], r['verdict'])} | {fired} | {detail} |")
+    lines.append("")
+    try:
+        with open(path, "a", encoding="utf-8") as f:
+            f.write("\n".join(lines) + "\n")
+    except Exception as e:  # a summary is a nicety; never fail the audit over it
+        print(f"[warn] could not write summary to {path}: {e}")
+
+
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--case", help="run a single corpus case by id")
@@ -292,6 +329,9 @@ def main() -> int:
                     help=f"open a sec-gap issue per MISS in {ISSUE_REPO}")
     ap.add_argument("--strict", action="store_true",
                     help="exit non-zero on any MISS (default: only on control failure)")
+    ap.add_argument("--summary",
+                    help="append a markdown verdict table to this path "
+                         "(point it at $GITHUB_STEP_SUMMARY in CI)")
     args = ap.parse_args()
 
     cases = _load_corpus(args.case)
@@ -327,6 +367,9 @@ def main() -> int:
         with open(args.json, "w", encoding="utf-8") as f:
             json.dump(results, f, indent=2)
         print(f"\nReport written to {args.json}")
+
+    if args.summary:
+        _write_summary(args.summary, results, misses, bad_controls)
 
     if misses:
         print(f"\nGaps ({len(misses)}):")


### PR DESCRIPTION
## Why

`tests/test_redteam_corpus.py` holds 24 passing tests (the GitSpawn, CHAINDROP and VS Code signatures, plus the controls) and CI ran none of them. This repo's jobs drive explicit file lists, so a test file nobody names runs in no job at all. That is the same failure that left five guard files in zero jobs.

A detection suite that nobody runs protects nobody, so this wires it in two directions: a PR gate that catches a regression a change introduces, and a scheduled audit that catches drift on `main` when nobody opens a PR.

## What

**PR gate** (`ci.yml`, job "Red-team corpus (disclosed attacks)"):
1. `pytest tests/test_redteam_corpus.py`
2. `scripts/redteam/audit.py --strict --summary "$GITHUB_STEP_SUMMARY"`, so the 9 per-case verdicts land in the job summary and the exit-code contract is enforced at the gate.

**Daily audit** (`.github/workflows/redteam-audit.yml`, 05:00 UTC + manual dispatch): the same replay with `--file-issues`, filing a `sec-gap` issue per MISS to the private tracker. The script already prints a dedupe fingerprint into each issue body, so a standing gap is filed once, not once a day. Safe to merge before the token exists: with no `CLOUD_REPO_PAT` the audit still runs and a gap still reds the run, only the filing is skipped, and the log says so.

**`audit.py --summary PATH`**: appends a markdown verdict table (case, surface, verdict, detectors that fired, detail). A scheduled run nobody can read is the same as no audit.

### The exit-code contract, handled everywhere it appears

| exit | meaning | job behaviour |
|---|---|---|
| 0 | every case passes | green |
| 1 | gaps, under `--strict` | red, "a disclosed attack is no longer detected" |
| 2 | a control failed, or a corpus payload executed | red, "CONTROL FAILURE, every other verdict in this run is untrustworthy" |

Exit 2 is deliberately not folded into "gaps found". A control failure means the harness cannot vouch for its own verdicts that day, so its whole report is worthless and the run has to say that.

## Verification (guard proven to fail before trusting it)

Deleted `core.fsmonitor` from `repo_scan._EXEC_KEYS`:

```
FAILED tests/test_redteam_corpus.py::test_corpus_case[gitspawn-core-fsmonitor]
FAILED tests/test_redteam_corpus.py::test_findings_never_echo_the_raw_payload
2 failed, 22 passed
audit --strict -> exit 1, "8/9 pass, 1 gap(s), 0 control failure(s)"
```

Poisoned `control-benign-repo.json` with an `fsmonitor` key:

```
[FP  ] control-benign-repo (control)
8/9 pass, 0 gap(s), 1 control failure(s)
audit --strict -> exit 2
```

Restored: `24 passed`, audit `9/9 pass`, exit 0. Also green: `tests/test_workflow_yaml_valid.py` and `tests/test_ci_workflow_invocations_are_real.py` (535 passed), and both workflow files parse.

Closes vivekchand/clawmetry-pro#225.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TtHxhGn2nwqoZ2v6SqcXMK
