### PR TITLE
Field-failure issues close themselves when the signature stops occurring

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,6 +172,14 @@ jobs:
       - name: Workflow integrity (dead steps, unreachable triggers, input injection)
         run: python3 -m pytest tests/test_ci_workflow_invocations_are_real.py -q
 
+      # #5739: the field-failure filer could open and refresh an issue but
+      # never close one, so a signature that stopped occurring left its issue
+      # open forever under a "Still occurring" comment. Runs the reconcile
+      # step's real shell against a fake gh -- including the case where the
+      # endpoint is unreachable, which must close nothing.
+      - name: Field-failure issues close when the signature stops
+        run: python3 -m pytest tests/test_field_failure_autoclose.py -q
+
       # Named explicitly because this repo's CI runs FILE LISTS, not
       # `pytest tests/`. /api/runtime-summary claimed to mirror the daemon's
       # runtimeSummary slice but re-implemented it as a capped raw-event scan:

--- a/.github/workflows/field-failure-issues.yml
+++ b/.github/workflows/field-failure-issues.yml
@@ -61,7 +61,22 @@ jobs:
           }
           count=$(jq '.signatures | length' <<<"$body" 2>/dev/null || echo 0)
           echo "signatures reported: $count"
-          [ "$count" = "0" ] && exit 0
+
+          # A well-formed payload declares its own window. Without that we
+          # cannot tell "nothing is failing" from "the endpoint changed shape
+          # and jq read every field as empty", and the difference decides
+          # whether the reconcile step below closes every open issue.
+          window=$(jq -r '.window_days // empty' <<<"$body" 2>/dev/null || echo "")
+          if [ -z "$window" ]; then
+            echo "payload declares no window_days; treating as malformed, nothing filed or closed"
+            exit 0
+          fi
+
+          # The set of signatures the last $window days actually report,
+          # as issue titles. Written before any filing so the reconcile
+          # step compares against the same snapshot the filing used.
+          : > /tmp/live-titles.txt
+          printf '%s\n' "$window" > /tmp/live-window.txt
 
           # Make sure the label exists (idempotent; never fails the job).
           gh label create field-failure \
@@ -82,6 +97,7 @@ jobs:
             pysuffix=""
             [ -n "$py" ] && pysuffix=" (py $py)"
             TITLE="[field-failure] $cls on $os$pysuffix"
+            printf '%s\n' "$TITLE" >> /tmp/live-titles.txt
 
             ISSUE_BODY=$(printf '%s\n' \
               "Aggregated desktop bootstrap-failure telemetry crossed the reporting threshold for this signature." \
@@ -128,4 +144,56 @@ jobs:
                 || echo "could not create issue for $TITLE"
               echo "filed: $TITLE"
             fi
+          done
+
+      # An alarm that cannot clear is not an alarm. Until now this job only
+      # ever opened and refreshed: a signature that stopped occurring aged out
+      # of the aggregate window and left its issue open forever, with the last
+      # comment still reading "Still occurring". #5739 is the example --
+      # one install, one event, silent since, and nothing would ever have
+      # closed it.
+      #
+      # Absence here is a real signal, not missing data: the endpoint reports
+      # every signature seen in the window, so a title that is absent has had
+      # no event on any machine for the whole window.
+      - name: Close issues whose signature stopped occurring
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          # The filing step exits 0 without writing this when the endpoint is
+          # unreachable or malformed. No snapshot means no evidence of absence,
+          # so close nothing -- a network blip must never sweep the tracker.
+          if [ ! -f /tmp/live-titles.txt ]; then
+            echo "no signature snapshot from this run; closing nothing"
+            exit 0
+          fi
+          sort -u /tmp/live-titles.txt > /tmp/live-sorted.txt
+          window=$(cat /tmp/live-window.txt 2>/dev/null || echo 30)
+          echo "live signatures this run: $(wc -l < /tmp/live-sorted.txt) (window ${window}d)"
+
+          gh issue list --repo "$REPO" --label field-failure --state open \
+            --limit 200 --json number,title > /tmp/open-issues.json
+
+          jq -c '.[]' /tmp/open-issues.json | while read -r row; do
+            num=$(jq -r .number <<<"$row")
+            title=$(jq -r .title <<<"$row")
+
+            if grep -qxF "$title" /tmp/live-sorted.txt; then
+              continue
+            fi
+
+            body=$(printf '%s\n' \
+              "No longer occurring: this signature reported no events on any machine in the last ${window} days, so it has aged out of the aggregate window at https://app.clawmetry.com/api/desktop/_failures. Closing." \
+              "" \
+              "That says the failure stopped, not why. A shipped fix and the last affected machine going away look identical from an aggregate, so this closure is not a claim that anything was repaired. If the signature recurs, this job files a fresh issue on its next tick.")
+
+            gh issue comment "$num" --repo "$REPO" --body "$body" \
+              || echo "could not comment on #$num"
+
+            gh issue close "$num" --repo "$REPO" --reason "not planned" \
+              || echo "could not close #$num"
+            echo "closed #$num ($title)"
           done

--- a/.github/workflows/field-failure-issues.yml
+++ b/.github/workflows/field-failure-issues.yml
@@ -146,7 +146,10 @@ jobs:
             fi
           done
 
-      # An alarm that cannot clear is not an alarm. Until now this job only
+      # An alarm that cannot clear is not an alarm -- the rule is recorded, not
+      # just applied: "An alarm that cannot clear is not an alarm" in the Field
+      # Failure Reporting and Auto-Triage blueprint carries the three guards
+      # below as contracts. Until now this job only
       # ever opened and refreshed: a signature that stopped occurring aged out
       # of the aggregate window and left its issue open forever, with the last
       # comment still reading "Still occurring". #5739 is the example --

--- a/tests/test_field_failure_autoclose.py
+++ b/tests/test_field_failure_autoclose.py
@@ -1,0 +1,150 @@
+"""An alarm that cannot clear is not an alarm (#5739).
+
+`field-failure-issues.yml` files one deduped issue per failure signature and
+refreshes it daily while it keeps happening. It had no third state. A
+signature that STOPPED simply aged out of the aggregate window, and its issue
+stayed open forever with the last comment still reading "Still occurring" --
+which is how #5739 (one install, one event, silent afterwards) would have sat
+on the tracker indefinitely.
+
+These tests execute the reconcile step's real shell, extracted from the
+workflow file, against a fake `gh`. Asserting on the YAML text would pass just
+as happily for a step that parses and does nothing, which is the failure mode
+this whole workflow exists to catch.
+
+The load-bearing case is `test_an_unreachable_endpoint_closes_nothing`:
+absence of evidence must never read as evidence of absence, or one network
+blip sweeps the tracker.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import textwrap
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+WORKFLOW = os.path.join(ROOT, ".github", "workflows", "field-failure-issues.yml")
+
+OPEN_ISSUES = [
+    {"number": 5739, "title": "[field-failure] no_distribution on Windows (py 3.11)"},
+    {"number": 5628, "title": "[field-failure] compiler_demand on Windows (py 3.14)"},
+]
+LIVE_5739 = "[field-failure] no_distribution on Windows (py 3.11)"
+LIVE_5628 = "[field-failure] compiler_demand on Windows (py 3.14)"
+
+FAKE_GH = textwrap.dedent(
+    """\
+    #!/bin/bash
+    case "$1 $2" in
+      "issue list")    cat "$FF_OPEN_ISSUES";;
+      "issue comment") echo "COMMENT $3" >> "$FF_LOG";;
+      "issue close")   echo "CLOSE $3" >> "$FF_LOG";;
+      *) : ;;
+    esac
+    """
+)
+
+
+def _reconcile_script() -> str:
+    doc = yaml.safe_load(open(WORKFLOW, encoding="utf-8"))
+    steps = doc["jobs"]["file-issues"]["steps"]
+    matching = [s for s in steps if s.get("name", "").startswith("Close issues")]
+    assert matching, "the workflow has no step that closes resolved signatures"
+    return matching[0]["run"]
+
+
+def _run(tmp_path, live_titles):
+    """Run the real reconcile step. `live_titles=None` means no snapshot at
+    all, i.e. the endpoint was unreachable and the filing step bailed."""
+    binp = tmp_path / "bin"
+    binp.mkdir()
+    gh = binp / "gh"
+    gh.write_text(FAKE_GH)
+    gh.chmod(0o755)
+
+    (tmp_path / "open.json").write_text(json.dumps(OPEN_ISSUES))
+    log = tmp_path / "log"
+    log.write_text("")
+    script = tmp_path / "reconcile.sh"
+    script.write_text(_reconcile_script())
+
+    # The step reads a fixed /tmp path, which is also what the real runner
+    # gives it; each case sets or clears it.
+    for f in ("/tmp/live-titles.txt", "/tmp/live-window.txt"):
+        if os.path.exists(f):
+            os.unlink(f)
+    if live_titles is not None:
+        with open("/tmp/live-titles.txt", "w") as fh:
+            fh.write("".join(t + "\n" for t in live_titles))
+        with open("/tmp/live-window.txt", "w") as fh:
+            fh.write("30\n")
+
+    env = dict(os.environ)
+    env.update(
+        PATH="{}:{}".format(binp, env["PATH"]),
+        FF_OPEN_ISSUES=str(tmp_path / "open.json"),
+        FF_LOG=str(log),
+        REPO="vivekchand/clawmetry",
+        GH_TOKEN="fake",
+    )
+    proc = subprocess.run(["bash", str(script)], env=env,
+                          capture_output=True, text=True, timeout=60)
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    closed = sorted(
+        line.split()[1] for line in log.read_text().splitlines()
+        if line.startswith("CLOSE")
+    )
+    return closed, proc.stdout
+
+
+def test_a_signature_that_still_occurs_is_left_open(tmp_path):
+    closed, _ = _run(tmp_path, [LIVE_5739, LIVE_5628])
+    assert closed == [], closed
+
+
+def test_a_signature_that_stopped_is_closed(tmp_path):
+    """The #5739 case: still-live 5628 stays, silent 5739 closes."""
+    closed, _ = _run(tmp_path, [LIVE_5628])
+    assert closed == ["5739"], closed
+
+
+def test_zero_live_signatures_closes_every_open_issue(tmp_path):
+    """An empty signature list is real data -- nothing is failing anywhere --
+    and is precisely when the tracker should end up clean. The malformed-payload
+    guard in the filing step is what keeps this from firing on a shape change."""
+    closed, _ = _run(tmp_path, [])
+    assert closed == ["5628", "5739"], closed
+
+
+def test_an_unreachable_endpoint_closes_nothing(tmp_path):
+    """No snapshot means no evidence of absence. A blip must not sweep the
+    tracker, so the step exits without touching a single issue."""
+    closed, out = _run(tmp_path, None)
+    assert closed == [], closed
+    assert "closing nothing" in out
+
+
+def test_every_closure_says_what_it_does_not_know(tmp_path):
+    """A closure comment that implies "fixed" would be a fabrication: from an
+    aggregate, a shipped fix and the last affected machine going away are
+    indistinguishable."""
+    script = _reconcile_script()
+    assert "not why" in script
+    assert "not a claim that anything was repaired" in script
+    assert "files a fresh issue" in script
+
+
+def test_the_filing_step_refuses_a_payload_with_no_window(tmp_path):
+    """The reconcile step trusts the snapshot completely, so the filing step
+    must not write one from a payload it cannot recognise."""
+    doc = yaml.safe_load(open(WORKFLOW, encoding="utf-8"))
+    filing = doc["jobs"]["file-issues"]["steps"][0]["run"]
+    assert "window_days" in filing
+    assert "nothing filed or closed" in filing
+    # The snapshot file is created only AFTER that guard.
+    assert filing.index("window_days") < filing.index("/tmp/live-titles.txt")


### PR DESCRIPTION
Closes #5739.

## The bug is in the pipeline, not the failure

`field-failure-issues.yml` files one deduped issue per failure signature and refreshes it daily while it keeps happening. It had **no third state**. A signature that *stopped* simply aged out of the 30-day aggregate window, and its issue stayed open forever with the last comment still reading "Still occurring".

#5739 is the example, and it is the whole of the current backlog:

```json
{"signatures":[{"failure_class":"no_distribution","os":"Windows",
  "bootstrap_python":"3.11","installs":1,"events":1,
  "last_seen":"2026-09-07T11:23:32Z","latest_desktop_version":"0.12.826"}],
 "window_days":30}
```

One install, one event, silent since — and nothing in the pipeline would ever have closed it.

I checked whether #5739 itself was fixable first, and it is not: `no_distribution / Windows / 3.11` is the *designed* fallback in `_retry_on_known_good_python`, reached when `_known_good_python()` returns `None` both before and after `_winget_install_python()`. Its splash message is already specific and already correct — the "Python too old" wrongness was fixed for #5628. So the issue is real, unfixable from here, and permanent. That last property is the defect worth shipping.

## What changed

A reconcile step closes any open `field-failure` issue whose signature is absent from the snapshot the filing step just took. Absence is a real signal, not missing data: the endpoint reports every signature seen in the window, so an absent title has had no event on any machine for the whole window.

Three guards keep it from sweeping the tracker on bad data:

| condition | behaviour |
|---|---|
| payload declares no `window_days` | malformed — file nothing, close nothing |
| no snapshot file (endpoint unreachable, filing step bailed) | close nothing |
| well-formed payload, zero signatures | close everything — the honest reading |

The closure comment states what it cannot know: from an aggregate, a shipped fix and the last affected machine going away are indistinguishable, so it says the failure stopped and explicitly **not** that anything was repaired. A recurrence files a fresh issue on the next tick.

## Verification

`tests/test_field_failure_autoclose.py` extracts the reconcile step's real shell from the workflow and executes it against a fake `gh`. Asserting on the YAML text would pass just as happily for a step that parses and does nothing — the exact failure mode this workflow exists to catch (ADR-005).

| case | expected | result |
|---|---|---|
| both signatures still live | close nothing | ✅ nothing |
| 5739 stopped, 5628 still live | close 5739 only | ✅ `CLOSE 5739` |
| zero live signatures | close both | ✅ `CLOSE 5628`, `CLOSE 5739` |
| endpoint unreachable, no snapshot | close nothing | ✅ nothing, logs `closing nothing` |

Proven red on the unfixed workflow:

```
AssertionError: the workflow has no step that closes resolved signatures
```

6 passed after. Named in `ci.yml` — CI here runs explicit file lists, so a test that is not listed runs in no job at all.

CI-only change: no package code, so no `[RELEASE]`.

No-PRD: closes an auto-filed field-failure issue by fixing the filer that cannot retire its own alarms; no product surface changes.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xb6A5G74JiMe3zHFs1JZEP
