### PR TITLE
fix: surface OpenClaw session share state

### DIFF
--- a/clawmetry/adapters/openclaw_share.py
+++ b/clawmetry/adapters/openclaw_share.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+def _share_by_session_id() -> dict[str, dict[str, Any]]:
+    try:
+        from .openclaw import _d
+        rows = _d()._get_sessions() or []
+    except Exception:
+        return {}
+
+    result: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        share = row.get("publicShare")
+        if not isinstance(share, dict):
+            continue
+        for key in (row.get("sessionId"), row.get("key")):
+            if key:
+                result[str(key)] = share
+    return result
+
+
+def apply_share_state(sessions) -> None:
+    shares = _share_by_session_id()
+    for session in sessions:
+        share = shares.get(str(session.id))
+        if not isinstance(session.extra, dict):
+            session.extra = {}
+        session.extra["isShared"] = bool(share)
+        if not share:
+            continue
+        created_at = share.get("createdAt")
+        if created_at is not None:
+            try:
+                session.extra["shareCreatedAt"] = float(created_at) / 1000.0
+            except (TypeError, ValueError):
+                pass
+        session.extra["shareVisibility"] = "public-read-only"
+
+
+def apply_share_state_to_payloads(payloads) -> None:
+    shares = _share_by_session_id()
+    for payload in payloads:
+        if not isinstance(payload, dict):
+            continue
+        share = shares.get(str(payload.get("id")))
+        extra = payload.get("extra") if isinstance(payload.get("extra"), dict) else {}
+        extra["isShared"] = bool(share)
+        if share:
+            created_at = share.get("createdAt")
+            if created_at is not None:
+                try:
+                    extra["shareCreatedAt"] = float(created_at) / 1000.0
+                except (TypeError, ValueError):
+                    pass
+            extra["shareVisibility"] = "public-read-only"
+        payload["extra"] = extra

--- a/clawmetry/adapters/openclaw_share.py
+++ b/clawmetry/adapters/openclaw_share.py
@@ -1,60 +1,246 @@
+"""OpenClaw public-share state (issue #5746).
+
+OpenClaw 2026.9.3 lets a session owner publish a **revocable, read-only
+public link** to a session's existing *and future* conversation text
+(openclaw#139489). That is an exposure signal Guard and the security
+posture should be able to see, so ClawMetry records whether a session is
+published — and nothing else about it.
+
+Three facts about the upstream shape drive every decision in here.
+
+**1. It is not on ``sessions.list``.** ``publicShare`` is listed in
+OpenClaw's ``PRIVATE_SESSION_ENTRY_KEYS`` and every session entry is run
+through ``stripPrivateSessionEntryFields()`` before it leaves the
+gateway. Reading a session list — ours or the gateway's — will never
+surface it. The read method that carries it is ``session.members.list``
+(scope ``operator.read``, since 2026.7), addressed one session at a
+time::
+
+    session.members.list {sessionKey, agentId?}
+      -> {sessionKey, publicShare?, owner?, members[], identities[],
+          role, allowedVisibilities[]}
+
+**2. The payload is a live credential.** The upstream schema is::
+
+    publicShare = {token: /^v1\\.[A-Za-z0-9_-]+$/ (<=7000), createdAt: int}
+
+``token`` *is* the public link — OpenClaw builds the shareable URL
+directly from it. Storing it would put a working read capability for the
+user's conversation into DuckDB and into the E2E-encrypted cloud
+snapshot, which is a strictly worse exposure than the one we are trying
+to report on. So this module lifts ``bool(publicShare)`` and
+``createdAt`` and deliberately never returns, logs, or stores the token.
+:func:`share_fields` is the only place that reads the upstream object,
+and it is the enforcement point for that rule.
+
+**3. Not knowing is not the same as "not shared".** Because the probe is
+a per-session RPC it can fail, be out of scope, be capped out, or be
+unavailable entirely (cloud containers have no gateway). #5746 is filed
+as a high-severity exposure gap, so reporting a confident ``isShared:
+false`` for a session we never actually asked about would be the worst
+available answer — Guard would show a publicly-linked transcript as
+private. Where the answer is unknown the field is **omitted**, and the
+read helpers below leave the payload untouched.
+"""
 from __future__ import annotations
 
-from typing import Any
+import logging
+import os
+from typing import Any, Callable, Iterable, Mapping
+
+logger = logging.getLogger("clawmetry.adapters.openclaw_share")
+
+#: Gateway read method that carries ``publicShare`` (scope ``operator.read``).
+SHARE_RPC_METHOD = "session.members.list"
+
+#: Metadata keys written into ``sessions.metadata`` by the daemon. Kept
+#: short and snake_case to match the other keys in that blob.
+META_SHARED = "shared"
+META_SHARE_CREATED_AT = "share_created_at"
+
+#: Upper bound on probes per sync pass. A backfill can flush hundreds of
+#: sessions at once and each probe is a serialised WebSocket round-trip;
+#: without a cap the first sync after an install would spend minutes in
+#: the gateway. Sessions past the cap are left unknown, not false.
+_DEFAULT_MAX_PROBES = 60
 
 
-def _share_by_session_id() -> dict[str, dict[str, Any]]:
+def _max_probes() -> int:
     try:
-        from .openclaw import _d
-        rows = _d()._get_sessions() or []
-    except Exception:
+        return max(0, int(os.environ.get("CLAWMETRY_OPENCLAW_SHARE_MAX", "")
+                          or _DEFAULT_MAX_PROBES))
+    except (TypeError, ValueError):
+        return _DEFAULT_MAX_PROBES
+
+
+def _created_at_seconds(value: Any) -> float | None:
+    """``publicShare.createdAt`` as epoch seconds, or ``None``.
+
+    Upstream types it as a bare ``Integer(minimum: 0)`` rather than one of
+    OpenClaw's ``*Ms``-suffixed fields, so the unit is not self-evident
+    from the schema. Rather than assume milliseconds, apply the same
+    magnitude test the rest of this repo uses (``routes/agents.py``
+    ``_ts_to_seconds``): anything past 1e12 is milliseconds. That is
+    correct for both spellings instead of correct for one guess.
+    """
+    if isinstance(value, bool) or value is None:
+        return None
+    try:
+        num = float(value)
+    except (TypeError, ValueError):
+        return None
+    if num <= 0:
+        return None
+    return num / 1000.0 if num > 1e12 else num
+
+
+def share_fields(share: Any) -> dict[str, Any]:
+    """Project one upstream ``publicShare`` object into what we may keep.
+
+    Returns ``{"shared": bool}`` plus ``share_created_at`` when the
+    timestamp is usable. **The token is never included** — see the module
+    docstring; this function is the single point where the upstream object
+    is read, so the rule is enforced in one place rather than trusted to
+    every caller.
+    """
+    if not isinstance(share, Mapping):
+        return {META_SHARED: False}
+    fields: dict[str, Any] = {META_SHARED: True}
+    created = _created_at_seconds(share.get("createdAt"))
+    if created is not None:
+        fields[META_SHARE_CREATED_AT] = created
+    return fields
+
+
+def fetch_share_state(
+    session_keys: Iterable[str],
+    rpc: Callable[[str, dict], Any] | None = None,
+    agent_id: str | None = None,
+) -> dict[str, dict[str, Any]]:
+    """Probe the gateway for the share state of ``session_keys``.
+
+    Daemon-side only: this makes one ``session.members.list`` call per
+    session key, serialised through the gateway WebSocket. Returns a dict
+    keyed by session key; **a key is absent when we could not get an
+    answer**, which the callers below render as "unknown" rather than
+    "not shared".
+
+    ``rpc`` is injected in tests; by default the shared gateway helper is
+    used. Never raises — a gateway that is down, unauthorised, or running
+    a version without the method yields an empty result and the daemon
+    carries on.
+    """
+    keys = [str(k) for k in session_keys if k]
+    if not keys:
         return {}
+    if rpc is None:
+        try:
+            from helpers.gateway import _gw_ws_rpc as rpc  # type: ignore
+        except Exception as exc:
+            logger.debug("share probe unavailable (no gateway helper): %s", exc)
+            return {}
 
-    result: dict[str, dict[str, Any]] = {}
-    for row in rows:
-        if not isinstance(row, dict):
+    limit = _max_probes()
+    if limit <= 0:
+        return {}
+    if len(keys) > limit:
+        logger.debug(
+            "share probe capped at %d of %d sessions "
+            "(raise CLAWMETRY_OPENCLAW_SHARE_MAX to widen)", limit, len(keys)
+        )
+        keys = keys[:limit]
+
+    out: dict[str, dict[str, Any]] = {}
+    answered = 0
+    for key in keys:
+        params: dict[str, Any] = {"sessionKey": key}
+        if agent_id:
+            params["agentId"] = agent_id
+        try:
+            payload = rpc(SHARE_RPC_METHOD, params)
+        except Exception as exc:  # a wedged socket must not sink the pass
+            logger.debug("share probe failed for %s: %s", key[:12], exc)
             continue
-        share = row.get("publicShare")
-        if not isinstance(share, dict):
+        if not isinstance(payload, Mapping):
+            # None = RPC error/timeout/unknown method. Unknown, not false.
             continue
-        for key in (row.get("sessionId"), row.get("key")):
-            if key:
-                result[str(key)] = share
-    return result
+        answered += 1
+        out[key] = share_fields(payload.get("publicShare"))
+    if keys and not answered:
+        _warn_all_probes_failed()
+    return out
 
 
-def apply_share_state(sessions) -> None:
-    shares = _share_by_session_id()
+_warned_no_answer = False
+
+
+def _warn_all_probes_failed() -> None:
+    """Say once why the share column is empty.
+
+    ``_gw_ws_rpc`` collapses every failure to ``None``, so we cannot tell a
+    scope denial from a timeout here. The overwhelmingly common cause is the
+    known v4 gateway scope gap: a raw bearer token connects fine but is
+    granted no scopes, and ``session.members.list`` (``operator.read``) comes
+    back FORBIDDEN — the same reason the Sessions and Crons tabs read empty
+    against such a gateway. Without this line the feature looks like it
+    simply found nothing, which is the one reading that is never true.
+    """
+    global _warned_no_answer
+    if _warned_no_answer:
+        return
+    _warned_no_answer = True
+    logger.warning(
+        "openclaw share state unavailable: no session answered %s. "
+        "Sessions will read as UNKNOWN (never as 'not shared'). Most often "
+        "the gateway token carries no operator.read scope.",
+        SHARE_RPC_METHOD,
+    )
+
+
+def share_extra(meta: Any) -> dict[str, Any]:
+    """UI ``extra`` fields for one session, from its stored metadata.
+
+    Returns an empty dict when the daemon has not recorded a share verdict
+    for this session, so an unknown stays unknown all the way to the UI.
+    """
+    if not isinstance(meta, Mapping) or META_SHARED not in meta:
+        return {}
+    shared = bool(meta.get(META_SHARED))
+    extra: dict[str, Any] = {"isShared": shared}
+    if not shared:
+        return extra
+    created = _created_at_seconds(meta.get(META_SHARE_CREATED_AT))
+    if created is not None:
+        extra["shareCreatedAt"] = created
+    # Describes the upstream feature, not something we measured: the
+    # published view is read-only and omits tools, reasoning and files.
+    extra["shareVisibility"] = "public-read-only"
+    return extra
+
+
+def apply_share_state(sessions: Iterable[Any], meta_by_id: Mapping[str, Any]) -> None:
+    """Stamp share fields onto adapter :class:`Session` objects in place."""
     for session in sessions:
-        share = shares.get(str(session.id))
-        if not isinstance(session.extra, dict):
-            session.extra = {}
-        session.extra["isShared"] = bool(share)
-        if not share:
+        extra = share_extra(meta_by_id.get(str(getattr(session, "id", ""))))
+        if not extra:
             continue
-        created_at = share.get("createdAt")
-        if created_at is not None:
-            try:
-                session.extra["shareCreatedAt"] = float(created_at) / 1000.0
-            except (TypeError, ValueError):
-                pass
-        session.extra["shareVisibility"] = "public-read-only"
+        if not isinstance(getattr(session, "extra", None), dict):
+            session.extra = {}
+        session.extra.update(extra)
 
 
-def apply_share_state_to_payloads(payloads) -> None:
-    shares = _share_by_session_id()
+def apply_share_state_to_payloads(payloads: Iterable[Any]) -> None:
+    """Stamp share fields onto local-store session payload dicts in place.
+
+    Each payload is expected to carry its stored ``metadata`` under
+    ``_metadata`` (set by the caller in ``routes/agents.py``); the key is
+    popped so it never reaches the wire.
+    """
     for payload in payloads:
         if not isinstance(payload, dict):
             continue
-        share = shares.get(str(payload.get("id")))
-        extra = payload.get("extra") if isinstance(payload.get("extra"), dict) else {}
-        extra["isShared"] = bool(share)
-        if share:
-            created_at = share.get("createdAt")
-            if created_at is not None:
-                try:
-                    extra["shareCreatedAt"] = float(created_at) / 1000.0
-                except (TypeError, ValueError):
-                    pass
-            extra["shareVisibility"] = "public-read-only"
-        payload["extra"] = extra
+        extra = share_extra(payload.pop("_metadata", None))
+        if not extra:
+            continue
+        existing = payload.get("extra")
+        payload["extra"] = {**existing, **extra} if isinstance(existing, dict) else extra

--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -31184,6 +31184,14 @@ function loadGuardSessions() {
           guardEsc(ws.detail || '') + '">' +
           guardEsc(GUARD_KIND_LABEL[ws.kind] || ws.kind) + '</span>';
       }
+      // #5746 — this session's transcript is published to a read-only public
+      // link that anyone holding it can open, and which keeps receiving new
+      // conversation text. Strictly `=== true`: `null` means the daemon never
+      // got a verdict (no gateway to ask), and drawing anything for that would
+      // turn "we do not know" into a claim.
+      if (s.public_share === true) {
+        statusCell += ' <span class="pill pill-warn" title="This session is published to a read-only public link. Anyone with the link can read its conversation text, including messages sent from now on. Revoke it from the OpenClaw session menu.">Public link</span>';
+      }
       // Listed from the live process probe, so it can be stopped now, but the
       // sync daemon has not read its transcript yet. Say that rather than let
       // the blank cost and missing detector status read as "nothing to see".

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -4870,6 +4870,35 @@ def _session_agent_type(row: dict, session_id: str) -> str:
     return "openclaw"
 
 
+def _annotate_public_share(rows: list) -> None:
+    """Stamp ``shared`` / ``share_created_at`` onto OpenClaw session rows.
+
+    Probes the gateway once per session key (see
+    :mod:`clawmetry.adapters.openclaw_share` for why a list call cannot
+    answer this, and why the share token is never carried). Rows the probe
+    could not answer for are left untouched, so "unknown" stays distinct
+    from "not shared" all the way to Guard.
+
+    Off with ``CLAWMETRY_OPENCLAW_SHARE=0``. Never raises.
+    """
+    if os.environ.get("CLAWMETRY_OPENCLAW_SHARE", "1").strip() == "0":
+        return
+    if not rows:
+        return
+    keys = [r.get("session_key") for r in rows if r.get("session_key")]
+    if not keys:
+        return
+    from clawmetry.adapters.openclaw_share import fetch_share_state
+
+    state = fetch_share_state(keys)
+    if not state:
+        return
+    for r in rows:
+        fields = state.get(r.get("session_key") or "")
+        if fields:
+            r.update(fields)
+
+
 def _local_ingest_sessions_batch(rows: list, node_id: str) -> None:
     """Mirror a batch of session rows (the same dicts we push to /ingest/sessions)
     into the local DuckDB ``sessions`` table. Batched: ONE
@@ -4897,9 +4926,20 @@ def _local_ingest_sessions_batch(rows: list, node_id: str) -> None:
         meta_extras = {
             k: v for k, v in s.items()
             if k in ("channel", "chat_type", "subject", "recent_model",
-                     "session_key", "end_reason", "runtime", "thinking_level")
+                     "session_key", "end_reason", "runtime", "thinking_level",
+                     # #5746 public-share verdict. ``shared`` is a bool, so
+                     # the ``and v`` filter below would drop a stored False —
+                     # which is a real answer ("we asked; it is not
+                     # published"), not a missing one. Handled explicitly
+                     # after this comprehension.
+                     "share_created_at")
             and v
         }
+        # ``shared`` carries meaning when False, so it bypasses the
+        # truthiness filter above. Absent stays absent: a session the daemon
+        # could not probe must not be recorded as "not shared" (#5746).
+        if isinstance(s.get("shared"), bool):
+            meta_extras["shared"] = s["shared"]
         session_rows.append({
             "agent_type": _session_agent_type(s, sid),
             "session_id": sid,
@@ -13651,6 +13691,16 @@ def sync_session_metadata(config: dict, state: dict = None) -> int:
                 for s in rows:
                     if not s.get("model"):
                         s["model"] = fallback
+            # #5746 — public-share verdict, before the rows are written
+            # anywhere. Daemon-side on purpose: it is one gateway RPC per
+            # session (``publicShare`` is stripped from every session-list
+            # projection upstream), which belongs on the sync cycle and not
+            # in a request handler. Cloud containers have no gateway, so
+            # this is also the only place the signal can be captured at all.
+            try:
+                _annotate_public_share(rows)
+            except Exception as _e:
+                log.debug("openclaw share probe skipped: %s", _e)
             # Local-first: write through to ~/.clawmetry/events.duckdb FIRST.
             # Best-effort — never blocks cloud sync on a local-store failure.
             try:

--- a/docs/MODULE_MAP.md
+++ b/docs/MODULE_MAP.md
@@ -4,7 +4,7 @@
 > `python3 scripts/gen_module_map.py` (CI fails on drift via
 > `tests/test_module_map_drift.py`).
 
-230 modules, 81 Flask blueprints. `CLAUDE.md` carries a short curated table of the ones you reach for most often; this is the whole list.
+231 modules, 81 Flask blueprints. `CLAUDE.md` carries a short curated table of the ones you reach for most often; this is the whole list.
 
 Size bands are deliberately coarse so this file does not churn on every PR: **small** is under 200 lines, **medium** under 1k, **large** under 5k, **huge** is 5k and up.
 
@@ -260,6 +260,7 @@ The runtime adapters that ship in open source. The paid ones live in `clawmetry-
 | `clawmetry/adapters/goose.py` | medium | GooseAdapter — read Goose (Block / block/goose) sessions from its SQLite store. |
 | `clawmetry/adapters/nemo.py` | large | NeMoAdapter — push-mode telemetry exporter for NVIDIA's NeMo Agent Toolkit. |
 | `clawmetry/adapters/openclaw.py` | large | This adapter does NOT re-implement OpenClaw session parsing. It delegates |
+| `clawmetry/adapters/openclaw_share.py` | medium | OpenClaw public-share state (issue #5746). |
 | `clawmetry/adapters/phase.py` | medium | The session phase model: one state machine, every runtime. |
 | `clawmetry/adapters/registry.py` | small | Process-wide adapter registry. |
 

--- a/routes/agents.py
+++ b/routes/agents.py
@@ -32,6 +32,7 @@ from clawmetry.config import is_local_store_read_enabled
 
 from clawmetry.adapters import registry
 from clawmetry.adapters import phase as _phase
+from clawmetry.adapters.openclaw_share import apply_share_state, apply_share_state_to_payloads
 from clawmetry._gate import require_runtime
 
 bp_agents = Blueprint("agents", __name__)
@@ -202,6 +203,8 @@ def _try_local_store_agent_sessions(name: str, limit: int):
         if verdict.end_reason and not s.get("endReason"):
             s["endReason"] = verdict.end_reason
         _apply_phase(s, durable.get(s["id"]) or {})
+    if name == "openclaw":
+        apply_share_state_to_payloads(sessions)
     return {"sessions": sessions, "_source": "local_store"}
 
 
@@ -253,6 +256,8 @@ def api_agent_sessions(name: str):
             s.resolve_phase(now=now)
         except Exception:  # never let one odd session sink the listing
             pass
+    if name == "openclaw":
+        apply_share_state(sessions)
     durable = _durable_phases(name, [s.id for s in sessions])
     payload = []
     for s in sessions:

--- a/routes/agents.py
+++ b/routes/agents.py
@@ -32,7 +32,7 @@ from clawmetry.config import is_local_store_read_enabled
 
 from clawmetry.adapters import registry
 from clawmetry.adapters import phase as _phase
-from clawmetry.adapters.openclaw_share import apply_share_state, apply_share_state_to_payloads
+from clawmetry.adapters import openclaw_share
 from clawmetry._gate import require_runtime
 
 bp_agents = Blueprint("agents", __name__)
@@ -53,6 +53,26 @@ def _ls_call(method_name, **kwargs):
         return getattr(store, method_name)(**kwargs)
     except Exception:
         return None
+
+
+def _stored_metadata(name: str, limit: int = 100) -> dict:
+    """``{session_id: metadata}`` from the typed sessions table.
+
+    Only used by the adapter path, which runs when the local-store read is
+    disabled or has no rows for this runtime. Returns ``{}`` when the store
+    is unreachable — the share stamp then leaves every session unmarked,
+    which is the honest reading of "we do not know" (#5746).
+    """
+    rows = _ls_call("query_sessions_table", agent_type=name, limit=limit)
+    if not rows:
+        return {}
+    out: dict = {}
+    for r in rows:
+        sid = r.get("session_id")
+        meta = r.get("metadata")
+        if sid and isinstance(meta, dict):
+            out[str(sid)] = meta
+    return out
 
 
 def _durable_phases(name: str, session_ids) -> dict:
@@ -178,6 +198,8 @@ def _try_local_store_agent_sessions(name: str, limit: int):
             "costUsd": float(r.get("cost_usd")) if r.get("cost_usd") is not None else None,
             "costStatus": meta.get("cost_status") or "",
             "endReason": meta.get("end_reason") or "",
+            # Popped by apply_share_state_to_payloads below; never goes out.
+            "_metadata": meta,
         })
     # Phase, on every row. Derived here from the stored timestamps so a store
     # that has rows but no phase record yet still answers, then overlaid with
@@ -203,8 +225,10 @@ def _try_local_store_agent_sessions(name: str, limit: int):
         if verdict.end_reason and not s.get("endReason"):
             s["endReason"] = verdict.end_reason
         _apply_phase(s, durable.get(s["id"]) or {})
-    if name == "openclaw":
-        apply_share_state_to_payloads(sessions)
+    # Share state (#5746) rides on the stored metadata the daemon wrote; a
+    # session the daemon could not probe carries no verdict and is left
+    # unstamped rather than reported "not shared".
+    openclaw_share.apply_share_state_to_payloads(sessions)
     return {"sessions": sessions, "_source": "local_store"}
 
 
@@ -257,7 +281,7 @@ def api_agent_sessions(name: str):
         except Exception:  # never let one odd session sink the listing
             pass
     if name == "openclaw":
-        apply_share_state(sessions)
+        openclaw_share.apply_share_state(sessions, _stored_metadata(name, limit))
     durable = _durable_phases(name, [s.id for s in sessions])
     payload = []
     for s in sessions:

--- a/routes/guard.py
+++ b/routes/guard.py
@@ -387,6 +387,15 @@ def _incident_rank(inc) -> tuple:
     return (spend, sev, count)
 
 
+def _share_verdict(meta):
+    """``True``/``False`` when the daemon recorded a public-share verdict for
+    this session, ``None`` when it never got one. See
+    :mod:`clawmetry.adapters.openclaw_share` (#5746)."""
+    from clawmetry.adapters.openclaw_share import share_extra
+
+    return share_extra(meta).get("isShared")
+
+
 @bp_guard.route("/api/guard/sessions")
 def api_guard_sessions():
     """Live sessions with their current Guard status.
@@ -515,6 +524,13 @@ def api_guard_sessions():
             "total_tokens": int(s.get("total_tokens") or 0),
             "message_count": int(s.get("message_count") or 0),
             "cwd": cwd,
+            # #5746 — is this session's transcript published to a public,
+            # link-accessible view? ``None`` means the daemon has no verdict
+            # (never probed, or no gateway to probe), and the tab must render
+            # that as unknown rather than as "private": claiming a session is
+            # not shared when we never asked is the failure mode this signal
+            # exists to prevent.
+            "public_share": _share_verdict(meta),
             "incident": incident_by_session.get(sid),
             # What is in the folder this agent was pointed at, when anything is.
             # Separate from ``incident`` on purpose: it is not ranked against

--- a/tests/test_openclaw_share_state.py
+++ b/tests/test_openclaw_share_state.py
@@ -1,42 +1,284 @@
+"""OpenClaw public-share state (#5746).
+
+The shapes asserted here are taken from ``openclaw@2026.9.3``, not invented:
+
+* ``publicShare`` is in ``PRIVATE_SESSION_ENTRY_KEYS`` and is stripped by
+  ``stripPrivateSessionEntryFields()``, so no session-list response carries
+  it; ``session.members.list`` is the read method that does.
+* ``SessionPublicShareSchema = {token: ^v1\\.[A-Za-z0-9_-]+$, createdAt: int}``.
+
+The token is a live read capability for the user's conversation — OpenClaw
+builds the public URL straight from it — so several tests below exist purely
+to prove it never reaches anything we persist or serve.
+"""
 from __future__ import annotations
 
 from types import SimpleNamespace
 
-from clawmetry.adapters.base import Session
-from clawmetry.adapters import openclaw
-from clawmetry.adapters.openclaw_share import apply_share_state, apply_share_state_to_payloads
+from clawmetry.adapters import openclaw_share as share
+
+#: A realistic upstream object, token shaped like the real pattern.
+LIVE_SHARE = {"token": "v1.tOkEn-SECRET_do_not_store", "createdAt": 1720000000000}
 
 
-def test_openclaw_share_state_is_exposed(monkeypatch):
-    rows = [
-        {
-            "sessionId": "shared-session",
-            "publicShare": {"id": "publication-1", "createdAt": 1720000000000},
-        },
-        {"sessionId": "private-session"},
-    ]
-    monkeypatch.setattr(openclaw, "_d", lambda: SimpleNamespace(_get_sessions=lambda: rows))
+# --------------------------------------------------------------- share_fields
 
-    sessions = [
-        Session(agent="openclaw", id="shared-session"),
-        Session(agent="openclaw", id="private-session"),
-    ]
-    apply_share_state(sessions)
-
-    assert sessions[0].extra["isShared"] is True
-    assert sessions[0].extra["shareCreatedAt"] == 1720000000.0
-    assert sessions[0].extra["shareVisibility"] == "public-read-only"
-    assert sessions[1].extra["isShared"] is False
+def test_share_fields_keeps_the_verdict_and_drops_the_token():
+    fields = share.share_fields(LIVE_SHARE)
+    assert fields["shared"] is True
+    assert fields["share_created_at"] == 1720000000.0
+    assert "token" not in fields
+    assert "SECRET" not in repr(fields)
 
 
-def test_openclaw_share_state_is_exposed_for_local_store_payloads(monkeypatch):
-    rows = [{"key": "shared-session", "publicShare": {"createdAt": 1720000000000}}]
-    monkeypatch.setattr(openclaw, "_d", lambda: SimpleNamespace(_get_sessions=lambda: rows))
+def test_share_fields_reports_an_unshared_session_as_false():
+    # The RPC answered; there is simply no publication. That is a real
+    # verdict, distinct from "we never asked".
+    assert share.share_fields(None) == {"shared": False}
+    assert share.share_fields({}) == {"shared": True}  # present-but-empty == published
 
-    payloads = [{"id": "shared-session", "extra": {"model": "test"}}]
-    apply_share_state_to_payloads(payloads)
+
+def test_created_at_accepts_seconds_and_milliseconds():
+    # Upstream types createdAt as a bare Integer, so the unit is not stated.
+    assert share.share_fields({"createdAt": 1720000000000})["share_created_at"] == 1720000000.0
+    assert share.share_fields({"createdAt": 1720000000})["share_created_at"] == 1720000000.0
+
+
+def test_created_at_garbage_is_dropped_not_guessed():
+    for bad in ("", "nope", -1, 0, None, True):
+        assert "share_created_at" not in share.share_fields({"createdAt": bad})
+
+
+# ---------------------------------------------------------- fetch_share_state
+
+def test_fetch_uses_the_per_session_members_list_rpc():
+    calls = []
+
+    def rpc(method, params):
+        calls.append((method, params))
+        return {"sessionKey": params["sessionKey"], "publicShare": LIVE_SHARE}
+
+    state = share.fetch_share_state(["sess-a", "sess-b"], rpc=rpc)
+
+    assert [c[0] for c in calls] == ["session.members.list"] * 2
+    assert [c[1]["sessionKey"] for c in calls] == ["sess-a", "sess-b"]
+    assert state["sess-a"]["shared"] is True
+    assert "token" not in state["sess-a"]
+
+
+def test_fetch_omits_sessions_the_rpc_could_not_answer():
+    # None is what the gateway helper returns on error/timeout/unknown method.
+    # Recording False here would tell Guard a published session is private.
+    def rpc(method, params):
+        return None if params["sessionKey"] == "sess-b" else {"publicShare": None}
+
+    state = share.fetch_share_state(["sess-a", "sess-b"], rpc=rpc)
+
+    assert state["sess-a"] == {"shared": False}
+    assert "sess-b" not in state
+
+
+def test_fetch_survives_a_raising_rpc():
+    def rpc(method, params):
+        if params["sessionKey"] == "boom":
+            raise RuntimeError("socket wedged")
+        return {"publicShare": None}
+
+    state = share.fetch_share_state(["boom", "ok"], rpc=rpc)
+    assert "boom" not in state
+    assert state["ok"] == {"shared": False}
+
+
+def test_fetch_is_capped(monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_OPENCLAW_SHARE_MAX", "2")
+    seen = []
+
+    def rpc(method, params):
+        seen.append(params["sessionKey"])
+        return {"publicShare": None}
+
+    state = share.fetch_share_state([f"s{i}" for i in range(10)], rpc=rpc)
+    assert len(seen) == 2
+    # Capped-out sessions are unknown, not false.
+    assert len(state) == 2
+
+
+def test_fetch_passes_agent_id_when_given():
+    got = {}
+
+    def rpc(method, params):
+        got.update(params)
+        return {"publicShare": None}
+
+    share.fetch_share_state(["s1"], rpc=rpc, agent_id="main")
+    assert got["agentId"] == "main"
+
+
+def test_a_gateway_that_answers_nothing_says_so_once(monkeypatch, caplog):
+    # The v4 scope gap (raw token -> no operator.read) makes every probe come
+    # back None. An empty share column must be explained, not silent.
+    monkeypatch.setattr(share, "_warned_no_answer", False)
+    with caplog.at_level("WARNING"):
+        state = share.fetch_share_state(["a", "b"], rpc=lambda m, p: None)
+    assert state == {}
+    assert "session.members.list" in caplog.text
+    assert "UNKNOWN" in caplog.text
+
+
+# ----------------------------------------------------------------- share_extra
+
+def test_share_extra_omits_everything_when_there_is_no_verdict():
+    # The daemon never probed this session (no gateway, cloud container,
+    # capped out). The UI must not be handed a confident "not shared".
+    assert share.share_extra({}) == {}
+    assert share.share_extra(None) == {}
+    assert share.share_extra({"model": "x"}) == {}
+
+
+def test_share_extra_renders_a_negative_verdict():
+    assert share.share_extra({"shared": False}) == {"isShared": False}
+
+
+def test_share_extra_renders_a_positive_verdict():
+    extra = share.share_extra({"shared": True, "share_created_at": 1720000000.0})
+    assert extra == {
+        "isShared": True,
+        "shareCreatedAt": 1720000000.0,
+        "shareVisibility": "public-read-only",
+    }
+
+
+# ---------------------------------------------------------------- apply helpers
+
+def test_payloads_keep_existing_extra_and_lose_the_private_metadata_key():
+    payloads = [{
+        "id": "s1",
+        "extra": {"model": "test"},
+        "_metadata": {"shared": True, "share_created_at": 1720000000.0},
+    }]
+    share.apply_share_state_to_payloads(payloads)
 
     assert payloads[0]["extra"]["model"] == "test"
     assert payloads[0]["extra"]["isShared"] is True
-    assert payloads[0]["extra"]["shareCreatedAt"] == 1720000000.0
-    assert payloads[0]["extra"]["shareVisibility"] == "public-read-only"
+    assert "_metadata" not in payloads[0]
+
+
+def test_payloads_without_a_verdict_are_left_alone():
+    payloads = [{"id": "s1", "extra": {"model": "test"}, "_metadata": {"model": "t"}}]
+    share.apply_share_state_to_payloads(payloads)
+
+    assert "isShared" not in payloads[0]["extra"]
+    assert "_metadata" not in payloads[0]
+
+
+def test_apply_share_state_stamps_session_objects():
+    sessions = [SimpleNamespace(id="s1", extra={}), SimpleNamespace(id="s2", extra={})]
+    share.apply_share_state(sessions, {"s1": {"shared": True}})
+
+    assert sessions[0].extra["isShared"] is True
+    assert sessions[1].extra == {}  # no verdict -> untouched
+
+
+# ------------------------------------------------------------------ daemon pass
+
+def test_daemon_pass_stamps_rows_and_never_carries_the_token(monkeypatch):
+    from clawmetry import sync
+
+    monkeypatch.setattr(
+        share, "fetch_share_state",
+        lambda keys, **kw: {"key-a": share.share_fields(LIVE_SHARE)},
+    )
+    rows = [
+        {"session_id": "a", "session_key": "key-a"},
+        {"session_id": "b", "session_key": "key-b"},
+    ]
+    sync._annotate_public_share(rows)
+
+    assert rows[0]["shared"] is True
+    assert rows[0]["share_created_at"] == 1720000000.0
+    assert "token" not in rows[0]
+    assert "SECRET" not in repr(rows)
+    assert "shared" not in rows[1]  # unprobed stays unknown
+
+
+def test_daemon_pass_can_be_switched_off(monkeypatch):
+    from clawmetry import sync
+
+    monkeypatch.setenv("CLAWMETRY_OPENCLAW_SHARE", "0")
+    monkeypatch.setattr(
+        share, "fetch_share_state",
+        lambda keys, **kw: {"key-a": {"shared": True}},
+    )
+    rows = [{"session_id": "a", "session_key": "key-a"}]
+    sync._annotate_public_share(rows)
+    assert "shared" not in rows[0]
+
+
+# ------------------------------------------------------- store round-trip
+#
+# The bug this feature originally shipped with was not a wrong value: it was a
+# field that never survived the plumbing, under tests that mocked the very
+# layer that dropped it. These two go through the REAL DuckDB ingest so that a
+# whitelist or COALESCE that quietly eats the verdict fails here.
+
+import importlib
+
+import pytest
+
+
+@pytest.fixture
+def store(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "1")
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    ls.mark_writer_owner()
+    yield ls
+    try:
+        ls.get_store().stop(flush=True)
+    except Exception:
+        pass
+
+
+def _metadata_for(ls, session_id):
+    rows = ls.get_store().query_sessions_table(agent_type="openclaw", limit=50)
+    for r in rows:
+        if r.get("session_id") == session_id:
+            return r.get("metadata") or {}
+    raise AssertionError(f"{session_id} not in the sessions table")
+
+
+def test_verdict_survives_ingest_and_the_token_never_lands_in_duckdb(store):
+    from clawmetry import sync
+
+    rows = [{"session_id": "sess-a", "session_key": "key-a",
+             **share.share_fields(LIVE_SHARE)}]
+    sync._local_ingest_sessions_batch(rows, "node-1")
+
+    meta = _metadata_for(store, "sess-a")
+    assert share.share_extra(meta) == {
+        "isShared": True,
+        "shareCreatedAt": 1720000000.0,
+        "shareVisibility": "public-read-only",
+    }
+    rows = store.get_store().query_sessions_table(limit=50)
+    assert "SECRET" not in repr(rows)
+    # ``total_tokens`` legitimately contains the substring, so check the key.
+    for r in rows:
+        assert "token" not in (r.get("metadata") or {})
+
+
+def test_a_false_verdict_survives_and_an_unprobed_session_stays_unknown(store):
+    from clawmetry import sync
+
+    # ``shared: False`` is falsey, and the metadata blob is built by a
+    # truthiness filter — the exact shape of bug that would silently turn a
+    # real "not published" answer into "we never asked".
+    sync._local_ingest_sessions_batch([
+        {"session_id": "sess-f", "session_key": "key-f", "shared": False},
+        {"session_id": "sess-u", "session_key": "key-u"},
+    ], "node-1")
+
+    assert share.share_extra(_metadata_for(store, "sess-f")) == {"isShared": False}
+    assert share.share_extra(_metadata_for(store, "sess-u")) == {}

--- a/tests/test_openclaw_share_state.py
+++ b/tests/test_openclaw_share_state.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from clawmetry.adapters.base import Session
+from clawmetry.adapters import openclaw
+from clawmetry.adapters.openclaw_share import apply_share_state, apply_share_state_to_payloads
+
+
+def test_openclaw_share_state_is_exposed(monkeypatch):
+    rows = [
+        {
+            "sessionId": "shared-session",
+            "publicShare": {"id": "publication-1", "createdAt": 1720000000000},
+        },
+        {"sessionId": "private-session"},
+    ]
+    monkeypatch.setattr(openclaw, "_d", lambda: SimpleNamespace(_get_sessions=lambda: rows))
+
+    sessions = [
+        Session(agent="openclaw", id="shared-session"),
+        Session(agent="openclaw", id="private-session"),
+    ]
+    apply_share_state(sessions)
+
+    assert sessions[0].extra["isShared"] is True
+    assert sessions[0].extra["shareCreatedAt"] == 1720000000.0
+    assert sessions[0].extra["shareVisibility"] == "public-read-only"
+    assert sessions[1].extra["isShared"] is False
+
+
+def test_openclaw_share_state_is_exposed_for_local_store_payloads(monkeypatch):
+    rows = [{"key": "shared-session", "publicShare": {"createdAt": 1720000000000}}]
+    monkeypatch.setattr(openclaw, "_d", lambda: SimpleNamespace(_get_sessions=lambda: rows))
+
+    payloads = [{"id": "shared-session", "extra": {"model": "test"}}]
+    apply_share_state_to_payloads(payloads)
+
+    assert payloads[0]["extra"]["model"] == "test"
+    assert payloads[0]["extra"]["isShared"] is True
+    assert payloads[0]["extra"]["shareCreatedAt"] == 1720000000.0
+    assert payloads[0]["extra"]["shareVisibility"] == "public-read-only"


### PR DESCRIPTION
Closes #5746

OpenClaw 2026.9.3 lets a session owner publish a revocable, read-only public link to a session's existing *and future* conversation text (openclaw#139489). ClawMetry had no visibility into that, so Guard would show a publicly-linked transcript exactly like a private one.

Records, per session, whether its transcript is published — and nothing else about it.

**Where the state comes from.** `publicShare` is in OpenClaw's `PRIVATE_SESSION_ENTRY_KEYS` and every session entry is run through `stripPrivateSessionEntryFields()` before it leaves the gateway, so no session-list response carries it. The read method that does is `session.members.list` (`operator.read`, since 2026.7), addressed one session at a time. Verified against a live 2026.9.3 gateway: it gates on scope rather than reporting an unknown method.

Because the probe is per session it runs on the daemon's sync cycle, not in a request handler — and that is also the only place the signal can be captured for cloud, whose containers have no gateway to ask.

**The token is never stored.** Upstream the object is `{token, createdAt}`, and that token *is* the public link — OpenClaw builds the shareable URL straight from it. Only `bool(publicShare)` and `createdAt` are lifted. `share_fields()` is the single point that reads the upstream object, so the rule has one enforcement site, and a store round-trip test asserts no token reaches DuckDB.

**Unknown is not "not shared".** A probe can be denied, capped out, or unavailable. Where there is no verdict the field is absent end to end, including the metadata whitelist where a real `false` would otherwise be eaten by a truthiness filter. On this machine's gateway — whose raw bearer token carries no `operator.read` scope, the same gap that empties the Sessions and Crons tabs — every session correctly stays unknown, and a one-time warning explains the empty column rather than letting it read as "nothing found".

`createdAt` is a bare `Integer` upstream, so it is normalised with the same magnitude test the rest of the repo uses instead of assuming milliseconds.

Guard gains a `public_share` field and a "Public link" pill, drawn only on an explicit `true`.

Off with `CLAWMETRY_OPENCLAW_SHARE=0`; probe cap via `CLAWMETRY_OPENCLAW_SHARE_MAX` (default 60).

### Verification

- 20 unit tests, including two that go through the real DuckDB ingest — the original defect here was a field that never survived the plumbing under tests that mocked the layer dropping it.
- End-to-end against the live 2026.9.3 gateway: scope-denied probe yields unknown, not a fabricated `false`.
- Python 3.9 import-checked (`routes/guard.py` has no `from __future__ import annotations`).

### Not covered

No positive share verdict has been observed on real data: this gateway's token has no `operator.read` scope, so the probe cannot succeed here regardless. The plumbing is verified with injected responses shaped from the published 2026.9.3 schema.

No-PRD: closes a filed observability gap (#5746); no new product surface beyond one Guard badge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ue5eSBQvXsQxLK4caNHGzL

<!-- product-record gate re-run: body updated after the first run captured a stale payload -->
