### PR TITLE
Two functions named _session_cwd: the later one silently replaced the other

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -567,6 +567,7 @@ jobs:
             tests/test_openclaw_detection_real.py \
             tests/test_repo_scan_daemon_wiring.py \
             tests/test_guard_workspace_kinds.py \
+            tests/test_no_shadowed_module_functions.py \
             tests/test_hooks_claude_code.py \
             tests/test_hook_ownership_quoted_launcher.py \
             tests/test_hook_lifecycle.py \

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -20502,18 +20502,19 @@ def _guard_enforcement_allowed() -> bool:
 # or where its workspace root is — and all three change what an incident MEANS.
 # The daemon already touches every candidate session on this tick, so gathering
 # them here is free, where a per-session store read would not be.
-def _session_cwd(session: dict) -> str:
-    """The directory a session ran in, or "" when the runtime never recorded one.
+def _session_row_cwd(session: dict) -> str:
+    """The directory a STORE ROW ran in, or "" when the runtime recorded none.
 
-    ``sessions.cwd`` is the COLUMN every cwd-aware consumer keys on
+    Distinct from :func:`_session_cwd`, which reads a raw adapter/gateway dict
+    by alias. This one reads a ``sessions`` table row: the ``cwd`` COLUMN first,
+    because that is what every cwd-aware consumer keys on
     (``query_repo_activity`` filters on it, ``process_control`` promotes it to
-    find a pid). Reading only ``metadata`` — which this helper replaced — meant
-    every runtime that fills the column and not the blob looked like it had no
-    workspace at all: on this machine that was cursor, goose, opencode, pi and
-    qwen_code, i.e. every session the column exists for.
+    find a pid), then the row's ``metadata`` blob through the SAME alias set,
+    so a runtime that only fills the blob is still found.
 
-    The metadata keys stay as the fallback: some adapters put it there and
-    nowhere else, and a runtime that records neither honestly has no cwd.
+    The two must not share a name. When they did, the later definition silently
+    replaced the earlier one for all three of its callers and the twelve-alias
+    lookup became a two-key one -- see ``test_no_shadowed_module_functions``.
     """
     if not isinstance(session, dict):
         return ""
@@ -20523,11 +20524,7 @@ def _session_cwd(session: dict) -> str:
     meta = session.get("metadata")
     if not isinstance(meta, dict):
         return ""
-    for key in ("cwd", "workspace", "project_dir", "working_dir", "path"):
-        val = meta.get(key)
-        if isinstance(val, str) and val.strip():
-            return val.strip()
-    return ""
+    return (_session_cwd(meta) or "").strip()
 
 
 # ── Workspace scan: the attack surface the tool stream cannot see ──────────
@@ -20665,7 +20662,7 @@ def _detector_session_facts(sessions: list, state: dict, now: float,
         sid = str(s.get("session_id") or "")
         if not sid:
             continue
-        cwd = _session_cwd(s)
+        cwd = _session_row_cwd(s)
         try:
             cost = float(s.get("cost_usd") or 0)
         except (TypeError, ValueError):
@@ -23123,10 +23120,6 @@ def sync_system_snapshot(config: dict, state: dict, paths: dict) -> int:
 
 
 # ── Real-time log streaming ────────────────────────────────────────────────────
-
-
-def start_log_streamer(config: dict, paths: dict) -> threading.Thread:
-    """Start a background thread that tails the local log file and POSTs lines to cloud in real-time."""
 
 
 def start_log_streamer(config: dict, paths: dict) -> threading.Thread:

--- a/tests/test_no_shadowed_module_functions.py
+++ b/tests/test_no_shadowed_module_functions.py
@@ -1,0 +1,114 @@
+"""A module may not define the same top-level name twice.
+
+Python keeps the LAST definition, silently. That is not a style nit: in
+``clawmetry/sync.py`` a helper named ``_session_cwd`` was added beside an
+existing one of the same name, and the new definition replaced the old for all
+THREE of its callers. The original read a raw adapter dict through a
+twelve-alias set (``workingDir``, ``directory``, ``folder``, ...); the
+replacement read two keys. Family sessions whose runtime spells the directory
+any other way stopped persisting ``sessions.cwd``, which is the column
+``process_control`` promotes to find a pid and the one the workspace scanner
+keys on. Nothing failed. The tests passed. The wheel shipped.
+
+Line coverage cannot see this, review rarely does in a 25,000-line module, and
+grep does not either unless you already suspect it. An AST walk does, in
+milliseconds, for every module at once, which is why this guard is
+auto-discovering rather than a list of files someone has to remember to extend.
+"""
+from __future__ import annotations
+
+import ast
+import collections
+import json
+import os
+
+import pytest
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+#: Every first-party module. Discovered, never listed: a guard with a
+#: hand-kept scope drifts the moment somebody adds a file.
+_ROOTS = ("clawmetry", "routes")
+
+
+def _modules() -> list:
+    out = []
+    for root in _ROOTS:
+        base = os.path.join(_REPO_ROOT, root)
+        for dirpath, dirnames, filenames in os.walk(base):
+            dirnames[:] = [d for d in dirnames
+                           if d not in {"__pycache__", "static", "templates",
+                                        "locales", "node_modules"}]
+            for name in filenames:
+                if name.endswith(".py"):
+                    out.append(os.path.join(dirpath, name))
+    out.append(os.path.join(_REPO_ROOT, "dashboard.py"))
+    return sorted(p for p in out if os.path.isfile(p))
+
+
+def _duplicates(path: str) -> dict:
+    """``{name: [line, line]}`` for every top-level def/class defined twice.
+
+    Only module scope: a method named the same in two classes is fine, and a
+    conditional re-definition inside a function is a different question.
+    """
+    try:
+        tree = ast.parse(open(path, encoding="utf-8").read())
+    except SyntaxError:
+        return {}
+    seen = collections.defaultdict(list)
+    for node in tree.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            seen[node.name].append(node.lineno)
+    return {n: ls for n, ls in seen.items() if len(ls) > 1}
+
+
+#: Files that already carry this debt, with the count they carry. A ratchet
+#: rather than an allowlist: the number may fall, never rise, so the existing
+#: 60 do not block work while nothing new joins them.
+_BASELINE_PATH = os.path.join(_REPO_ROOT, "verification",
+                              "shadowed_definitions.json")
+
+
+def _baseline() -> dict:
+    try:
+        with open(_BASELINE_PATH, encoding="utf-8") as fh:
+            return json.load(fh).get("baseline") or {}
+    except Exception:
+        return {}
+
+
+@pytest.mark.parametrize("path", _modules(),
+                         ids=lambda p: os.path.relpath(p, _REPO_ROOT))
+def test_no_shadowed_module_functions(path):
+    rel = os.path.relpath(path, _REPO_ROOT)
+    dupes = _duplicates(path)
+    allowed = int(_baseline().get(rel, 0))
+    assert len(dupes) <= allowed, (
+        f"{rel} defines {len(dupes)} top-level names more than once "
+        f"(baseline {allowed}): {dict(list(dupes.items())[:8])}.\n"
+        "Python keeps the LAST one and says nothing, so every caller of the "
+        "first silently changes behaviour. Rename one, or delete the dead copy."
+    )
+
+
+def test_the_baseline_is_measured_not_aspirational():
+    """A baseline higher than reality lets new debt in under cover of old."""
+    for rel, allowed in _baseline().items():
+        path = os.path.join(_REPO_ROOT, rel)
+        if not os.path.isfile(path):
+            continue
+        actual = len(_duplicates(path))
+        assert actual == allowed, (
+            f"{rel} carries {actual} shadowed names but the baseline records "
+            f"{allowed}. Lower it to {actual} (progress) rather than leaving "
+            f"headroom for the next one."
+        )
+
+
+def test_the_guard_sees_a_shadow_when_there_is_one(tmp_path):
+    """A guard nobody has watched fail is not a guard."""
+    p = tmp_path / "m.py"
+    p.write_text("def f():\n    return 1\n\n\ndef f():\n    return 2\n",
+                 encoding="utf-8")
+    assert _duplicates(str(p)) == {"f": [1, 5]}

--- a/tests/test_repo_scan_daemon_wiring.py
+++ b/tests/test_repo_scan_daemon_wiring.py
@@ -41,15 +41,33 @@ def _poisoned_repo(tmp_path, name="repo"):
 
 
 # ── the cwd the scan keys on ────────────────────────────────────────────────
-def test_session_cwd_prefers_the_column_over_metadata():
+def test_session_row_cwd_prefers_the_column_over_metadata():
     """Regression: reading only ``metadata`` hid the column every cwd-aware
     consumer already uses, so cursor/goose/opencode/pi/qwen_code sessions all
-    looked like they had no workspace."""
-    assert _sync._session_cwd({"cwd": "/tmp/a", "metadata": {"cwd": "/tmp/b"}}) == "/tmp/a"
-    assert _sync._session_cwd({"cwd": None, "metadata": {"cwd": "/tmp/b"}}) == "/tmp/b"
-    assert _sync._session_cwd({"cwd": "  ", "metadata": {"project_dir": "/tmp/c"}}) == "/tmp/c"
-    assert _sync._session_cwd({"metadata": {}}) == ""
-    assert _sync._session_cwd(None) == ""
+    looked like they had no workspace.
+
+    Named ``_session_row_cwd`` because ``_session_cwd`` was already taken by
+    the alias-based reader for raw adapter dicts; sharing the name silently
+    replaced that one for all three of its callers.
+    """
+    assert _sync._session_row_cwd({"cwd": "/tmp/a", "metadata": {"cwd": "/tmp/b"}}) == "/tmp/a"
+    assert _sync._session_row_cwd({"cwd": None, "metadata": {"cwd": "/tmp/b"}}) == "/tmp/b"
+    assert _sync._session_row_cwd({"cwd": "  ", "metadata": {"project_dir": "/tmp/c"}}) == "/tmp/c"
+    assert _sync._session_row_cwd({"metadata": {}}) == ""
+    assert _sync._session_row_cwd(None) == ""
+    # The metadata fallback goes through the SAME twelve-alias set the raw
+    # reader uses, so a runtime that spells it `workingDir` or `directory` is
+    # found. Reading two keys is what the shadowing accident reduced it to.
+    assert _sync._session_row_cwd({"metadata": {"workingDir": "/tmp/d"}}) == "/tmp/d"
+    assert _sync._session_row_cwd({"metadata": {"directory": "/tmp/e"}}) == "/tmp/e"
+
+
+def test_the_alias_reader_still_answers_for_raw_dicts():
+    """``_session_cwd`` is the OTHER helper: a raw adapter/gateway dict read by
+    alias. Its three callers are why the shadowing mattered."""
+    assert _sync._session_cwd({"workingDir": "/tmp/w"}) == "/tmp/w"
+    assert _sync._session_cwd({"directory": "/tmp/d"}) == "/tmp/d"
+    assert _sync._session_cwd({"folder": "/tmp/f"}) == "/tmp/f"
 
 
 def test_detector_facts_carry_the_column_cwd():

--- a/verification/shadowed_definitions.json
+++ b/verification/shadowed_definitions.json
@@ -1,0 +1,7 @@
+{
+  "_comment": "Known top-level names defined more than once, per file. Python keeps the LAST definition silently, so every caller of the first changes behaviour without a diff anyone reads. tests/test_no_shadowed_module_functions.py asserts a file's count never RISES, which lets the existing debt shrink without blocking work on it. A file absent from this map must have zero. Lowering a number here is the only way to record progress; raising one is a deliberate act somebody has to justify in review.",
+  "baseline": {
+    "dashboard.py": 59,
+    "routes/entitlement.py": 1
+  }
+}


### PR DESCRIPTION
No-PRD: fixes a regression I introduced in #5677 (shipped in 0.12.837) and adds the guard for its whole class.

## What happened

`sync.py` already had `_session_cwd(row)`: a raw adapter/gateway dict read through a **twelve-alias** set (`cwd`, `workingDir`, `workingDirectory`, `workspace`, `workspaceRoot`, `project_dir`, `projectRoot`, `directory`, `folder`, …). #5677 added a second function with the same name 2,000 lines below it, reading two keys.

Python keeps the last definition and says nothing. All three callers of the original silently switched:

```
sync.py:4328   seen_cwd = _session_cwd(obj)        gateway session shaping
sync.py:4586   "cwd": _session_cwd(s)              session row build
sync.py:15293  or _session_cwd(metadata)           FAMILY ingest cwd
```

That third one writes `sessions.cwd` — the column `process_control` promotes to find a pid, and the one the workspace scanner keys on. A runtime that spells its directory `workingDir` or `directory` in metadata stopped persisting it.

Nothing failed. The tests passed. Three wheels shipped.

## The fix

The newer helper becomes `_session_row_cwd` (it reads a **store row**: the `cwd` column first, then metadata), and its metadata fallback now **delegates** to `_session_cwd`, so both paths honour the same alias set. Both are strictly better than they were before the collision.

Also removes a second shadowing the same walk found: `start_log_streamer` was defined twice, the first an empty docstring-only stub.

## The guard is the point

`tests/test_no_shadowed_module_functions.py` walks the AST of every first-party module and fails on a top-level name defined twice. Line coverage cannot see this class, review rarely does in a 25,000-line module, and grep does not either unless you already suspect it. It is auto-discovering, so a new module is covered without anyone remembering to add it.

**It found pre-existing debt**, recorded as a ratchet rather than fixed here:

| file | shadowed names |
|---|---|
| `dashboard.py` | **59** — 39 byte-identical dead pairs, and **20 that differ**, meaning someone edited one copy and not the other |
| `routes/entitlement.py` | 1 |

`verification/shadowed_definitions.json` holds those counts. The test asserts a file never rises above its baseline **and** that each baseline equals reality, so headroom cannot be left for the next one and the debt can only shrink. The 20 differing pairs in `dashboard.py` are the dangerous half and deserve their own issue.

## Verified

Restoring the old name reproduces `_session_cwd: 2` in the AST walk and reds the guard; with the fix, 235 module files pass. The guard also has a self-test that it detects a shadow in a synthetic module, because a guard nobody has watched fail is not a guard. 273 pass across the daemon-wiring, detector and workspace-kind suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TtHxhGn2nwqoZ2v6SqcXMK
