### PR TITLE
feat(discovery): find apps already emitting OpenTelemetry, honestly (#4784)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -580,6 +580,7 @@ jobs:
             tests/test_muse_code_runtime_wiring.py \
             tests/test_delegated_usage.py \
             tests/test_local_query_api.py \
+            tests/test_otel_discovery.py \
             tests/test_meeting_transcripts.py \
             tests/test_harness_audit_reads_whole_adapter.py \
             tests/test_otlp_sessionless_spans.py \

--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -7082,6 +7082,42 @@ def _cmd_diagnose(args) -> None:
         _row("Cache error:", payload["cache_error"])
 
     _diagnose_runtime_paths()
+    _diagnose_otel_emitters()
+
+
+def _diagnose_otel_emitters() -> None:
+    """Applications on this machine already emitting OpenTelemetry (#4784).
+
+    Surfaced here rather than only as a snapshot slice, so the discovery has a
+    reader from the first commit. A slice nothing renders is the shape that
+    left /api/run-ledger with zero consumers.
+
+    Read-only and suggestion-only (ADR-005): it prints the line a person can
+    apply, and never edits another application's environment.
+    """
+    try:
+        from clawmetry import otel_discovery as _od
+        r = _od.discover_otel_emitters()
+    except Exception:
+        return
+    apps = r.get("apps") or []
+    print()
+    print("OpenTelemetry on this machine:")
+    if not apps and not r.get("degraded"):
+        ports = ", ".join(str(p) for p in r.get("checked_ports") or [])
+        print(f"  Nothing found. Checked ports {ports} and this user's processes.")
+    for a in apps:
+        tag = " (this is ClawMetry)" if a.get("is_clawmetry_receiver") else ""
+        how = "port" if a.get("evidence") == "port_probe" else "env"
+        print(f"    [{how:>4}] {a.get('name')} -> {a.get('endpoint')}{tag}")
+    if r.get("degraded"):
+        print(f"  Partial: {r.get('degraded_reason')}")
+    suggestable = r.get("suggestable") or []
+    if suggestable:
+        print()
+        print("  To send a copy here, start the app with:")
+        print(f"    {_od.redirect_instruction()}")
+        print("  ClawMetry never edits another application's configuration.")
 
 
 def _diagnose_runtime_paths() -> None:

--- a/clawmetry/otel_discovery.py
+++ b/clawmetry/otel_discovery.py
@@ -37,6 +37,12 @@ and the guard is an explicit username comparison rather than waiting for
 ``AccessDenied``. Measured why: ``psutil.Process(0).environ()`` on macOS
 returns ``{}`` and raises NOTHING, so an implementation that relies on the
 exception has no boundary at all where the kernel task is concerned.
+
+Product record: requirement "OpenTelemetry Emitter Discovery"
+(8c1ea52d-df48-4b74-b0d2-cbe0488535ad), a child of Local Agent Observability.
+Repo-side design: ``docs/blueprints/otel-sdk-and-ingest.md``, component
+``#OtelEmitterDiscovery``, ADR-005. The three measured facts above are
+AC-OTD-001.1, .3 and .7 there, recorded so they are not re-assumed next time.
 """
 
 from __future__ import annotations

--- a/clawmetry/otel_discovery.py
+++ b/clawmetry/otel_discovery.py
@@ -1,0 +1,262 @@
+"""Find applications on this machine that already emit OpenTelemetry (#4784).
+
+Runtime detection is filesystem-shaped: ``~/.claude``, ``~/.codex`` and
+friends. It cannot see the LangChain service two terminal windows over that is
+already exporting OTLP, to a collector or to nowhere. Discovery is passive
+today, so such an app becomes visible only once somebody points it at us.
+
+Two cheap, read-only strategies:
+
+* **port probe** - something is listening on a conventional collector port
+  (4317 OTLP/gRPC, 4318 OTLP/HTTP). Stdlib, every platform, no permissions;
+* **process env scan** - a same-user process carries
+  ``OTEL_EXPORTER_OTLP_ENDPOINT`` or a per-signal sibling. Names the app AND
+  the endpoint it currently uses, which is what makes the suggestion
+  actionable.
+
+READ-ONLY, and it stays that way (ADR-005). Nothing here modifies another
+application's environment, config or files. We detect and suggest; the person
+applies. A detected app has sent us nothing, so it is never reported as an
+observed runtime: counting it as one with zero cost would be a lie about
+coverage.
+
+THE PLATFORM FACT, measured rather than assumed. The issue expected macOS to
+block reading another process's environment, and to degrade to port-probing
+there. That is not what happens: on macOS 26 with psutil 7.2.2, a same-user
+process's environ reads fine (699 readable, 39 blocked, of this machine's own
+processes). Same-user is the only population this module is allowed to look at
+anyway, so there is no macOS-specific degradation to declare, and declaring
+one would tell users about a limitation they do not have.
+
+What DOES degrade is psutil's absence: it is not in ``install_requires`` (it
+is lazily imported in three places in ``sync.py``), so on an install without
+it the env scan cannot run and the result says exactly that.
+
+CROSS-USER IS FILTERED, NOT CAUGHT. Another user's process must never be read,
+and the guard is an explicit username comparison rather than waiting for
+``AccessDenied``. Measured why: ``psutil.Process(0).environ()`` on macOS
+returns ``{}`` and raises NOTHING, so an implementation that relies on the
+exception has no boundary at all where the kernel task is concerned.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+import time
+from typing import Any
+
+# Conventional OTLP collector ports. Deliberately short: a long list turns a
+# cheap probe into a port scan of the user's own machine.
+COLLECTOR_PORTS: tuple = (
+    (4317, "OTLP/gRPC"),
+    (4318, "OTLP/HTTP"),
+)
+
+# The endpoint variables an exporter actually reads, most specific first, so a
+# per-signal override is reported ahead of the general one.
+_ENDPOINT_VARS: tuple = (
+    "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+    "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT",
+    "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT",
+    "OTEL_EXPORTER_OTLP_ENDPOINT",
+)
+
+_PROBE_TIMEOUT_S = 0.1
+_MAX_PROCESSES = 2000
+
+
+def _port_is_listening(port: int, timeout: float = _PROBE_TIMEOUT_S) -> bool:
+    """True when something accepts a loopback TCP connection on ``port``.
+
+    Loopback only and a 100 ms budget, so the whole sweep costs well under a
+    second on a quiet machine and never touches a remote host.
+    """
+    for family, addr in ((socket.AF_INET, "127.0.0.1"), (socket.AF_INET6, "::1")):
+        s = None
+        try:
+            s = socket.socket(family, socket.SOCK_STREAM)
+            s.settimeout(timeout)
+            if s.connect_ex((addr, port)) == 0:
+                return True
+        except OSError:
+            continue
+        finally:
+            if s is not None:
+                try:
+                    s.close()
+                except OSError:
+                    pass
+    return False
+
+
+def _own_receiver_port() -> int | None:
+    """The port ClawMetry's OWN OTLP receiver is listening on, if any.
+
+    Without this the feature suggests redirecting the user's app to
+    ClawMetry... at ClawMetry. Measured on this machine: :4318 was live and
+    the listener was our own Flask compat receiver
+    (``instrument._COMPAT_PORT``), which a naive probe reports as "a
+    collector is running, send us a copy".
+    """
+    try:
+        from clawmetry import instrument as _inst
+        info = _inst.probe_receiver()
+        if info and info.get("listening"):
+            return int(info.get("port") or 0) or None
+    except Exception:
+        pass
+    return None
+
+
+def probe_collector_ports() -> list:
+    """Conventional collector ports with something listening on them.
+
+    A port probe proves something ACCEPTS a connection. It cannot prove WHO,
+    and on this platform it cannot be made to: ``psutil.net_connections()``
+    raises ``AccessDenied`` on macOS without root, and requiring root to
+    render a suggestion is not a trade this product makes. So a finding here
+    is reported as what it is, and a port ClawMetry may itself own carries
+    ``is_clawmetry_receiver`` and is never offered a redirect instruction.
+    """
+    mine = _own_receiver_port()
+    out = []
+    for port, proto in COLLECTOR_PORTS:
+        try:
+            if not _port_is_listening(port):
+                continue
+            is_self = (mine is not None and port == mine)
+            out.append({
+                "name": ("ClawMetry's own OTLP receiver" if is_self
+                         else f"something listening on :{port}"),
+                "endpoint": f"http://localhost:{port}",
+                "protocol": proto,
+                "evidence": "port_probe",
+                "is_clawmetry_receiver": is_self,
+                # A port probe never identifies the process, so never claim it
+                # did. The env scan below is what NAMES an application.
+                "identified": False,
+            })
+        except Exception:
+            continue
+    return out
+
+
+def _current_username() -> str:
+    for getter in (lambda: os.getlogin(), lambda: os.environ.get("USER", ""),
+                   lambda: os.environ.get("USERNAME", "")):
+        try:
+            v = getter()
+            if v:
+                return str(v)
+        except Exception:
+            continue
+    return ""
+
+
+def scan_process_env() -> tuple:
+    """Same-user processes exporting OTLP. Returns ``(apps, degraded_reason)``.
+
+    ``degraded_reason`` is a plain-words sentence when the scan could not run
+    at all, and ``None`` when it did. A caller must be able to tell "nothing
+    is exporting" from "I could not look", which is the same distinction the
+    rest of the product draws between an empty result and an unreadable one.
+    """
+    try:
+        import psutil  # type: ignore
+    except ImportError:
+        return [], ("Cannot list processes: psutil is not installed. "
+                    "Install it (pip install psutil) to also find apps that "
+                    "export to somewhere other than a local collector.")
+
+    me = _current_username()
+    apps: list = []
+    seen: set = set()
+    scanned = 0
+    try:
+        procs = psutil.process_iter(["pid", "name", "username"])
+    except Exception as exc:  # pragma: no cover - defensive
+        return [], f"Cannot list processes on this machine ({type(exc).__name__})."
+
+    for proc in procs:
+        if scanned >= _MAX_PROCESSES:
+            break
+        scanned += 1
+        info = getattr(proc, "info", {}) or {}
+        owner = info.get("username") or ""
+        # Explicit ownership filter. NOT a try/except around environ(): a
+        # process we do not own must never be read, and on macOS pid 0
+        # answers {} without raising, so the exception is not a boundary.
+        if not me or owner != me:
+            continue
+        try:
+            env = proc.environ() or {}
+        except Exception:
+            continue
+        endpoint = None
+        for var in _ENDPOINT_VARS:
+            if env.get(var):
+                endpoint = env[var]
+                break
+        if not endpoint:
+            continue
+        # OTEL_SERVICE_NAME is the app's own name for itself and is what a
+        # reader recognises; the process name is often just "Python".
+        proc_name = info.get("name") or f"pid {info.get('pid')}"
+        name = env.get("OTEL_SERVICE_NAME") or proc_name
+        key = (name, endpoint)
+        if key in seen:
+            continue
+        seen.add(key)
+        apps.append({
+            "name": str(name),
+            "process": str(proc_name),
+            "endpoint": str(endpoint),
+            "evidence": "process_env",
+            "service_name": env.get("OTEL_SERVICE_NAME") or None,
+            "identified": True,
+        })
+    return apps, None
+
+
+def discover_otel_emitters(now_ms: int | None = None) -> dict:
+    """Applications on this machine that already emit OpenTelemetry.
+
+    Returns ``{apps, degraded, degraded_reason, checked_ports, scanned_at_ms}``.
+    Never raises: discovery is a suggestion, and a suggestion that can break
+    the snapshot is worse than no suggestion.
+    """
+    now_ms = int(now_ms if now_ms is not None else time.time() * 1000)
+    apps: list = []
+    try:
+        apps.extend(probe_collector_ports())
+    except Exception:
+        pass
+    try:
+        env_apps, reason = scan_process_env()
+    except Exception as exc:  # pragma: no cover - defensive
+        env_apps, reason = [], f"Process scan failed ({type(exc).__name__})."
+    apps.extend(env_apps)
+    for a in apps:
+        a.setdefault("first_seen_ms", now_ms)
+        a.setdefault("is_clawmetry_receiver", False)
+    # Only somebody else's exporter is worth a redirect suggestion. Ours is
+    # already here, and an unidentified listener might be ours.
+    suggestable = [a for a in apps if not a.get("is_clawmetry_receiver")]
+    return {
+        "apps": apps,
+        "suggestable": suggestable,
+        "degraded": bool(reason),
+        "degraded_reason": reason,
+        "checked_ports": [p for p, _ in COLLECTOR_PORTS],
+        "scanned_at_ms": now_ms,
+    }
+
+
+def redirect_instruction(endpoint_here: str = "http://localhost:8900") -> str:
+    """The copyable line that points an app's exporter at ClawMetry.
+
+    A suggestion, never applied for the user (ADR-005): we do not edit another
+    application's environment.
+    """
+    return f"OTEL_EXPORTER_OTLP_ENDPOINT={endpoint_here} <your app command>"

--- a/clawmetry/otel_discovery.py
+++ b/clawmetry/otel_discovery.py
@@ -42,7 +42,8 @@ Product record: requirement "OpenTelemetry Emitter Discovery"
 (8c1ea52d-df48-4b74-b0d2-cbe0488535ad), a child of Local Agent Observability.
 Repo-side design: ``docs/blueprints/otel-sdk-and-ingest.md``, component
 ``#OtelEmitterDiscovery``, ADR-005. The three measured facts above are
-AC-OTD-001.1, .3 and .7 there, recorded so they are not re-assumed next time.
+AC-OTD-001.1, .3 and .7 there, and blueprint ADR-001/002/004, recorded so they
+are not re-assumed next time.
 """
 
 from __future__ import annotations

--- a/docs/MODULE_MAP.md
+++ b/docs/MODULE_MAP.md
@@ -4,7 +4,7 @@
 > `python3 scripts/gen_module_map.py` (CI fails on drift via
 > `tests/test_module_map_drift.py`).
 
-231 modules, 81 Flask blueprints. `CLAUDE.md` carries a short curated table of the ones you reach for most often; this is the whole list.
+232 modules, 81 Flask blueprints. `CLAUDE.md` carries a short curated table of the ones you reach for most often; this is the whole list.
 
 Size bands are deliberately coarse so this file does not churn on every PR: **small** is under 200 lines, **medium** under 1k, **large** under 5k, **huge** is 5k and up.
 
@@ -191,6 +191,7 @@ The pip-installable package: CLI, sync daemon, DuckDB store, detectors, enforcem
 | `clawmetry/numbat_ingest.py` | medium | map Perplexity numbat NDJSON records into ClawMetry rows. |
 | `clawmetry/onboarding_state.py` | small | the ONE writer for the first-run gate's |
 | `clawmetry/org_key.py` | small | The organisation key: one secret, shared by the people in one organisation. |
+| `clawmetry/otel_discovery.py` | medium | Find applications on this machine that already emit OpenTelemetry (#4784). |
 | `clawmetry/otel_exporter.py` | medium | Outbound OTLP trace exporter for ClawMetry. |
 | `clawmetry/otel_profiles.py` | small | OTel runtime profiles — the seam between the generic OTLP receiver and |
 | `clawmetry/otel_push.py` | small | OSS delegating shim after the impl moved to clawmetry-pro. |

--- a/tests/test_otel_discovery.py
+++ b/tests/test_otel_discovery.py
@@ -1,0 +1,213 @@
+"""Find apps already emitting OpenTelemetry, without lying about what we saw (#4784).
+
+Runtime detection is filesystem-shaped, so the LangChain service two terminal
+windows over is invisible until someone points it at us. This finds it, and
+the interesting part is not the finding, it is the honesty around it.
+
+Three platform facts were MEASURED rather than assumed, and each changed the
+design away from the issue's own plan:
+
+1. **macOS does not block same-user process environs.** The issue expected it
+   to, and specified a macOS-wide degraded path. On macOS 26 with psutil
+   7.2.2 a same-user child's environ reads fine (699 readable / 39 blocked of
+   this machine's processes). Shipping the planned degradation would have
+   told macOS users about a limitation they do not have. What actually
+   degrades is psutil being absent, since it is not in ``install_requires``.
+
+2. **A port probe cannot identify who is listening, and cannot be made to.**
+   ``psutil.net_connections()`` raises ``AccessDenied`` on macOS without
+   root, and requiring root to render a suggestion is not a trade this
+   product makes. So a port finding says something listens, never who.
+
+3. **ClawMetry itself listens on 4318** (``instrument._COMPAT_PORT``).
+   Measured live: the naive probe reported "a collector is running, send us a
+   copy" pointing at our own receiver. A port we may own is never offered a
+   redirect.
+
+Read-only throughout (ADR-005): nothing here edits another application's
+environment, config or files.
+"""
+from __future__ import annotations
+
+import os
+import socket
+import subprocess
+import sys
+import time
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from clawmetry import otel_discovery as od  # noqa: E402
+
+
+# ── port probing ────────────────────────────────────────────────────────────
+
+
+def test_a_dead_port_is_not_reported(monkeypatch):
+    monkeypatch.setattr(od, "_port_is_listening", lambda *a, **k: False)
+    assert od.probe_collector_ports() == []
+
+
+def test_a_live_port_is_reported_but_never_claims_to_know_who(monkeypatch):
+    """The honesty that root-less port probing forces."""
+    monkeypatch.setattr(od, "_port_is_listening", lambda *a, **k: True)
+    monkeypatch.setattr(od, "_own_receiver_port", lambda: None)
+    apps = od.probe_collector_ports()
+    assert apps, "a listening port must be reported"
+    for a in apps:
+        assert a["evidence"] == "port_probe"
+        assert a["identified"] is False, "a port probe identifies nothing"
+        assert "something listening" in a["name"]
+
+
+def test_our_own_receiver_is_recognised_and_never_offered_a_redirect(monkeypatch):
+    """The live false positive: ClawMetry binds 4318, so a naive probe says
+    'a collector is running, send us a copy' about ClawMetry."""
+    monkeypatch.setattr(od, "_port_is_listening", lambda *a, **k: True)
+    monkeypatch.setattr(od, "_own_receiver_port", lambda: 4318)
+    monkeypatch.setattr(od, "scan_process_env", lambda: ([], None))
+    r = od.discover_otel_emitters()
+    mine = [a for a in r["apps"] if a["endpoint"].endswith(":4318")]
+    assert mine and mine[0]["is_clawmetry_receiver"] is True
+    assert "ClawMetry" in mine[0]["name"]
+    assert all(not a["is_clawmetry_receiver"] for a in r["suggestable"])
+    assert not any(a["endpoint"].endswith(":4318") for a in r["suggestable"])
+
+
+def test_the_port_probe_only_touches_loopback():
+    """A discovery feature must never become a scan of anything remote."""
+    import inspect
+    src = inspect.getsource(od._port_is_listening)
+    assert "127.0.0.1" in src and "::1" in src
+    assert "0.0.0.0" not in src
+
+
+def test_the_probed_port_list_stays_short():
+    """Two conventional ports is a probe. Twenty is a port scan of the user's
+    own machine."""
+    assert len(od.COLLECTOR_PORTS) <= 4
+
+
+# ── process env scan ────────────────────────────────────────────────────────
+
+
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="POSIX spawn")
+def test_names_a_real_app_and_the_endpoint_it_currently_uses():
+    """Acceptance case 2, against a REAL process, not a mock."""
+    pytest.importorskip("psutil")
+    env = dict(os.environ,
+               OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:9999",
+               OTEL_SERVICE_NAME="cm-test-langchain-app")
+    child = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(20)"],
+                             env=env)
+    try:
+        found = None
+        for _ in range(20):
+            apps, reason = od.scan_process_env()
+            found = next((a for a in apps
+                          if a.get("service_name") == "cm-test-langchain-app"), None)
+            if found:
+                break
+            time.sleep(0.25)
+        assert found, "a same-user OTLP-exporting process must be found"
+        assert found["endpoint"] == "http://localhost:9999"
+        assert found["evidence"] == "process_env"
+        assert found["identified"] is True
+        assert found["name"] == "cm-test-langchain-app", (
+            "the app's own name beats the process name, which is often "
+            "just 'Python'")
+    finally:
+        child.terminate()
+
+
+def test_a_per_signal_endpoint_wins_over_the_general_one():
+    """An exporter reads the specific variable first, so reporting the
+    general one would name an endpoint the app is not using."""
+    assert od._ENDPOINT_VARS[0].endswith("TRACES_ENDPOINT")
+    assert od._ENDPOINT_VARS[-1] == "OTEL_EXPORTER_OTLP_ENDPOINT"
+
+
+def test_another_users_process_is_filtered_by_ownership_not_by_exception():
+    """Measured why this matters: psutil.Process(0).environ() on macOS
+    returns {} and raises NOTHING, so an implementation that waits for
+    AccessDenied has no cross-user boundary at all."""
+    import inspect
+    src = inspect.getsource(od.scan_process_env)
+    assert "owner != me" in src, "ownership must be compared explicitly"
+
+
+def test_no_psutil_degrades_with_a_reason_a_person_can_act_on(monkeypatch):
+    """And the reason names psutil, NOT the operating system."""
+    import builtins
+    real = builtins.__import__
+
+    def _no_psutil(name, *a, **k):
+        if name == "psutil":
+            raise ImportError("no psutil")
+        return real(name, *a, **k)
+
+    monkeypatch.setattr(builtins, "__import__", _no_psutil)
+    apps, reason = od.scan_process_env()
+    assert apps == []
+    assert reason and "psutil" in reason
+    for os_word in ("macOS", "Mac", "Darwin", "Windows"):
+        assert os_word not in reason, (
+            "the limitation is a missing package, not the platform: macOS "
+            "same-user environ reads were measured working")
+
+
+def test_discovery_reports_degradation_up_to_the_caller(monkeypatch):
+    monkeypatch.setattr(od, "scan_process_env",
+                        lambda: ([], "Cannot list processes: psutil is not installed."))
+    monkeypatch.setattr(od, "probe_collector_ports", lambda: [])
+    r = od.discover_otel_emitters()
+    assert r["degraded"] is True and "psutil" in r["degraded_reason"]
+    assert r["apps"] == []
+
+
+# ── contract ────────────────────────────────────────────────────────────────
+
+
+def test_discovery_never_raises(monkeypatch):
+    def boom(*a, **k):
+        raise RuntimeError("boom")
+    monkeypatch.setattr(od, "probe_collector_ports", boom)
+    monkeypatch.setattr(od, "scan_process_env", boom)
+    r = od.discover_otel_emitters()
+    assert r["apps"] == [] and r["degraded"] is True
+
+
+def test_the_instruction_is_a_suggestion_never_an_edit():
+    """ADR-005: we detect and suggest; the person applies."""
+    line = od.redirect_instruction("http://localhost:8900")
+    assert line.startswith("OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:8900")
+    import inspect
+    src = inspect.getsource(od)
+    for forbidden in ("os.environ[", "subprocess.run", "shutil.copy", "open("):
+        assert forbidden not in src, (
+            f"discovery must never write anything ({forbidden})")
+
+
+def test_the_discovery_has_a_reader_from_the_first_commit():
+    """A snapshot slice nothing renders is the shape that left
+    /api/run-ledger with zero UI consumers (#5721). Discovery ships with a
+    surface: `clawmetry diagnose`."""
+    import inspect
+    from clawmetry import cli as _cli
+
+    assert hasattr(_cli, "_diagnose_otel_emitters")
+    assert "_diagnose_otel_emitters()" in inspect.getsource(_cli._cmd_diagnose), (
+        "the surface exists but nothing calls it"
+    )
+    src = inspect.getsource(_cli._diagnose_otel_emitters)
+    assert "never edits" in src, "the read-only promise must be on screen"
+
+
+def test_a_pass_is_cheap_enough_for_the_snapshot_timer():
+    """FLYWHEEL 1e: the daemon budget. Measured at 86 ms of CPU per pass on
+    the dev machine, 0.14% of one core on a 60s timer."""
+    t0 = time.perf_counter()
+    od.discover_otel_emitters()
+    assert (time.perf_counter() - t0) < 5.0, "a discovery pass must stay cheap"


### PR DESCRIPTION
Part of #4784 (#4779). **Leaves the issue open** — see *Remaining* at the bottom.

Runtime detection is filesystem-shaped, so the LangChain service two terminal windows over is invisible until somebody points it at us. This finds it: a loopback probe of the conventional collector ports, plus a same-user process-environment scan for `OTEL_EXPORTER_OTLP_ENDPOINT` and its per-signal siblings.

## Three platform facts, measured — each moved the design away from the issue's plan

**1. macOS does *not* block same-user process environs.** The issue specified a macOS-wide degraded path on that assumption. Measured on macOS 26 / psutil 7.2.2: a same-user child's environ reads fine, **699 readable / 39 blocked** across this machine's processes. Same-user is the only population this is allowed to read anyway, so shipping the planned degradation would have told macOS users about a limitation they don't have.

What actually degrades is **psutil being absent** — it is *not* in `install_requires` (lazily imported in three places in `sync.py`) — so that is what the message names. A test asserts the reason mentions psutil and **not** any OS name.

**2. A port probe cannot identify who is listening, and cannot be made to.** `psutil.net_connections()` raises `AccessDenied` on macOS without root, and requiring root to render a *suggestion* is not a trade this product makes. So a port finding carries `identified: False` and says something listens, never who. The env scan is what names an application.

**3. ClawMetry itself listens on 4318** (`instrument._COMPAT_PORT`). Measured live — the naive probe produced exactly this:

```
"name": "collector on :4318", "endpoint": "http://localhost:4318"
```

That is us, and it would have shipped as *"a collector is running, send us a copy"* pointing at ClawMetry. A port we may own is now marked `is_clawmetry_receiver` and never offered a redirect.

## What it looks like

```
OpenTelemetry on this machine:
    [port] ClawMetry's own OTLP receiver -> http://localhost:4318 (this is ClawMetry)
    [ env] my-langchain-app -> http://localhost:9999

  To send a copy here, start the app with:
    OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:8900 <your app command>
  ClawMetry never edits another application's configuration.
```

Acceptance case 2 verified against a **real spawned process**, not a mock: named by its own `OTEL_SERVICE_NAME` (the process name is usually just "Python") with the endpoint it currently uses.

## Read-only, and tested as such

ADR-005: we detect and suggest; the person applies. A test asserts the module contains no `os.environ[...]` assignment, no `subprocess.run`, no `open()`, no `shutil.copy`. Cross-user processes are excluded by an **explicit ownership comparison**, not by catching `AccessDenied` — measured why: `psutil.Process(0).environ()` on macOS returns `{}` and raises nothing, so an exception-based guard has no boundary at all.

A detected app has sent us nothing, so it is never reported as an observed runtime.

## Cost

**86 ms CPU / 128 ms wall per pass — 0.14% of one core on a 60s timer.** Inside the FLYWHEEL 1e budget.

## Ships with a reader

`clawmetry diagnose` renders it, and a test asserts `_cmd_diagnose` actually calls it. A slice nothing consumes is the shape that left `/api/run-ledger` with zero UI consumers (#5721).

**Guards proven red:** removing self-recognition, or renaming the degradation to blame macOS, each fails its own test. 14 tests, wired into the CI file list.

## Remaining (issue stays open)

The `detectedOtelApps[]` **snapshot slice** and the **dashboard prompt**. Deliberately not added here: a slice with no renderer is the exact dead-data shape this commit's own test guards against, so it should land together with the UI that reads it.

No-PRD: increment against filed issue #4784.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xb6A5G74JiMe3zHFs1JZEP