### PR TITLE
package.json was scanned but not stamped, so a repo poisoned later stayed clean

### DIFF
--- a/clawmetry/repo_scan.py
+++ b/clawmetry/repo_scan.py
@@ -38,6 +38,23 @@ import os
 import re
 from typing import Optional
 
+#: Every file a scan READS, relative to the workspace. Declared here so the
+#: daemon's cache stamp cannot miss one: the stamp is what decides whether a
+#: repo is re-scanned, so a file the scanner reads but the stamp ignores means
+#: a checkout poisoned AFTER first sight stays invisible forever. That is
+#: exactly what happened when package.json scanning was added and the stamp's
+#: hand-kept list was not, and it is why this list lives beside the scanners
+#: rather than beside the cache.
+#:
+#: ``.git/config`` is the ordinary-layout spelling; a linked worktree's real
+#: config is resolved at scan time and is deliberately NOT stamped, because it
+#: lives outside the workspace and is shared by every worktree of that repo.
+SCANNED_FILES = (
+    os.path.join(".git", "config"),
+    os.path.join(".vscode", "tasks.json"),
+    "package.json",
+)
+
 #: The incident kinds this module can emit. Declared here, where they are
 #: produced, and re-exported as ``detectors.WORKSPACE_KINDS`` so every surface
 #: that renders or matches an incident reads ONE list. ``DETECTOR_KINDS`` exists

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -20546,11 +20546,14 @@ def _session_row_cwd(session: dict) -> str:
 # repos re-reads nothing until one of those files changes.
 _REPO_SCAN_ON = "CLAWMETRY_REPO_SCAN"        # "0" disables the workspace scan
 _REPO_SCAN_CACHE_MAX = int(os.environ.get("CLAWMETRY_REPO_SCAN_CACHE_MAX", "500"))
-#: Files a scan actually reads. The stamp is built from these and nothing else,
-#: so an unrelated write inside the repo does not invalidate the cache.
+#: Fallback for a repo_scan too old to declare ``SCANNED_FILES``. The live list
+#: is DERIVED from the scanner (see ``_repo_scan_stamp``): a hand-kept copy here
+#: is how package.json ended up scanned but not stamped, which left a checkout
+#: poisoned after first sight invisible forever.
 _REPO_SCAN_STAMP_FILES = (
     os.path.join(".git", "config"),
     os.path.join(".vscode", "tasks.json"),
+    "package.json",
 )
 
 
@@ -20565,9 +20568,11 @@ def _repo_scan_stamp(workspace: str) -> tuple:
     try:
         from clawmetry import repo_scan as _rs
         hook_files = tuple(getattr(_rs, "_AGENT_HOOK_FILES", ()) or ())
+        scanned = tuple(getattr(_rs, "SCANNED_FILES", ()) or ())
     except Exception:  # noqa: BLE001
         hook_files = ()
-    names = list(_REPO_SCAN_STAMP_FILES)
+        scanned = ()
+    names = list(scanned or _REPO_SCAN_STAMP_FILES)
     for entry in hook_files:
         # _AGENT_HOOK_FILES entries are relative paths, or (path, ...) tuples.
         rel = entry[0] if isinstance(entry, (tuple, list)) and entry else entry

--- a/tests/test_repo_scan_daemon_wiring.py
+++ b/tests/test_repo_scan_daemon_wiring.py
@@ -159,15 +159,44 @@ def test_cache_is_bounded(tmp_path, monkeypatch):
     assert len(state["repo_scan_memo"]) <= 5
 
 
-def test_stamp_covers_the_agent_hook_files(tmp_path):
-    """The stamp must include every file a scan reads, or a tampered
-    ``.claude/settings.json`` would sit behind a cache that never expires."""
+def test_stamp_covers_every_file_the_scanner_declares(tmp_path):
+    """The stamp must include every file a scan reads, or a checkout poisoned
+    AFTER first sight sits behind a cache that never expires.
+
+    Derived from ``repo_scan.SCANNED_FILES`` rather than listed here, because a
+    hand-kept copy is exactly how package.json ended up scanned-but-not-stamped:
+    the scanner learned a new file and the cache did not.
+    """
+    from clawmetry import repo_scan as _rs
     ws = tmp_path / "hooks"
     (ws / ".claude").mkdir(parents=True)
     names = {rel for rel, _m, _s in _sync._repo_scan_stamp(str(ws))}
-    assert os.path.join(".git", "config") in names
-    assert ".claude/settings.json" in names
-    assert os.path.join(".vscode", "tasks.json") in names
+    for rel in _rs.SCANNED_FILES:
+        assert rel in names, f"{rel} is scanned but not stamped"
+    for entry in _rs._AGENT_HOOK_FILES:
+        rel = entry[0] if isinstance(entry, (tuple, list)) else entry
+        assert rel in names, f"{rel} is scanned but not stamped"
+
+
+def test_a_manifest_poisoned_after_first_sight_is_caught(tmp_path):
+    """The bug this pins: package.json was read by the scanner and ignored by
+    the cache stamp, so a repo that was clean when first seen stayed clean
+    forever, whatever anyone added to it afterwards."""
+    import json as _json
+    ws = tmp_path / "later"
+    (ws / ".git").mkdir(parents=True)
+    (ws / ".git" / "config").write_text("[core]\n\tbare = false\n", encoding="utf-8")
+    (ws / "package.json").write_text(
+        _json.dumps({"name": "x", "scripts": {"build": "tsc"}}), encoding="utf-8")
+    state = {}
+    assert _sync._workspace_incidents(state, str(ws), "s", "cursor", time.time()) == []
+    (ws / "package.json").write_text(
+        _json.dumps({"name": "x", "scripts": {"postinstall": "cat ~/.npmrc"}}),
+        encoding="utf-8")
+    os.utime(ws / "package.json", (time.time() + 5, time.time() + 5))
+    found = _sync._workspace_incidents(state, str(ws), "s", "cursor", time.time())
+    assert [f["kind"] for f in found] == ["package_manifest_exec"]
+    assert found[0]["severity"] == "critical"
 
 
 # ── the emit path ──────────────────────────────────────────────────────────


### PR DESCRIPTION
No-PRD: fixes a bug I shipped in #5700 an hour ago, caught before it reached a release.

## The bug

The daemon caches a workspace scan on the mtime and size of the files that scan reads. #5700 taught the **scanner** to read `package.json` and did not teach the **stamp**, whose file list was a hand-kept copy.

Reproduced before fixing:

```
first scan of a clean repo           -> []
add a postinstall reading ~/.npmrc   -> NOTHING (cache never invalidated)
```

A checkout that was clean when first seen stayed clean forever, whatever anyone added to it afterwards. That is precisely the contract the blueprint states this feature must hold: **a clean answer must mean clean.** It is also the same failure shape as the linked-worktree gap — a layout the scanner does not look at reading as an all-clear.

## The fix, at the root

`repo_scan` now declares `SCANNED_FILES` — the files it reads — beside the scanners that read them, and the daemon's stamp **derives** from it (falling back to its old literal for a `repo_scan` too old to declare it). A scanner that learns a new file now teaches the cache automatically.

The guard is derived too: it walks `SCANNED_FILES` and `_AGENT_HOOK_FILES` and asserts each appears in the stamp, so the next file needs no test edit. Plus the reproduction above as a behavioural test.

One deliberate exclusion, documented where it is made: a linked worktree's real config lives outside the workspace and is shared by every worktree of that repo, so it is resolved at scan time and not stamped.

## Verified

Both new tests proven red against the unfixed `sync.py`. 119 pass across the wiring, corpus and workspace-kind suites.

If this merges before #5708, that release carries it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TtHxhGn2nwqoZ2v6SqcXMK
