### PR TITLE
Isolate sync_logs in the daemon's steady-state cycle

### DIFF
--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -25152,7 +25152,11 @@ def run_daemon() -> None:
             lg = 0
             now_log = time.time()
             if now_log - last_log_sync > log_sync_interval:
-                lg = sync_logs(config, state, paths)
+                try:
+                    lg = sync_logs(config, state, paths)
+                except Exception as _lg_e:
+                    log.warning("log sync error (non-fatal): %s", _lg_e)
+                    lg = 0
                 last_log_sync = now_log
             try:
                 sync_voice_log_events(config, state, paths)

--- a/tests/test_sync_cycle_fault_isolation.py
+++ b/tests/test_sync_cycle_fault_isolation.py
@@ -1,22 +1,27 @@
-"""Regression for field-failures #5800 / #5801 (``daemon_ingest_stalled`` on
-Darwin py3.14 and Linux py3.12).
+"""Regression for field-failures #5800 / #5801 / #5829-#5834
+(``daemon_ingest_stalled`` on Darwin py3.14, Linux py3.12, and, after the
+first fix (#5802) missed one more call, again on Darwin py3.10/3.11/3.12/3.14
+and Linux py3.10/3.12).
 
 ``run_daemon``'s steady-state ``while True:`` cycle wraps almost every ingest
 call in its own ``try/except`` so one bad data source cannot take down the
 rest -- see the many "non-fatal" log lines throughout the loop in
-``clawmetry/sync.py``. Six calls (memory, the two session syncs, the
-subagent/flow snapshot, session metadata, crons) were the exception: they ran
-bare. A persistent exception in any one of them -- e.g. one session file that
-parses the same wrong way on every retry -- aborted the WHOLE cycle before it
-ever reached ``state["last_sync"] = ...``, and because ``state = load_state()``
-re-reads the same broken input at the top of the next cycle too, that single
-bad source froze ``last_sync`` forever. The daemon process stays up and the
-separate lock-heartbeat thread (``_start_lock_heartbeat`` /
-``_report_if_ingest_stalled``) keeps touching its heartbeat file the whole
-time, so nothing looks dead -- until ``field_report.last_sync_age_secs()``
-crosses ``CLAWMETRY_STALLED_INGEST_SECS`` (1h) and the daemon reports itself
-as ``daemon_ingest_stalled``, which is exactly the two field failures this
-pins.
+``clawmetry/sync.py``. Seven calls (memory, the two session syncs, the
+subagent/flow snapshot, session metadata, crons, and log-line sync) were the
+exception: they ran bare. A persistent exception in any one of them -- e.g.
+one session file that parses the same wrong way on every retry -- aborted the
+WHOLE cycle before it ever reached ``state["last_sync"] = ...``, and because
+``state = load_state()`` re-reads the same broken input at the top of the
+next cycle too, that single bad source froze ``last_sync`` forever. The
+daemon process stays up and the separate lock-heartbeat thread
+(``_start_lock_heartbeat`` / ``_report_if_ingest_stalled``) keeps touching
+its heartbeat file the whole time, so nothing looks dead -- until
+``field_report.last_sync_age_secs()`` crosses ``CLAWMETRY_STALLED_INGEST_SECS``
+(1h) and the daemon reports itself as ``daemon_ingest_stalled``. #5802 fixed
+the first six calls; ``sync_logs`` kept running bare a few lines further down
+the same loop (it is gated behind its own throttle interval, so it was easy
+to miss in the earlier sweep), and the field failure recurred on six more
+OS/Python combinations the very next day.
 
 This test parses ``clawmetry/sync.py`` with ``ast`` rather than importing it,
 so it needs no daemon dependencies (DuckDB, cryptography, ...) and runs in the
@@ -31,7 +36,7 @@ SYNC_PATH = os.path.join(
     os.path.dirname(__file__), "..", "clawmetry", "sync.py"
 )
 
-# The six calls that used to run outside any try/except in the steady-state
+# The calls that used to run outside any try/except in the steady-state
 # loop. A persistent exception in any one of them must not stop the others,
 # and must not stop `state["last_sync"]` from advancing.
 TARGET_CALLS = frozenset({
@@ -41,6 +46,7 @@ TARGET_CALLS = frozenset({
     "sync_system_snapshot",
     "sync_session_metadata",
     "sync_crons",
+    "sync_logs",
 })
 
 


### PR DESCRIPTION
**Product record:**

No-PRD: fix of field-reported bug #5829

**Risk:** None. This only adds a try/except around one call that was previously unguarded; on success the code path is unchanged, and on failure the cycle now logs a warning and continues instead of aborting — strictly safer than today's behavior. Nothing retroactive, no migration, no delete, nothing else in flight touches this line.

---

## Summary

- `run_daemon()`'s steady-state loop in `clawmetry/sync.py` calls `sync_logs(...)` bare (no try/except) behind its own throttle interval. A persistent exception there aborts the whole cycle before `state["last_sync"]` advances, and since the next cycle reloads the same on-disk state, one bad log source freezes `last_sync` forever while the separate lock-heartbeat thread keeps reporting the daemon as alive — the `daemon_ingest_stalled` field-failure class.
- PR #5802 fixed six calls with exactly this shape (`sync_memory`, `sync_sessions`, `sync_claude_cli_sessions`, `sync_system_snapshot`, `sync_session_metadata`, `sync_crons`) after field-failures #5800/#5801, but missed `sync_logs`, a few lines further down the same loop behind its own throttle gate. The class recurred the very next day across six more OS/Python combinations: #5829, #5830, #5831, #5832, #5833, #5834.
- Fix: wrap `sync_logs(...)` in the same try/except pattern as its six siblings (log a warning, `lg = 0`, continue).

## Reproduction

- Extended `tests/test_sync_cycle_fault_isolation.py`'s `TARGET_CALLS` (the AST-based guard added by #5802) to include `sync_logs`.
- Confirmed **red** against the pre-fix code: `AssertionError: ... calls ['sync_logs'] without wrapping each in its own try/except ...`
- Applied the one-line-guard fix in `clawmetry/sync.py`, confirmed **green**.

## Test plan

- [x] `python3 -m pytest tests/test_sync_cycle_fault_isolation.py -v` — 2 passed (both `test_steady_state_cycle_isolates_every_ingest_call` and `test_target_calls_are_still_present_in_the_loop`)
- [x] Proved the guard fails on the un-fixed code (revert → red → restore → green), per the repo's ruthless-verify rule
- [x] `python3 -c "import ast; ast.parse(open('clawmetry/sync.py').read())"` — syntax OK
- [x] Already wired into `ci.yml` (`tests/test_sync_cycle_fault_isolation.py` was named there by #5802, no new file-list entry needed)

Closes #5829.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tate6nNPQHbVPN5TwaT9t2

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tate6nNPQHbVPN5TwaT9t2)_