### PR TITLE
The stall detector reports every sleeping laptop as broken

### DIFF
--- a/clawmetry/field_report.py
+++ b/clawmetry/field_report.py
@@ -128,6 +128,17 @@ def _stamp_reported(failure_class: str) -> None:
         log.debug("field report: stamp not written: %s", e)
 
 
+def last_sync_raw():
+    """The raw ``last_sync`` value, or None. Used to tell "the same cycle stamp
+    is still current" from "a new cycle completed", without re-parsing dates."""
+    try:
+        from clawmetry.sync import STATE_FILE
+
+        return json.loads(STATE_FILE.read_text()).get("last_sync")
+    except Exception:  # noqa: BLE001 - missing, unreadable, unparseable
+        return None
+
+
 def last_sync_age_secs():
     """Seconds since the daemon last COMPLETED a sync cycle, or None.
 

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -402,6 +402,11 @@ def _acquire_pid_lock() -> bool:
 # in the stack says so.
 _STALLED_INGEST_SECS = float(os.environ.get("CLAWMETRY_STALLED_INGEST_SECS", "") or 3600)
 
+# What the watchdog last saw, as (last_sync value, time.monotonic() when we
+# first saw that value). The pair is what lets the check tell a suspended
+# machine from a wedged ingest loop; see _report_if_ingest_stalled.
+_STALL_WATCH = {"last_sync": None, "since_mono": None}
+
 
 def _report_if_ingest_stalled() -> None:
     """detectors.py ships ``no_progress`` to tell a customer their agent has
@@ -413,9 +418,34 @@ def _report_if_ingest_stalled() -> None:
         from clawmetry import field_report as _fr
 
         age = _fr.last_sync_age_secs()
-        if age is not None and age > _STALLED_INGEST_SECS:
-            _fr.report_daemon_failure("daemon_ingest_stalled",
-                                      version=_get_version())
+
+        # Track how long THIS value of last_sync has been the current one, on a
+        # clock that does not advance while the machine is suspended.
+        raw = _fr.last_sync_raw()
+        now_mono = time.monotonic()
+        if raw != _STALL_WATCH["last_sync"]:
+            _STALL_WATCH["last_sync"] = raw
+            _STALL_WATCH["since_mono"] = now_mono
+
+        if age is None or age <= _STALLED_INGEST_SECS:
+            return
+
+        # The wall clock says it has been a long time, which on its own does not
+        # mean ingest stalled. `last_sync` is a wall-clock stamp, so a laptop
+        # suspended overnight wakes with an age of hours while the daemon is
+        # healthy and its next cycle completes seconds later. Reporting that
+        # marks every sleeping machine as broken, and an alarm that fires on
+        # healthy nodes is one people learn to ignore.
+        #
+        # time.monotonic() does not advance across suspend on Darwin or Linux,
+        # so "how long have we been watching this same last_sync while actually
+        # running" is the honest measure. Both clocks must agree.
+        since = _STALL_WATCH["since_mono"]
+        if since is None or (now_mono - since) <= _STALLED_INGEST_SECS:
+            return
+
+        _fr.report_daemon_failure("daemon_ingest_stalled",
+                                  version=_get_version())
     except Exception as e:  # noqa: BLE001 - the watchdog must never die
         log.debug("stall check skipped: %s", e)
 

--- a/tests/test_daemon_field_report.py
+++ b/tests/test_daemon_field_report.py
@@ -224,14 +224,85 @@ def test_a_healthy_daemon_reports_nothing(home, monkeypatch, sent):
     assert sent == []
 
 
+def _watch(sync, monkeypatch, *, mono_now, since=None, last_sync="seen"):
+    """Drive the watchdog's own bookkeeping directly.
+
+    `_STALL_WATCH` records which `last_sync` value is current and the
+    `time.monotonic()` reading when it first became current. `since=None`
+    means "the watchdog has only just started looking".
+    """
+    monkeypatch.setattr(sync.time, "monotonic", lambda: mono_now)
+    sync._STALL_WATCH["last_sync"] = last_sync
+    sync._STALL_WATCH["since_mono"] = since
+
+
 def test_a_wedged_daemon_reports_itself(home, monkeypatch, sent):
-    """AC-FFR-005.2. The process is up, the watchdog thread is scheduling, and no cycle has
-    completed in an hour. Every liveness probe in the stack says fine."""
+    """AC-FFR-005.2. The process is up, the watchdog thread is scheduling, and
+    no cycle has completed in an hour -- on BOTH clocks. Every liveness probe
+    in the stack says fine."""
+    import clawmetry.sync as sync
+
+    f = _state(home, monkeypatch, "2026-09-08T19:32:21+00:00")
+    raw = "2026-09-08T19:32:21+00:00"
+    # The watchdog has been watching this same stamp for two hours of running
+    # time, so the machine was awake for it.
+    _watch(sync, monkeypatch, mono_now=7200.0, since=0.0, last_sync=raw)
+    sync._report_if_ingest_stalled()
+    assert [p["failure_class"] for p in sent] == ["daemon_ingest_stalled"]
+
+
+def test_a_laptop_that_slept_is_not_called_broken(home, monkeypatch, sent):
+    """The false positive this guard exists for.
+
+    `last_sync` is a WALL-CLOCK stamp, so a machine suspended overnight wakes
+    with an age of hours while the daemon is healthy and its next cycle
+    completes seconds later. `time.monotonic()` does not advance across
+    suspend, so a small monotonic age proves the gap was sleep.
+
+    Reporting here marks every sleeping laptop as broken, and an alarm that
+    fires on healthy nodes is one people learn to ignore.
+    """
+    import clawmetry.sync as sync
+
+    raw = "2026-09-08T19:32:21+00:00"
+    _state(home, monkeypatch, raw)
+    # Wall age: days. Monotonic age: 40 seconds -- we just woke up.
+    _watch(sync, monkeypatch, mono_now=40.0, since=0.0, last_sync=raw)
+    sync._report_if_ingest_stalled()
+    assert sent == [], sent
+
+
+def test_a_daemon_that_just_started_is_not_called_broken(home, monkeypatch, sent):
+    """The same false positive by a different route, and the likelier one.
+
+    Every node auto-updates from PyPI, so every daemon restarts when a release
+    ships. A machine that was powered off overnight starts its daemon with a
+    `last_sync` from yesterday: wall age hours, nothing wrong. The watchdog has
+    no observation history yet, which is "no idea" -- and no idea is never
+    reported as broken.
+    """
+    import clawmetry.sync as sync
+
+    raw = "2026-09-08T19:32:21+00:00"
+    _state(home, monkeypatch, raw)
+    _watch(sync, monkeypatch, mono_now=5.0, since=None, last_sync=None)
+    sync._report_if_ingest_stalled()
+    assert sent == [], sent
+
+
+def test_a_completed_cycle_restarts_the_clock(home, monkeypatch, sent):
+    """A new `last_sync` value means ingest is working again, so the monotonic
+    window restarts -- otherwise one old stall would keep reporting forever."""
     import clawmetry.sync as sync
 
     _state(home, monkeypatch, "2026-09-08T19:32:21+00:00")
+    # The watchdog was watching a DIFFERENT (older) stamp for hours.
+    _watch(sync, monkeypatch, mono_now=9000.0, since=0.0, last_sync="an-older-stamp")
     sync._report_if_ingest_stalled()
-    assert [p["failure_class"] for p in sent] == ["daemon_ingest_stalled"]
+    assert sent == [], sent
+    # ...and it has now latched onto the current stamp, starting a fresh window.
+    assert sync._STALL_WATCH["last_sync"] == "2026-09-08T19:32:21+00:00"
+    assert sync._STALL_WATCH["since_mono"] == 9000.0
 
 
 def test_the_stall_check_never_raises(monkeypatch):


### PR DESCRIPTION
The stall detector reports every sleeping laptop as broken

Six field-failure issues were auto-filed overnight (#5829-#5834), all
daemon_ingest_stalled. The live aggregate shows 8 distinct installs and 9
events in under a day, across Darwin and Linux and five Python versions --
against the one bootstrap signature that has 1 install in 30 days. This is the
detector shipped in 0.12.855 reporting on itself.

The reports are not trustworthy, and the reason is in the clock.

last_sync is a WALL-CLOCK stamp and the check is `now - last_sync > 3600`.
Wall-clock elapsed time cannot distinguish "the ingest loop is wedged" from
"this machine was not running". Two benign cases therefore report as broken:

  - a laptop suspended overnight wakes with an age of hours while the daemon
    is healthy and its next cycle completes seconds later; the watchdog ticks
    within 30s of wake, before that cycle lands;
  - a daemon that just started on a machine that was powered off overnight
    reads a last_sync from yesterday. Every node auto-updates from PyPI, so
    every daemon restarted when 0.12.855 shipped -- which is when these
    reports began.

6 of the 8 installs are Darwin. Laptops sleep.

The fix: the watchdog records which last_sync value is current and the
time.monotonic() reading when it first became current. monotonic() does not
advance across suspend on Darwin or Linux, so "how long have we been watching
this same stamp while actually running" is the honest measure. Both clocks
must now exceed the threshold before anything is reported, and a new last_sync
restarts the window.

No observation history means no report: a daemon that has just started has no
idea, and no idea is never "broken" -- the same rule last_sync_age_secs()
already applies to a node that never synced.

Cost, stated plainly: a genuinely wedged loop is now reported an hour after
the watchdog starts watching rather than immediately at process start. That is
the correct trade. The detector's own definition is "no cycle completed in an
hour", and reporting healthy nodes is worse than reporting a real one late --
an alarm that fires on working machines is one people learn to ignore, which
is exactly what this pipeline was built to avoid.

Four tests, three of them new, all proven RED against the pre-fix code:
the slept-laptop case, the just-restarted case, and the completed-cycle window
restart all fire a report without the guard.

I have NOT proven sleep is the cause of all eight reports -- I could not
reproduce it locally (this machine runs caffeinate and has never slept). The
change is correct either way: if the reports were noise they stop, and if any
were real they keep coming and now mean something.

---

**Requirement:** [Daemon Field-Failure Reporting](https://factory.8090.ai/project/b415065f-ab2f-4f53-8864-0c009fd098cb/requirements/6f04d779-788b-488f-be94-bf89b34cba1c) — this is a correctness fix to **AC-FFR-005.2**, the stall detector that requirement specifies. The requirement says the daemon reports when no cycle has completed in an hour; it does not say "report when the machine was switched off for an hour", which is what the wall-clock-only check actually did.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xb6A5G74JiMe3zHFs1JZEP
