### PR TITLE
Correct a comment I shipped: no channel name actually differs

### DIFF
--- a/clawmetry/gateway_tap.py
+++ b/clawmetry/gateway_tap.py
@@ -86,8 +86,11 @@ log = logging.getLogger("clawmetry-sync")  # share the daemon logger sink
 #
 # Gateway tap identifiers are compound words without hyphens (matching
 # the convention used throughout this file). ``_CHANNEL_DIRS`` in
-# sync.py is the authoritative source of filesystem directory names and
-# may differ (e.g. ``fish-audio`` on disk vs ``fishaudio`` here).
+# sync.py is the authoritative source of filesystem directory names. The
+# two lists are maintained separately and MAY diverge in spelling, but as of
+# 0.12.861 every name is byte-identical in both -- the ``fish-audio`` vs
+# ``fishaudio`` example this comment used to give was hypothetical and never
+# matched the shipped lists, which is worse than no example.
 CHANNEL_NAMES: tuple[str, ...] = (
     "telegram",
     "signal",

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -6473,9 +6473,12 @@ def sync_openclaw_claude_sessions_via_index(
 #
 # Miss the gateway list and live messages never arrive while history works.
 # Miss the catalogue and the channel is invisible even with rows in the store.
-# The disk name and the wire name may legitimately differ (``fish-audio`` on
-# disk, ``fishaudio`` on the wire), so neither list may be derived from the
-# other by string munging.
+#
+# Every name is currently byte-identical across all four lists -- none even
+# contains a hyphen. They are still four separate edits: nothing derives one
+# list from another, and nothing enforces that they agree beyond
+# tests/test_channel_four_lists.py, which compares on a normalised form so a
+# future adapter that does need different spellings does not silently pass.
 #
 # Recorded as "A chat channel is four lists, and a channel in three of them is
 # broken" in the Runtime and Session Observability blueprint, with an ADR for


### PR DESCRIPTION
Correct a comment I shipped: no channel name actually differs

While verifying 0.12.861 I checked the published wheel and found the claim I
had written -- and shipped -- is false.

The record said the disk name and the wire name legitimately differ, giving
"fish-audio on disk vs fishaudio on the wire" as the example. Measured against
the wheel:

  _CHANNEL_DIRS 24   ALL_CHANNELS 24   CHANNEL_NAMES 24
  channels whose disk name differs from its wire name: NONE
  names containing a hyphen or underscore at all:      none

The channel is "fishaudio" everywhere, including on disk. Every name is
byte-identical across all four lists.

Provenance, because it matters for how far the error spread: the example came
from a pre-existing comment in gateway_tap.py ("may differ (e.g. fish-audio on
disk vs fishaudio here)"), which was hypothetical. I took it as fact and
repeated it in the sync.py comment, the blueprint contract, the CHANGELOG and
the release PR. One unverified comment became four confident statements.

Both comments now say what is true: the lists are maintained separately and
MAY diverge, nothing derives one from another, and today they agree by
convention rather than by construction. The blueprint contract is corrected
with an explicit note that the earlier example was never real.

tests/test_channel_four_lists.py still compares on a normalised form, and that
is still right -- it means an adapter that genuinely needs different spellings
cannot slip through unnoticed. The normalisation was defensible; the
justification I gave for it was not.

33 tests pass across the four-list and catalogue guards.

No-PRD: corrects an inaccurate code comment and the contract derived from it.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Xb6A5G74JiMe3zHFs1JZEP
