### PR TITLE
Resolve .git-as-a-file: a poisoned linked worktree read as CLEAN

### DIFF
--- a/clawmetry/repo_scan.py
+++ b/clawmetry/repo_scan.py
@@ -128,6 +128,95 @@ def _hook_manager_for(value: str) -> Optional[str]:
     return _KNOWN_HOOK_MANAGERS.get("." + first.lstrip("."))
 
 
+def _config_label(workspace: str, path: str) -> str:
+    """A short, honest name for the config a finding came from.
+
+    ``.git/config`` for the ordinary layout. For a linked worktree the file is
+    outside the workspace, so the label keeps the last three components rather
+    than an absolute path: an incident travels to a UI and a device, and the
+    reader needs to know WHICH config without being handed the user's home
+    directory.
+    """
+    try:
+        ws = os.path.realpath(workspace)
+        real = os.path.realpath(path)
+        if real == os.path.join(ws, ".git", "config"):
+            return ".git/config"
+        if real.startswith(ws + os.sep):
+            return os.path.relpath(real, ws)
+        parts = real.split(os.sep)
+        return ".../" + "/".join(parts[-3:]) if len(parts) > 3 else real
+    except Exception:  # noqa: BLE001
+        return "git config"
+
+
+def _git_dirs(workspace: str) -> tuple:
+    """``(git_dir, common_dir)`` for ``workspace``, resolving a LINKED WORKTREE.
+
+    In a linked worktree ``.git`` is a **file** holding ``gitdir: /abs/path``,
+    and the config git actually reads lives in the *common* directory that
+    path points at, not at ``<workspace>/.git/config``. A scanner that assumes
+    a directory finds no config at all and reports the workspace clean, which
+    is worse than reporting nothing: it is a confident all-clear over a
+    repository git will happily execute ``core.fsmonitor`` from. Agents and CI
+    run inside worktrees routinely, and CVE-2026-55607 is the vendor-confirmed
+    version of exactly this confusion.
+
+    Returns ``("", "")`` when there is no git directory to read. Never raises.
+    """
+    try:
+        dot_git = os.path.join(workspace, ".git")
+        if os.path.isdir(dot_git):
+            return (dot_git, dot_git)
+        if not os.path.isfile(dot_git):
+            return ("", "")
+        with open(dot_git, encoding="utf-8", errors="replace") as f:
+            head = f.read(4096).strip()
+        if not head.lower().startswith("gitdir:"):
+            return ("", "")
+        target = head.split(":", 1)[1].strip()
+        if not target:
+            return ("", "")
+        if not os.path.isabs(target):
+            target = os.path.join(workspace, target)
+        git_dir = os.path.realpath(target)
+        if not os.path.isdir(git_dir):
+            return ("", "")
+        # ``commondir`` is written by git for a linked worktree and is usually
+        # the relative ``../..``. Absent (a plain gitdir redirect, a submodule)
+        # means the gitdir IS the common dir.
+        common = git_dir
+        cd_file = os.path.join(git_dir, "commondir")
+        if os.path.isfile(cd_file):
+            with open(cd_file, encoding="utf-8", errors="replace") as f:
+                rel = f.read(4096).strip()
+            if rel:
+                common = os.path.realpath(
+                    rel if os.path.isabs(rel) else os.path.join(git_dir, rel))
+        return (git_dir, common)
+    except Exception:  # noqa: BLE001 - a scan must never raise
+        return ("", "")
+
+
+def _git_config_paths(workspace: str) -> list:
+    """Every config file git reads for this checkout, nearest last.
+
+    ``<common>/config`` is the repository config. ``<gitdir>/config.worktree``
+    is the per-worktree override git honours when ``extensions.worktreeConfig``
+    is set, and it is writable by whoever supplied the worktree, so it is
+    scanned too rather than assumed absent.
+    """
+    git_dir, common = _git_dirs(workspace)
+    if not git_dir:
+        return []
+    out = []
+    for candidate in (os.path.join(common, "config"),
+                      os.path.join(git_dir, "config.worktree")):
+        if os.path.isfile(candidate) and candidate not in out:
+            out.append(candidate)
+    return out
+
+
 def _hookspath_is_repo_supplied(workspace: str, value: str) -> bool:
     """True when core.hooksPath points at hooks the CHECKOUT ships.
 
@@ -216,31 +305,40 @@ def _finding(kind: str, severity: str, title: str, detail: str,
 
 def scan_git_config(workspace: str, session_id: str = "",
                     runtime: str = "unknown") -> list:
-    """Flag command-valued keys in the repository's own ``.git/config``."""
-    path = os.path.join(workspace, ".git", "config")
-    if not os.path.isfile(path):
-        return []
-    try:
-        with open(path, encoding="utf-8", errors="replace") as f:
-            text = f.read()
-    except Exception:
+    """Flag command-valued keys in every config file git reads for this checkout.
+
+    Not just ``<workspace>/.git/config``: in a linked worktree ``.git`` is a
+    file and the config lives in the common dir it points at. See
+    ``_git_dirs``.
+    """
+    paths = _git_config_paths(workspace)
+    if not paths:
         return []
 
     hits = []
-    for full_key, value, lineno in _parse_git_config(text):
-        if not value or not _key_is_executable(full_key, value):
+    for path in paths:
+        try:
+            with open(path, encoding="utf-8", errors="replace") as f:
+                text = f.read()
+        except Exception:
             continue
-        if _is_known_good(value):
-            continue
-        manager = None
-        if full_key == "core.hookspath":
-            if not _hookspath_is_repo_supplied(workspace, value):
+        for full_key, value, lineno in _parse_git_config(text):
+            if not value or not _key_is_executable(full_key, value):
                 continue
-            manager = _hook_manager_for(value)
-        hits.append({"key": full_key, "command": _sketch(value),
-                     "line": lineno, "manager": manager})
+            if _is_known_good(value):
+                continue
+            manager = None
+            if full_key == "core.hookspath":
+                if not _hookspath_is_repo_supplied(workspace, value):
+                    continue
+                manager = _hook_manager_for(value)
+            hits.append({"key": full_key, "command": _sketch(value),
+                         "line": lineno, "manager": manager})
     if not hits:
         return []
+    # Where the finding was actually read from, so a reader of a worktree
+    # incident is not sent to a .git/config that does not exist.
+    config_label = _config_label(workspace, paths[0])
 
     keys = sorted({h["key"] for h in hits})
     head = keys[0]
@@ -260,7 +358,7 @@ def scan_git_config(workspace: str, session_id: str = "",
             "here can run code on your machine when an agent touches the repo. "
             "Expected for a project you trust; read the hook directory for one "
             "you do not.",
-            {"keys": keys, "hits": hits[:5], "config": ".git/config",
+            {"keys": keys, "hits": hits[:5], "config": config_label,
              "hook_manager": tool, "observed": "repository_config"},
             session_id, runtime)]
     return [_finding(
@@ -272,7 +370,7 @@ def scan_git_config(workspace: str, session_id: str = "",
         "with your privileges, outside the agent's sandbox, before any approval "
         "prompt. Inspect .git/config before letting an agent work here; to "
         "neutralise it for one command, run `git -c core.fsmonitor=false status`.",
-        {"keys": keys, "hits": hits[:5], "config": ".git/config",
+        {"keys": keys, "hits": hits[:5], "config": config_label,
          "observed": "repository_config"},
         session_id, runtime)]
 

--- a/scripts/redteam/audit.py
+++ b/scripts/redteam/audit.py
@@ -90,7 +90,13 @@ def _materialise(case: dict, root: str) -> str:
         dest = os.path.join(ws, rel)
         os.makedirs(os.path.dirname(dest), exist_ok=True)
         with open(dest, "w", encoding="utf-8") as f:
-            f.write(str(content).replace("{{MARKER_CMD}}", marker_cmd))
+            # {{WORKSPACE}} is the materialised workspace's absolute path. A
+            # linked-worktree case needs it: git writes an ABSOLUTE gitdir into
+            # the .git FILE, and a case that used a relative one would exercise
+            # a path git does not actually produce.
+            f.write(str(content)
+                    .replace("{{MARKER_CMD}}", marker_cmd)
+                    .replace("{{WORKSPACE}}", ws))
     for rel in ((case.get("workspace") or {}).get("executable") or []):
         dest = os.path.join(ws, rel)
         if os.path.exists(dest):

--- a/scripts/redteam/corpus/gitspawn-linked-worktree.json
+++ b/scripts/redteam/corpus/gitspawn-linked-worktree.json
@@ -1,0 +1,35 @@
+{
+  "id": "gitspawn-linked-worktree",
+  "name": "GitSpawn in a linked git worktree: .git is a FILE, the config lives in the common dir",
+  "disclosed": "2026-07-24",
+  "source": "https://github.com/advisories/GHSA-7835-87q9-rgvv",
+  "cve": ["CVE-2026-55607"],
+  "attack_class": "silent-rce",
+  "surface": "repo_config",
+  "affects_runtimes": ["claude_code", "codex", "cursor", "goose", "hermes", "qwen_code", "grok"],
+  "summary": "The same core.fsmonitor payload, in a linked worktree. There .git is a file holding `gitdir: /abs/path`, and the config git reads lives in the common directory that path points at. Git executes the value in the worktree exactly as it would in the main checkout.",
+  "why_hard_to_see": "A scanner that assumes <workspace>/.git is a directory finds no config file and reports the workspace CLEAN. That is worse than reporting nothing: it is a confident all-clear over a repository git will happily run code from. Agents and CI work inside worktrees routinely, and CVE-2026-55607 is the vendor-confirmed version of the same git-directory confusion.",
+
+  "workspace": {
+    "files": {
+      ".git": "gitdir: {{WORKSPACE}}/checkout/.git/worktrees/feature\n",
+      "README.md": "# a feature worktree\n",
+      "checkout/.git/config": "[core]\n\trepositoryformatversion = 0\n\tbare = false\n\tfsmonitor = \"{{MARKER_CMD}}\"\n[remote \"origin\"]\n\turl = https://example.invalid/benign.git\n",
+      "checkout/.git/worktrees/feature/commondir": "../..\n",
+      "checkout/.git/worktrees/feature/gitdir": "{{WORKSPACE}}/.git\n",
+      "checkout/.git/worktrees/feature/HEAD": "ref: refs/heads/feature\n"
+    }
+  },
+
+  "events": [
+    {"event_type": "tool_call", "ts": "2026-09-08T09:00:01", "data": {"tool": "Bash", "args": {"command": "git status --porcelain"}}},
+    {"event_type": "tool_call", "ts": "2026-09-08T09:00:06", "data": {"tool": "Read", "args": {"file_path": "README.md"}}}
+  ],
+
+  "expect": {
+    "detected": true,
+    "any_of": ["repo_config_exec"],
+    "min_severity": "critical",
+    "rationale": "Resolving .git-as-a-file through its gitdir and commondir to the real config is what makes the scanner correct rather than narrowly fitted to the one layout GitSpawn was first demonstrated on."
+  }
+}

--- a/tests/test_redteam_corpus.py
+++ b/tests/test_redteam_corpus.py
@@ -215,3 +215,97 @@ def test_gitignored_settings_outranks_committed(tmp_path):
     both = repo_scan.scan_agent_hooks(str(tmp_path))
     sev = {f["evidence"]["file"]: f["severity"] for f in both}
     assert sev[".claude/settings.local.json"] == "critical"
+
+# ── linked worktrees: .git is a FILE, the config is elsewhere ────────────────
+def _git(*args, cwd):
+    import subprocess
+    return subprocess.run(["git", *args], cwd=cwd, capture_output=True, text=True)
+
+
+def _real_worktree(tmp_path):
+    """A real `git worktree add`, not a hand-built fixture.
+
+    The layout git actually writes is the thing under test: an absolute
+    ``gitdir:`` in the ``.git`` file, a ``commondir`` of ``../..``, and the
+    config in the main checkout. A fixture written from memory would pass
+    against a resolver that only handles the layout the fixture author
+    imagined.
+    """
+    import shutil
+    if not shutil.which("git"):
+        pytest.skip("git not available")
+    main = tmp_path / "main"
+    main.mkdir()
+    _git("init", "-q", ".", cwd=main)
+    (main / "README.md").write_text("x\n", encoding="utf-8")
+    _git("add", "-A", cwd=main)
+    _git("-c", "user.email=t@t", "-c", "user.name=t", "commit", "-qm", "i", cwd=main)
+    wt = tmp_path / "wt"
+    r = _git("worktree", "add", "-q", str(wt), "-b", "feature", cwd=main)
+    if not (wt / ".git").exists():
+        pytest.skip(f"git worktree unavailable: {r.stderr.strip()[:120]}")
+    return main, wt
+
+
+def test_a_linked_worktree_resolves_to_the_common_config(tmp_path):
+    """The gap CVE-2026-55607 is the vendor-confirmed version of: a scanner
+    that assumes ``.git`` is a directory reports a poisoned worktree CLEAN,
+    which is worse than reporting nothing."""
+    main, wt = _real_worktree(tmp_path)
+    assert (main / ".git" / "config").is_file()
+    with open(main / ".git" / "config", "a", encoding="utf-8") as f:
+        f.write('\n[core]\n\tfsmonitor = "/tmp/payload.sh"\n')
+
+    assert (wt / ".git").is_file(), "a linked worktree's .git must be a file"
+    findings = repo_scan.scan_workspace(str(wt))
+    assert [f["kind"] for f in findings] == ["repo_config_exec"]
+    assert findings[0]["severity"] == "critical"
+    # The label must point at the config that was actually read, or a reader
+    # goes looking for a .git/config that does not exist.
+    assert findings[0]["evidence"]["config"].endswith("main/.git/config")
+
+
+def test_a_clean_worktree_stays_quiet(tmp_path):
+    _main, wt = _real_worktree(tmp_path)
+    assert repo_scan.scan_workspace(str(wt)) == []
+
+
+def test_git_dirs_resolves_the_pair(tmp_path):
+    main, wt = _real_worktree(tmp_path)
+    git_dir, common = repo_scan._git_dirs(str(wt))
+    # git names the worktree admin dir after the worktree PATH ("wt"), not the
+    # branch ("feature") -- the kind of detail a hand-built fixture gets wrong.
+    assert git_dir.endswith(os.path.join(".git", "worktrees", "wt"))
+    assert os.path.realpath(common) == os.path.realpath(str(main / ".git"))
+    # An ordinary checkout answers with itself for both.
+    d, c = repo_scan._git_dirs(str(main))
+    assert d == c == os.path.join(str(main), ".git")
+
+
+def test_a_worktree_config_override_is_scanned(tmp_path):
+    """``config.worktree`` is honoured by git when extensions.worktreeConfig is
+    set, and is writable by whoever supplied the worktree."""
+    _main, wt = _real_worktree(tmp_path)
+    git_dir, _common = repo_scan._git_dirs(str(wt))
+    with open(os.path.join(git_dir, "config.worktree"), "w", encoding="utf-8") as f:
+        f.write('[core]\n\tfsmonitor = "/tmp/payload.sh"\n')
+    kinds = [f["kind"] for f in repo_scan.scan_workspace(str(wt))]
+    assert kinds == ["repo_config_exec"]
+
+
+@pytest.mark.parametrize("content", [
+    "gitdir: /nonexistent/path/nowhere",
+    "gitdir:",
+    "not a gitdir line at all",
+    "",
+    "\x00\xff binary junk",
+])
+def test_a_broken_dot_git_file_is_quiet_not_fatal(tmp_path, content):
+    """A scan must never raise, and must never guess. ``scan_workspace``
+    swallows exceptions per check, so a crash here would show up as a silent
+    all-clear rather than an error."""
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    (ws / ".git").write_text(content, encoding="utf-8")
+    assert repo_scan._git_dirs(str(ws)) == ("", "")
+    assert repo_scan.scan_git_config(str(ws)) == []


### PR DESCRIPTION
No-PRD: closes a `sec-gap` issue the red-team audit filed automatically on the private tracker (vivekchand/clawmetry-pro#229).

## The bug

`repo_scan.scan_git_config` opened `<workspace>/.git/config` and nothing else. In a **linked worktree** `.git` is a **file** holding `gitdir: /abs/path`, and the config git actually reads lives in the common directory that path points at.

So a poisoned worktree scanned **clean**. That is worse than scanning nothing: it is a confident all-clear over a repository git will happily execute `core.fsmonitor` from, on a layout agents and CI use routinely. CVE-2026-55607 is the vendor-confirmed version of the same git-directory confusion.

Filed by `scripts/redteam/audit.py` itself, which is the audit doing the job it was wired into CI for.

## The fix

- `_git_dirs(workspace)` resolves `(git_dir, common_dir)` through the `.git` file's `gitdir:` and the worktree's `commondir`.
- `_git_config_paths(workspace)` returns every config git reads: `<common>/config` plus `<gitdir>/config.worktree`, which git honours when `extensions.worktreeConfig` is set and which is writable by whoever supplied the worktree.
- The finding reports the config it was **actually read from**, keeping only the last three path components: an incident travels to a UI and to a device, and it must not carry the user's home directory.
- Ordinary checkouts are unchanged: `_git_dirs` answers with `.git` for both values and the label stays `.git/config`.

Corpus case `gitspawn-linked-worktree` added. The materialiser gained `{{WORKSPACE}}` so the case can carry the **absolute** gitdir git really writes, rather than a relative one no git produces.

## Verified against real git, not a fixture

The tests build the worktree with `git worktree add`, because the layout git writes is the thing under test and a fixture written from memory passes against a resolver that only handles the layout its author imagined. Mine got the admin-directory name wrong on the first run (git names it after the worktree **path**, not the branch) — exactly the class of detail that would have made a fixture-only test green against broken code.

**Guard proven to fail:** reverting `clawmetry/repo_scan.py` alone reds **9 of 38** tests, including the corpus case and all five malformed-`.git` cases. `audit.py` drops from 14/14 to a MISS on the new case, and `control-benign-repo` stays PASS either way (no false positive introduced).

Closes vivekchand/clawmetry-pro#229.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TtHxhGn2nwqoZ2v6SqcXMK
