### PR TITLE
Keep the probe map out of the product: the count in the UI, the paths in `clawmetry diagnose`

### DIFF
--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -7081,6 +7081,43 @@ def _cmd_diagnose(args) -> None:
     if payload.get("cache_error"):
         _row("Cache error:", payload["cache_error"])
 
+    _diagnose_runtime_paths()
+
+
+def _diagnose_runtime_paths() -> None:
+    """Where ClawMetry looked for each runtime.
+
+    The first-run panel says HOW MANY runtimes were checked and sends the
+    reader here for the list. The map lands in a local command rather than
+    in the dashboard because a screen ships with every install and appears
+    in every screenshot of a fresh machine, while this output is something a
+    person runs and chooses to share. Paths are home-collapsed by the probe
+    itself, so pasting this into an issue names nobody.
+
+    Never raises: an older probe module simply prints nothing.
+    """
+    try:
+        from clawmetry import runtime_probe as _rp
+        probes = _rp.probe_runtimes()
+    except Exception:
+        return
+    if not probes:
+        return
+    found = [p for p in probes if p.get("found")]
+    print()
+    print(f"Runtimes: {len(found)} detected of {len(probes)} checked")
+    print()
+    print("  Where ClawMetry looked:")
+    for p in probes:
+        mark = "found" if p.get("found") else "-"
+        print(f"    [{mark:>5}] {p.get('label')}")
+        for pth in (p.get("paths") or []):
+            print(f"            {pth}")
+    print()
+    print("  On macOS, reading some of these needs Full Disk Access for your")
+    print("  terminal. A runtime that stores its sessions elsewhere can be")
+    print("  pointed at ClawMetry with the env vars in docs/compatibility.md.")
+
 
 
 def _cmd_extensions(args) -> None:

--- a/clawmetry/runtime_probe.py
+++ b/clawmetry/runtime_probe.py
@@ -37,6 +37,24 @@ except Exception:  # pragma: no cover - defensive; keep onboarding alive
     FREE_RUNTIMES = frozenset({"openclaw", "nemoclaw", "goose"})
 
 
+def _tilde(path: str) -> str:
+    """``/Users/ada/.codex`` -> ``~/.codex``. Never widens a path.
+
+    Every rendered path ends up somewhere it was not written for: a
+    screenshot, a screen-share, a support ticket, a pasted issue. An absolute
+    path carries the account name and buys nothing, because ``~/.codex`` is
+    exactly as checkable. This is the rule the detector surface already holds
+    itself to (AC-OBS-RSO-030.7: no report carries a full filesystem path).
+    """
+    try:
+        home = os.path.expanduser("~")
+        if home and home != os.sep and path.startswith(home):
+            return "~" + path[len(home):]
+    except Exception:
+        pass
+    return path
+
+
 @dataclass
 class RuntimeProbe:
     """One supported runtime: id, human label, and where its data lives."""
@@ -61,10 +79,11 @@ class RuntimeProbe:
             if self.env:
                 root = os.environ.get(self.env)
                 out.append(
-                    os.path.expanduser(root) if root else f"${self.env} (unset)"
+                    _tilde(os.path.expanduser(root)) if root
+                    else f"${self.env} (unset)"
                 )
             for p in self.paths:
-                out.append(os.path.expanduser(os.path.expandvars(p)))
+                out.append(_tilde(os.path.expanduser(os.path.expandvars(p))))
         except Exception:
             return out
         return out

--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -32412,27 +32412,34 @@ async function renderFirstRunReport(overview) {
   } else if (!noIngest) {
     h += '<p style="margin:0 0 10px;font-size:13.5px;color:var(--text-secondary);">'
        + 'No supported runtime was detected. That is a real answer, not an error. '
-       + 'Here is exactly where ClawMetry looked, so you can tell us if it looked '
-       + 'in the wrong place.</p>';
+       + 'If you think it looked in the wrong place, the command below prints '
+       + 'every location it checked.</p>';
   }
 
-  // Where we looked. Collapsed by default: it is reassurance, not the message.
-  var rows = probes.slice(0, 40).map(function (p) {
-    var paths = (p.paths || []).map(function (x) { return escHtml(x); }).join('<br>');
-    return '<tr><td style="padding:3px 12px 3px 0;white-space:nowrap;color:var(--text-primary);">'
-         + (p.found ? '\u2713 ' : '\u00b7 ') + escHtml(p.label || p.id)
-         + '</td><td style="padding:3px 0;color:var(--text-muted);font-family:ui-monospace,monospace;font-size:11.5px;">'
-         + (paths || '<i>no default location</i>') + '</td></tr>';
-  }).join('');
-  if (rows) {
-    h += '<details style="margin:0 0 12px;"><summary style="cursor:pointer;font-size:13px;color:var(--text-secondary);">'
-       + 'Where ClawMetry looked (' + probes.length + ' runtimes)</summary>'
-       + '<div style="overflow-x:auto;margin-top:8px;"><table style="border-collapse:collapse;font-size:12.5px;">'
-       + rows + '</table></div>'
-       + '<p style="margin:8px 0 0;font-size:12.5px;color:var(--text-muted);">'
-       + 'On macOS, reading some of these needs Full Disk Access for your terminal. '
+  // How widely we looked, and where to get the detail.
+  //
+  // This used to render the expanded probe path for all 30 runtimes. Two
+  // problems with putting that on a screen. It carries the account name
+  // (`/Users/<name>/...`) into every screenshot, screen-share and pasted
+  // issue of an empty dashboard, which is the rule the detector surface
+  // already holds itself to (AC-OBS-RSO-030.7: no report carries a full
+  // filesystem path). And a complete, copy-pasteable map of where we look
+  // for every supported runtime is a different artefact from the same table
+  // sitting in a source file: it ships with every install and lands in every
+  // screenshot of a fresh machine.
+  //
+  // So the panel says HOW MANY runtimes were checked, which is what makes
+  // "nothing detected" trustworthy, and points at `clawmetry diagnose` for
+  // the list. That is a local command whose output a person runs and chooses
+  // to share.
+  if (probes.length) {
+    h += '<p style="margin:0 0 12px;font-size:12.5px;color:var(--text-muted);">'
+       + 'ClawMetry checked <b>' + probes.length + ' runtimes</b> in their default locations. '
+       + 'To see exactly where it looked, run '
+       + '<code style="background:var(--bg-primary);padding:2px 6px;border-radius:4px;">clawmetry diagnose</code>.'
+       + '<br>On macOS, reading some of them needs Full Disk Access for your terminal. '
        + 'A runtime storing its sessions somewhere else can be pointed at ClawMetry '
-       + 'with the environment variables in docs/compatibility.md.</p></details>';
+       + 'with the environment variables in docs/compatibility.md.</p>';
   }
 
   h += '<div style="border-top:1px solid var(--border-secondary);padding-top:11px;font-size:13.5px;color:var(--text-secondary);">'

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -47018,10 +47018,14 @@ def api_entitlement_runtime_detection():
                 "allowed": bool(p.get("free")),
                 "required_tier": None,
                 "required_tier_label": None,
-                # Where we actually looked. A first-run screen that says
-                # "nothing detected" without this is indistinguishable from a
-                # broken install (#5716).
-                "paths": list(p.get("paths") or []),
+                # NOT the probed paths. A first-run screen needs to know
+                # THAT we looked and how widely, which the runtime list and
+                # its count already say. Serving the expanded location of
+                # every runtime turns each install into a copy-pasteable map
+                # of our whole detection strategy, and carries the account
+                # name into every screenshot of an empty dashboard. The map
+                # lives in `clawmetry diagnose`, a local command whose output
+                # a person runs and chooses to share.
                 "env": p.get("env") or "",
             }
             for p in raw
@@ -47078,8 +47082,8 @@ def api_entitlement_runtime_detection():
                 "allowed": bool(rid and rid in allowed_runtimes),
                 "required_tier": req_t,
                 "required_tier_label": req_lbl,
-                # Where we actually looked (#5716).
-                "paths": list(p.get("paths") or []) if isinstance(p, dict) else [],
+                # No probed paths on the wire: see the note on the other
+                # payload shape above (#5716).
                 "env": (p.get("env") or "") if isinstance(p, dict) else "",
             }
         )

--- a/tests/test_first_run_report.py
+++ b/tests/test_first_run_report.py
@@ -3,8 +3,24 @@
 A dashboard showing nothing is indistinguishable from a broken install. The
 panel that fixes that is only as good as the data behind it, so this pins the
 part that can silently rot: the probe must expose the paths it actually
-checked, and the detection endpoint must pass them through (it whitelists
-keys, so a new field on the probe does not reach the UI by itself).
+checked, and ``clawmetry diagnose`` must print them.
+
+WHERE those paths are allowed to appear changed after review. They are
+printed by ``clawmetry diagnose``, a local command whose output a person
+runs and chooses to share, and they are NOT served over HTTP or rendered in
+the dashboard. Two reasons, both load-bearing:
+
+  * an expanded path carries the account name (``/Users/<name>/...``) into
+    every screenshot, screen-share and pasted issue of an empty dashboard.
+    ``AC-OBS-RSO-030.7`` already forbids a report carrying a full filesystem
+    path, and the detector surface holds itself to it;
+  * a complete, copy-pasteable map of where we look for every supported
+    runtime is a different artefact from the same table sitting in a source
+    file. It would ship with every install and land in every screenshot of a
+    fresh machine.
+
+The panel still says HOW MANY runtimes were checked, which is what makes
+"nothing detected" trustworthy, and points at the command for the list.
 """
 from __future__ import annotations
 
@@ -25,12 +41,29 @@ def test_every_probe_reports_the_paths_it_checked() -> None:
         assert r["paths"], f"{r.get('id')} reports an empty path list"
 
 
-def test_checked_paths_are_expanded_not_raw_globs() -> None:
-    """A user cannot act on '~/.claude/projects' if their home is elsewhere."""
+def test_checked_paths_are_home_collapsed() -> None:
+    """Reversed after review.
+
+    This asserted the EXPANDED path, on the reasoning that a user cannot act
+    on ``~/.claude/projects`` if their home is elsewhere. ``~`` IS their home
+    on every platform we support, and the shell expands it, so the tilde form
+    is exactly as actionable and names nobody.
+    """
     rows = {r["id"]: r for r in runtime_probe.probe_runtimes()}
     cc = rows.get("claude_code")
     assert cc, "claude_code probe missing"
-    assert not any(p.startswith("~") for p in cc["paths"]), cc["paths"]
+    assert cc["paths"] == ["~/.claude/projects"], cc["paths"]
+
+
+def test_no_reported_path_carries_the_home_directory() -> None:
+    """Auto-discovering over the catalogue, so a runtime added later cannot
+    reintroduce an absolute path without this failing."""
+    home = os.path.expanduser("~")
+    if home in ("", os.sep):
+        return
+    for r in runtime_probe.probe_runtimes():
+        for path in r.get("paths") or []:
+            assert home not in path, (r.get("id"), path)
 
 
 def test_unset_env_candidate_is_named_not_dropped() -> None:
@@ -51,21 +84,60 @@ def test_checked_paths_never_raises(monkeypatch) -> None:
     assert probe.checked_paths() == []
 
 
-def test_detection_endpoint_passes_paths_through() -> None:
-    """The endpoint builds its payload from an explicit key whitelist, so a
-    field added to the probe does NOT reach the UI unless it is added there
-    too. That is the failure this test exists to catch."""
+def test_detection_endpoint_serves_no_probed_paths() -> None:
+    """The probe map must not travel over HTTP.
+
+    Reversed after review: this used to assert that BOTH payload builders
+    forwarded ``paths``. Serving them turns every install into a
+    copy-pasteable map of our detection strategy and puts the account name in
+    the response. Both builders are checked, because leaving it in one is the
+    same leak on that code path.
+    """
     import re
     here = os.path.dirname(os.path.abspath(__file__))
     src = open(os.path.join(here, "..", "routes", "entitlement.py"),
                encoding="utf-8").read()
-    # Both payload builders (the no-plan fallback and the tier-decorated one).
-    hits = len(re.findall(r'"paths": list\(p\.get\("paths"\)', src))
-    assert hits >= 2, (
-        f"only {hits} of the 2 runtime-detection payload builders forward "
-        "'paths'; the first-run report would show an empty 'where we looked' "
-        "list on that code path"
+    hits = re.findall(r'"paths": list\(p\.get\("paths"\)', src)
+    assert not hits, (
+        f"{len(hits)} runtime-detection payload builder(s) still forward the "
+        "probed paths; they belong in `clawmetry diagnose`, not in an HTTP "
+        "response"
     )
+
+
+def test_the_served_response_carries_no_path_and_no_home() -> None:
+    """The behavioural half of the test above, against the real endpoint."""
+    import json
+    from flask import Flask
+    import routes.entitlement as ent
+
+    app = Flask(__name__)
+    app.register_blueprint(ent.bp_entitlement)
+    with app.test_client() as c:
+        body = c.get("/api/entitlement/runtime-detection").get_json()
+    blob = json.dumps(body)
+    home = os.path.expanduser("~")
+    if home not in ("", os.sep):
+        assert home not in blob, "the endpoint must not carry the account name"
+    for probe in body.get("probes") or []:
+        assert "paths" not in probe, probe.get("id")
+
+
+def test_the_panel_points_at_the_command_instead_of_listing_paths() -> None:
+    here = os.path.dirname(os.path.abspath(__file__))
+    app_js = open(os.path.join(here, "..", "clawmetry", "static", "js", "app.js"),
+                  encoding="utf-8").read()
+    assert "clawmetry diagnose" in app_js
+    assert "p.paths" not in app_js, "the first-run panel must not render the map"
+
+
+def test_diagnose_is_where_the_map_lives() -> None:
+    import inspect
+    from clawmetry import cli as _cli
+
+    assert hasattr(_cli, "_diagnose_runtime_paths")
+    src = inspect.getsource(_cli._diagnose_runtime_paths)
+    assert "Where ClawMetry looked" in src
 
 
 def test_endpoint_reports_whether_anything_is_ingesting() -> None:

--- a/tests/test_first_run_report.py
+++ b/tests/test_first_run_report.py
@@ -21,6 +21,10 @@ the dashboard. Two reasons, both load-bearing:
 
 The panel still says HOW MANY runtimes were checked, which is what makes
 "nothing detected" trustworthy, and points at the command for the list.
+
+Recorded in the product record as ADR-005 on the Sample Mode and First-Run
+Report blueprint, and in the requirement's Capability 2, so the spec and the
+code agree on where the map is allowed to appear.
 """
 from __future__ import annotations
 


### PR DESCRIPTION
Follow-up to #5753, which closed #5716 and shipped the first-run report. That report also shipped the **expanded probe path for all 30 runtimes** — served by `/api/entitlement/runtime-detection` in both payload builders, and rendered as a table in the Overview panel. Founder review of a screenshot flagged it.

The three-case panel from #5753 (including its #5740 "nothing is ingesting" case) is good and is **untouched**. Only the path map moves.

## Two problems, one already forbidden by the repo

**1. The account name.** `RuntimeProbe.checked_paths()` expanded `~`, so a real machine renders `/Users/<name>/...` on the screen most likely to end up in a screenshot, a screen-share, a support ticket, or a marketing shot of a fresh install. **`AC-OBS-RSO-030.7` already says no report carries a full filesystem path**, and the detector surface holds itself to it. `~` *is* the home directory on every platform we support and the shell expands it, so the tilde form is exactly as actionable and names nobody.

**2. The detection map.** The paths are readable in `runtime_probe.py` either way — this repo is public. But a table in source and a finished, copy-pasteable list of where we look for every supported runtime are different artefacts: the second ships with every install and lands in every screenshot of a fresh machine. `CLAUDE.md` splits the repos so runtime knowledge is the moat; the product should not hand the finished map over.

## What changed

| | before | after |
|---|---|---|
| probe reports | `/Users/ada/.codex/sessions` | `~/.codex/sessions` |
| API payload | `paths: [...]` in **both** builders | no `paths` key at all |
| Overview panel | table of 30 runtimes × paths | "checked **30 runtimes** … run `clawmetry diagnose`" |
| the map | nowhere else | `clawmetry diagnose` |

The panel still says **how many** runtimes were checked, which is what makes "nothing detected" trustworthy, and its lead sentence no longer promises a list it does not show.

## Three tests reversed on purpose

Not to get green — each pinned something that is now wrong:

* `test_checked_paths_are_expanded_not_raw_globs` asserted the expanded form, reasoning a user cannot act on `~/.claude/projects`. They can.
* `test_detection_endpoint_passes_paths_through` asserted **both** builders forward the paths. Both must now forward neither, since leaving it in one is the same leak on that code path.
* New: a behavioural test asserts the served body contains no `$HOME`, and a catalogue-wide test asserts no reported path does either, so a runtime added later cannot reintroduce one.

**Guard proven red:** re-adding `"paths": list(p.get("paths") or [])` to a builder fails `test_detection_endpoint_serves_no_probed_paths`.

## Verified live

On a HOME with no agent data:

```
probe row keys  : [allowed, env, found, free, id, label, required_tier, required_tier_label]
carries 'paths' : False
carries $HOME   : False
carries .openclaw: False
```

Rendered panel: *"No supported runtime was detected. That is a real answer, not an error. If you think it looked in the wrong place, the command below prints every location it checked. ClawMetry checked **30 runtimes** in their default locations. To see exactly where it looked, run `clawmetry diagnose`."* — and no probe path anywhere on the page.

107 tests pass across every detection suite.

**Unrelated, noted not fixed:** the self-host diagnostics panel (`#sh-diagnostics`) still renders the absolute workspace path. Pre-existing and a different surface; flagging rather than widening this PR.

No-PRD: follow-up correction to merged #5753 / issue #5716.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xb6A5G74JiMe3zHFs1JZEP