### PR TITLE
Harden: declare the audit fingerprints as non-cryptographic

### DIFF
--- a/scripts/harness/audit.py
+++ b/scripts/harness/audit.py
@@ -278,8 +278,15 @@ def _extract_json_array(text: str) -> list:
 
 
 def _fingerprint(runtime: str, gap: dict) -> str:
+    # usedforsecurity=False: this is a dedupe key, not a security control. The
+    # digest only has to be stable so a daily run recognises a gap it already
+    # filed — nothing authenticates or authorises on it, and an attacker who
+    # could forge one would gain the ability to suppress their own issue.
+    # Declaring the intent is also what clears bandit B324 (CWE-327); SHA-1 is
+    # kept rather than widened to SHA-256 because changing the digest would
+    # re-file every gap already on file exactly once.
     key = f"{runtime}:{gap.get('title', '')}:{gap.get('where', '')}".lower()
-    return "hgap-" + hashlib.sha1(key.encode()).hexdigest()[:10]
+    return "hgap-" + hashlib.sha1(key.encode(), usedforsecurity=False).hexdigest()[:10]
 
 
 def _existing_fingerprints():

--- a/scripts/redteam/audit.py
+++ b/scripts/redteam/audit.py
@@ -218,8 +218,13 @@ def run_case(case: dict) -> dict:
 
 
 def _fingerprint(case: dict) -> str:
+    # usedforsecurity=False: this is a dedupe key, not a security control. See
+    # the matching note in scripts/harness/audit.py — the digest only has to be
+    # stable so a daily run recognises a gap it already filed. Clears bandit
+    # B324 (CWE-327); SHA-1 is kept rather than widened to SHA-256 because
+    # changing the digest would re-file every gap already on file exactly once.
     key = f"{case.get('id', '')}:{case.get('surface', '')}".lower()
-    return "sgap-" + hashlib.sha1(key.encode()).hexdigest()[:10]
+    return "sgap-" + hashlib.sha1(key.encode(), usedforsecurity=False).hexdigest()[:10]
 
 
 def _existing_fingerprints() -> set:


### PR DESCRIPTION
bandit's only two HIGH findings on this repo are both B324 (CWE-327, weak hash), on the `_fingerprint` helpers in `scripts/harness/audit.py` and `scripts/redteam/audit.py`. This clears both.

## What these hashes do

Neither is a security control. The digest is a dedupe key: it lets a daily audit run recognise a gap it has already filed so it doesn't open a duplicate issue. Nothing authenticates, authorises, or verifies integrity on it.

So the fix is the one bandit's own message asks for — pass `usedforsecurity=False`, which is exactly what that flag exists to express — plus a comment at each call site saying why, so the next reader doesn't have to re-derive it.

## Why SHA-1 is kept rather than widened to SHA-256

The digest value is load-bearing. `_existing_fingerprints()` matches it against the IDs embedded in already-filed issue bodies, so changing the algorithm would make every gap currently on file look new and re-file it exactly once — a one-off duplicate-issue burst in the two workflows that open issues.

`usedforsecurity=False` leaves the digest byte-identical. Verified before and after on both helpers:

```
harness: hgap-19ac608cd6 -> hgap-19ac608cd6   MATCH
redteam: sgap-3c36d77281 -> sgap-3c36d77281   MATCH
```

## Python floor

`usedforsecurity` is keyword-only on all hashlib constructors since Python 3.9 ("Changed in version 3.9"). That floor matters here rather than being incidental: `scripts/redteam/audit.py` runs in `ci.yml`'s `lint` job on **3.9**, and in `redteam-audit.yml` / `redteam-corpus` on 3.11. `scripts/harness/audit.py` runs on 3.11 only. Nothing runs either script on 3.8, so the repo's `python_requires=">=3.8"` floor for the shipped package is not involved — neither file is part of the package.

## Verification

- `bandit -ll` on both files: **0 results** (was 2 HIGH)
- fingerprints byte-identical, both helpers (above)
- `python3 scripts/redteam/audit.py --strict`: 15/15 pass, 0 gaps, 0 control failures, exit 0
- `tests/test_redteam_corpus.py`: 59 passed
- `py_compile` clean on both

## Scope

Two files, both under `scripts/` — an exempt path for the product-record gate. No workflow files touched, no product code, no user-facing behaviour change.

No-PRD: CI/tooling only; both files are under `scripts/`, an exempt path for the product-record gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017QsobgPCfPSND1NGGKr2Hx

---
_Generated by [Claude Code](https://claude.ai/code/session_017QsobgPCfPSND1NGGKr2Hx)_