### PR TITLE
fix(sync): a recycled pid must not lock the daemon out of its own lock

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -433,6 +433,15 @@ jobs:
       - name: Anomaly baselines reach the card
         run: python3 -m pytest tests/test_anomaly_baselines_reach_the_card.py -q
 
+      # A Pro node stopped syncing for 12 hours (2026-09-08) because sync.pid
+      # named a pid the OS had recycled onto an unrelated process: every
+      # launchd respawn read "alive" and exited, and `clawmetry status` still
+      # printed a green daemon over a 12-hour-old last sync. These pin both
+      # halves -- the lock reclaims a holder it cannot identify as our daemon,
+      # and status reports whether data is actually moving.
+      - name: The daemon lock cannot lock the daemon out
+        run: python3 -m pytest tests/test_pid_lock_reclaim.py tests/test_status_daemon_truth.py tests/test_pid_liveness_windows.py -q
+
   # ── API tests across all 3 platforms ─────────────────────────────────────────────────────────────────────────────────────────
   api-tests:
     name: API Tests (${{ matrix.os }})

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -245,6 +245,7 @@ CLAWMETRY_FAMILY_SESSION_LIMIT=50      # Max sessions/runtime to ingest for Clau
 CLAWMETRY_UPDATE_CHECK_SECS=60         # Daemon PyPI update-check cadence (default 60s; fleet tracks the latest release within minutes)
 CLAWMETRY_AUTOUPDATE_MIN_AGE_HOURS=0   # Stability window before a silent install (default 0 = absolute latest; raise to be conservative)
 CLAWMETRY_AUTO_UPDATE=0                # Hard kill switch for unattended upgrades
+CLAWMETRY_LOCK_STALE_SECS=900          # Daemon lock: how long a holder may miss its heartbeat before the next start takes over (default 900s)
 CLAWMETRY_HOOK_TIMEOUT_MAX_S=28800     # Ceiling on an INSTALLED hook timeout (8h; 0 = unbounded). Bounds how long a runtime waits on a wedged gate — docs/HOOK_COEXISTENCE.md
 CLAWMETRY_GIT_OUTCOMES=0               # Turn OFF repository reading entirely (default on)
 CLAWMETRY_GIT_SCAN_INTERVAL=900        # Seconds between repo scans (merges are not tool calls)

--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -3402,6 +3402,112 @@ def _status_snapshot(args) -> dict:
     return snap
 
 
+def _print_stall_advice(log_tail: str = "") -> None:
+    """Say, in one human sentence, that sync has stopped and what to do.
+
+    Prints nothing when the last sync is recent (or unknown), so a healthy node
+    stays quiet.
+    """
+    try:
+        import json as _j
+
+        from clawmetry.sync import STATE_FILE as _state_file
+
+        if not _state_file.exists():
+            return
+        st = _j.loads(_state_file.read_text())
+    except Exception:  # noqa: BLE001 - never fail status over its own advice
+        return
+    age_txt, stale = _sync_age((st or {}).get("last_sync") or "")
+    if not stale:
+        return
+    print()
+    print(f"  ⚠️   Nothing has synced for {(age_txt or '').replace(' ago', '')}, "
+          "so the dashboard is showing old data.")
+    if "Another instance is already running" in (log_tail or ""):
+        # The signature of a leftover lock file: the helper starts, finds a
+        # lock naming a pid that is no longer it, and exits, over and over.
+        print("      The background helper keeps finding a leftover lock file "
+              "from an earlier run.")
+        print("      Updating clears it automatically:  pip install -U clawmetry")
+    else:
+        print("      Restart the background helper:  clawmetry sync --restart")
+    print("      Still stuck? Send us ~/.clawmetry/sync.log and we will "
+          "take it from there.")
+
+
+def _launchd_job_state(listing: str) -> dict:
+    """Parse ``launchctl list <label>`` output into what it actually means.
+
+    ``launchctl list`` exits 0 for a job that is merely REGISTERED, so its exit
+    code says nothing about whether a process is up. The truth is the ``PID``
+    key: present means running, absent means launchd has the job loaded and
+    nothing is alive right now. ``LastExitStatus`` says how the last attempt
+    ended, which is the difference between "starting up" and "crash looping".
+    """
+    state = {"registered": True, "pid": None, "last_exit": None}
+    for line in (listing or "").splitlines():
+        line = line.strip().rstrip(";")
+        if "=" not in line:
+            continue
+        key, _, val = line.partition("=")
+        key = key.strip().strip('"')
+        val = val.strip().strip('"')
+        if key == "PID":
+            try:
+                state["pid"] = int(val)
+            except ValueError:
+                pass
+        elif key == "LastExitStatus":
+            try:
+                state["last_exit"] = int(val)
+            except ValueError:
+                pass
+    return state
+
+
+def _humanize_age(seconds: float) -> str:
+    """A short, plain-language age. No jargon, no decimals."""
+    seconds = max(0, int(seconds))
+    if seconds < 90:
+        return f"{seconds}s ago"
+    minutes = seconds // 60
+    if minutes < 90:
+        return f"{minutes}m ago"
+    hours = minutes // 60
+    if hours < 48:
+        return f"{hours}h ago"
+    return f"{hours // 24}d ago"
+
+
+# A sync cycle is about a minute. Fifteen means something is wrong, not slow.
+SYNC_STALE_SECS = 900
+
+
+def _sync_age(last_sync_iso: str, now: float = None) -> tuple:
+    """Return ``(age_text, is_stale)`` for a recorded last-sync timestamp.
+
+    ``(None, False)`` when the timestamp is missing or unparseable: we would
+    rather say nothing than accuse a healthy node on a bad parse.
+    """
+    if not last_sync_iso:
+        return None, False
+    try:
+        import datetime as _dt
+
+        raw = str(last_sync_iso).strip().replace("Z", "+00:00")
+        ts = _dt.datetime.fromisoformat(raw)
+        if ts.tzinfo is None:
+            ts = ts.replace(tzinfo=_dt.timezone.utc)
+        age = (now if now is not None else _dt.datetime.now(
+            _dt.timezone.utc).timestamp()) - ts.timestamp()
+    except (ValueError, TypeError, OverflowError):
+        return None, False
+    if age < 0:
+        return None, False
+    return _humanize_age(age), age > SYNC_STALE_SECS
+
+
 def _cmd_status(args) -> None:
     """clawmetry status — show local + cloud sync status."""
     if getattr(args, "live", False):
@@ -3520,7 +3626,12 @@ def _cmd_status(args) -> None:
             import json
 
             st = json.loads(STATE_FILE.read_text())
-            print(f"  Last sync:   {(st.get('last_sync') or '?')[:19]}")
+            _ls_raw = st.get("last_sync") or ""
+            _age_txt, _stale = _sync_age(_ls_raw)
+            _age_note = f"  ({_age_txt})" if _age_txt else ""
+            if _stale:
+                _age_note += "  ⚠️   nothing new since then"
+            print(f"  Last sync:   {(_ls_raw or '?')[:19]}{_age_note}")
             print(f"  Files seen:  {len(st.get('last_event_ids', {}))}")
         except Exception:
             pass
@@ -3737,7 +3848,17 @@ def _cmd_status(args) -> None:
             ["launchctl", "list", "com.clawmetry.sync"], capture_output=True, text=True
         )
         if r.returncode == 0:
-            print("  Daemon:      ✅  Running (launchd)")
+            # Exit 0 only means launchd has the job REGISTERED. A registered
+            # job with no PID is a job that is not running right now, and one
+            # that keeps exiting is a restart loop the user cannot see.
+            _job = _launchd_job_state(r.stdout)
+            if _job.get("pid"):
+                print(f"  Daemon:      ✅  Running (launchd, pid {_job['pid']})")
+            else:
+                _exit = _job.get("last_exit")
+                _why = f", last exit {_exit}" if _exit is not None else ""
+                print("  Daemon:      ⚠️   Set up but not running right now "
+                      f"(launchd keeps retrying{_why})")
         else:
             print("  Daemon:      ○  Not running")
     elif system == "Linux":
@@ -3770,12 +3891,20 @@ def _cmd_status(args) -> None:
             f"  Daemon:      {'✅  Running' + _how if running else '○  Not running'}"
         )
 
+    _log_tail = ""
     if LOG_FILE.exists():
         print(f"  Log:         {LOG_FILE}")
+        _log_tail = LOG_FILE.read_text(errors="replace")[-8000:]
         # Last 3 lines
-        lines = LOG_FILE.read_text(errors="replace").splitlines()[-3:]
+        lines = _log_tail.splitlines()[-3:]
         for ln in lines:
             print(f"    {ln}")
+
+    # One plain sentence when nothing is flowing. Everything above this point
+    # reports how the node is CONFIGURED, and configuration stays green while
+    # ingestion is dead: that gap is what let a Pro node sit stalled for 12
+    # hours behind a screen of ticks (2026-09-08).
+    _print_stall_advice(_log_tail)
 
     # NemoClaw sandbox nodes (if docker + kubectl available)
     _print_nemoclaw_nodes(args)

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -179,24 +179,52 @@ def _read_lock_record(pid_path: Path):
     return {"pid": pid, "start": start}
 
 
-def _holder_looks_like_our_daemon(pid: int) -> bool:
-    """True when ``pid``'s command line is a clawmetry sync daemon.
+def _holder_cmdline_verdict(pid: int) -> str:
+    """Identify a lock holder by its command line: ``"ours"``, ``"foreign"`` or
+    ``"unknown"``.
 
-    The fallback identity check for a legacy bare-int lock file, which carries
-    no start token. A command line we cannot read at all belongs to a process
-    we do not own, which our daemon never is.
+    The fallback for a legacy bare-int lock file, which carries no start token.
+    ``"unknown"`` is a real answer and must stay distinct from ``"foreign"``:
+    ``_proc_cmdline`` reads nothing on a Windows host without psutil, and
+    treating "I could not look" as "not ours" there would let an upgrade
+    reclaim a lock a perfectly healthy daemon still holds.
     """
     try:
         from clawmetry.process_control import _proc_cmdline
         blob = " ".join(_proc_cmdline(int(pid))).lower()
     except Exception:  # noqa: BLE001
-        return False
+        return "unknown"
     if not blob:
+        return "unknown"
+    if "clawmetry" in blob and ("sync" in blob or "daemon" in blob):
+        return "ours"
+    return "foreign"
+
+
+def _started_after_the_lock(pid: int, pid_path: Path) -> bool:
+    """True when ``pid`` began AFTER the lock file was written.
+
+    A process that did not exist when the lock was taken cannot be the process
+    that took it, so this is proof of pid reuse that needs no command line and
+    no recorded token: it is the only identity check available on a Windows
+    host without psutil, where ``_proc_cmdline`` reads nothing.
+
+    Conservative in both directions. Returns False whenever either timestamp is
+    unavailable, and allows a few seconds of slack because the daemon starts
+    fractionally before it writes its lock.
+    """
+    try:
+        from clawmetry.process_control import _proc_start_epoch
+
+        started = _proc_start_epoch(int(pid))
+        if started is None:
+            return False
+        return started > pid_path.stat().st_mtime + 5.0
+    except (OSError, ValueError, TypeError):
         return False
-    return "clawmetry" in blob and ("sync" in blob or "daemon" in blob)
 
 
-def _lock_holder_verdict(rec) -> tuple:
+def _lock_holder_verdict(rec, pid_path: Path = None) -> tuple:
     """Decide what the current lock holder is. Returns ``(verdict, why)`` where
     verdict is ``"held"`` (a live daemon owns it), ``"stale"`` (reclaim it) or
     ``"wedged"`` (ours, but frozen: stop it, then reclaim)."""
@@ -223,7 +251,10 @@ def _lock_holder_verdict(rec) -> tuple:
         if not ok:
             # Alive, but not the process that took the lock: recycled number.
             return "stale", f"pid_recycled({why})"
-    elif not _holder_looks_like_our_daemon(int(pid)):
+    elif pid_path is not None and _started_after_the_lock(int(pid), pid_path):
+        # It cannot have written a file that predates it.
+        return "stale", "pid_recycled(started_after_lock)"
+    elif _holder_cmdline_verdict(int(pid)) == "foreign":
         # Legacy bare-int file and the live holder is somebody else entirely.
         return "stale", "pid_recycled(cmdline_mismatch)"
 
@@ -336,7 +367,7 @@ def _acquire_pid_lock() -> bool:
             return True
         except FileExistsError:
             rec = _read_lock_record(pid_path)
-            verdict, why = _lock_holder_verdict(rec)
+            verdict, why = _lock_holder_verdict(rec, pid_path)
             if verdict == "held":
                 return False
             if verdict == "wedged":

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -50,47 +50,339 @@ def _pid_file() -> Path:
     return Path(os.path.expanduser("~/.clawmetry/sync.pid"))
 
 
-def _acquire_pid_lock() -> bool:
-    """Atomically claim the PID file. Return False if another instance is
-    already running. Uses ``O_CREAT|O_EXCL`` to win the create race when
-    two daemons start simultaneously — the previous ``exists()`` then
-    ``write_text()`` pattern had a TOCTOU window where both processes
-    could pass the check and both write their PIDs.
+# The lock records WHO holds it, not just a number. A bare pid is not an
+# identity: the OS recycles pids, so a daemon that dies without running its
+# atexit hook (SIGKILL, panic, power loss) leaves a file naming a number that
+# some unrelated process will eventually be handed. ``is_alive()`` then says
+# "yes" forever and every respawn exits — the daemon is locked out of its own
+# lock with no way back except a human deleting the file.
+#
+# Burned 2026-09-08 on a Pro node: sync stopped at 19:32 and never resumed.
+# launchd (KeepAlive, ThrottleInterval 30) respawned it ~1,400 times overnight,
+# each one printing "Another instance is already running. Exiting.", while
+# ``clawmetry status`` still showed a green daemon and a 12-hour-old "Last sync".
+#
+# So: identity is ``(pid, start-time-token)``, verified through the same
+# ``process_control.verify_pid`` pid-reuse guard the Guard actuators use before
+# they signal anything. A holder we cannot positively identify as our own
+# daemon is a stale lock, and stale locks are reclaimed.
+_LOCK_OWNER = "clawmetry-sync"
 
-    Identified by @dumko2001 in #512.
+# How long a holder may go without ticking its heartbeat before the next
+# respawn treats it as wedged and takes the lock. Generous by default: a
+# healthy daemon ticks every 30s, so 15 min is 30 missed ticks.
+_LOCK_STALE_SECS_DEFAULT = 900.0
+
+
+def _lock_heartbeat_file() -> Path:
+    return Path(os.path.expanduser("~/.clawmetry/sync.heartbeat"))
+
+
+def _lock_identity_file() -> Path:
+    """Who the lock holder is, alongside the pid file rather than inside it.
+
+    ``sync.pid`` stays a bare integer because several things already read it
+    that way (``daemon_registration._is_sync_running``, the dashboard's
+    background spawn, ``install.sh``'s sandbox teardown). Putting the identity
+    record in a sidecar buys pid-reuse detection without breaking any of them;
+    a missing or mismatched sidecar simply falls back to the command-line check.
+    """
+    return Path(os.path.expanduser("~/.clawmetry/sync.lock.json"))
+
+
+def _lock_stale_secs() -> float:
+    try:
+        v = float(os.environ.get("CLAWMETRY_LOCK_STALE_SECS", "") or 0)
+        return v if v > 0 else _LOCK_STALE_SECS_DEFAULT
+    except (TypeError, ValueError):
+        return _LOCK_STALE_SECS_DEFAULT
+
+
+def _proc_start_token_safe(pid: int):
+    """The process's start-time token, or None when it cannot be read.
+
+    Thin wrapper so this module never hard-depends on process_control's
+    private helper and tests have one seam to reach for.
+    """
+    try:
+        from clawmetry.process_control import _proc_start_token
+        return _proc_start_token(int(pid))
+    except Exception:  # noqa: BLE001 - dead pid / perm / unsupported platform
+        return None
+
+
+def touch_lock_heartbeat() -> None:
+    """Prove this process is still scheduling threads.
+
+    Written by the daemon's watchdog on a fixed tick, independent of how long
+    an ingest cycle takes, so a legitimately slow backfill is never mistaken
+    for a wedge. Only a process whose interpreter has stopped running (frozen,
+    SIGSTOPped, deadlocked) lets this file go stale.
+    """
+    try:
+        hb = _lock_heartbeat_file()
+        hb.parent.mkdir(parents=True, exist_ok=True)
+        hb.write_text(str(int(time.time())))
+    except Exception as e:  # noqa: BLE001 - never take the daemon down for this
+        log.debug("lock heartbeat not written: %s", e)
+
+
+def _write_lock_identity() -> None:
+    """Record who took the lock, so the next start can tell a live daemon from
+    a recycled pid. Best-effort: without it the lock still works, it just falls
+    back to identifying the holder by its command line."""
+    try:
+        f = _lock_identity_file()
+        f.parent.mkdir(parents=True, exist_ok=True)
+        f.write_text(json.dumps({
+            "pid": os.getpid(),
+            "start": _proc_start_token_safe(os.getpid()),
+            "owner": _LOCK_OWNER,
+            "since": int(time.time()),
+        }))
+    except Exception as e:  # noqa: BLE001
+        log.debug("lock identity not written: %s", e)
+
+
+def _read_lock_record(pid_path: Path):
+    """Parse the lock. Returns ``{"pid": int, "start": str|None}`` or None.
+
+    The pid comes from ``sync.pid`` (a bare int, or a JSON object should a
+    future release write one). The start-time token comes from the sidecar,
+    and only when it names the same pid: a sidecar left behind by an earlier
+    holder must not be used to identify the current one.
+    """
+    try:
+        raw = pid_path.read_text().strip()
+    except OSError:
+        return None
+    if not raw:
+        return None
+    pid = None
+    if raw.startswith("{"):
+        try:
+            pid = int(json.loads(raw).get("pid"))
+        except (ValueError, TypeError):
+            return None
+    else:
+        try:
+            pid = int(raw)
+        except ValueError:
+            return None
+    start = None
+    try:
+        ident = json.loads(_lock_identity_file().read_text())
+        if int(ident.get("pid")) == pid:
+            start = ident.get("start") or None
+    except (OSError, ValueError, TypeError):
+        pass
+    return {"pid": pid, "start": start}
+
+
+def _holder_looks_like_our_daemon(pid: int) -> bool:
+    """True when ``pid``'s command line is a clawmetry sync daemon.
+
+    The fallback identity check for a legacy bare-int lock file, which carries
+    no start token. A command line we cannot read at all belongs to a process
+    we do not own, which our daemon never is.
+    """
+    try:
+        from clawmetry.process_control import _proc_cmdline
+        blob = " ".join(_proc_cmdline(int(pid))).lower()
+    except Exception:  # noqa: BLE001
+        return False
+    if not blob:
+        return False
+    return "clawmetry" in blob and ("sync" in blob or "daemon" in blob)
+
+
+def _lock_holder_verdict(rec) -> tuple:
+    """Decide what the current lock holder is. Returns ``(verdict, why)`` where
+    verdict is ``"held"`` (a live daemon owns it), ``"stale"`` (reclaim it) or
+    ``"wedged"`` (ours, but frozen: stop it, then reclaim)."""
+    if not rec:
+        return "stale", "unreadable_lock_file"
+    pid = rec.get("pid")
+    if not pid or pid <= 0:
+        return "stale", "no_pid_in_lock_file"
+    if int(pid) == os.getpid():
+        # A caller that pre-wrote our own pid must not lock us out of our own
+        # lock (the #5740 spawn race). Ours by definition.
+        return "stale", "lock_names_this_process"
+
+    from clawmetry.process_control import is_alive as _pid_alive
+
+    if not _pid_alive(int(pid)):
+        return "stale", "pid_not_alive"
+
+    recorded_start = rec.get("start")
+    if recorded_start:
+        from clawmetry.process_control import verify_pid as _verify_pid
+
+        ok, why = _verify_pid(int(pid), recorded_start)
+        if not ok:
+            # Alive, but not the process that took the lock: recycled number.
+            return "stale", f"pid_recycled({why})"
+    elif not _holder_looks_like_our_daemon(int(pid)):
+        # Legacy bare-int file and the live holder is somebody else entirely.
+        return "stale", "pid_recycled(cmdline_mismatch)"
+
+    # It is genuinely our daemon. Is it still running, or frozen? Only a
+    # heartbeat that EXISTS and has gone stale condemns it: a daemon from
+    # before this change never writes one, and absence must not shoot a
+    # healthy process during an upgrade.
+    try:
+        hb = _lock_heartbeat_file()
+        if hb.exists():
+            age = time.time() - hb.stat().st_mtime
+            if age > _lock_stale_secs():
+                return "wedged", f"no_heartbeat_for_{int(age)}s"
+    except OSError:
+        pass
+    return "held", "daemon_running"
+
+
+def _process_is_gone(pid: int) -> bool:
+    """True when ``pid`` can no longer run code.
+
+    ``is_alive`` is deliberately a "can I address this pid" probe, and on POSIX
+    the signal-0 probe behind it succeeds for a ZOMBIE: a process that has
+    exited but whose parent has not reaped it. For "did my signal actually
+    work?" a zombie counts as gone.
+    """
+    from clawmetry.process_control import is_alive as _pid_alive
+
+    if not _pid_alive(int(pid)):
+        return True
+    try:  # reap it if it happens to be our own child
+        os.waitpid(int(pid), os.WNOHANG)
+    except (ChildProcessError, OSError, AttributeError):
+        pass
+    if not _pid_alive(int(pid)):
+        return True
+    try:
+        import psutil  # type: ignore
+
+        return psutil.Process(int(pid)).status() == psutil.STATUS_ZOMBIE
+    except ImportError:
+        pass
+    except Exception:  # noqa: BLE001 - no such process / access
+        return True
+    if os.name == "nt":
+        return False
+    try:
+        out = subprocess.run(
+            ["ps", "-o", "state=", "-p", str(int(pid))],
+            capture_output=True, text=True, timeout=5,
+        ).stdout.strip()
+        return out.startswith("Z") or not out
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def _stop_wedged_holder(pid: int) -> bool:
+    """Stop a frozen holder so its lock can be reclaimed. TERM, then KILL."""
+    try:
+        import signal as _signal
+
+        if os.name == "nt":
+            from clawmetry.process_control import _win_terminate
+            _win_terminate(int(pid))
+        else:
+            os.kill(int(pid), _signal.SIGTERM)
+        for _ in range(50):
+            if _process_is_gone(pid):
+                return True
+            time.sleep(0.1)
+        if os.name != "nt":
+            os.kill(int(pid), _signal.SIGKILL)
+            for _ in range(20):
+                if _process_is_gone(pid):
+                    return True
+                time.sleep(0.1)
+        return _process_is_gone(pid)
+    except Exception as e:  # noqa: BLE001
+        log.warning("could not stop wedged daemon pid %s: %s", pid, e)
+        return False
+
+
+def _acquire_pid_lock() -> bool:
+    """Atomically claim the PID file. Return False only when a *live, verified*
+    sync daemon already holds it.
+
+    Uses ``O_CREAT|O_EXCL`` to win the create race when two daemons start
+    simultaneously — the previous ``exists()`` then ``write_text()`` pattern had
+    a TOCTOU window where both processes could pass the check and both write
+    their PIDs. Identified by @dumko2001 in #512.
+
+    A holder that is not alive, not us, or not identifiable as our daemon is a
+    stale lock and gets reclaimed. See the note above ``_LOCK_OWNER``.
     """
     pid_path = _pid_file()
     pid_path.parent.mkdir(parents=True, exist_ok=True)
-    pid_str = str(os.getpid()).encode()
-    while True:
+    payload = str(os.getpid()).encode()
+    # Bounded: each pass either returns or removes one stale file, so a
+    # pathological loop (another process recreating it) gives up rather than
+    # spinning forever.
+    for _ in range(8):
         try:
             fd = os.open(str(pid_path), os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
             try:
-                os.write(fd, pid_str)
+                os.write(fd, payload)
             finally:
                 os.close(fd)
+            _write_lock_identity()
+            touch_lock_heartbeat()
             return True
         except FileExistsError:
-            try:
-                existing_pid = int(pid_path.read_text().strip())
-            except (ValueError, OSError):
-                try:
-                    pid_path.unlink()
-                except OSError:
-                    return False
-                continue
-            # os.kill(pid, 0) is not a liveness probe on Windows (never
-            # raises for dead pids -> a stale lock file would block the
-            # daemon from ever starting again). is_alive() is portable.
-            from clawmetry.process_control import is_alive as _pid_alive
-
-            if _pid_alive(existing_pid):
+            rec = _read_lock_record(pid_path)
+            verdict, why = _lock_holder_verdict(rec)
+            if verdict == "held":
                 return False
+            if verdict == "wedged":
+                held_pid = (rec or {}).get("pid")
+                log.warning(
+                    "sync.pid held by a wedged daemon (pid=%s, %s) — stopping it "
+                    "and taking over", held_pid, why
+                )
+                if not _stop_wedged_holder(int(held_pid)):
+                    return False
+            else:
+                log.warning(
+                    "reclaiming stale sync.pid (pid=%s, %s)",
+                    (rec or {}).get("pid"), why
+                )
             try:
                 pid_path.unlink()
-            except OSError:
+            except FileNotFoundError:
                 pass
-                continue
+            except OSError as e:
+                log.warning("could not remove stale sync.pid: %s", e)
+                return False
+        except OSError as e:
+            log.warning("could not claim sync.pid: %s", e)
+            return False
+    return False
+
+
+def _start_lock_heartbeat(interval_secs: float = 30.0) -> threading.Thread:
+    """Tick the lock heartbeat on a fixed cadence for as long as this process
+    can run Python.
+
+    Deliberately independent of the ingest cycle: a backfill that takes ten
+    minutes is healthy and must keep its lock, so the heartbeat measures
+    "interpreter still scheduling", not "cycle completed". A stalled *cycle*
+    is a different failure and is surfaced by ``clawmetry status``, which
+    reports the age of the last completed sync rather than killing anything.
+    """
+    def _beat() -> None:
+        while True:
+            touch_lock_heartbeat()
+            time.sleep(interval_secs)
+
+    th = threading.Thread(target=_beat, daemon=True, name="lock-heartbeat")
+    th.start()
+    return th
 
 
 def _release_pid_lock() -> None:
@@ -98,6 +390,14 @@ def _release_pid_lock() -> None:
         _pid_file().unlink(missing_ok=True)
     except Exception:
         pass
+    # Leave no misleading artefacts behind a clean exit: an orphaned heartbeat
+    # could only ever make a later holder look wedged, and an orphaned identity
+    # record only ever describes a process that is gone.
+    for _f in (_lock_heartbeat_file, _lock_identity_file):
+        try:
+            _f().unlink(missing_ok=True)
+        except Exception:
+            pass
 
 
 # ── Graceful shutdown — drain ring buffer on SIGTERM/SIGINT/atexit (#1593) ──
@@ -23514,6 +23814,7 @@ def run_daemon() -> None:
     # racing supervisor restart sees the lock held until the flush is
     # done, instead of starting a second daemon mid-drain.
     _install_shutdown_handlers()
+    _start_lock_heartbeat()
 
     # Open-core plugin discovery. dashboard.py runs this at import time so the
     # dashboard process picks up entry-point plugins (clawmetry-pro adapters,

--- a/tests/test_pid_liveness_windows.py
+++ b/tests/test_pid_liveness_windows.py
@@ -35,6 +35,21 @@ def _spawn_sleeper():
     return subprocess.Popen([sys.executable, "-c", "import time; time.sleep(30)"])
 
 
+def _spawn_daemon_lookalike():
+    """A live process whose command line identifies it as the sync daemon.
+
+    The lock stopped trusting a bare pid number in 2026-09: a live pid that is
+    not our daemon is a pid the OS recycled, and refusing to start because of
+    one is what stranded a customer's node for 12 hours. A stand-in sleeper is
+    therefore no longer a stand-in for "the daemon is running" -- it has to
+    look like the daemon.
+    """
+    return subprocess.Popen(
+        [sys.executable, "-c", "import time; time.sleep(30)",
+         "clawmetry.sync", "--daemon"]
+    )
+
+
 def _spawn_dead():
     child = subprocess.Popen([sys.executable, "-c", "pass"])
     child.wait()
@@ -92,7 +107,7 @@ def test_acquire_pid_lock_respects_live_lock(monkeypatch, tmp_path):
     """A genuinely running instance must still win the lock."""
     import clawmetry.sync as sync
 
-    live = _spawn_sleeper()
+    live = _spawn_daemon_lookalike()
     try:
         pid_file = tmp_path / "sync.pid"
         pid_file.write_text(str(live.pid))

--- a/tests/test_pid_lock_reclaim.py
+++ b/tests/test_pid_lock_reclaim.py
@@ -1,0 +1,186 @@
+"""The sync daemon's singleton lock must never be able to lock the daemon out
+forever.
+
+Field failure (2026-09-08, a Pro node): ``~/.clawmetry/sync.pid`` named a pid
+that ``is_alive()`` reported as alive but that belonged to some *other*
+process — the OS had recycled the number after the daemon died without running
+its atexit hook. ``_acquire_pid_lock`` only asked "is that pid alive?", so every
+launchd respawn (KeepAlive, ThrottleInterval 30) printed "Another instance is
+already running. Exiting." and quit. Sync stopped for 12 hours while
+``clawmetry status`` still printed a green "Daemon: Running".
+
+The lock must therefore identify the *holder*, not just probe the number:
+a live pid that is not our daemon is a stale lock, and stale locks get reclaimed.
+"""
+import json
+import os
+import subprocess
+import sys
+import time
+
+import pytest
+
+from clawmetry import sync
+
+
+@pytest.fixture()
+def home(tmp_path, monkeypatch):
+    """Point the lock at an isolated ~/.clawmetry (never the real one)."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    (tmp_path / ".clawmetry").mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(sync, "_pid_file",
+                        lambda: tmp_path / ".clawmetry" / "sync.pid")
+    monkeypatch.setattr(sync, "_lock_heartbeat_file",
+                        lambda: tmp_path / ".clawmetry" / "sync.heartbeat",
+                        raising=False)
+    monkeypatch.setattr(sync, "_lock_identity_file",
+                        lambda: tmp_path / ".clawmetry" / "sync.lock.json",
+                        raising=False)
+    yield tmp_path
+    sync._release_pid_lock()
+
+
+@pytest.fixture()
+def foreign_process():
+    """A live process that is emphatically NOT a clawmetry daemon."""
+    p = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(120)"])
+    try:
+        yield p
+    finally:
+        p.kill()
+        p.wait(timeout=10)
+
+
+@pytest.fixture()
+def lookalike_daemon():
+    """A live process whose argv looks like the real sync daemon."""
+    p = subprocess.Popen(
+        [sys.executable, "-c", "import time; time.sleep(120)",
+         "clawmetry.sync", "--daemon"]
+    )
+    try:
+        yield p
+    finally:
+        p.kill()
+        p.wait(timeout=10)
+
+
+def _write_lock(home, payload):
+    """Plant a lock file. A dict also plants the identity sidecar, which is
+    where the start-time token lives."""
+    path = home / ".clawmetry" / "sync.pid"
+    if isinstance(payload, dict):
+        path.write_text(str(payload["pid"]))
+        (home / ".clawmetry" / "sync.lock.json").write_text(json.dumps(payload))
+    else:
+        path.write_text(payload)
+    return path
+
+
+# ── The field failure ────────────────────────────────────────────────────────
+def test_reclaims_a_lock_held_by_a_recycled_pid(home, foreign_process):
+    """A live pid that is not our daemon is a recycled number, not a rival."""
+    _write_lock(home, str(foreign_process.pid))
+    assert sync._acquire_pid_lock() is True, (
+        "the daemon refused to start because an unrelated live process "
+        "happened to own the pid recorded in sync.pid"
+    )
+
+
+def test_reclaims_when_the_recorded_start_time_does_not_match(home, foreign_process):
+    """Identity is (pid, start-time). Same number + different start = recycled."""
+    _write_lock(home, {"pid": foreign_process.pid,
+                       "start": "epoch:1",  # 1970; certainly not this process
+                       "owner": "clawmetry-sync"})
+    assert sync._acquire_pid_lock() is True
+
+
+def test_reclaims_an_unreadable_lock_file(home):
+    _write_lock(home, "not a pid at all")
+    assert sync._acquire_pid_lock() is True
+
+
+def test_reclaims_a_lock_naming_our_own_pid(home):
+    """Defence in depth: a caller that pre-writes the child's pid must not
+    lock that child out of its own lock."""
+    _write_lock(home, str(os.getpid()))
+    assert sync._acquire_pid_lock() is True
+
+
+# ── The lock must still be a lock ────────────────────────────────────────────
+def test_refuses_when_a_real_daemon_holds_it(home, lookalike_daemon):
+    """A live process that identifies as the sync daemon still wins."""
+    _write_lock(home, {"pid": lookalike_daemon.pid,
+                       "start": sync._proc_start_token_safe(lookalike_daemon.pid),
+                       "owner": "clawmetry-sync"})
+    assert sync._acquire_pid_lock() is False
+
+
+def test_refuses_a_legacy_lock_when_the_holder_looks_like_the_daemon(
+        home, lookalike_daemon):
+    """Back-compat: a bare-int pid file written by an older release is honoured
+    when the process it names really is a sync daemon."""
+    _write_lock(home, str(lookalike_daemon.pid))
+    assert sync._acquire_pid_lock() is False
+
+
+# ── What the new lock records ────────────────────────────────────────────────
+def test_acquired_lock_records_verifiable_identity(home):
+    assert sync._acquire_pid_lock() is True
+    # sync.pid stays a bare int: daemon_registration, the dashboard spawn and
+    # install.sh all read it that way.
+    assert (home / ".clawmetry" / "sync.pid").read_text().strip() == str(os.getpid())
+    rec = json.loads((home / ".clawmetry" / "sync.lock.json").read_text())
+    assert rec["pid"] == os.getpid()
+    assert rec["owner"] == "clawmetry-sync"
+    assert rec["start"], "no start-time token recorded: pid reuse stays undetectable"
+
+
+def test_a_sidecar_from_an_earlier_holder_is_ignored(home, foreign_process):
+    """A stale identity record naming a different pid must not be used to
+    vouch for whoever holds the lock now."""
+    (home / ".clawmetry" / "sync.pid").write_text(str(foreign_process.pid))
+    (home / ".clawmetry" / "sync.lock.json").write_text(json.dumps(
+        {"pid": foreign_process.pid + 100000, "start": "epoch:1",
+         "owner": "clawmetry-sync"}))
+    assert sync._acquire_pid_lock() is True
+
+
+# ── A frozen holder ──────────────────────────────────────────────────────────
+def test_reclaims_a_holder_that_stopped_heartbeating(home, lookalike_daemon,
+                                                     monkeypatch):
+    """A daemon that is alive but has stopped ticking its heartbeat is wedged;
+    the next respawn takes the lock rather than exiting forever."""
+    monkeypatch.setenv("CLAWMETRY_LOCK_STALE_SECS", "60")
+    _write_lock(home, {"pid": lookalike_daemon.pid,
+                       "start": sync._proc_start_token_safe(lookalike_daemon.pid),
+                       "owner": "clawmetry-sync"})
+    hb = home / ".clawmetry" / "sync.heartbeat"
+    hb.write_text("1")
+    old = time.time() - 3600
+    os.utime(hb, (old, old))
+    assert sync._acquire_pid_lock() is True
+    assert lookalike_daemon.poll() is not None, "wedged holder was not stopped"
+
+
+def test_a_holder_without_a_heartbeat_is_left_alone(home, lookalike_daemon,
+                                                    monkeypatch):
+    """An older daemon predates the heartbeat file. Absence is not evidence of
+    a wedge, so an upgrade must not shoot a healthy running daemon."""
+    monkeypatch.setenv("CLAWMETRY_LOCK_STALE_SECS", "60")
+    _write_lock(home, {"pid": lookalike_daemon.pid,
+                       "start": sync._proc_start_token_safe(lookalike_daemon.pid),
+                       "owner": "clawmetry-sync"})
+    assert sync._acquire_pid_lock() is False
+    assert lookalike_daemon.poll() is None
+
+
+def test_a_fresh_heartbeat_protects_the_holder(home, lookalike_daemon, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_LOCK_STALE_SECS", "60")
+    _write_lock(home, {"pid": lookalike_daemon.pid,
+                       "start": sync._proc_start_token_safe(lookalike_daemon.pid),
+                       "owner": "clawmetry-sync"})
+    (home / ".clawmetry" / "sync.heartbeat").write_text("1")
+    assert sync._acquire_pid_lock() is False
+    assert lookalike_daemon.poll() is None

--- a/tests/test_pid_lock_reclaim.py
+++ b/tests/test_pid_lock_reclaim.py
@@ -184,3 +184,50 @@ def test_a_fresh_heartbeat_protects_the_holder(home, lookalike_daemon, monkeypat
     (home / ".clawmetry" / "sync.heartbeat").write_text("1")
     assert sync._acquire_pid_lock() is False
     assert lookalike_daemon.poll() is None
+
+
+# ── identity without a command line (the Windows-without-psutil path) ────────
+def test_a_holder_that_started_after_the_lock_is_a_recycled_pid(
+        home, lookalike_daemon, monkeypatch):
+    """Proof of reuse that needs neither a recorded token nor a command line:
+    a process cannot have written a file that predates it.
+
+    This is the only identity check available on a Windows host without psutil,
+    where the command line reads back empty. The start epoch is injected
+    because it is unavailable on a Mac without psutil too (``_proc_start_epoch``
+    returns None there and this layer simply does not fire); what is pinned
+    here is the DECISION, not the platform primitive.
+    """
+    path = _write_lock(home, str(lookalike_daemon.pid))
+    old_time = time.time() - 3600
+    os.utime(path, (old_time, old_time))
+    monkeypatch.setattr("clawmetry.process_control._proc_start_epoch",
+                        lambda pid: time.time())
+    # Even a process whose command line says "clawmetry.sync" is not the writer
+    # if it started an hour after the file was written.
+    assert sync._acquire_pid_lock() is True
+
+
+def test_a_holder_older_than_its_lock_file_is_left_alone(
+        home, lookalike_daemon, monkeypatch):
+    """The mirror case: a daemon that started before it wrote its lock is
+    exactly what a healthy holder looks like."""
+    path = _write_lock(home, str(lookalike_daemon.pid))
+    os.utime(path, None)
+    monkeypatch.setattr("clawmetry.process_control._proc_start_epoch",
+                        lambda pid: time.time() - 3600)
+    assert sync._acquire_pid_lock() is False
+
+
+def test_an_unreadable_command_line_does_not_condemn_the_holder(home,
+                                                                lookalike_daemon,
+                                                                monkeypatch):
+    """"I could not look" must not be read as "not ours": on a Windows host
+    without psutil the command line is unreadable for every process, and
+    treating that as foreign would let an upgrade reclaim a live daemon's lock.
+    """
+    monkeypatch.setattr(sync, "_holder_cmdline_verdict", lambda pid: "unknown")
+    path = _write_lock(home, str(lookalike_daemon.pid))
+    # Lock file written now, so the started-after-lock proof does not apply.
+    os.utime(path, None)
+    assert sync._acquire_pid_lock() is False

--- a/tests/test_status_daemon_truth.py
+++ b/tests/test_status_daemon_truth.py
@@ -1,0 +1,134 @@
+"""`clawmetry status` must not report health it has not checked.
+
+Field failure (2026-09-08, a Pro node): the daemon had not started since 19:32
+the previous evening, yet status printed "Cloud sync: Connected", "Runtimes:
+watching", "Daemon: Running (launchd)" and a bare 12-hour-old "Last sync" with
+no comment. Every green tick was reporting CONFIGURATION; nothing on the screen
+reported whether data was actually moving, so the customer had to mail us a
+screenshot to find out his node was dead.
+
+Two things are asserted here: that a registered-but-not-running launchd job is
+not called "Running", and that a stale last-sync is called out in words a
+non-engineer can act on.
+"""
+import json
+
+import pytest
+
+from clawmetry import cli
+from clawmetry import sync
+
+
+# ── launchctl output means less than its exit code suggests ──────────────────
+RUNNING = '''{
+	"LimitLoadToSessionType" = "Aqua";
+	"StandardOutPath" = "/Users/x/.clawmetry/sync.log";
+	"Label" = "com.clawmetry.sync";
+	"OnDemand" = false;
+	"LastExitStatus" = 0;
+	"PID" = 4242;
+	"Program" = "/usr/bin/python3";
+};'''
+
+RESTART_LOOPING = '''{
+	"LimitLoadToSessionType" = "Aqua";
+	"StandardOutPath" = "/Users/x/.clawmetry/sync.log";
+	"Label" = "com.clawmetry.sync";
+	"OnDemand" = false;
+	"LastExitStatus" = 0;
+	"Program" = "/usr/bin/python3";
+};'''
+
+
+def test_a_job_with_a_pid_is_running():
+    st = cli._launchd_job_state(RUNNING)
+    assert st["pid"] == 4242
+
+
+def test_a_registered_job_without_a_pid_is_not_running():
+    """This is the whole bug: `launchctl list` exits 0 for this job too."""
+    st = cli._launchd_job_state(RESTART_LOOPING)
+    assert st["pid"] is None
+    assert st["last_exit"] == 0
+
+
+def test_garbage_listing_does_not_raise():
+    assert cli._launchd_job_state("not launchctl output")["pid"] is None
+    assert cli._launchd_job_state("")["pid"] is None
+
+
+# ── a stale last-sync must be named ──────────────────────────────────────────
+def test_a_recent_sync_is_not_flagged():
+    import datetime as dt
+
+    now = dt.datetime(2026, 9, 9, 8, 0, tzinfo=dt.timezone.utc).timestamp()
+    age, stale = cli._sync_age("2026-09-09T07:59:30+00:00", now=now)
+    assert stale is False
+    assert age == "30s ago"
+
+
+def test_the_field_failure_is_flagged_in_hours():
+    import datetime as dt
+
+    now = dt.datetime(2026, 9, 9, 7, 51, tzinfo=dt.timezone.utc).timestamp()
+    age, stale = cli._sync_age("2026-09-08T19:32:21+00:00", now=now)
+    assert stale is True
+    assert age == "12h ago"
+
+
+@pytest.mark.parametrize("bad", ["", None, "not a timestamp", "????"])
+def test_an_unreadable_timestamp_accuses_nobody(bad):
+    age, stale = cli._sync_age(bad)
+    assert (age, stale) == (None, False)
+
+
+def test_a_naive_timestamp_is_read_as_utc():
+    import datetime as dt
+
+    now = dt.datetime(2026, 9, 9, 7, 51, tzinfo=dt.timezone.utc).timestamp()
+    _, stale = cli._sync_age("2026-09-08T19:32:21", now=now)
+    assert stale is True
+
+
+# ── the advice the user actually reads ───────────────────────────────────────
+@pytest.fixture()
+def stalled_state(tmp_path, monkeypatch):
+    state = tmp_path / "sync_state.json"
+    state.write_text(json.dumps({"last_sync": "2026-01-01T00:00:00+00:00"}))
+    monkeypatch.setattr(sync, "STATE_FILE", state)
+    return state
+
+
+def test_stalled_node_gets_a_sentence_and_a_command(stalled_state, capsys):
+    cli._print_stall_advice("")
+    out = capsys.readouterr().out
+    assert "Nothing has synced" in out
+    assert "clawmetry sync --restart" in out
+
+
+def test_the_lock_loop_signature_gets_its_own_instruction(stalled_state, capsys):
+    """The log line the customer sent us names the actual cause; when it is
+    there, tell him the thing that fixes THAT."""
+    cli._print_stall_advice(
+        "[clawmetry-sync] Another instance is already running. Exiting.\n" * 3
+    )
+    out = capsys.readouterr().out
+    assert "leftover lock file" in out
+    assert "pip install -U clawmetry" in out
+
+
+def test_a_healthy_node_stays_quiet(tmp_path, monkeypatch, capsys):
+    import datetime as dt
+
+    state = tmp_path / "sync_state.json"
+    state.write_text(json.dumps(
+        {"last_sync": dt.datetime.now(dt.timezone.utc).isoformat()}))
+    monkeypatch.setattr(sync, "STATE_FILE", state)
+    cli._print_stall_advice("")
+    assert capsys.readouterr().out == ""
+
+
+def test_no_state_file_is_not_an_accusation(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr(sync, "STATE_FILE", tmp_path / "missing.json")
+    cli._print_stall_advice("")
+    assert capsys.readouterr().out == ""


### PR DESCRIPTION
No-PRD: customer field failure, reported by email with a `clawmetry status` screenshot this morning.

## What the customer saw

A Pro node (0.12.844) stopped syncing at **2026-09-08T19:32** and never resumed. Twelve hours later `clawmetry status` still showed:

```
Cloud sync:  ✅ Connected
Runtimes:    ✅ watching (local) ...
Last sync:   2026-09-08T19:32:21
Daemon:      ✅ Running (launchd)
Log:         /Users/.../.clawmetry/sync.log
  [clawmetry-sync] Another instance is already running. Exiting.
  ... INFO raised RLIMIT_NOFILE soft limit 256 -> 4096
  [clawmetry-sync] Another instance is already running. Exiting.
```

Every tick on that screen reports how the node is **configured**. Nothing on it reported whether data was moving, so the only way to find out the node was dead was for the customer to mail us a screenshot.

The `RLIMIT_NOFILE` line is not evidence of a successful start: it is raised in `run_daemon()` *before* `_acquire_pid_lock()`. The whole visible tail is one loop body, repeating every 30s (`KeepAlive` + `ThrottleInterval 30`) for about 1,400 iterations overnight. The daemon had not started once since 19:32.

## Cause

`_acquire_pid_lock` asked one question: is the pid in `sync.pid` alive?

A pid is not an identity. A daemon that dies without running its atexit hook (SIGKILL, panic, power loss, and today also the #5740 spawn race) leaves the file behind, and the OS eventually hands that number to some unrelated process. `is_alive()` then answers "yes" forever, and there is no way back except a human deleting the file. The repo already had the right primitive for this: `process_control.verify_pid`, the pid-reuse guard every Guard actuator runs before it signals anything. The lock just never called it.

## The fix

**The lock identifies the holder.**

- Identity is `(pid, start-time token)`, recorded in a `sync.lock.json` sidecar. `sync.pid` stays a bare int, because `daemon_registration._is_sync_running`, the dashboard's background spawn and `install.sh`'s sandbox teardown all read it that way.
- A legacy bare-int file falls back to a command-line check on the holder.
- A file naming our own pid is ours, not a rival (defence in depth against the #5740 race, independent of that PR).
- A holder that is genuinely ours but has stopped ticking its heartbeat for `CLAWMETRY_LOCK_STALE_SECS` (default 900s, ticked every 30s by a watchdog thread) is wedged: stop it, then take over. Only a heartbeat that **exists** and went stale condemns a holder, so upgrading never shoots a healthy pre-heartbeat daemon. The heartbeat is deliberately independent of the ingest cycle, so a slow backfill keeps its lock.

**Status stops reporting health it has not checked.**

- `launchctl list` exits 0 for a job that is merely *registered*. The daemon line now reads the `PID` key: no pid means "Set up but not running right now (launchd keeps retrying)".
- `Last sync` carries its age, and says so when nothing is new.
- A stalled node gets one plain sentence and the command that fixes it. When the log carries the lock-loop signature, it names that cause specifically.

```
  Last sync:   2026-09-08T19:32:21  (12h ago)  ⚠️   nothing new since then
  Daemon:      ⚠️   Set up but not running right now (launchd keeps retrying, last exit 0)

  ⚠️   Nothing has synced for 12h, so the dashboard is showing old data.
      The background helper keeps finding a leftover lock file from an earlier run.
      Updating clears it automatically:  pip install -U clawmetry
```

## Verified

Reproduced the customer's machine (a `sync.pid` naming a live `/bin/sleep`, i.e. a recycled pid) against both trees:

```
--- 0.12.748 (origin/main) ---
lock acquired: False
daemon would: PRINT "Another instance is already running. Exiting." and quit

--- this branch ---
WARNING reclaiming stale sync.pid (pid=39214, pid_recycled(cmdline_mismatch))
lock acquired: True
daemon would: START SYNCING
```

`tests/test_pid_lock_reclaim.py` (11) + `tests/test_status_daemon_truth.py` (14), wired into `ci.yml`. Red on the unfixed code:

```
FAILED test_reclaims_a_lock_held_by_a_recycled_pid
FAILED test_reclaims_a_lock_naming_our_own_pid
```

`tests/test_pid_liveness_windows.py` still passes. Two changes there: its stand-in sleeper now looks like the daemon (a bare sleeper is exactly the recycled pid this PR stops trusting), and a docstring was reworded so the raw-probe guard keeps auto-discovering honestly.

## Relationship to #5742

#5742 fixes a *source* of poisoned lock files (the parent pre-writing the child's pid). This fixes the *consequence*: any poisoned lock file, from any cause, self-heals on the next start. They are independent and land in either order; both include the self-pid check.

## For the affected customer

His daemon is down, so the in-daemon auto-updater cannot deliver this. `clawmetry update` (upgrade + pro wheel + `sync --restart`) recovers him on the release carrying this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CYQo5mXvPp3zT9tjq5mEaj