### PR TITLE
[RELEASE] A swarm can no longer teach Guard its own destination is normal (carries #5810)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - **Also fixed, from the Hugging Face intrusion timeline:** `credential_access` missed `env` used as a statement (`id; env; cat …`, the intrusion's first command) because the environment-dump pattern required a pipe or end of line after it, and it had no category for a pod's mounted service-account token. Both now match; the token is a strong category, so a read followed by egress is `critical`. `env FOO=1 prog` still does not match.
 - **Not in scope:** correlating one new host across many sessions into a single incident (cross-session correlation) is separate work. During the settle window a swarm raises one `first_time` per session, deduplicated per session by the existing alert path.
 - **Verified:** new cases in `tests/test_detectors_behavioural.py` (swarm, settled host, legacy baseline, window disabled, store round-trip keeps the first arrival time, the two credential patterns and their look-alikes).
+- **Carries:** #5810.
 
 ### Added: the gateway's own failures reach the dashboard (2026-09-10)
 - **Why:** a whole class of failure never appears in a session transcript, because it happens *to* the harness rather than inside a conversation. The gateway boots degraded, the kernel kills the local model server, a backup archive is rejected as corrupt, replies are recovered after a restart — each explains an otherwise-silent outage that a reader looking at sessions cannot see at all.


### PR DESCRIPTION
Publishes #5810 (merged) to PyPI.

**Why this needs to ship, not just merge.** The fix lives in `clawmetry/detector_calibration.py`, `clawmetry/detector_behaviour.py` and `clawmetry/local_store.py`, all inside the wheel, and the detectors run in each node's daemon. No node is protected until the package is on PyPI and the daemon auto-updates.

**What rides this:** #5810 only.

- `network_egress`: a learned host counts as known only after `CLAWMETRY_EGRESS_SETTLE_HOURS` (default 24) in the cohort's memory. A swarm's sibling sessions now get `first_time` instead of silence.
- `credential_access`: `env` used as a statement (`id; env; …`) and a pod's mounted service-account token now match. Reading the token and then reaching the network is `critical`.

**Verified before release:** on `main` with #5810, 54/54 in `tests/test_detectors_behavioural.py`. The DseWiki simulation's swarm scenario now raises `network_egress first_time` (it produced nothing before), and the Hugging Face recon sequence raises `credential_access` critical. All 41 checks on #5810 were green, including CodeQL and the E2E Gate.

No-PRD: release of a bug fix (#5810); CHANGELOG only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011U3Bd1FvXvK8x78vGU2rhQ