### PR TITLE
Guard and policies learn the two workspace kinds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -566,6 +566,7 @@ jobs:
             tests/test_phase4_adapter_move.py \
             tests/test_openclaw_detection_real.py \
             tests/test_repo_scan_daemon_wiring.py \
+            tests/test_guard_workspace_kinds.py \
             tests/test_hooks_claude_code.py \
             tests/test_hook_ownership_quoted_launcher.py \
             tests/test_hook_lifecycle.py \

--- a/clawmetry/detectors.py
+++ b/clawmetry/detectors.py
@@ -86,6 +86,12 @@ from clawmetry.detector_money import (  # noqa: F401
 from clawmetry.detector_behaviour import (  # noqa: F401
     credential_access, file_blast_radius, network_egress, privilege_change,
 )
+# The workspace surface (``repo_scan``) emits incidents in this module's shape
+# but is not a detector: it reads the FOLDER, not the tool stream. Its kinds are
+# re-exported here so a consumer needs one import to know every kind the product
+# can show, and ``ALL_INCIDENT_KINDS`` is the list every renderer and policy form
+# derives from. Two lists that must agree are two lists that will drift.
+from clawmetry.repo_scan import WORKSPACE_KINDS  # noqa: F401
 
 # What this module detects, declared once and up front rather than derived at
 # the bottom of the file. Two reasons it is a literal:
@@ -113,6 +119,11 @@ DETECTOR_KINDS = (
     "blocked_on_user",
     "crashed",
 )
+
+#: Every incident kind the product can render or match, detector or workspace.
+#: Surfaces that render an incident (Guard tab labels, the policy form) and
+#: anything that validates a kind read THIS, never one of the halves.
+ALL_INCIDENT_KINDS = DETECTOR_KINDS + WORKSPACE_KINDS
 
 
 # ── Tunable thresholds (env-overridable) ─────────────────────────────────────

--- a/clawmetry/policy_engine.py
+++ b/clawmetry/policy_engine.py
@@ -20,7 +20,9 @@ A policy row (see ``local_store.session_policy``)::
       "enabled":        bool,
       "scope_runtime":  str,   # "" = every runtime
       "scope_agent_id": str,   # "" = every agent
-      "trigger_kind":   str,   # "" = any detector kind
+      "trigger_kind":   str,   # "" = any detector kind. A WORKSPACE kind
+                               # (repo_scan.WORKSPACE_KINDS) must be named
+                               # explicitly; see "Workspace findings" below.
       "min_severity":   "info" | "warning",
       "min_repeat":     int,   # incident count must be >= this
       "min_duration_s": int,   # session bad for at least this long
@@ -65,6 +67,15 @@ which is why every existing policy keeps behaving identically.
 All thresholds are AND-ed. An unset threshold (0) never blocks a match, so a
 policy with everything zeroed fires on the first matching incident.
 
+**Workspace findings must be named.** ``repo_scan`` emits two kinds
+(``repo_config_exec``, ``agent_config_tamper``) that describe the FOLDER an
+agent was pointed at, not the agent's behaviour, and both are ``critical`` by
+construction. An empty ``trigger_kind`` therefore does NOT match them: a
+standing "pause anything critical" rule, written about runaway agents, would
+otherwise start pausing sessions because of a property of a checkout, with no
+way to write "except that". A policy that wants to act on a poisoned repo says
+so by name, which is also what makes that intent visible in the policy list.
+
 A decision::
 
     {
@@ -97,6 +108,14 @@ flag and the one-shot latch):
 from __future__ import annotations
 
 from typing import Any, Dict, Iterable, List, Optional
+
+# The one list of workspace kinds, declared where they are produced. Imported
+# defensively: this module is pure and must still evaluate policies on an
+# install where repo_scan is unavailable.
+try:  # pragma: no cover - trivial fallback
+    from clawmetry.repo_scan import WORKSPACE_KINDS
+except Exception:  # noqa: BLE001
+    WORKSPACE_KINDS = ("repo_config_exec", "agent_config_tamper")
 
 # Action ladder, weakest first. Order IS the escalation order and the
 # strongest-wins comparison; do not reorder without updating the UI copy.
@@ -284,7 +303,13 @@ def _match(policy: Dict[str, Any], incident: Dict[str, Any],
 
     kind = str(incident.get("kind") or "").strip()
     want_kind = str(policy.get("trigger_kind") or "").strip()
-    if want_kind and want_kind != kind:
+    if want_kind:
+        if want_kind != kind:
+            return None
+    elif kind in WORKSPACE_KINDS:
+        # "any signal" means any signal about the AGENT. A workspace finding is
+        # a property of the folder and is always critical, so folding it into
+        # the catch-all would silently repurpose every existing rule.
         return None
 
     if not _scope_matches(policy.get("scope_runtime"), incident.get("runtime")):

--- a/clawmetry/repo_scan.py
+++ b/clawmetry/repo_scan.py
@@ -38,6 +38,17 @@ import os
 import re
 from typing import Optional
 
+#: The incident kinds this module can emit. Declared here, where they are
+#: produced, and re-exported as ``detectors.WORKSPACE_KINDS`` so every surface
+#: that renders or matches an incident reads ONE list. ``DETECTOR_KINDS`` exists
+#: precisely so a new detector cannot be added without the surfaces noticing;
+#: these two kinds bypassed it once by living outside ``detectors``, and the
+#: Guard tab rendered them as "unknown".
+WORKSPACE_KINDS = (
+    "repo_config_exec",      # the checkout's own config names a program
+    "agent_config_tamper",   # an agent hook config was changed under us
+)
+
 # Git config keys whose VALUE is a program git will execute. Section+key, lowered.
 # Sourced from git-config(1); the wildcard forms cover per-name subsections.
 _EXEC_KEYS = (

--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -10459,7 +10459,11 @@ var LOOP_KIND_LABEL = {
   privilege_change: 'Asked for admin rights',
   rate_limited: 'Being rate limited by its provider',
   blocked_on_user: 'Waiting for you to answer',
-  crashed: 'Crashed and restarted'
+  crashed: 'Crashed and restarted',
+  // Not the agent's behaviour: what was in the folder it was pointed at.
+  // Mirrors clawmetry/repo_scan.py WORKSPACE_KINDS.
+  repo_config_exec: 'This folder is set up to run a program',
+  agent_config_tamper: 'An agent hook config in this folder was changed'
 };
 
 // What ignoring this is estimated to cost. Blank when we do not know, because
@@ -30783,8 +30787,42 @@ var GUARD_KIND_LABEL = {
   // Silent failure: it stopped, and nobody was told.
   rate_limited: 'Rate limited by the provider',
   blocked_on_user: 'Waiting on you',
-  crashed: 'Crashed and restarted'
+  crashed: 'Crashed and restarted',
+  // Workspace: what is in the folder this agent was pointed at. Not a
+  // behaviour, which is why these two sort on their own axis and why the
+  // policy form makes you name them rather than folding them into "any
+  // signal". Keys mirror clawmetry/repo_scan.py WORKSPACE_KINDS.
+  repo_config_exec: 'Repo config runs a program',
+  agent_config_tamper: 'Agent hook config changed'
 };
+
+// The workspace half of GUARD_KIND_LABEL, so a renderer can tell the two
+// questions apart without hard-coding kind strings a second time.
+var GUARD_WORKSPACE_KINDS = ['repo_config_exec', 'agent_config_tamper'];
+
+// The policy form's condition list, built from GUARD_KIND_LABEL rather than
+// re-typed. A hand-kept second copy is how a new kind ends up renderable but
+// not selectable, which is the shape of the bug that hid the two workspace
+// kinds from every Guard surface.
+//
+// "any signal" deliberately excludes the workspace kinds, matching
+// policy_engine: a rule written about runaway agents must not start acting on
+// a property of a checkout because both happen to be critical. The option text
+// says so, because a rule you cannot see the boundary of is a rule you will
+// misuse.
+function guardKindOptions() {
+  var html = '<option value="">any signal about the agent</option>';
+  Object.keys(GUARD_KIND_LABEL).forEach(function (k) {
+    if (GUARD_WORKSPACE_KINDS.indexOf(k) >= 0) return;
+    html += '<option value="' + guardEsc(k) + '">' + guardEsc(GUARD_KIND_LABEL[k]) + '</option>';
+  });
+  html += '<optgroup label="The workspace (must be named)">';
+  GUARD_WORKSPACE_KINDS.forEach(function (k) {
+    html += '<option value="' + guardEsc(k) + '">' + guardEsc(GUARD_KIND_LABEL[k]) + '</option>';
+  });
+  html += '</optgroup>';
+  return html;
+}
 
 // Money first: "$1.20 at risk" is the number that decides what to open next.
 function guardMoney(n) {
@@ -31052,10 +31090,22 @@ function loadGuardSessions() {
       } else {
         statusCell = '<span class="pill pill-ok">Running</span>';
       }
+      // What is in the FOLDER this agent was pointed at. A second pill rather
+      // than a replacement: "looping" and "the checkout runs its own code"
+      // are different questions and an operator needs both. It carries no
+      // money, so the At risk column stays blank for it, and the tooltip says
+      // what was found rather than implying we stopped it.
+      var ws = s.workspace;
+      if (ws) {
+        if (!inc) flagged++;
+        statusCell += ' <span class="pill ' + guardSeverityClass(ws.severity) + '" title="' +
+          guardEsc(ws.detail || '') + '">' +
+          guardEsc(GUARD_KIND_LABEL[ws.kind] || ws.kind) + '</span>';
+      }
       // Listed from the live process probe, so it can be stopped now, but the
       // sync daemon has not read its transcript yet. Say that rather than let
       // the blank cost and missing detector status read as "nothing to see".
-      if (!inc && s.pending_ingest) {
+      if (!inc && !ws && s.pending_ingest) {
         statusCell += ' <span class="muted" title="This session is running and can be stopped now. Its cost and detector status appear once the sync daemon reads its transcript.">&middot; just started</span>';
       }
       // The estimate says what it is: a burn-rate figure and a
@@ -31457,18 +31507,7 @@ function guardShowPolicyForm() {
   el.innerHTML =
     '<div class="form-row"><label>Name</label><input id="gp-name" placeholder="Pause loopers"></div>' +
     '<div class="form-row"><label>When</label><select id="gp-kind">' +
-      '<option value="">any signal</option>' +
-      '<option value="stuck_loop">Looping</option>' +
-      '<option value="no_progress">Not progressing</option>' +
-      '<option value="repeated_tool_failure">Tool failing repeatedly</option>' +
-      '<option value="action_discrepancy">Continued after a failure</option>' +
-      '<option value="file_blast_radius">Wide or destructive file changes</option>' +
-      '<option value="credential_access">Read credentials</option>' +
-      '<option value="network_egress">Unusual network destination</option>' +
-      '<option value="privilege_change">Privilege change</option>' +
-      '<option value="rate_limited">Rate limited by the provider</option>' +
-      '<option value="blocked_on_user">Waiting on you</option>' +
-      '<option value="crashed">Crashed and restarted</option>' +
+      guardKindOptions() +
     '</select></div>' +
     '<div class="form-row"><label>At least this severe</label><select id="gp-severity">' +
       '<option value="info">info</option>' +

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -21301,16 +21301,16 @@ def _emit_detector_incidents(store, state: dict) -> int:
         # .git/config, an autorun task, a tampered agent hook). Same incident
         # shape, same loop_signals row, same Guard tab.
         #
-        # Deliberately NOT added to all_incidents, which is what the policy
-        # pass reads: a policy with trigger_kind "" matches ANY kind, so
-        # feeding workspace findings in today would let an existing
-        # "pause anything critical" rule pause a session because of a property
-        # of its folder, with no way to express "except that". Teaching the
-        # policy engine and the Guard policy form these two kinds is its own
-        # change (clawmetry-pro#223); until then the operator is TOLD and
-        # nothing is signalled.
-        incidents = list(incidents) + _workspace_incidents(
+        # These DO reach the policy pass, but only a policy that NAMES the kind
+        # can act on them: policy_engine excludes WORKSPACE_KINDS from the
+        # catch-all `trigger_kind: ""` precisely so a standing "pause anything
+        # critical" rule, written about runaway agents, cannot start pausing
+        # sessions over a property of a checkout.
+        workspace = _workspace_incidents(
             state, facts.get("cwd") or "", sid, runtime or "unknown", now)
+        if workspace:
+            all_incidents.extend(workspace)
+        incidents = list(incidents) + workspace
         if not incidents:
             continue
 

--- a/routes/guard.py
+++ b/routes/guard.py
@@ -355,6 +355,16 @@ def _live_only_rows(store_rows: list) -> list:
 _SEVERITY_RANK = {"info": 0, "warning": 1, "critical": 2}
 
 
+# The two kinds ``clawmetry.repo_scan`` emits. Imported from where they are
+# declared so this route cannot drift from the daemon; the literal fallback
+# exists because the Guard tab must render on a cloud instance where the
+# scanner module may be absent, and a missing import must not blank the tab.
+try:  # pragma: no cover - trivial fallback
+    from clawmetry.repo_scan import WORKSPACE_KINDS as _WORKSPACE_KINDS
+except Exception:  # noqa: BLE001
+    _WORKSPACE_KINDS = ("repo_config_exec", "agent_config_tamper")
+
+
 def _incident_rank(inc) -> tuple:
     """Sort key for one incident: money, then severity, then size.
 
@@ -396,7 +406,14 @@ def api_guard_sessions():
                        since_minutes=30) or []
 
     # Newest incident per session wins; a session can trip several detectors.
+    #
+    # Workspace findings are kept in their OWN map rather than competing here.
+    # They carry no spend (a poisoned checkout is not a stretch of expensive
+    # tokens), so on the money ranking they would lose to every behavioural
+    # incident and vanish behind it. Two fields, two questions: "what is this
+    # agent doing" and "what is in the folder you pointed it at".
     incident_by_session = {}
+    workspace_by_session = {}
     for sig in signals:
         if not isinstance(sig, dict):
             continue
@@ -437,6 +454,11 @@ def api_guard_sessions():
         # severity and then to count when no cost is known — the same order
         # ``detectors.incident_rank`` uses, so the tab and the daemon agree on
         # which finding is the loudest.
+        if candidate["kind"] in _WORKSPACE_KINDS:
+            prev_ws = workspace_by_session.get(sid)
+            if prev_ws is None or _incident_rank(candidate) > _incident_rank(prev_ws):
+                workspace_by_session[sid] = candidate
+            continue
         if prev is None or _incident_rank(candidate) > _incident_rank(prev):
             incident_by_session[sid] = candidate
 
@@ -461,12 +483,21 @@ def api_guard_sessions():
         runtime = _session_runtime(sid, s.get("agent_type") or "")
         meta = s.get("metadata")
         meta = meta if isinstance(meta, dict) else {}
+        # ``sessions.cwd`` is the COLUMN the rest of the product keys on, and
+        # reading only ``metadata`` here meant every runtime that fills the
+        # column and not the blob handed ``runtime_control_support`` an empty
+        # cwd, which is what it promotes to find a pid. Same bug, same class,
+        # as the one fixed in ``sync._detector_session_facts``.
         cwd = ""
-        for key in ("cwd", "workspace", "project_dir", "working_dir", "path"):
-            val = meta.get(key)
-            if isinstance(val, str) and val.strip():
-                cwd = val.strip()
-                break
+        col = s.get("cwd")
+        if isinstance(col, str) and col.strip():
+            cwd = col.strip()
+        else:
+            for key in ("cwd", "workspace", "project_dir", "working_dir", "path"):
+                val = meta.get(key)
+                if isinstance(val, str) and val.strip():
+                    cwd = val.strip()
+                    break
         try:
             cost = round(float(s.get("cost_usd") or 0), 4)
         except (TypeError, ValueError):
@@ -485,6 +516,10 @@ def api_guard_sessions():
             "message_count": int(s.get("message_count") or 0),
             "cwd": cwd,
             "incident": incident_by_session.get(sid),
+            # What is in the folder this agent was pointed at, when anything is.
+            # Separate from ``incident`` on purpose: it is not ranked against
+            # money, because it is not a cost.
+            "workspace": workspace_by_session.get(sid),
             "controllable": support["controllable"],
             "control_reason": support.get("reason", ""),
             # Why it is not controllable, in one machine-readable word (see
@@ -514,13 +549,23 @@ def api_guard_sessions():
     # only breaks exact ties among flagged rows — but it decides the whole
     # unflagged group, which is what puts a just-started session at the top of
     # it instead of at the bottom of a 50-row table.
+    #
+    # A workspace finding sorts on its OWN axis, ahead of the money one. This
+    # is the one deliberate exception to "ranked by spend at risk", and it is
+    # not a fudge of the money model: the alternative was to invent a dollar
+    # figure so a critical finding would sort well, which is exactly what
+    # ``annotate_spend`` refuses to do. A poisoned checkout has no cost
+    # attached because it has no cost; it is a property of the machine, and
+    # burying it under every session that happens to be spending would make it
+    # unreachable in a 50-row table.
     out.sort(key=lambda r: (
-        1 if r.get("incident") else 0,
+        1 if (r.get("incident") or r.get("workspace")) else 0,
+        1 if r.get("workspace") else 0,
         _incident_rank(r.get("incident")),
         _ts_epoch(r.get("last_active_at")),
     ), reverse=True)
 
-    flagged = [r for r in out if r.get("incident")]
+    flagged = [r for r in out if r.get("incident") or r.get("workspace")]
     return jsonify({
         "sessions": out,
         "count": len(out),

--- a/tests/test_guard_workspace_kinds.py
+++ b/tests/test_guard_workspace_kinds.py
@@ -1,0 +1,260 @@
+"""Guard knows the two workspace kinds, and cannot silently act on them.
+
+``repo_scan`` emits ``repo_config_exec`` and ``agent_config_tamper`` in the same
+shape as every detector incident. They bypassed ``DETECTOR_KINDS`` (which exists
+so a new detector cannot be added without the surfaces that render it noticing)
+because they live outside ``detectors``, and every Guard surface rendered them
+as their raw id.
+
+Four properties are pinned here:
+
+* one list, not two that drift: ``ALL_INCIDENT_KINDS`` is the union, every
+  renderable kind has plain-words copy, and the policy form is BUILT from that
+  copy rather than re-typed;
+* a policy must NAME a workspace kind to act on it. ``trigger_kind: ""`` means
+  any signal about the agent, so a standing "pause anything critical" rule
+  cannot start pausing sessions over a property of a checkout;
+* the daemon still hands workspace findings to the policy pass (that is what
+  makes a named policy possible at all);
+* a workspace finding is reachable in the Guard list: it carries no spend, so
+  the money ranking would bury it, and it sorts on its own axis instead of
+  being given an invented dollar figure.
+"""
+from __future__ import annotations
+
+import os
+import re
+import sys
+import time
+
+import pytest
+from flask import Flask
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+import routes.guard as guard  # noqa: E402
+from clawmetry import detectors as _det  # noqa: E402
+from clawmetry import policy_engine as pe  # noqa: E402
+from clawmetry import repo_scan as _rs  # noqa: E402
+from clawmetry import sync as _sync  # noqa: E402
+
+_APP_JS = os.path.join(_REPO_ROOT, "clawmetry", "static", "js", "app.js")
+
+
+def _js() -> str:
+    with open(_APP_JS, encoding="utf-8") as fh:
+        return fh.read()
+
+
+def _js_map(name: str) -> dict:
+    """Parse a `var NAME = { key: 'value', ... };` literal out of app.js."""
+    src = _js()
+    start = src.index("var " + name + " = {")
+    end = src.index("};", start)
+    body = src[start:end]
+    return dict(re.findall(r"^\s*([a-z_]+)\s*:\s*'([^']*)'", body, re.M))
+
+
+# ── one list ───────────────────────────────────────────────────────────────
+def test_the_union_is_the_two_halves():
+    assert _det.WORKSPACE_KINDS == _rs.WORKSPACE_KINDS
+    assert _det.ALL_INCIDENT_KINDS == _det.DETECTOR_KINDS + _det.WORKSPACE_KINDS
+    assert set(_det.DETECTOR_KINDS).isdisjoint(_det.WORKSPACE_KINDS)
+
+
+def test_repo_scan_emits_only_declared_kinds(tmp_path):
+    ws = tmp_path / "repo"
+    (ws / ".git").mkdir(parents=True)
+    (ws / ".git" / "config").write_text("[core]\n\tfsmonitor = /tmp/x.sh\n",
+                                        encoding="utf-8")
+    (ws / ".claude").mkdir()
+    (ws / ".claude" / "settings.json").write_text(
+        '{"hooks": {"PreToolUse": [{"hooks": [{"command": "/tmp/y.sh"}]}]}}',
+        encoding="utf-8")
+    kinds = {f["kind"] for f in _rs.scan_workspace(str(ws))}
+    assert kinds, "fixture should trip both scanners"
+    assert kinds <= set(_rs.WORKSPACE_KINDS), f"undeclared kind emitted: {kinds}"
+
+
+@pytest.mark.parametrize("kind", _det.ALL_INCIDENT_KINDS)
+def test_every_kind_has_plain_words_in_the_guard_tab(kind):
+    """The whole point of the union: a kind the product can emit cannot reach
+    a screen as its raw id."""
+    assert kind in _js_map("GUARD_KIND_LABEL"), (
+        f"{kind} renders as its raw id in the Guard tab; add it to "
+        f"GUARD_KIND_LABEL in app.js")
+
+
+@pytest.mark.parametrize("kind", _det.ALL_INCIDENT_KINDS)
+def test_every_kind_has_plain_words_in_the_alerts_feed(kind):
+    assert kind in _js_map("LOOP_KIND_LABEL"), (
+        f"{kind} renders as its raw id in the alerts feed; add it to "
+        f"LOOP_KIND_LABEL in app.js")
+
+
+def test_the_policy_form_is_built_from_the_label_map():
+    """A second hand-kept list is how a kind ends up renderable but not
+    selectable, which is exactly how these two stayed invisible."""
+    src = _js()
+    assert "guardKindOptions()" in src
+    for kind in _det.DETECTOR_KINDS:
+        assert "'<option value=\"%s\">" % kind not in src, (
+            f"the policy form re-types {kind}; build the options from "
+            f"GUARD_KIND_LABEL instead")
+
+
+def test_the_js_workspace_list_matches_python():
+    src = _js()
+    listed = re.search(r"var GUARD_WORKSPACE_KINDS = \[([^\]]*)\]", src).group(1)
+    got = tuple(re.findall(r"'([a-z_]+)'", listed))
+    assert got == _rs.WORKSPACE_KINDS
+
+
+# ── a policy must name it ──────────────────────────────────────────────────
+def _incident(kind, severity="critical"):
+    return {"kind": kind, "session_id": "cursor:1", "runtime": "cursor",
+            "severity": severity, "title": "t", "detail": "d", "evidence": {},
+            "spend_at_risk_usd": 0.0, "spend_basis": "unknown"}
+
+
+def _policy(trigger_kind="", action="pause"):
+    return {"policy_id": "p1", "enabled": True, "scope_runtime": "",
+            "scope_agent_id": "", "trigger_kind": trigger_kind,
+            "min_severity": "warning", "min_repeat": 0, "min_duration_s": 0,
+            "min_spend_usd": 0, "min_spend_at_risk_usd": 0, "action": action}
+
+
+_FACTS = {"cursor:1": {"cost_usd": 1.0, "bad_for_seconds": 999,
+                       "runtime": "cursor", "cwd": "/w", "agent_id": "main"}}
+
+
+@pytest.mark.parametrize("kind", _rs.WORKSPACE_KINDS)
+def test_any_signal_does_not_match_a_workspace_finding(kind):
+    """The burn this prevents: one preset with no condition paused everything
+    on the node. A rule written about runaway agents must not silently acquire
+    a new meaning because a scanner started emitting critical findings."""
+    assert pe.evaluate([_incident(kind)], [_policy("")], _FACTS) == []
+
+
+@pytest.mark.parametrize("kind", _rs.WORKSPACE_KINDS)
+def test_a_policy_that_names_the_kind_matches(kind):
+    decisions = pe.evaluate([_incident(kind)], [_policy(kind)], _FACTS)
+    assert [d["kind"] for d in decisions] == [kind]
+    assert decisions[0]["action"] == "pause"
+
+
+def test_any_signal_still_matches_a_detector_kind():
+    """The exclusion must be surgical: catch-all rules keep working."""
+    decisions = pe.evaluate([_incident("stuck_loop")], [_policy("")], _FACTS)
+    assert [d["kind"] for d in decisions] == ["stuck_loop"]
+
+
+# ── the daemon hands them to the policy pass ───────────────────────────────
+class _EmitStore:
+    def __init__(self, cwd):
+        now_iso = time.strftime("%Y-%m-%dT%H:%M:%S", time.localtime())
+        self.row = {"session_id": "cursor:abc", "agent_type": "cursor",
+                    "started_at": now_iso, "last_active_at": now_iso,
+                    "status": "active", "cost_usd": 1.0, "cwd": cwd,
+                    "metadata": {}}
+
+    def query_sessions_table(self, limit=300):
+        return [self.row]
+
+    def query_events(self, **kw):
+        return [{"event_type": "tool_call", "ts": self.row["started_at"],
+                 "data": {"tool": "x"}}]
+
+    def query_approvals(self, **kw):
+        return []
+
+    def ingest_loop_signal(self, **kw):
+        return None
+
+    def __getattr__(self, name):
+        return lambda *a, **k: None
+
+
+def test_workspace_findings_reach_the_policy_pass(tmp_path, monkeypatch):
+    ws = tmp_path / "repo"
+    (ws / ".git").mkdir(parents=True)
+    (ws / ".git" / "config").write_text("[core]\n\tfsmonitor = /tmp/x.sh\n",
+                                        encoding="utf-8")
+    monkeypatch.setattr(_det, "run_all", lambda *a, **k: [])
+    monkeypatch.setattr(_sync, "_record_guard_observation", lambda *a, **k: None)
+    seen = []
+    monkeypatch.setattr(_sync, "_apply_guard_policies",
+                        lambda store, state, incs, facts: seen.append(
+                            [i["kind"] for i in incs]))
+    _sync._emit_detector_incidents(_EmitStore(str(ws)), {})
+    assert seen == [["repo_config_exec"]], (
+        "a named policy cannot fire on a finding the pass never sees")
+
+
+# ── reachable in the list ──────────────────────────────────────────────────
+@pytest.fixture()
+def client():
+    app = Flask(__name__)
+    app.register_blueprint(guard.bp_guard)
+    return app.test_client()
+
+
+def _sig(sid, kind, sev, spend):
+    return {"session_id": sid, "signature": "daemon_detect_" + kind,
+            "severity": sev, "repeat_count": 3, "first_seen": None,
+            "details": {"kind": kind, "message": kind, "detail": "d",
+                        "spend_at_risk_usd": spend, "spend_basis":
+                        "burn_rate" if spend else "unknown", "evidence": {}}}
+
+
+@pytest.fixture()
+def rows(monkeypatch, client):
+    now_iso = time.strftime("%Y-%m-%dT%H:%M:%S", time.localtime())
+    sessions = [
+        {"session_id": "cursor:rich", "status": "active", "cost_usd": 200.0,
+         "started_at": now_iso, "last_active_at": now_iso, "metadata": {}},
+        {"session_id": "cursor:poisoned", "status": "active", "cost_usd": 0.0,
+         "started_at": now_iso, "last_active_at": now_iso, "metadata": {},
+         "cwd": "/w/poisoned"},
+    ]
+    signals = [_sig("cursor:rich", "stuck_loop", "warning", 170.0),
+               _sig("cursor:poisoned", "repo_config_exec", "critical", 0.0)]
+    monkeypatch.setattr(guard, "_ls_call", lambda m, **kw: (
+        sessions if m == "query_sessions_table"
+        else signals if m == "query_recent_loop_signals" else None))
+    monkeypatch.setattr(guard, "_live_only_rows", lambda out: [])
+    monkeypatch.setattr(guard, "_runtime_supports_signals", lambda *a, **k: {
+        "controllable": True, "reason": "", "state": "controllable",
+        "actions": ["pause", "stop", "kill"], "no_pause": False})
+    return client.get("/api/guard/sessions").get_json()
+
+
+def test_the_workspace_finding_is_its_own_field(rows):
+    by_id = {r["session_id"]: r for r in rows["sessions"]}
+    poisoned = by_id["cursor:poisoned"]
+    assert poisoned["workspace"]["kind"] == "repo_config_exec"
+    # Not ranked against money: it does not displace the behavioural incident.
+    assert poisoned["incident"] is None
+    assert by_id["cursor:rich"]["workspace"] is None
+    assert by_id["cursor:rich"]["incident"]["kind"] == "stuck_loop"
+
+
+def test_a_poisoned_checkout_sorts_above_an_expensive_loop(rows):
+    """It is not more expensive. It is uncosted and irreversible, and burying
+    it under every spending session would make it unreachable. The alternative
+    was to invent a dollar figure so it would sort well, which is the thing
+    ``annotate_spend`` refuses to do."""
+    assert [r["session_id"] for r in rows["sessions"]][0] == "cursor:poisoned"
+
+
+def test_it_counts_as_flagged(rows):
+    assert rows["flagged"] == 2
+    # ...but contributes no money to the headline, because none is known.
+    assert rows["spend_at_risk_usd"] == 170.0
+
+
+def test_the_row_cwd_comes_from_the_column(rows):
+    by_id = {r["session_id"]: r for r in rows["sessions"]}
+    assert by_id["cursor:poisoned"]["cwd"] == "/w/poisoned"

--- a/tests/test_repo_scan_daemon_wiring.py
+++ b/tests/test_repo_scan_daemon_wiring.py
@@ -8,8 +8,9 @@ path. This file pins the four properties that wiring has to keep:
 * a poisoned repo produces a ``repo_config_exec`` loop_signals row,
 * the scan is cached on the mtime of exactly the files it reads (a 50-repo
   fleet must not re-read them every tick) and re-runs the moment one changes,
-* workspace findings do NOT reach the policy pass (a ``trigger_kind: ""``
-  policy would otherwise pause a session over a property of its folder),
+* workspace findings reach the policy pass, so a policy that names the kind
+  can act on them (the catch-all exclusion is pinned in
+  ``tests/test_guard_workspace_kinds.py``),
 * the cwd comes from the ``sessions.cwd`` COLUMN, which is where every
   cwd-aware consumer already keys.
 """
@@ -199,17 +200,20 @@ def test_emit_writes_a_loop_signal_for_a_poisoned_workspace(tmp_path, _quiet,
     assert sig["details"]["spend_basis"] == "unknown"
 
 
-def test_workspace_findings_never_reach_the_policy_pass(tmp_path, _quiet,
-                                                        monkeypatch):
-    """A policy with ``trigger_kind: ""`` matches any kind. Until the policy
-    form can express these two kinds (clawmetry-pro#223), a poisoned folder
-    must not be able to pause the session that opened it."""
+def test_workspace_findings_reach_the_policy_pass(tmp_path, _quiet,
+                                                 monkeypatch):
+    """They are handed to the pass so a policy that NAMES the kind can act.
+    The safety property lives in ``policy_engine`` instead, where an empty
+    ``trigger_kind`` excludes them: see
+    ``tests/test_guard_workspace_kinds.py``, which pins that a catch-all rule
+    cannot fire on a poisoned checkout."""
     seen = []
     monkeypatch.setattr(_sync, "_apply_guard_policies",
-                        lambda store, state, incs, facts: seen.append(list(incs)))
+                        lambda store, state, incs, facts: seen.append(
+                            [i["kind"] for i in incs]))
     store = _EmitStore(_poisoned_repo(tmp_path))
     _sync._emit_detector_incidents(store, {})
-    assert seen == [], f"workspace findings reached the policy pass: {seen}"
+    assert seen == [["repo_config_exec"]]
 
 
 def test_a_clean_workspace_emits_nothing(tmp_path, _quiet, monkeypatch):

--- a/verification/guards.json
+++ b/verification/guards.json
@@ -120,6 +120,16 @@
       "path": "tests/test_ac_coverage_guard.py",
       "why": "Pins the AC gate's declaration rule. Without it the first draft's loophole returns, where a file naming a criterion it does NOT cover marks that criterion covered.",
       "min_bytes": 3000
+    },
+    {
+      "path": "tests/test_repo_scan_daemon_wiring.py",
+      "why": "Pins that the daemon actually RUNS the workspace scanner, cached per directory. repo_scan shipped for weeks with no caller: a detector nobody runs protects nobody, and nothing failed while that was true.",
+      "min_bytes": 4000
+    },
+    {
+      "path": "tests/test_guard_workspace_kinds.py",
+      "why": "Pins that a policy must NAME a workspace kind to act on it. Without it a catch-all 'pause anything critical' rule silently acquires power over every poisoned checkout, which is the shape of the preset that paused 280 sessions in 22 minutes.",
+      "min_bytes": 4000
     }
   ],
   "ratchets": {


### PR DESCRIPTION
No-PRD: closes a specced security-gap issue on the private tracker (vivekchand/clawmetry-pro#223), which carries the requirement and the ranking question.

## Why

`repo_scan` emits `repo_config_exec` and `agent_config_tamper` in the same shape as every detector incident, and no surface knew them. The Guard tab printed the raw id, the policy form could not select them, and `detectors.DETECTOR_KINDS` (which exists precisely so a new detector cannot be added without the surfaces that render it noticing) could not see them because they live outside `detectors.py`.

## One list, not two that drift

- `repo_scan.WORKSPACE_KINDS` is declared where the kinds are produced, re-exported as `detectors.WORKSPACE_KINDS`, and `detectors.ALL_INCIDENT_KINDS` is the union every renderer reads.
- The Guard policy form is now built from `GUARD_KIND_LABEL` rather than a third hand-typed `<option>` list. A second copy is exactly how a kind ends up renderable but not selectable, which is how these two stayed invisible.
- A parametrised guard walks `ALL_INCIDENT_KINDS` and asserts plain-words copy exists in both JS label maps, so a kind added later is covered without editing the test.

## A policy must name a workspace kind

`trigger_kind: ""` now means "any signal about the agent". Both workspace kinds are `critical` by construction, so folding them into the catch-all would silently repurpose every existing "pause anything critical" rule into one that also pauses sessions over a property of a checkout. That is the shape of the preset that paused 280 sessions in 22 minutes. The form says so, with the two kinds in their own optgroup.

With that boundary in place the daemon hands workspace findings to the policy pass, which is what makes a named policy possible at all.

## Ranking: decided, not fudged

A workspace finding carries no spend because it has no spend. On the money ranking it loses to every behavioural incident, so a critical finding sits below every session that happens to be spending. `/api/guard/sessions` gives it its own axis: a separate `workspace` field on the row, sorted ahead of the money key, and the row renders both pills. The alternative was to attach a dollar figure so it would sort well, which is the thing `annotate_spend` exists to refuse.

Also fixes the same cwd bug in `routes/guard.py` that `sync` had: the row read only `metadata` and ignored the `sessions.cwd` column, which is what `runtime_control_support` promotes to find a pid.

## Verified

**Guard proven to fail on the unfixed code, per property:**

```
reverted the catch-all exclusion in policy_engine:
  FAILED test_any_signal_does_not_match_a_workspace_finding[repo_config_exec]
  FAILED test_any_signal_does_not_match_a_workspace_finding[agent_config_tamper]

reverted the workspace split in routes/guard.py:
  FAILED test_the_workspace_finding_is_its_own_field
  FAILED test_a_poisoned_checkout_sorts_above_an_expensive_loop
```

40 tests in `tests/test_guard_workspace_kinds.py`, registered in `ci.yml` (explicit file lists) and in `verification/guards.json`. 207 pass across the guard, detector and policy suites. `make lint-js` and `lint-module-map` green.

Closes vivekchand/clawmetry-pro#223.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TtHxhGn2nwqoZ2v6SqcXMK
