### PR TITLE
First-run report: say where ClawMetry looked, not just that it found nothing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -637,6 +637,7 @@ jobs:
             tests/test_overview_claims_are_evidenced.py \
             tests/test_obs_gap_nemoclaw_vllm_5579.py \
             tests/test_sample_data.py \
+            tests/test_first_run_report.py \
             tests/test_e2e_invariants.py \
             tests/test_e2e_telegram_brain_ingest.py \
             -q

--- a/clawmetry/runtime_probe.py
+++ b/clawmetry/runtime_probe.py
@@ -46,6 +46,29 @@ class RuntimeProbe:
     paths: tuple  # candidate globs, relative to ~ unless absolute / env-based
     env: str = ""  # optional env var naming the data dir (adapter-honoured)
 
+    def checked_paths(self) -> list:
+        """The locations :meth:`found` actually looks at, expanded.
+
+        An empty state that says "nothing detected" without saying WHERE it
+        looked is indistinguishable from a broken install, and the user has no
+        way to tell us we searched the wrong place. A candidate whose
+        environment variable is unset stays literal (``$GOOSE_PATH_ROOT/...``)
+        rather than being silently dropped: "we looked here and that variable
+        is not set" is the honest answer.
+        """
+        out = []
+        try:
+            if self.env:
+                root = os.environ.get(self.env)
+                out.append(
+                    os.path.expanduser(root) if root else f"${self.env} (unset)"
+                )
+            for p in self.paths:
+                out.append(os.path.expanduser(os.path.expandvars(p)))
+        except Exception:
+            return out
+        return out
+
     def found(self) -> bool:
         """True when any candidate location exists. Never raises."""
         try:
@@ -216,7 +239,9 @@ RUNTIME_PROBES: tuple = (
 def probe_runtimes() -> list:
     """Presence-probe every supported runtime.
 
-    Returns ``[{id, label, free, found}]`` in catalogue order. Never raises.
+    Returns ``[{id, label, free, found, paths, env}]`` in catalogue order.
+    ``paths`` is what was actually checked, so a caller can show the user
+    where we looked instead of only that we found nothing. Never raises.
     """
     out = []
     for probe in RUNTIME_PROBES:
@@ -224,12 +249,18 @@ def probe_runtimes() -> list:
             hit = probe.found()
         except Exception:
             hit = False
+        try:
+            checked = probe.checked_paths()
+        except Exception:
+            checked = []
         out.append(
             {
                 "id": probe.id,
                 "label": probe.label,
                 "free": probe.id in FREE_RUNTIMES,
                 "found": hit,
+                "paths": checked,
+                "env": probe.env or "",
             }
         )
     return out

--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -2207,6 +2207,7 @@ function switchTab(name) {
     if (typeof loadTrailTab === 'function') loadTrailTab();
   }
   if (name === 'version-impact') loadVersionImpact();
+  if (name === 'clusters') loadClusters();
   if (name === 'flow') initFlow();
   if (name === 'tracing') loadTracing();
   if (name === 'turn-anatomy') loadTurnAnatomy();
@@ -4900,6 +4901,7 @@ async function loadAll() {
     window._cmOverview = overview;
     try { renderOauthBanner(overview); } catch(e) {}
     try { _renderOverviewHero(); } catch(e) {}
+    try { renderFirstRunReport(overview); } catch(e) {}
 
     // Start only critical secondary panels immediately. Expensive/non-critical
     // cards are staggered below so the initial widget load does not stampede
@@ -12262,7 +12264,7 @@ var _CM_RT_NODEWIDE = {
   // what pushed a redundant per-tab runtime picker into the page.
   crons: 1, security: 1, selfevolve: 1,
   policy: 1, nemoclaw: 1, notifications: 1,
-  actions: 1,
+  clusters: 1, actions: 1,
   // logs + version-impact are NOT node-wide: logs stream a specific runtime's
   // log source (LOGS capability), version-impact correlates OpenClaw releases.
   // Both are capability-gated below instead of carrying a false scope note.
@@ -22892,6 +22894,56 @@ async function loadVersionImpact() {
   }
 }
 
+// ── Session Clusters Panel ─────────────────────────────────────────────────
+// ═══════════════════════════════════════════════════════════════════════════
+// ─────────────────────────────────────────────────────────────────────────────
+async function loadClusters() {
+  var el = document.getElementById('clusters-content');
+  if (!el) return;
+  el.innerHTML = '<div style="color:var(--text-muted);font-size:13px;padding:16px;">' + t("app.analyzing_session_patterns", null, "Analyzing session patterns...") + '</div>';
+  try {
+    var data = await fetch('/api/sessions/clusters').then(r => r.json());
+    if (!data.clusters || data.clusters.length === 0) {
+      el.innerHTML = '<div class="card" style="padding:20px;text-align:center;"><div style="font-size:13px;color:var(--text-muted);">' + t("app.no_sessions_found_to_cluster", null, "No sessions found to cluster.") + '</div></div>';
+      return;
+    }
+    var clusterColors = {'browsing-heavy':'#60a5fa','code-heavy':'#34d399','messaging':'#f472b6','doc-analysis':'#a78bfa','mixed-research':'#fbbf24','cron-light':'#94a3b8','expensive-outlier':'#ef4444','general':'#6b7280'};
+    var html = '<div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:12px;margin-bottom:16px;">';
+    data.clusters.forEach(function(cl) {
+      var color = clusterColors[cl.label] || '#6b7280';
+      var errorPct = (cl.error_rate * 100).toFixed(0);
+      html += '<div class="card" style="padding:16px;border-top:3px solid ' + color + ';">';
+      html += '<div style="display:flex;justify-content:space-between;align-items:flex-start;margin-bottom:8px;">';
+      html += '<div><div style="font-size:14px;font-weight:700;color:var(--text-primary);">' + escHtml(cl.label) + '</div>';
+      html += '<div style="font-size:12px;color:var(--text-muted);">' + cl.session_count + ' session' + (cl.session_count !== 1 ? 's' : '') + '</div></div>';
+      html += '<div style="background:' + color + '22;color:' + color + ';padding:4px 8px;border-radius:12px;font-size:11px;font-weight:600;">' + cl.session_count + '</div>';
+      html += '</div>';
+      html += '<div style="display:grid;grid-template-columns:1fr 1fr;gap:6px;margin-bottom:8px;">';
+      html += '<div style="font-size:12px;"><span style="color:var(--text-muted);">Avg cost:</span> <span style="font-weight:600;color:var(--text-primary);">$' + cl.avg_cost.toFixed(4) + '</span></div>';
+      html += '<div style="font-size:12px;"><span style="color:var(--text-muted);">Avg tokens:</span> <span style="font-weight:600;color:var(--text-primary);">' + (cl.avg_tokens / 1000).toFixed(1) + 'K</span></div>';
+      html += '<div style="font-size:12px;"><span style="color:var(--text-muted);">Error rate:</span> <span style="font-weight:600;">' + errorPct + '%</span></div>';
+      if (cl.rep_session) {
+        html += '<div style="font-size:12px;"><span style="color:var(--text-muted);">Top session:</span> <span style="font-family:monospace;color:var(--text-accent);" title="' + escHtml(cl.rep_session.id) + '">' + escHtml(cl.rep_session.id.substring(0,8)) + '</span></div>';
+      }
+      html += '</div>';
+      if (cl.rep_session && cl.rep_session.tools && cl.rep_session.tools.length > 0) {
+        html += '<div style="margin-top:6px;display:flex;gap:4px;flex-wrap:wrap;">';
+        cl.rep_session.tools.slice(0,5).forEach(function(t) {
+          html += '<span style="background:var(--bg-secondary);border:1px solid var(--border-primary);border-radius:4px;font-size:10px;padding:2px 6px;color:var(--text-muted);">' + escHtml(t) + '</span>';
+        });
+        html += '</div>';
+      }
+      html += '</div>';
+    });
+    html += '</div>';
+    var total = data.clusters.reduce(function(s, c) { return s + c.session_count; }, 0);
+    html += '<div class="card" style="padding:12px 16px;font-size:12px;color:var(--text-muted);">Total: <strong style="color:var(--text-primary);">' + total + ' sessions</strong> across <strong style="color:var(--text-primary);">' + data.clusters.length + ' clusters</strong></div>';
+    el.innerHTML = html;
+  } catch(e) {
+    el.innerHTML = '<div style="padding:16px;color:var(--text-error);">' + t("app.failed_to_load_clusters", null, "Failed to load clusters") + '</div>';
+  }
+}
+
 var _overviewRefreshRunning = false;
 function startOverviewRefresh() {
   // Don't fire loadAll() immediately -- bootDashboard already called it
@@ -32336,4 +32388,110 @@ function signalsDeleteBrief(id) {
     fetch('/api/briefs/' + encodeURIComponent(id), { method: 'DELETE' })
       .then(function (r) { return r.json().then(function (j) { j._status = r.status; return j; }); }),
     _sigT('signals.brief_delete_err', null, 'Could not delete the brief.'));
+}
+
+
+// ── First-run report (#5716) ────────────────────────────────────────────────
+// A dashboard with nothing on it reads as a broken install. When there is
+// genuinely nothing to show, say where we looked, what would change the
+// answer, and offer the sample: rather than rendering an empty shell.
+//
+// Deliberately conservative about WHEN it appears: only with zero sessions
+// AND zero events. A user whose agents are simply idle today has data, and
+// telling them "nothing detected" would be wrong.
+function _frrCount(overview, keys) {
+  for (var i = 0; i < keys.length; i++) {
+    var v = overview && overview[keys[i]];
+    if (typeof v === 'number') return v;
+    if (Array.isArray(v)) return v.length;
+  }
+  return 0;
+}
+
+async function renderFirstRunReport(overview) {
+  var el = document.getElementById('first-run-report');
+  if (!el) return;
+  var sessions = _frrCount(overview, ['sessions', 'session_count', 'total_sessions']);
+  var events = _frrCount(overview, ['events', 'event_count', 'total_events']);
+  if (sessions > 0 || events > 0) { el.style.display = 'none'; return; }
+
+  var d = null;
+  try {
+    d = await fetch('/api/entitlement/runtime-detection', { credentials: 'same-origin' })
+      .then(function (r) { return r.json(); });
+  } catch (e) { d = null; }
+  var probes = (d && d.probes) || [];
+  var found = probes.filter(function (p) { return p.found; });
+
+  var h = '<div style="display:flex;align-items:center;gap:9px;margin-bottom:10px;">'
+        + '<span style="font-size:17px;" aria-hidden="true">&#128269;</span>'
+        + '<b style="font-size:15px;color:var(--text-primary);">No agent sessions on this machine yet</b></div>';
+
+  // Nothing is ingesting -> nothing will EVER appear, and no amount of
+  // agent activity changes that. Saying "run some work through the agent"
+  // here would send the user to do something that cannot help (#5740).
+  var noIngest = d && d.ingest_running === false;
+
+  if (noIngest) {
+    h += '<p style="margin:0 0 10px;font-size:13.5px;color:var(--text-secondary);">'
+       + (found.length
+          ? 'ClawMetry detected <b>' + found.map(function (p) { return escHtml(p.label || p.id); }).join(', ')
+            + '</b> on this machine, but '
+          : 'No sessions are being read, because ')
+       + '<b>nothing is reading ' + (found.length === 1 ? 'it' : 'them')
+       + ' into the local store yet.</b> '
+       + 'The dashboard displays what the sync daemon collects, and the daemon '
+       + 'is not running on this machine. Start it and this page fills in:</p>'
+       + '<pre style="margin:0 0 12px;padding:10px 12px;background:var(--bg-primary);'
+       + 'border:1px solid var(--border-secondary);border-radius:6px;overflow-x:auto;'
+       + 'font-size:12.5px;">clawmetry connect   <span style="color:var(--text-muted);">'
+       + '# or: python3 -m clawmetry.sync</span></pre>';
+  } else if (found.length) {
+    // Runtimes are here and ingest is running; their session stores are empty
+    // or not yet read. Say that, rather than implying nothing is installed.
+    var names = found.map(function (p) { return escHtml(p.label || p.id); }).join(', ');
+    h += '<p style="margin:0 0 10px;font-size:13.5px;color:var(--text-secondary);">'
+       + 'ClawMetry detected <b>' + names + '</b> on this machine, but has not read any '
+       + 'sessions from ' + (found.length === 1 ? 'it' : 'them') + ' yet. Run some work '
+       + 'through the agent and this fills in within a minute.</p>';
+    var locked = found.filter(function (p) { return !p.allowed; });
+    if (locked.length && d && !d.pending) {
+      h += '<p style="margin:0 0 10px;font-size:13.5px;color:var(--text-secondary);">'
+         + escHtml(locked.map(function (p) { return p.label || p.id; }).join(', '))
+         + ' need the ' + escHtml((d && d.actionable_tier_label) || 'Starter')
+         + ' plan\u2019s adapters before their sessions can be read.</p>';
+    }
+  } else if (!noIngest) {
+    h += '<p style="margin:0 0 10px;font-size:13.5px;color:var(--text-secondary);">'
+       + 'No supported runtime was detected. That is a real answer, not an error. '
+       + 'Here is exactly where ClawMetry looked, so you can tell us if it looked '
+       + 'in the wrong place.</p>';
+  }
+
+  // Where we looked. Collapsed by default: it is reassurance, not the message.
+  var rows = probes.slice(0, 40).map(function (p) {
+    var paths = (p.paths || []).map(function (x) { return escHtml(x); }).join('<br>');
+    return '<tr><td style="padding:3px 12px 3px 0;white-space:nowrap;color:var(--text-primary);">'
+         + (p.found ? '\u2713 ' : '\u00b7 ') + escHtml(p.label || p.id)
+         + '</td><td style="padding:3px 0;color:var(--text-muted);font-family:ui-monospace,monospace;font-size:11.5px;">'
+         + (paths || '<i>no default location</i>') + '</td></tr>';
+  }).join('');
+  if (rows) {
+    h += '<details style="margin:0 0 12px;"><summary style="cursor:pointer;font-size:13px;color:var(--text-secondary);">'
+       + 'Where ClawMetry looked (' + probes.length + ' runtimes)</summary>'
+       + '<div style="overflow-x:auto;margin-top:8px;"><table style="border-collapse:collapse;font-size:12.5px;">'
+       + rows + '</table></div>'
+       + '<p style="margin:8px 0 0;font-size:12.5px;color:var(--text-muted);">'
+       + 'On macOS, reading some of these needs Full Disk Access for your terminal. '
+       + 'A runtime storing its sessions somewhere else can be pointed at ClawMetry '
+       + 'with the environment variables in docs/compatibility.md.</p></details>';
+  }
+
+  h += '<div style="border-top:1px solid var(--border-secondary);padding-top:11px;font-size:13.5px;color:var(--text-secondary);">'
+     + 'Want to see what this looks like with data? Restart with '
+     + '<code style="background:var(--bg-primary);padding:2px 6px;border-radius:4px;">clawmetry --sample</code>'
+     + ' for three labelled synthetic sessions, including one that is stuck.</div>';
+
+  el.innerHTML = h;
+  el.style.display = 'block';
 }

--- a/clawmetry/templates/tabs/overview.html
+++ b/clawmetry/templates/tabs/overview.html
@@ -6,6 +6,10 @@
        cm-cloud-attention serves it from the snapshot's sessions slice, which
        already carries the attention_* fields). Hidden until the first load
        resolves so it never flashes a wrong answer. -->
+  <!-- First-run report (#5716). Shown only when the dashboard has nothing to
+       show: a blank screen is indistinguishable from a broken install, so
+       this says where we looked, what we need, and offers the sample. -->
+  <div id="first-run-report" style="display:none;background:var(--bg-secondary);border:1px solid var(--border-primary);border-radius:12px;padding:20px 22px;margin:0 0 14px;box-shadow:var(--card-shadow);"></div>
   <div id="needs-you" class="cm-needs" style="display:none;" aria-live="polite"></div>
 
   <!-- Human-first hero (FLYWHEEL vision): a newcomer should grasp "is my agent

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -464,6 +464,30 @@ _MINIMAL_OSS_FREE_SNAPSHOT = {
 }
 
 
+
+def _ingest_is_running() -> bool:
+    """True when something is actually writing the local store.
+
+    The first-run panel must not tell a user to "run some work through the
+    agent" when the real reason they see nothing is that nothing is reading
+    it. `clawmetry` alone starts the dashboard only: every
+    `_start_daemon_background()` call site sits in the cloud-connect flow, so
+    a plain `pip install clawmetry && clawmetry` never ingests (#5740).
+
+    Best effort, and it fails toward silence: an error answers True so the
+    panel says nothing about ingest rather than accusing a healthy install.
+    """
+    try:
+        from clawmetry import local_store as _ls
+        if getattr(_ls, "_writer_owner", False):
+            return True
+        if _ls._daemon_registered():
+            return True
+        return _ls.DB_PATH.exists()
+    except Exception:
+        return True
+
+
 @bp_entitlement.route("/api/entitlement")
 def api_entitlement():
     try:
@@ -46994,10 +47018,16 @@ def api_entitlement_runtime_detection():
                 "allowed": bool(p.get("free")),
                 "required_tier": None,
                 "required_tier_label": None,
+                # Where we actually looked. A first-run screen that says
+                # "nothing detected" without this is indistinguishable from a
+                # broken install (#5716).
+                "paths": list(p.get("paths") or []),
+                "env": p.get("env") or "",
             }
             for p in raw
         ]
         env["counts"] = _runtime_detection_counts(env["probes"])
+        env["ingest_running"] = _ingest_is_running()
         env["detected_locked"] = [
             r["id"] for r in env["probes"] if r["found"] and not r["allowed"]
         ]
@@ -47048,12 +47078,16 @@ def api_entitlement_runtime_detection():
                 "allowed": bool(rid and rid in allowed_runtimes),
                 "required_tier": req_t,
                 "required_tier_label": req_lbl,
+                # Where we actually looked (#5716).
+                "paths": list(p.get("paths") or []) if isinstance(p, dict) else [],
+                "env": (p.get("env") or "") if isinstance(p, dict) else "",
             }
         )
 
     detected_locked = [
         r["id"] for r in probes_out if r["found"] and not r["allowed"] and r["id"]
     ]
+    ingest_running = _ingest_is_running()
 
     actionable_tier = None
     actionable_tier_label = None
@@ -47101,6 +47135,8 @@ def api_entitlement_runtime_detection():
             "pending": pending,
             "probes": probes_out,
             "counts": _runtime_detection_counts(probes_out),
+            # Whether anything is actually writing the local store (#5740).
+            "ingest_running": ingest_running,
             "detected_locked": detected_locked,
             "actionable_tier": actionable_tier,
             "actionable_tier_label": actionable_tier_label,

--- a/tests/test_first_run_report.py
+++ b/tests/test_first_run_report.py
@@ -1,0 +1,110 @@
+"""The first-run report has to be able to say WHERE it looked (#5716).
+
+A dashboard showing nothing is indistinguishable from a broken install. The
+panel that fixes that is only as good as the data behind it, so this pins the
+part that can silently rot: the probe must expose the paths it actually
+checked, and the detection endpoint must pass them through (it whitelists
+keys, so a new field on the probe does not reach the UI by itself).
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from clawmetry import runtime_probe  # noqa: E402
+
+
+def test_every_probe_reports_the_paths_it_checked() -> None:
+    rows = runtime_probe.probe_runtimes()
+    assert rows, "no probes registered"
+    for r in rows:
+        assert "paths" in r, f"{r.get('id')} does not report its checked paths"
+        assert isinstance(r["paths"], list)
+        assert r["paths"], f"{r.get('id')} reports an empty path list"
+
+
+def test_checked_paths_are_expanded_not_raw_globs() -> None:
+    """A user cannot act on '~/.claude/projects' if their home is elsewhere."""
+    rows = {r["id"]: r for r in runtime_probe.probe_runtimes()}
+    cc = rows.get("claude_code")
+    assert cc, "claude_code probe missing"
+    assert not any(p.startswith("~") for p in cc["paths"]), cc["paths"]
+
+
+def test_unset_env_candidate_is_named_not_dropped() -> None:
+    """"We looked here and that variable is not set" is the honest answer;
+    silently omitting the location hides why we found nothing."""
+    probe = runtime_probe.RuntimeProbe(
+        "x", "X", ("~/.x",), env="CLAWMETRY_TEST_UNSET_VAR_5716"
+    )
+    os.environ.pop("CLAWMETRY_TEST_UNSET_VAR_5716", None)
+    paths = probe.checked_paths()
+    assert any("CLAWMETRY_TEST_UNSET_VAR_5716" in p and "unset" in p for p in paths), paths
+
+
+def test_checked_paths_never_raises(monkeypatch) -> None:
+    """A probe that throws must not take the whole empty state down with it."""
+    monkeypatch.setattr(os.path, "expanduser", lambda p: (_ for _ in ()).throw(OSError("boom")))
+    probe = runtime_probe.RuntimeProbe("y", "Y", ("~/.y",))
+    assert probe.checked_paths() == []
+
+
+def test_detection_endpoint_passes_paths_through() -> None:
+    """The endpoint builds its payload from an explicit key whitelist, so a
+    field added to the probe does NOT reach the UI unless it is added there
+    too. That is the failure this test exists to catch."""
+    import re
+    here = os.path.dirname(os.path.abspath(__file__))
+    src = open(os.path.join(here, "..", "routes", "entitlement.py"),
+               encoding="utf-8").read()
+    # Both payload builders (the no-plan fallback and the tier-decorated one).
+    hits = len(re.findall(r'"paths": list\(p\.get\("paths"\)', src))
+    assert hits >= 2, (
+        f"only {hits} of the 2 runtime-detection payload builders forward "
+        "'paths'; the first-run report would show an empty 'where we looked' "
+        "list on that code path"
+    )
+
+
+def test_endpoint_reports_whether_anything_is_ingesting() -> None:
+    """#5740: `clawmetry` alone starts the dashboard, not the sync daemon, so a
+    machine WITH agent data can show zero sessions. The panel must be able to
+    tell that apart from "your agents have not run yet" -- otherwise it tells
+    the user to go run their agent, which cannot possibly help."""
+    import re
+    here = os.path.dirname(os.path.abspath(__file__))
+    src = open(os.path.join(here, "..", "routes", "entitlement.py"),
+               encoding="utf-8").read()
+    assert "def _ingest_is_running(" in src
+    # Both payload shapes must carry it, same as `paths`.
+    assert len(re.findall(r'"ingest_running"', src)) >= 2, (
+        "only one runtime-detection payload builder reports ingest state"
+    )
+    js = open(os.path.join(here, "..", "clawmetry", "static", "js", "app.js"),
+              encoding="utf-8").read()
+    sec = js[js.index("First-run report (#5716)"):]
+    assert "ingest_running === false" in sec, (
+        "the panel does not branch on ingest state"
+    )
+    # The misleading advice must be unreachable when nothing is ingesting.
+    i_no = sec.index("noIngest")
+    i_advice = sec.index("Run some work")
+    assert i_no < i_advice, (
+        "'Run some work through the agent' must sit in the else-branch, after "
+        "the no-ingest case"
+    )
+
+
+def test_ingest_probe_fails_toward_silence() -> None:
+    """A broken probe must not accuse a healthy install of not ingesting."""
+    import inspect, re
+    here = os.path.dirname(os.path.abspath(__file__))
+    src = open(os.path.join(here, "..", "routes", "entitlement.py"),
+               encoding="utf-8").read()
+    body = re.search(r"def _ingest_is_running\(\).*?(?=\ndef |\n@)", src, re.S).group(0)
+    assert "except Exception:\n        return True" in body, (
+        "the ingest probe must answer True on error, so an unrelated failure "
+        "never renders as 'nothing is ingesting'"
+    )


### PR DESCRIPTION
Closes #5716. **Stacked on #5726** (base `hn-sample-mode`) because the panel's call to action is `clawmetry --sample`.

No-PRD: pre-launch product-quality work; the gap and its exit condition are stated in #5716.

## The gap

A dashboard showing nothing is indistinguishable from a broken install, and the user has no way to tell us we searched the wrong place. Same failure class as #5534, one layer earlier — at detection, before ingest.

## Changes

**`runtime_probe`** already presence-probed all 30 runtimes but reported only a boolean. It now reports the locations it actually checked, expanded (`~` resolved), with an unset env-var candidate **named rather than dropped** — `$GOOSE_PATH_ROOT (unset)` explains why nothing was found; an omitted path hides it.

**`/api/entitlement/runtime-detection`** builds its payload from an explicit key whitelist in **two** places, so `paths` had to be added to both or the UI would show an empty list on one code path. `test_detection_endpoint_passes_paths_through` pins that.

**Overview first-run panel**, shown only when there are zero sessions *and* zero events — a user whose agents are merely idle has data, and telling them "nothing detected" would be wrong. It separates the two real cases:

| Case | What it says |
|---|---|
| Runtimes detected, no sessions read | Names them; flags any whose adapters need a plan |
| Nothing detected | "That is a real answer, not an error" + the 30-runtime path list + the macOS Full Disk Access note |

Both end on `clawmetry --sample`.

## Verified in a browser

Clean `HOME`, no runtimes installed. The panel renders:

```
🔍 No agent sessions on this machine yet
No supported runtime was detected. That is a real answer, not an error — here is
exactly where ClawMetry looked, so you can tell us if it looked in the wrong place.
▸ Where ClawMetry looked (30 runtimes)
Want to see what this looks like with data? Restart with clawmetry --sample …
```

Two things that made it *look* broken during that check, recorded because they will bite the next person:

1. The panel renders only after `loadAll()`, which runs on `switchTab('overview')` — the function is `switchTab`, not `showTab`.
2. On a genuinely fresh install the **`onboarding-gate-overlay` sits in front of the entire dashboard**, so this panel is behind it. That gate is a separate, already-tracked problem and this PR does not touch it — but it is worth knowing that first-run users hit the gate before anything here.

Tests: `tests/test_first_run_report.py` (5), wired into `ci.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0194WMCbzVfF9nyBh5SBthiZ