### PR TITLE
feat(discovery): surface the OTel emitters, in the snapshot and on the panel (closes #4784)

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -32495,6 +32495,40 @@ async function renderFirstRunReport(overview) {
      + '<code style="background:var(--bg-primary);padding:2px 6px;border-radius:4px;">clawmetry --sample</code>'
      + ' for three labelled synthetic sessions, including one that is stuck.</div>';
 
+  // #4784: something on this machine already emits OpenTelemetry and does not
+  // send it here. That is the most actionable thing we can say to someone
+  // looking at an empty dashboard, because it needs no install and no signup:
+  // one environment variable and their existing traces arrive.
+  //
+  // Reads `suggestable`, never `apps`: the latter can include a port
+  // ClawMetry itself holds (it binds 4318), and telling someone to redirect
+  // their app to ClawMetry, from ClawMetry, is worse than saying nothing.
+  try {
+    var otel = (overview && overview.detectedOtelApps) || {};
+    var sugg = otel.suggestable || [];
+    if (sugg.length) {
+      var named = sugg.filter(function (a) { return a.identified; });
+      var lead = named.length
+        ? ('<b>' + escHtml(named[0].name) + '</b>'
+           + (sugg.length > 1 ? ' and ' + (sugg.length - 1) + ' other'
+              + (sugg.length > 2 ? 's' : '') : '')
+           + ' on this machine ' + (sugg.length > 1 ? 'are' : 'is')
+           + ' already emitting OpenTelemetry, to '
+           + '<code>' + escHtml(named[0].endpoint) + '</code>.')
+        : ('Something on this machine is already emitting OpenTelemetry.');
+      h += '<div style="border-top:1px solid var(--border-secondary);margin-top:11px;'
+         + 'padding-top:11px;font-size:13.5px;color:var(--text-secondary);">'
+         + lead
+         + ' Send a copy here and it shows up in these tabs, with nothing to install:'
+         + '<pre style="margin:8px 0 0;padding:10px 12px;background:var(--bg-primary);'
+         + 'border:1px solid var(--border-secondary);border-radius:6px;overflow-x:auto;'
+         + 'font-size:12.5px;">' + escHtml(otel.instruction || '') + '</pre>'
+         + '<div style="margin-top:6px;font-size:12px;color:var(--text-muted);">'
+         + 'ClawMetry never changes another application\'s configuration.</div>'
+         + '</div>';
+    }
+  } catch (e) { /* the panel is worth more than the prompt */ }
+
   el.innerHTML = h;
   el.style.display = 'block';
 }

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -22570,6 +22570,37 @@ def _build_bench_slice(store, *, days: int = 30) -> dict:
     return out
 
 
+def _build_detected_otel_apps() -> dict:
+    """The ``detectedOtelApps`` snapshot slice (#4784).
+
+    Runs on the daemon's snapshot timer, never per request, and costs about
+    86 ms of CPU (0.14% of one core at a 60 second cadence). Never raises: a
+    suggestion that can break the snapshot carrying it is worse than no
+    suggestion, so a failure degrades to an empty slice.
+
+    ``suggestable`` is the list a prompt renders. It excludes any port
+    ClawMetry may itself hold, so the dashboard never tells someone to
+    redirect their app to ClawMetry from ClawMetry.
+    """
+    try:
+        from clawmetry import otel_discovery as _od
+        r = _od.discover_otel_emitters()
+        return {
+            "apps": r.get("apps") or [],
+            "suggestable": r.get("suggestable") or [],
+            "degraded": bool(r.get("degraded")),
+            "degradedReason": r.get("degraded_reason"),
+            "checkedPorts": r.get("checked_ports") or [],
+            "instruction": _od.redirect_instruction(),
+            "scannedAtMs": r.get("scanned_at_ms"),
+        }
+    except Exception as e:  # noqa: BLE001
+        log.debug("detectedOtelApps slice failed: %s", e)
+        return {"apps": [], "suggestable": [], "degraded": False,
+                "degradedReason": None, "checkedPorts": [],
+                "instruction": "", "scannedAtMs": 0}
+
+
 def sync_system_snapshot(config: dict, state: dict, paths: dict) -> int:
     """Push system info + subagent data as encrypted snapshot.
 
@@ -23475,6 +23506,13 @@ def sync_system_snapshot(config: dict, state: dict, paths: dict) -> int:
         "diagnostics": _build_diagnostics(paths.get("workspace")),
         "modelAttribution": _build_model_attribution(),
         "runtimeSummary": _runtime_summary,
+        # Applications on this machine that already emit OpenTelemetry but do
+        # not send it here (#4784). Rides the ENCRYPTED snapshot, never the
+        # plaintext heartbeat: an OTEL_SERVICE_NAME is the user's own name for
+        # their own service ("acme-billing-prod"), which is theirs to see and
+        # not ours to hold in the clear. A node with no key uploads nothing at
+        # all, by the same no-key rule the rest of this payload obeys.
+        "detectedOtelApps": _build_detected_otel_apps(),
         # What each runtime actually records (clawmetry/runtime_records.py).
         # Rides the snapshot so the HOSTED dashboard can tell "this runtime
         # was idle" apart from "this runtime keeps no cost record" — without

--- a/routes/overview.py
+++ b/routes/overview.py
@@ -1160,6 +1160,33 @@ def _try_local_store_overview():
     }
 
 
+
+# #4784: the discovery costs ~86 ms of CPU, which is fine on the daemon's
+# snapshot timer and NOT fine on every /api/overview poll. Memoised so a
+# dashboard refreshing every few seconds pays it at most once a minute.
+_OTEL_DISCOVERY_TTL_S = 60.0
+_otel_discovery_cache: dict = {"at": 0.0, "value": None}
+
+
+def _detected_otel_apps_cached() -> dict:
+    """Discovery result for the overview payload, memoised. Never raises."""
+    import time as _t
+    now = _t.monotonic()
+    hit = _otel_discovery_cache.get("value")
+    if hit is not None and (now - _otel_discovery_cache["at"]) < _OTEL_DISCOVERY_TTL_S:
+        return hit
+    try:
+        from clawmetry import sync as _sync
+        val = _sync._build_detected_otel_apps()
+    except Exception:
+        val = {"apps": [], "suggestable": [], "degraded": False,
+               "degradedReason": None, "checkedPorts": [],
+               "instruction": "", "scannedAtMs": 0}
+    _otel_discovery_cache["at"] = now
+    _otel_discovery_cache["value"] = val
+    return val
+
+
 @bp_overview.route("/api/overview")
 def api_overview():
     import dashboard as _d
@@ -1243,6 +1270,12 @@ def api_overview():
         {
             "model": model_name,
             "provider": _d._infer_provider_from_model(model_name),
+            # #4784: apps on this machine already emitting OpenTelemetry
+            # somewhere else. Served here as well as in the cloud snapshot,
+            # because the first-run panel reads THIS payload on a local
+            # dashboard: building only the snapshot slice made the prompt
+            # appear on the hosted dashboard and never on localhost.
+            "detectedOtelApps": _detected_otel_apps_cached(),
             "sessionCount": len(sessions),
             "sessions": len(sessions),  # alias for E2E compatibility
             "activeSessions": len([s for s in sessions if s.get("active")]),

--- a/tests/test_otel_discovery.py
+++ b/tests/test_otel_discovery.py
@@ -205,6 +205,79 @@ def test_the_discovery_has_a_reader_from_the_first_commit():
     assert "never edits" in src, "the read-only promise must be on screen"
 
 
+# ── the snapshot slice and the prompt (#4784, second half) ──────────────────
+
+
+def test_the_snapshot_slice_is_built_and_never_raises(monkeypatch):
+    import clawmetry.sync as sync
+
+    slice_ = sync._build_detected_otel_apps()
+    for key in ("apps", "suggestable", "degraded", "degradedReason",
+                "checkedPorts", "instruction", "scannedAtMs"):
+        assert key in slice_, key
+
+    def boom(*a, **k):
+        raise RuntimeError("boom")
+    monkeypatch.setattr(od, "discover_otel_emitters", boom)
+    degraded = sync._build_detected_otel_apps()
+    assert degraded["apps"] == [] and degraded["suggestable"] == []
+
+
+def test_the_slice_is_in_the_encrypted_snapshot_not_the_heartbeat():
+    """An OTEL_SERVICE_NAME is the user's own name for their own service
+    ("acme-billing-prod"). It is theirs to see and not ours to hold in the
+    clear, so it rides the AES-encrypted snapshot like session content."""
+    import inspect
+    import clawmetry.sync as sync
+
+    src = inspect.getsource(sync)
+    i = src.find('"detectedOtelApps"')
+    assert i > 0, "the slice must be in the snapshot payload"
+    # The snapshot builder, not _build_heartbeat / the plaintext path.
+    window = src[max(0, i - 4000):i]
+    assert '"securityPosture"' in window, (
+        "detectedOtelApps must sit in the same encrypted snapshot dict as "
+        "securityPosture, which documents the encrypted-only rule"
+    )
+
+
+def test_the_overview_payload_carries_the_slice_too():
+    """The bug the browser caught, not the tests.
+
+    The slice was built into the cloud SNAPSHOT only, and the first-run panel
+    reads `/api/overview`. On a local dashboard the prompt therefore never
+    rendered: it would have appeared on the hosted dashboard and nowhere
+    else. Both payloads carry it now.
+    """
+    import inspect
+    import routes.overview as ov
+
+    src = inspect.getsource(ov)
+    assert '"detectedOtelApps"' in src, "the local overview must serve it"
+    assert hasattr(ov, "_detected_otel_apps_cached")
+    cached = inspect.getsource(ov._detected_otel_apps_cached)
+    assert "monotonic" in cached, (
+        "discovery costs ~86 ms; /api/overview is polled every few seconds, "
+        "so it must be memoised rather than run per request"
+    )
+
+
+def test_the_prompt_reads_suggestable_never_apps():
+    """`apps` can include a port ClawMetry itself holds (it binds 4318).
+    Telling someone to redirect their app to ClawMetry, from ClawMetry, is
+    worse than saying nothing."""
+    from pathlib import Path
+    app_js = (Path(__file__).resolve().parents[1] / "clawmetry" / "static"
+              / "js" / "app.js").read_text(encoding="utf-8")
+    i = app_js.find("detectedOtelApps")
+    assert i > 0, "the first-run panel must read the slice"
+    block = app_js[i:i + 1800]
+    assert "otel.suggestable" in block
+    assert "otel.apps" not in block, "the prompt must not render self-detections"
+    assert "never changes another application" in block, (
+        "the read-only promise belongs on screen next to the instruction")
+
+
 def test_a_pass_is_cheap_enough_for_the_snapshot_timer():
     """FLYWHEEL 1e: the daemon budget. Measured at 86 ms of CPU per pass on
     the dev machine, 0.14% of one core on a 60s timer."""


### PR DESCRIPTION
Closes #4784. The second half of the capability — the half blueprint ADR-003 said must land *with* its renderer rather than before it.

## What ships

* **`detectedOtelApps` snapshot slice**, built on the daemon timer, inside the AES-encrypted snapshot. An `OTEL_SERVICE_NAME` is the user's own name for their own service ("acme-billing-prod"): theirs to see, not ours to hold in the clear. A node with no key uploads nothing, by the same no-key rule the rest of that payload obeys.
* **The first-run panel** names the app, its current endpoint, and the one line that sends a copy here.

It reads `suggestable`, never `apps` — the latter can include a port ClawMetry itself holds, and telling someone to redirect their app to ClawMetry, *from* ClawMetry, is worse than saying nothing.

## The browser caught a bug the tests did not

Built as a snapshot slice alone, the prompt rendered on the **hosted** dashboard and **never on localhost** — the first-run panel reads `/api/overview`, and that payload had no such key. Every unit test passed. It only showed up when I actually loaded the page.

`/api/overview` now serves it too, **memoised for 60 s**, because discovery costs ~86 ms and that endpoint is polled every few seconds. `test_the_overview_payload_carries_the_slice_too` pins both halves and asserts the memo exists.

This is the mirror image of the usual cloud-parity bug (FLYWHEEL 0a.1): built for the snapshot, missing locally.

## Verified in a browser, against a real emitting process

> **prod-rag-service** on this machine is already emitting OpenTelemetry, to `http://localhost:9999`. Send a copy here and it shows up in these tabs, with nothing to install:
> ```
> OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:8900 <your app command>
> ```
> ClawMetry never changes another application's configuration.

## One measurement worth recording

Overriding `HOME` in a test harness moves `site.USER_SITE`, so a user-installed `psutil` vanishes from the child process — and discovery correctly reported itself **degraded**, naming psutil rather than the OS. That was my harness, not the product, and the degraded message doing its job is exactly why it names the real cause.

18 tests, named in the CI file list; 33 pass across the first-run suites.

No-PRD: completes filed issue #4784, under requirement *OpenTelemetry Emitter Discovery* and its blueprint ADR-003.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xb6A5G74JiMe3zHFs1JZEP