### PR TITLE
Scan a session's workspace in the daemon, once per directory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -552,6 +552,7 @@ jobs:
             tests/test_family_runtime_ingest.py \
             tests/test_phase4_adapter_move.py \
             tests/test_openclaw_detection_real.py \
+            tests/test_repo_scan_daemon_wiring.py \
             tests/test_hooks_claude_code.py \
             tests/test_hook_ownership_quoted_launcher.py \
             tests/test_hook_lifecycle.py \

--- a/clawmetry/repo_scan.py
+++ b/clawmetry/repo_scan.py
@@ -193,6 +193,13 @@ def _finding(kind: str, severity: str, title: str, detail: str,
         "detail": detail,
         "evidence": evidence,
         "first_bad_step": None,
+        # A workspace finding is a property of the FOLDER, not a stretch of
+        # expensive tokens, so there is no spend to attach. 0.0 with basis
+        # "unknown" is the shape CLAUDE.md requires where no cost is known:
+        # never a fabricated figure, because sorting a queue by an invented
+        # dollar number is worse than not sorting it at all.
+        "spend_at_risk_usd": 0.0,
+        "spend_basis": "unknown",
     }
 
 

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -20502,6 +20502,148 @@ def _guard_enforcement_allowed() -> bool:
 # or where its workspace root is — and all three change what an incident MEANS.
 # The daemon already touches every candidate session on this tick, so gathering
 # them here is free, where a per-session store read would not be.
+def _session_cwd(session: dict) -> str:
+    """The directory a session ran in, or "" when the runtime never recorded one.
+
+    ``sessions.cwd`` is the COLUMN every cwd-aware consumer keys on
+    (``query_repo_activity`` filters on it, ``process_control`` promotes it to
+    find a pid). Reading only ``metadata`` — which this helper replaced — meant
+    every runtime that fills the column and not the blob looked like it had no
+    workspace at all: on this machine that was cursor, goose, opencode, pi and
+    qwen_code, i.e. every session the column exists for.
+
+    The metadata keys stay as the fallback: some adapters put it there and
+    nowhere else, and a runtime that records neither honestly has no cwd.
+    """
+    if not isinstance(session, dict):
+        return ""
+    val = session.get("cwd")
+    if isinstance(val, str) and val.strip():
+        return val.strip()
+    meta = session.get("metadata")
+    if not isinstance(meta, dict):
+        return ""
+    for key in ("cwd", "workspace", "project_dir", "working_dir", "path"):
+        val = meta.get(key)
+        if isinstance(val, str) and val.strip():
+            return val.strip()
+    return ""
+
+
+# ── Workspace scan: the attack surface the tool stream cannot see ──────────
+#
+# Every behavioural detector reads what the agent CHOSE to do. GitSpawn is the
+# proof that this is a partial view: a poisoned `.git/config` makes *git* spawn
+# the payload during the `git status` the runtime fires on open, the agent calls
+# no tool, and `detectors.run_all` sees a clean session. `clawmetry.repo_scan`
+# reads the workspace instead, which is the only place that attack is visible.
+#
+# Honesty about what this buys: for GitSpawn the payload has usually ALREADY RUN
+# by the time a session exists, so this is not prevention. It tells the operator
+# the machine may be compromised — which today they never learn at all — and on
+# runtimes with a pre-tool gate it can hold the NEXT action. `clawmetry
+# scan-repo` stays the preventive path, run before an agent opens the folder.
+#
+# Cost: the scan is a handful of file reads, and the cache below keys on the
+# mtime+size of exactly the files it reads, so a fleet of 200 sessions in 50
+# repos re-reads nothing until one of those files changes.
+_REPO_SCAN_ON = "CLAWMETRY_REPO_SCAN"        # "0" disables the workspace scan
+_REPO_SCAN_CACHE_MAX = int(os.environ.get("CLAWMETRY_REPO_SCAN_CACHE_MAX", "500"))
+#: Files a scan actually reads. The stamp is built from these and nothing else,
+#: so an unrelated write inside the repo does not invalidate the cache.
+_REPO_SCAN_STAMP_FILES = (
+    os.path.join(".git", "config"),
+    os.path.join(".vscode", "tasks.json"),
+)
+
+
+def _repo_scan_stamp(workspace: str) -> tuple:
+    """``(path, mtime_ns, size)`` for every file a scan reads; missing = None.
+
+    Cheap enough to run per session per tick (a few ``stat`` calls) and exact
+    enough that a re-scan happens the moment one of those files changes —
+    including the case that matters most, a repo poisoned after it was first
+    seen clean.
+    """
+    try:
+        from clawmetry import repo_scan as _rs
+        hook_files = tuple(getattr(_rs, "_AGENT_HOOK_FILES", ()) or ())
+    except Exception:  # noqa: BLE001
+        hook_files = ()
+    names = list(_REPO_SCAN_STAMP_FILES)
+    for entry in hook_files:
+        # _AGENT_HOOK_FILES entries are relative paths, or (path, ...) tuples.
+        rel = entry[0] if isinstance(entry, (tuple, list)) and entry else entry
+        if isinstance(rel, str) and rel:
+            names.append(rel)
+    out = []
+    for rel in names:
+        try:
+            st = os.stat(os.path.join(workspace, rel))
+            out.append((rel, st.st_mtime_ns, st.st_size))
+        except Exception:  # noqa: BLE001 — absent is a state, not an error
+            out.append((rel, None, None))
+    return tuple(out)
+
+
+def _workspace_incidents(state: dict, cwd: str, session_id: str,
+                         runtime: str, now: float) -> list:
+    """Workspace findings for ``cwd``, scanned once per (cwd, file stamp).
+
+    Returns incidents in ``detectors.run_all`` shape, re-stamped with THIS
+    session's id and runtime — the cache holds one scan per directory, not one
+    per session, which is the whole point of it.
+    """
+    if os.environ.get(_REPO_SCAN_ON, "1").strip().lower() in ("0", "false", "no"):
+        return []
+    if not cwd:
+        return []
+    try:
+        root = os.path.realpath(cwd)
+    except Exception:  # noqa: BLE001
+        return []
+    if not os.path.isdir(root):
+        return []
+
+    memo = state.setdefault("repo_scan_memo", {})
+    if not isinstance(memo, dict):
+        memo = {}
+        state["repo_scan_memo"] = memo
+
+    stamp = _repo_scan_stamp(root)
+    entry = memo.get(root)
+    if isinstance(entry, dict) and entry.get("stamp") == stamp:
+        entry["ts"] = now
+        findings = entry.get("findings") or []
+    else:
+        try:
+            from clawmetry import repo_scan as _rs
+            findings = _rs.scan_workspace(root) or []
+        except Exception as e:  # noqa: BLE001 — a scan must never stop ingest
+            log.debug("repo-scan: %s failed: %s", root, e)
+            findings = []
+        memo[root] = {"stamp": stamp, "findings": findings, "ts": now}
+        if findings:
+            log.info("repo-scan: %d finding(s) in %s", len(findings), root)
+        # Bound the cache: a long-lived daemon on a busy machine must not hold
+        # a row per directory it has ever seen.
+        if len(memo) > _REPO_SCAN_CACHE_MAX:
+            for stale in sorted(memo, key=lambda k: memo[k].get("ts", 0)
+                                )[:len(memo) - _REPO_SCAN_CACHE_MAX]:
+                memo.pop(stale, None)
+
+    out = []
+    for f in findings:
+        if not isinstance(f, dict):
+            continue
+        inc = dict(f)
+        inc["session_id"] = session_id
+        inc["runtime"] = runtime or inc.get("runtime") or "unknown"
+        inc["workspace"] = root
+        out.append(inc)
+    return out
+
+
 def _detector_session_facts(sessions: list, state: dict, now: float,
                             store=None) -> dict:
     """``session_id -> {cost_usd, bad_for_seconds, session_seconds, cwd,
@@ -20523,14 +20665,7 @@ def _detector_session_facts(sessions: list, state: dict, now: float,
         sid = str(s.get("session_id") or "")
         if not sid:
             continue
-        meta = s.get("metadata")
-        meta = meta if isinstance(meta, dict) else {}
-        cwd = ""
-        for key in ("cwd", "workspace", "project_dir", "working_dir", "path"):
-            val = meta.get(key)
-            if isinstance(val, str) and val.strip():
-                cwd = val.strip()
-                break
+        cwd = _session_cwd(s)
         try:
             cost = float(s.get("cost_usd") or 0)
         except (TypeError, ValueError):
@@ -21150,15 +21285,34 @@ def _emit_detector_incidents(store, state: dict) -> int:
                                      thresholds=thresholds, steps=steps) or []
         except Exception as e:  # noqa: BLE001
             log.warning("detectors: run_all errored for %s: %s", sid, e)
-            continue
+            incidents = []
+        if incidents:
+            all_incidents.extend(incidents)
+            # Remember when this session FIRST looked wrong, so the next tick
+            # can say how long it has been that way (and price the stretch).
+            # Behavioural incidents only: a poisoned repo is a property of the
+            # FOLDER, not a stretch of the session going off track, and letting
+            # it start the clock would inflate the spend at risk of a real
+            # trajectory incident found later.
+            bad_sessions.add(sid)
+            first_seen_memo.setdefault(sid, now)
+
+        # The workspace surface: what the tool stream cannot see (a poisoned
+        # .git/config, an autorun task, a tampered agent hook). Same incident
+        # shape, same loop_signals row, same Guard tab.
+        #
+        # Deliberately NOT added to all_incidents, which is what the policy
+        # pass reads: a policy with trigger_kind "" matches ANY kind, so
+        # feeding workspace findings in today would let an existing
+        # "pause anything critical" rule pause a session because of a property
+        # of its folder, with no way to express "except that". Teaching the
+        # policy engine and the Guard policy form these two kinds is its own
+        # change (clawmetry-pro#223); until then the operator is TOLD and
+        # nothing is signalled.
+        incidents = list(incidents) + _workspace_incidents(
+            state, facts.get("cwd") or "", sid, runtime or "unknown", now)
         if not incidents:
             continue
-        all_incidents.extend(incidents)
-
-        # Remember when this session FIRST looked wrong, so the next tick can
-        # say how long it has been that way (and price the stretch).
-        bad_sessions.add(sid)
-        first_seen_memo.setdefault(sid, now)
 
         # Fold the LOUDEST incident into the heartbeat slice. run_all orders by
         # spend at risk first and severity second, so on a session with a known

--- a/tests/test_repo_scan_daemon_wiring.py
+++ b/tests/test_repo_scan_daemon_wiring.py
@@ -1,0 +1,222 @@
+"""The workspace scan runs in the daemon, once per (directory, file stamp).
+
+``clawmetry/repo_scan.py`` shipped with a CLI and nothing in the product called
+it. A detector nobody runs protects nobody, so ``sync._emit_detector_incidents``
+now scans each session's workspace and emits findings on the existing Guard
+path. This file pins the four properties that wiring has to keep:
+
+* a poisoned repo produces a ``repo_config_exec`` loop_signals row,
+* the scan is cached on the mtime of exactly the files it reads (a 50-repo
+  fleet must not re-read them every tick) and re-runs the moment one changes,
+* workspace findings do NOT reach the policy pass (a ``trigger_kind: ""``
+  policy would otherwise pause a session over a property of its folder),
+* the cwd comes from the ``sessions.cwd`` COLUMN, which is where every
+  cwd-aware consumer already keys.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import time
+
+import pytest
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+from clawmetry import detectors as _det  # noqa: E402
+from clawmetry import repo_scan as _rs  # noqa: E402
+from clawmetry import sync as _sync  # noqa: E402
+
+_POISON = "[core]\n\tfsmonitor = /tmp/payload.sh\n"
+
+
+def _poisoned_repo(tmp_path, name="repo"):
+    ws = tmp_path / name
+    (ws / ".git").mkdir(parents=True)
+    (ws / ".git" / "config").write_text(_POISON, encoding="utf-8")
+    return str(ws)
+
+
+# ── the cwd the scan keys on ────────────────────────────────────────────────
+def test_session_cwd_prefers_the_column_over_metadata():
+    """Regression: reading only ``metadata`` hid the column every cwd-aware
+    consumer already uses, so cursor/goose/opencode/pi/qwen_code sessions all
+    looked like they had no workspace."""
+    assert _sync._session_cwd({"cwd": "/tmp/a", "metadata": {"cwd": "/tmp/b"}}) == "/tmp/a"
+    assert _sync._session_cwd({"cwd": None, "metadata": {"cwd": "/tmp/b"}}) == "/tmp/b"
+    assert _sync._session_cwd({"cwd": "  ", "metadata": {"project_dir": "/tmp/c"}}) == "/tmp/c"
+    assert _sync._session_cwd({"metadata": {}}) == ""
+    assert _sync._session_cwd(None) == ""
+
+
+def test_detector_facts_carry_the_column_cwd():
+    facts = _sync._detector_session_facts(
+        [{"session_id": "goose:1", "cwd": "/tmp/ws", "metadata": {}}], {}, time.time())
+    assert facts["goose:1"]["cwd"] == "/tmp/ws"
+
+
+# ── the scan itself ────────────────────────────────────────────────────────
+def test_poisoned_workspace_yields_an_incident(tmp_path):
+    inc = _sync._workspace_incidents({}, _poisoned_repo(tmp_path), "cursor:1",
+                                     "cursor", time.time())
+    assert [i["kind"] for i in inc] == ["repo_config_exec"]
+    assert inc[0]["session_id"] == "cursor:1" and inc[0]["runtime"] == "cursor"
+    # No cost is knowable for a property of a folder; it must not be invented.
+    assert inc[0]["spend_at_risk_usd"] == 0.0
+    assert inc[0]["spend_basis"] == "unknown"
+
+
+def test_clean_workspace_is_quiet(tmp_path):
+    ws = tmp_path / "clean"
+    (ws / ".git").mkdir(parents=True)
+    (ws / ".git" / "config").write_text("[core]\n\tbare = false\n", encoding="utf-8")
+    assert _sync._workspace_incidents({}, str(ws), "s", "openclaw", time.time()) == []
+
+
+def test_missing_or_empty_cwd_is_quiet(tmp_path):
+    state = {}
+    assert _sync._workspace_incidents(state, "", "s", "openclaw", time.time()) == []
+    assert _sync._workspace_incidents(
+        state, str(tmp_path / "gone"), "s", "openclaw", time.time()) == []
+    assert state.get("repo_scan_memo") in (None, {})
+
+
+def test_kill_switch_disables_the_scan(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_REPO_SCAN", "0")
+    assert _sync._workspace_incidents({}, _poisoned_repo(tmp_path), "s",
+                                      "cursor", time.time()) == []
+
+
+# ── the cache: this is what makes it affordable on a fleet ─────────────────
+def test_scan_runs_once_per_directory_then_reuses_the_cache(tmp_path, monkeypatch):
+    ws = _poisoned_repo(tmp_path)
+    calls = []
+    real = _rs.scan_workspace
+    monkeypatch.setattr(_rs, "scan_workspace",
+                        lambda *a, **k: (calls.append(a[0]), real(*a, **k))[1])
+    state = {}
+    for sid in ("a", "b", "c", "d"):          # four sessions, one repo
+        assert _sync._workspace_incidents(state, ws, sid, "cursor", time.time())
+    assert len(calls) == 1, f"re-scanned {len(calls)}x for one unchanged repo"
+
+
+def test_a_changed_config_is_rescanned(tmp_path, monkeypatch):
+    ws = _poisoned_repo(tmp_path)
+    calls = []
+    real = _rs.scan_workspace
+    monkeypatch.setattr(_rs, "scan_workspace",
+                        lambda *a, **k: (calls.append(a[0]), real(*a, **k))[1])
+    state = {}
+    assert _sync._workspace_incidents(state, ws, "a", "cursor", time.time())
+    cfg = os.path.join(ws, ".git", "config")
+    os.utime(cfg, (time.time() + 5, time.time() + 5))
+    _sync._workspace_incidents(state, ws, "a", "cursor", time.time())
+    assert len(calls) == 2, "a repo poisoned after first sight must be re-scanned"
+
+
+def test_a_repo_poisoned_later_is_caught(tmp_path, monkeypatch):
+    """The case that matters: clean at first sight, poisoned five minutes on."""
+    ws = tmp_path / "later"
+    (ws / ".git").mkdir(parents=True)
+    cfg = ws / ".git" / "config"
+    cfg.write_text("[core]\n\tbare = false\n", encoding="utf-8")
+    state = {}
+    assert _sync._workspace_incidents(state, str(ws), "a", "cursor", time.time()) == []
+    cfg.write_text(_POISON, encoding="utf-8")
+    os.utime(cfg, (time.time() + 5, time.time() + 5))
+    found = _sync._workspace_incidents(state, str(ws), "a", "cursor", time.time())
+    assert [i["kind"] for i in found] == ["repo_config_exec"]
+
+
+def test_cache_is_bounded(tmp_path, monkeypatch):
+    monkeypatch.setattr(_sync, "_REPO_SCAN_CACHE_MAX", 5)
+    state = {}
+    for i in range(12):
+        ws = tmp_path / f"r{i}"
+        ws.mkdir()
+        _sync._workspace_incidents(state, str(ws), "s", "openclaw", time.time() + i)
+    assert len(state["repo_scan_memo"]) <= 5
+
+
+def test_stamp_covers_the_agent_hook_files(tmp_path):
+    """The stamp must include every file a scan reads, or a tampered
+    ``.claude/settings.json`` would sit behind a cache that never expires."""
+    ws = tmp_path / "hooks"
+    (ws / ".claude").mkdir(parents=True)
+    names = {rel for rel, _m, _s in _sync._repo_scan_stamp(str(ws))}
+    assert os.path.join(".git", "config") in names
+    assert ".claude/settings.json" in names
+    assert os.path.join(".vscode", "tasks.json") in names
+
+
+# ── the emit path ──────────────────────────────────────────────────────────
+class _EmitStore:
+    def __init__(self, cwd):
+        self.cwd = cwd
+        self.signals = []
+        now_iso = time.strftime("%Y-%m-%dT%H:%M:%S", time.localtime())
+        self.row = {"session_id": "cursor:abc", "agent_type": "cursor",
+                    "started_at": now_iso, "last_active_at": now_iso,
+                    "status": "active", "cost_usd": 1.0, "cwd": cwd,
+                    "metadata": {}}
+
+    def query_sessions_table(self, limit=300):
+        return [self.row]
+
+    def query_events(self, **kw):
+        return [{"event_type": "tool_call", "ts": self.row["started_at"],
+                 "data": {"tool": "x"}}]
+
+    def query_approvals(self, **kw):
+        return []
+
+    def ingest_loop_signal(self, **kw):
+        self.signals.append(kw)
+
+    def __getattr__(self, name):
+        return lambda *a, **k: None
+
+
+@pytest.fixture()
+def _quiet(monkeypatch):
+    monkeypatch.setattr(_det, "run_all", lambda *a, **k: [])
+    monkeypatch.setattr(_sync, "_record_guard_observation", lambda *a, **k: None)
+
+
+def test_emit_writes_a_loop_signal_for_a_poisoned_workspace(tmp_path, _quiet,
+                                                            monkeypatch):
+    """End of the wire: a session in a poisoned repo, no behavioural incident
+    at all, still produces a Guard row within one tick."""
+    monkeypatch.setattr(_sync, "_apply_guard_policies", lambda *a, **k: 0)
+    store = _EmitStore(_poisoned_repo(tmp_path))
+    assert _sync._emit_detector_incidents(store, {}) == 1
+    sig = store.signals[0]
+    assert sig["signature"] == "daemon_detect_repo_config_exec"
+    assert sig["details"]["kind"] == "repo_config_exec"
+    assert sig["details"]["spend_at_risk_usd"] == 0.0
+    assert sig["details"]["spend_basis"] == "unknown"
+
+
+def test_workspace_findings_never_reach_the_policy_pass(tmp_path, _quiet,
+                                                        monkeypatch):
+    """A policy with ``trigger_kind: ""`` matches any kind. Until the policy
+    form can express these two kinds (clawmetry-pro#223), a poisoned folder
+    must not be able to pause the session that opened it."""
+    seen = []
+    monkeypatch.setattr(_sync, "_apply_guard_policies",
+                        lambda store, state, incs, facts: seen.append(list(incs)))
+    store = _EmitStore(_poisoned_repo(tmp_path))
+    _sync._emit_detector_incidents(store, {})
+    assert seen == [], f"workspace findings reached the policy pass: {seen}"
+
+
+def test_a_clean_workspace_emits_nothing(tmp_path, _quiet, monkeypatch):
+    monkeypatch.setattr(_sync, "_apply_guard_policies", lambda *a, **k: 0)
+    ws = tmp_path / "clean"
+    (ws / ".git").mkdir(parents=True)
+    (ws / ".git" / "config").write_text("[core]\n\tbare = false\n", encoding="utf-8")
+    store = _EmitStore(str(ws))
+    assert _sync._emit_detector_incidents(store, {}) == 0
+    assert store.signals == []


### PR DESCRIPTION
No-PRD: closes a specced security-gap issue on the private tracker (vivekchand/clawmetry-pro#222), which carries the requirement, the timing caveat and the done-when.

## Why

`clawmetry/repo_scan.py` ships, detects all three GitSpawn variants and the CHAINDROP hook shapes, and `clawmetry scan-repo` exposes it to a human. Nothing in the product called it. A detector nobody runs protects nobody.

Every behavioural detector reads the tool stream, which is a partial view of the machine. GitSpawn is the proof: a poisoned `.git/config` makes *git* spawn the payload during the background `git status` a runtime fires on open, the agent calls no tool, and `detectors.run_all` sees a clean session.

## What

`sync._emit_detector_incidents` now scans each session's `cwd` and emits any findings on the path detector incidents already take: a `loop_signals` row (`daemon_detect_repo_config_exec` / `daemon_detect_agent_config_tamper`), `incident_alerts` delivery, and the heartbeat fold.

**Cached on the files it reads.** The stamp is the mtime and size of `.git/config`, `.vscode/tasks.json` and each `_AGENT_HOOK_FILES` entry, and nothing else. An unchanged repo is never re-read; a repo poisoned *after* it was first seen clean is re-scanned on the next tick. Measured here: 50 repos cold, 6.7 ms. 200 sessions spread over those 50 repos, warm, 8.1 ms total (0.04 ms per session). Cache bounded at 500 directories, oldest evicted. `CLAWMETRY_REPO_SCAN=0` disables it.

**Not prevention, and the copy does not claim to be.** For GitSpawn the payload has usually already run by the time a session exists. What this buys: the operator learns the machine may be compromised, which today they never learn at all, and on runtimes with a pre-tool gate the finding can hold the next action. `clawmetry scan-repo` stays the genuinely preventive path.

**Workspace findings do not enter the policy pass.** A policy with `trigger_kind: ""` matches any kind, so feeding them in today would let an existing "pause anything critical" rule pause a session because of a property of its folder, with no way to write "except that". Teaching `policy_engine` and the Guard policy form these two kinds is vivekchand/clawmetry-pro#223; until then the operator is told and nothing is signalled. Findings carry `spend_at_risk_usd: 0.0` with basis `unknown`, never an invented figure.

### A cwd bug underneath it

`_detector_session_facts` read only `metadata` and ignored the `sessions.cwd` column that `query_repo_activity` filters on and `process_control` promotes to find a pid. On this machine that column is the only cwd source for all 41 sessions that have one, so the facts every detector prices path escapes against carried `""` for every cursor, opencode, goose, pi and qwen_code session. `_session_cwd()` now reads the column first and keeps the metadata keys as the fallback.

## Verified on live data

A real `opencode` run in a repo whose `.git/config` sets `core.fsmonitor` to an inert marker command landed in DuckDB with that cwd. Feeding that real session row plus its 3 real events through `_emit_detector_incidents`:

```
repo-scan: 1 finding(s) in .../scratchpad/poisoned
detectors: repository config names a program to run: core.fsmonitor
emitted: 1
  daemon_detect_repo_config_exec critical | repository config names a program to run: core.fsmonitor
```

`python3 scripts/redteam/audit.py` still reports 9/9. Detector, guard and policy suites green (107 + 133 tests).

**Guard proven to fail first:** with this change reverted, 12 of the 14 tests in `tests/test_repo_scan_daemon_wiring.py` go red. The file is named in the MOAT job's list, because this repo's CI runs explicit file lists.

## Honest coverage limit

The scan runs wherever the store has a cwd. Today that is 41 of 211 recent sessions here: cursor, opencode, goose, pi, qwen_code. `claude_code`, `openclaw` and `codex` do not populate `sessions.cwd`, so the scan is inert for them even though their transcripts carry the directory. Filed as a follow-up rather than guessed at, because attributing a session to the wrong folder would be worse than reporting none.

Closes vivekchand/clawmetry-pro#222.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TtHxhGn2nwqoZ2v6SqcXMK
