### PR TITLE
fix(e2e): remove clusters from CANONICAL_TABS, PR_SCREENSHOT_TABS, DEFAULT_TABS

### DIFF
--- a/.github/scripts/visual-diff.mjs
+++ b/.github/scripts/visual-diff.mjs
@@ -55,7 +55,7 @@ const AUTH_TOKEN = process.env.CLAWMETRY_VISUAL_DIFF_TOKEN || "";
 // switchTab() name here, in CANONICAL_TABS, and in PR_SCREENSHOT_TABS.
 // `overview` is the implicit default -- listed first for a `root` baseline.
 const DEFAULT_TABS =
-  "overview,flow,brain,usage,crons,memory,security,subagents,transcripts,logs,skills,models,approvals,alerts,notifications,limits,clusters,history,channels,harness,inventory,nemoclaw,guard,signals,policy,selfevolve,swimlane,tool-catalog,tracing,turn-anatomy,version-impact,context-economics,agents,evals,bench,trail";
+  "overview,flow,brain,usage,crons,memory,security,subagents,transcripts,logs,skills,models,approvals,alerts,notifications,limits,history,channels,harness,inventory,nemoclaw,guard,signals,policy,selfevolve,swimlane,tool-catalog,tracing,turn-anatomy,version-impact,context-economics,agents,evals,bench,trail";
 const TABS = (process.env.PR_SCREENSHOT_TABS || DEFAULT_TABS)
   .split(",")
   .map((p) => p.trim())

--- a/.github/workflows/pr-screenshots.yml
+++ b/.github/workflows/pr-screenshots.yml
@@ -39,7 +39,7 @@ env:
   # clawmetry/templates/tabs/*.html and be reachable via window.switchTab().
   # See routes/* for the API endpoints each tab calls.
   # Must stay in sync with CANONICAL_TABS in tests/test_e2e_oss_all_tabs.py.
-  PR_SCREENSHOT_TABS: "overview,flow,brain,usage,crons,memory,security,subagents,transcripts,logs,skills,models,approvals,alerts,notifications,limits,clusters,history,channels,harness,inventory,nemoclaw,guard,signals,policy,selfevolve,swimlane,tool-catalog,tracing,turn-anatomy,version-impact,context-economics,agents,evals,bench,trail"
+  PR_SCREENSHOT_TABS: "overview,flow,brain,usage,crons,memory,security,subagents,transcripts,logs,skills,models,approvals,alerts,notifications,limits,history,channels,harness,inventory,nemoclaw,guard,signals,policy,selfevolve,swimlane,tool-catalog,tracing,turn-anatomy,version-impact,context-economics,agents,evals,bench,trail"
   HEAD_PORT: "8082"
   BASE_PORT: "8081"
   # Local-store fast-paths must be on so the dashboard renders the seeded

--- a/tests/test_e2e_oss_all_tabs.py
+++ b/tests/test_e2e_oss_all_tabs.py
@@ -121,7 +121,6 @@ CANONICAL_TABS = [
     # 2026-08-01: the old tab rendered hardcoded token estimates node-wide.
     # switchTab('context') aliases to context-economics for old deep links.
     "limits",
-    "clusters",
     "history",
     # Tabs added after initial C5 coverage -- verified present in
     # clawmetry/templates/tabs/ or routes/ as of 2026-06-09.


### PR DESCRIPTION
## What

The Session Clusters tab was cut in `dad465a` (2026-09-09). Its template (`clusters.html`), `switchTab()` branch and `loadClusters()` loader were all removed, but the three E2E coverage lists were not updated.

**Drift before this PR:**

| Source | "clusters" present |
|---|---|
| `tests/test_e2e_oss_all_tabs.py` `CANONICAL_TABS` | yes |
| `.github/workflows/pr-screenshots.yml` `PR_SCREENSHOT_TABS` | yes |
| `.github/scripts/visual-diff.mjs` `DEFAULT_TABS` | yes |

**After this PR:** "clusters" removed from all three. All three sources remain in sync at 35 tabs.

## Why it matters

The three sources are kept identical by `test_pr_screenshot_tabs_match_canonical` and `test_visual_diff_default_tabs_match_canonical`. As long as all three consistently include "clusters", those tests pass and the drift is invisible. But the actual coverage claim is false:

- The visual-diff run screenshotted "clusters" as whatever tab was previously visible (`switchTab('clusters')` silently no-ops since the branch is gone).
- The C5 post-auth sweep reported covering 36 tabs; it covered 35.

## Guard

`test_every_tab_is_reachable.py` (added in the same `dad465a` commit) prevents the tab from returning without a nav entry. This PR prevents the coverage lists from claiming it is tested when it is not.

## No-PRD

Drift-fix only. Closes a coverage gap introduced by the `dad465a` deployment earlier today.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019bocRvLsyt9VWLTZArBrjF

---
_Generated by [Claude Code](https://claude.ai/code/session_019bocRvLsyt9VWLTZArBrjF)_