### PR TITLE
A blocked agent always reaches a person; the gate hook can't fail closed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -747,6 +747,7 @@ jobs:
             tests/test_process_control.py \
             tests/test_process_control_windows.py \
             tests/test_detector_incident_delivery.py \
+            tests/test_blocked_agent_always_notifies.py \
             tests/test_detectors_rate_limited_blocked_crashed.py \
             tests/test_detectors.py \
             tests/test_detectors_behavioural.py \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -261,6 +261,8 @@ CLAWMETRY_SIGNALS=1                    # Behaviour Signals tick on/off; CLAWMETR
 # Guard / enforcement. Every one of these defaults to the safe side.
 CLAWMETRY_DETECTORS=1                  # Trajectory + behavioural detectors on/off
 CLAWMETRY_GUARD_POLICIES=1             # Evaluate Guard policies at all (0 = skip the pass entirely)
+CLAWMETRY_DESKTOP_ALERTS=1             # Urgent incidents (critical, or an agent blocked on you) pop a desktop notification (0 = off)
+CLAWMETRY_CLOUD_INCIDENT_ALERTS=1      # Connected nodes hand urgent incidents to cloud, which always emails the account owner (0 = off)
 CLAWMETRY_POLICY_ENFORCE=0             # Let a policy actually signal a process. Default 0 = dry run; this one env var disables every policy on the node
 CLAWMETRY_GUARD_CRITICAL_USD=...       # Spend-at-risk above which a warning becomes critical
 CLAWMETRY_NOPROG_TOOLS__<RUNTIME>=40   # Per-runtime threshold override (highest layer in resolve_thresholds)

--- a/clawmetry/claude_code_gate.py
+++ b/clawmetry/claude_code_gate.py
@@ -385,7 +385,12 @@ def _launcher_prefix() -> str:
     else:
         import shlex as _shlex
         quoted = _shlex.quote(launcher)
-    return quoted if script else f"{quoted} -m clawmetry"
+    if script:
+        return quoted
+    # No console script: fall back to -m, isolated so the agent's working
+    # directory cannot shadow the package (see module_launch_flags).
+    flags = hook_ownership.module_launch_flags()
+    return f"{quoted} {flags} -m clawmetry" if flags else f"{quoted} -m clawmetry"
 
 
 def _hook_command(base: str) -> str:

--- a/clawmetry/detectors.py
+++ b/clawmetry/detectors.py
@@ -846,6 +846,22 @@ _BLOCKED_TOOL_NAMES = frozenset({
     "askuserquestion", "ask_user_question", "ask_user", "request_permission",
     "elicit", "elicitation",
 })
+# The runtime's own words for "a pre-tool hook crashed, so this call never
+# ran". Claude Code: ``PreToolUse:<Tool> hook error: [<command>]: <stderr>``;
+# Cursor and Copilot name their blocking events. Only an ERROR counts: a hook
+# that deliberately denies a call (a policy a person set) is a decision, not a
+# stuck agent.
+_HOOK_EVENT_NAMES = ("pretooluse", "beforeshellexecution", "beforemcpexecution",
+                     "beforereadfile")
+# Present in every command line ClawMetry's gates install (console script or
+# ``python -m clawmetry``), so a failing hook naming it is our own gate.
+_OWN_GATE_MARKER = "clawmetry hook "
+
+
+def _is_hook_error(text: str) -> bool:
+    """True when a lower-cased tool result says a pre-tool hook errored."""
+    t = text or ""
+    return "hook error" in t and any(n in t for n in _HOOK_EVENT_NAMES)
 _RESTART_TYPES = frozenset({"session.started", "session.restarted",
                             "session.reset"})
 
@@ -1034,6 +1050,62 @@ def blocked_on_user(events: Iterable[dict], session_id: str,
                  "observed": "pending rows in the approvals table for this session"},
                 None,
             )
+
+        # Hook path: the runtime refused the agent's tool calls before they
+        # ran because a pre-tool hook ERRORED, and nothing has succeeded
+        # since. The agent cannot do anything until a person fixes the hook,
+        # and it usually stops and says so in a terminal nobody is watching.
+        # When the failing hook is ClawMetry's own gate, every call is being
+        # blocked by our bug, so it is critical.
+        rejections, own_gate, hook_idx = 0, False, None
+        for i, ev in enumerate(_chronological(events)):
+            et = str(ev.get("event_type") or "").strip().lower()
+            data = _coerce_dict(ev.get("data"))
+            role = _event_role(data)
+            if et in _USER_TYPES or role == "user":
+                rejections, own_gate, hook_idx = 0, False, None  # a human is here
+                continue
+            if et != "tool_result" and role != "tool":
+                continue
+            text = _result_text(data)
+            if _is_hook_error(text):
+                rejections += 1
+                own_gate = own_gate or _OWN_GATE_MARKER in text
+                if hook_idx is None:
+                    hook_idx = i
+            else:
+                rejections, own_gate, hook_idx = 0, False, None  # it recovered
+        if rejections and (rejections >= 2 or idle >= wait_need):
+            evidence = {
+                "pending_approvals": 0, "idle_seconds": int(idle),
+                "hook_errors": rejections, "own_gate": own_gate,
+                "threshold": wait_need,
+                "threshold_source": th["sources"].get("blocked_wait_sec", "static"),
+                "observed": "tool results rejected because a pre-tool hook "
+                            "errored, with nothing succeeding after them",
+                "asked_via": "hook",
+            }
+            if own_gate:
+                return _incident(
+                    "blocked_on_user", session_id, runtime, "critical",
+                    f"ClawMetry's own gate is blocking {rt_label}",
+                    f"Every tool call this agent tries is rejected before it "
+                    f"runs because ClawMetry's pre-tool hook is erroring "
+                    f"({rejections} so far). The agent cannot do anything "
+                    f"until that is fixed. A hook that runs python -m clawmetry "
+                    f"picks up an older clawmetry checkout if one sits in the "
+                    f"agent's working directory. Removing the ClawMetry entry "
+                    f"from the runtime's PreToolUse hook settings unblocks the "
+                    f"agent now.",
+                    evidence, hook_idx)
+            return _incident(
+                "blocked_on_user", session_id, runtime, "warning",
+                f"{rt_label} is blocked by a failing hook",
+                f"{rejections} tool call(s) were rejected because a pre-tool "
+                f"hook errored, and nothing has succeeded since. The agent "
+                f"cannot continue until the hook is fixed or removed from the "
+                f"runtime's hook settings.",
+                evidence, hook_idx)
 
         # Runtime event path: find the last question / permission request and
         # make sure nothing from the user followed it.

--- a/clawmetry/hook_ownership.py
+++ b/clawmetry/hook_ownership.py
@@ -28,9 +28,42 @@ write.**
 from __future__ import annotations
 
 import os
+import sys
 from typing import Callable, Iterable, List, Optional, Sequence, Tuple
 
 _QUOTE_CHARS = ("'", '"')
+
+
+def _installed_in_user_site() -> bool:
+    """True when the running clawmetry package lives in the user site."""
+    try:
+        import site
+        import clawmetry
+        usp = os.path.abspath(site.getusersitepackages())
+        return os.path.abspath(clawmetry.__file__).startswith(usp + os.sep)
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def module_launch_flags(version_info=None, user_site_install=None) -> str:
+    """Interpreter flags for a ``python -m clawmetry`` hook command that keep
+    the agent's working directory off ``sys.path``.
+
+    The runtimes start hooks in the AGENT'S working directory, and ``-m`` puts
+    that directory first on ``sys.path``. A project holding a ``clawmetry/``
+    folder (any checkout of this repo) then shadows the installed package, its
+    CLI rejects the ``hook`` subcommand, and argparse exits 2, which Claude
+    Code reads as "block this tool call". A gate that promises to fail open
+    blocked every call instead (2026-09-11, about six hours, nobody told).
+    ``-P`` (Python 3.11+) drops only that entry. Older interpreters get ``-I``,
+    unless the package is a user-site install, which ``-I`` would also hide.
+    """
+    vi = tuple((version_info or sys.version_info)[:2])
+    if vi >= (3, 11):
+        return "-P"
+    if user_site_install is None:
+        user_site_install = _installed_in_user_site()
+    return "" if user_site_install else "-I"
 
 
 def normalize_command(cmd: str) -> str:

--- a/clawmetry/incident_alerts.py
+++ b/clawmetry/incident_alerts.py
@@ -58,6 +58,98 @@ FREE_CHANNELS = frozenset({"banner", "telegram"})
 #: Channels that need the ``alert_webhooks`` entitlement.
 GATED_CHANNELS = frozenset({"slack", "discord", "webhook"})
 
+#: Urgent incidents also go out on channels nobody has to set up: a desktop
+#: notification on this machine and, on a node connected to ClawMetry cloud, a
+#: cloud notice that always emails the account owner and reaches every channel
+#: they enabled (PagerDuty included). An agent that is blocked and tells nobody
+#: is the failure these exist for: the banner only helps if the dashboard is
+#: open, and Telegram only if someone configured a bot.
+URGENT_KINDS = frozenset({"blocked_on_user"})
+_CLOUD_NOTIFY_PATH = "/api/cloud/incidents/notify"
+
+
+def is_urgent(kind: str, severity: str) -> bool:
+    """Critical anything, or an agent that cannot continue without a person."""
+    return severity == "critical" or kind in URGENT_KINDS
+
+
+def send_desktop(title: str, message: str) -> bool:
+    """A native notification on this machine, no configuration: ``osascript``
+    on macOS, ``notify-send`` on Linux. The text travels as argv, never inside
+    the AppleScript source, so an incident title cannot inject script. Off
+    with ``CLAWMETRY_DESKTOP_ALERTS=0``. Never raises."""
+    if os.environ.get("CLAWMETRY_DESKTOP_ALERTS", "1").strip() == "0":
+        return False
+    try:
+        import shutil
+        import subprocess
+        t = str(title or "ClawMetry")[:120]
+        m = str(message or "")[:400]
+        if sys.platform == "darwin" and shutil.which("osascript"):
+            argv = ["osascript",
+                    "-e", "on run argv",
+                    "-e", "display notification (item 2 of argv) with title "
+                          "(item 1 of argv) sound name \"Basso\"",
+                    "-e", "end run", t, m]
+        elif sys.platform.startswith("linux") and shutil.which("notify-send"):
+            argv = ["notify-send", "--urgency=critical", "--app-name=ClawMetry", t, m]
+        else:
+            return False
+        return subprocess.run(argv, timeout=5, capture_output=True).returncode == 0
+    except Exception as e:  # noqa: BLE001
+        log.debug("desktop notification failed: %s", e)
+        return False
+
+
+def send_cloud(incident: dict, message: str) -> bool:
+    """Hand an urgent incident to ClawMetry cloud, which emails the account
+    owner every time (no channel setup needed) and fans out to every channel
+    they enabled. Only on nodes connected with a ``cm_`` key; honours
+    local-only mode and ``CLAWMETRY_CLOUD_INCIDENT_ALERTS=0``. One attempt
+    with a short timeout, because this runs inside the detector pass.
+    Never raises."""
+    if os.environ.get("CLAWMETRY_CLOUD_INCIDENT_ALERTS", "1").strip() == "0":
+        return False
+    try:
+        from clawmetry.config import is_cloud_disabled
+        if is_cloud_disabled():
+            return False
+    except Exception:  # noqa: BLE001
+        pass
+    try:
+        from clawmetry import sync as _sync
+        cfg = _sync.load_config()
+        base = str(_sync.INGEST_URL or "").rstrip("/")
+    except Exception:  # noqa: BLE001
+        return False
+    api_key = str(cfg.get("api_key") or "").strip()
+    node_id = str(cfg.get("node_id") or "").strip()
+    if not api_key.startswith("cm_") or not node_id or not base:
+        return False
+    sid = str(incident.get("session_id") or "")
+    kind = str(incident.get("kind") or "")
+    payload = {
+        "node_id": node_id, "session_id": sid, "kind": kind,
+        "severity": str(incident.get("severity") or "warning"),
+        "title": str(incident.get("title") or "")[:200],
+        "message": str(message or "")[:1500],
+        "runtime": str(incident.get("runtime") or ""),
+        "event_id": f"{sid}:{kind}",
+    }
+    try:
+        req = urllib.request.Request(
+            base + _CLOUD_NOTIFY_PATH, data=json.dumps(payload).encode("utf-8"),
+            headers={"Content-Type": "application/json",
+                     "Authorization": f"Bearer {api_key}",
+                     "X-Node-Id": node_id, "User-Agent": "clawmetry"},
+            method="POST")
+        with urllib.request.urlopen(req, timeout=_HTTP_TIMEOUT) as resp:
+            body = json.loads(resp.read() or b"{}")
+        return bool(isinstance(body, dict) and body.get("ok"))
+    except Exception as e:  # noqa: BLE001
+        log.warning("cloud incident notice failed: %s", e)
+        return False
+
 _ALERTS_CONFIG_FILE = os.path.expanduser("~/.openclaw/clawmetry-alerts.json")
 _BUILTIN_PREFS_FILE = os.path.expanduser("~/.clawmetry/builtin_monitors.json")
 _HTTP_TIMEOUT = 10
@@ -461,6 +553,13 @@ def deliver_incident(store: Any, incident: dict, *,
             }
             if send_webhook(payload):
                 via.append("webhook")
+        # Urgent: also the channels nobody has to configure.
+        if is_urgent(kind, sev):
+            head = str(incident.get("title") or "Your agent needs attention")
+            if send_desktop(f"ClawMetry: {head}", message):
+                via.append("desktop")
+            if send_cloud(incident, message):
+                via.append("cloud")
 
         if not via:
             out["reason"] = "no channel accepted the alert (banner write failed)"

--- a/clawmetry/runtime_gates.py
+++ b/clawmetry/runtime_gates.py
@@ -87,7 +87,13 @@ def _hook_command(runtime_slug: str, base: str) -> str:
         quoted = _sp.list2cmdline([launcher])
     else:
         quoted = shlex.quote(launcher)
-    suffix = "" if _console_script() else " -m clawmetry"
+    if _console_script():
+        suffix = ""
+    else:
+        # Isolated -m so the agent's working directory cannot shadow the
+        # package (see hook_ownership.module_launch_flags).
+        flags = hook_ownership.module_launch_flags()
+        suffix = f" {flags} -m clawmetry" if flags else " -m clawmetry"
     return f"{quoted}{suffix} hook {runtime_slug} --base {base}"
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,12 @@ import requests
 # store and rendered in the Alerts tab. The per-process ownership check in
 # ``local_server.discovery_serves_this_db`` stops the proxy hop; this default
 # stops the direct-open leak for every test that forgot to isolate itself.
+# Urgent incidents also notify through a desktop pop-up and ClawMetry cloud
+# (incident_alerts.send_desktop / send_cloud). A unit test must never do
+# either on a developer's machine; the tests for those senders opt back in.
+os.environ.setdefault("CLAWMETRY_DESKTOP_ALERTS", "0")
+os.environ.setdefault("CLAWMETRY_CLOUD_INCIDENT_ALERTS", "0")
+
 _CONFTEST_SET_STORE_PATH = "CLAWMETRY_LOCAL_STORE_PATH" not in os.environ
 if _CONFTEST_SET_STORE_PATH:
     import tempfile as _tempfile

--- a/tests/test_blocked_agent_always_notifies.py
+++ b/tests/test_blocked_agent_always_notifies.py
@@ -1,0 +1,286 @@
+"""A blocked agent reaches a human with nothing configured.
+
+Burned 2026-09-11: Claude Code's pre-tool hook ran ``python -m clawmetry`` from
+a directory holding an older clawmetry checkout, argparse exited 2, and Claude
+Code blocked every tool call for about six hours. The hook errors were ingested,
+but ``blocked_on_user`` did not know a hook-rejected call meant "blocked",
+nothing paged, and the only zero-config channel was a banner in a dashboard
+nobody had open. These tests pin the three fixes:
+
+* detection: hook errors with nothing succeeding after them are a blocked
+  agent, critical when the failing hook is ClawMetry's own gate;
+* delivery: urgent incidents also go to a desktop notification and, on a
+  cloud-connected node, to cloud (which always emails the account owner);
+* prevention: the ``-m`` hook fallback keeps the agent's cwd off sys.path.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import time
+
+import pytest
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+from clawmetry import detectors  # noqa: E402
+from clawmetry import hook_ownership  # noqa: E402
+from clawmetry import incident_alerts as ia  # noqa: E402
+
+_OWN = ("PreToolUse:Read hook error: [/Users/v/.clawmetry/bin/python3 -m "
+        "clawmetry hook claude-code --base http://127.0.0.1:8900]: usage: "
+        "clawmetry ... error: argument command: invalid choice: 'hook'")
+_FOREIGN = ("PreToolUse:Bash hook error: [/opt/acme/guard.sh]: "
+            "guard.sh: line 3: jq: command not found")
+
+
+def _ts(i: int) -> str:
+    return f"2026-09-11T01:{i // 60:02d}:{i % 60:02d}"
+
+
+def _ev(et: str, data: dict, i: int) -> dict:
+    return {"event_type": et, "ts": _ts(i), "data": data}
+
+
+def _call(tool: str, i: int) -> dict:
+    return _ev("tool_call", {"role": "assistant", "tool_name": tool,
+                             "tool_calls": [{"name": tool, "input": {}}]}, i)
+
+
+def _hook_err(text: str, i: int) -> dict:
+    return _ev("tool_result", {"role": "tool", "content": text,
+                               "extra": {"isError": True}}, i)
+
+
+def _newest_first(*evs):
+    return list(reversed(list(evs)))
+
+
+# ── detection ────────────────────────────────────────────────────────────────
+
+def test_own_gate_erroring_twice_is_critical_blocked_on_user():
+    evs = _newest_first(_call("Read", 1), _hook_err(_OWN, 2),
+                        _call("Bash", 3), _hook_err(_OWN, 4))
+    inc = detectors.blocked_on_user(evs, "claude_code:s1", "claude_code",
+                                    facts={"idle_seconds": 5})
+    assert inc and inc["kind"] == "blocked_on_user"
+    assert inc["severity"] == "critical"
+    assert "ClawMetry's own gate" in inc["title"]
+    assert inc["evidence"]["own_gate"] is True
+    assert inc["evidence"]["hook_errors"] == 2
+    assert inc["evidence"]["asked_via"] == "hook"
+
+
+def test_foreign_hook_error_after_idle_is_a_warning():
+    evs = _newest_first(_call("Bash", 1), _hook_err(_FOREIGN, 2))
+    inc = detectors.blocked_on_user(evs, "claude_code:s2", "claude_code",
+                                    facts={"idle_seconds": 600})
+    assert inc and inc["severity"] == "warning"
+    assert "failing hook" in inc["title"]
+    assert inc["evidence"]["own_gate"] is False
+
+
+def test_single_fresh_hook_error_is_not_yet_an_incident():
+    evs = _newest_first(_call("Bash", 1), _hook_err(_FOREIGN, 2))
+    assert detectors.blocked_on_user(evs, "s3", "claude_code",
+                                     facts={"idle_seconds": 10}) is None
+
+
+def test_a_successful_call_after_the_errors_means_it_recovered():
+    evs = _newest_first(
+        _call("Read", 1), _hook_err(_OWN, 2), _call("Read", 3), _hook_err(_OWN, 4),
+        _call("Read", 5), _ev("tool_result", {"role": "tool", "content": "ok"}, 6))
+    assert detectors.blocked_on_user(evs, "s4", "claude_code",
+                                     facts={"idle_seconds": 9999}) is None
+
+
+def test_a_human_reply_after_the_errors_clears_it():
+    evs = _newest_first(
+        _call("Read", 1), _hook_err(_OWN, 2), _call("Bash", 3), _hook_err(_OWN, 4),
+        _ev("message", {"role": "user", "content": "fixed the hook"}, 5))
+    assert detectors.blocked_on_user(evs, "s5", "claude_code",
+                                     facts={"idle_seconds": 9999}) is None
+
+
+def test_a_deliberate_hook_denial_is_not_a_blocked_agent():
+    """A policy a person set that denies a call is a decision, not a fault."""
+    denied = "Hook PreToolUse:Bash denied this tool call: rm -rf is not allowed"
+    evs = _newest_first(_call("Bash", 1), _hook_err(denied, 2),
+                        _call("Bash", 3), _hook_err(denied, 4))
+    assert detectors.blocked_on_user(evs, "s6", "claude_code",
+                                     facts={"idle_seconds": 9999}) is None
+
+
+def test_run_all_surfaces_the_own_gate_incident():
+    evs = _newest_first(_call("Read", 1), _hook_err(_OWN, 2),
+                        _call("Bash", 3), _hook_err(_OWN, 4))
+    kinds = [i["kind"] for i in detectors.run_all(evs, "claude_code:s7", "claude_code",
+                                                  facts={"idle_seconds": 5})]
+    assert "blocked_on_user" in kinds
+
+
+# ── delivery ─────────────────────────────────────────────────────────────────
+
+class _Latch:
+    def __init__(self):
+        self.sent = {}
+
+    def incident_alert_last_sent(self, *, session_id, kind):
+        return self.sent.get((session_id, kind), 0)
+
+    def record_incident_alert(self, *, session_id, kind, delivered_via=None, severity=""):
+        self.sent[(session_id, kind)] = int(time.time() * 1000)
+
+
+@pytest.fixture
+def quiet_sinks(monkeypatch, tmp_path):
+    monkeypatch.setattr(ia, "_fleet_db_path", lambda: str(tmp_path / "fleet.db"))
+    monkeypatch.setattr(ia, "_BUILTIN_PREFS_FILE", str(tmp_path / "prefs.json"))
+    monkeypatch.setattr(ia, "_load_alerts_config", lambda: {})
+    monkeypatch.setattr(ia, "_budget_config", lambda: {})
+    monkeypatch.setattr(ia, "_MEMO", {})
+    calls = {"desktop": [], "cloud": []}
+    monkeypatch.setattr(ia, "send_desktop",
+                        lambda t, m: calls["desktop"].append((t, m)) or True)
+    monkeypatch.setattr(ia, "send_cloud",
+                        lambda inc, m: calls["cloud"].append(inc["kind"]) or True)
+    return calls
+
+
+def _inc(kind, sev):
+    return {"kind": kind, "session_id": "claude_code:s1", "runtime": "claude_code",
+            "severity": sev, "title": "ClawMetry's own gate is blocking claude_code",
+            "detail": "Every tool call is rejected.", "evidence": {}}
+
+
+def test_a_blocked_agent_goes_to_desktop_and_cloud_with_nothing_configured(quiet_sinks):
+    res = ia.deliver_incident(_Latch(), _inc("blocked_on_user", "warning"))
+    assert res["delivered"] is True
+    assert {"banner", "desktop", "cloud"} <= set(res["delivered_via"])
+    assert quiet_sinks["cloud"] == ["blocked_on_user"]
+    assert quiet_sinks["desktop"][0][0].startswith("ClawMetry: ")
+
+
+def test_any_critical_incident_is_urgent(quiet_sinks):
+    res = ia.deliver_incident(_Latch(), _inc("file_blast_radius", "critical"))
+    assert {"desktop", "cloud"} <= set(res["delivered_via"])
+
+
+def test_an_ordinary_warning_does_not_pop_up_or_email(quiet_sinks):
+    res = ia.deliver_incident(_Latch(), _inc("network_egress", "warning"))
+    assert res["delivered"] is True
+    assert "desktop" not in res["delivered_via"]
+    assert quiet_sinks["desktop"] == [] and quiet_sinks["cloud"] == []
+
+
+def test_desktop_notification_passes_text_as_argv_not_script(monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_DESKTOP_ALERTS", "1")
+    monkeypatch.setattr(ia.sys, "platform", "darwin")
+    import shutil
+    monkeypatch.setattr(shutil, "which", lambda name: "/usr/bin/" + name)
+    seen = {}
+
+    def fake_run(argv, **kw):
+        seen["argv"] = argv
+        return subprocess.CompletedProcess(argv, 0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    evil = 'x" & do shell script "rm -rf ~" & "'
+    assert ia.send_desktop(evil, "body") is True
+    script = " ".join(a for a in seen["argv"][:-2])
+    assert "rm -rf" not in script, "incident text must never enter the AppleScript"
+    assert seen["argv"][-2:] == [evil, "body"]
+
+
+def test_desktop_is_off_by_env(monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_DESKTOP_ALERTS", "0")
+    assert ia.send_desktop("t", "m") is False
+
+
+def test_cloud_notice_posts_with_the_node_key(monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_CLOUD_INCIDENT_ALERTS", "1")
+    from clawmetry import sync as _sync
+    import clawmetry.config as _cfg
+    monkeypatch.setattr(_cfg, "is_cloud_disabled", lambda: False)
+    monkeypatch.setattr(_sync, "load_config",
+                        lambda: {"api_key": "cm_test", "node_id": "mac-1"})
+    monkeypatch.setattr(_sync, "INGEST_URL", "https://ingest.example")
+    seen = {}
+
+    class _Resp:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def read(self):
+            return b'{"ok": true, "dispatched": ["email:owner"]}'
+
+    def fake_urlopen(req, timeout=None):
+        seen["url"] = req.full_url
+        seen["auth"] = req.get_header("Authorization")
+        seen["body"] = json.loads(req.data)
+        return _Resp()
+
+    monkeypatch.setattr(ia.urllib.request, "urlopen", fake_urlopen)
+    assert ia.send_cloud(_inc("blocked_on_user", "critical"), "msg") is True
+    assert seen["url"] == "https://ingest.example/api/cloud/incidents/notify"
+    assert seen["auth"] == "Bearer cm_test"
+    assert seen["body"]["node_id"] == "mac-1"
+    assert seen["body"]["kind"] == "blocked_on_user"
+
+
+def test_cloud_notice_needs_a_connected_node(monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_CLOUD_INCIDENT_ALERTS", "1")
+    from clawmetry import sync as _sync
+    import clawmetry.config as _cfg
+    monkeypatch.setattr(_cfg, "is_cloud_disabled", lambda: False)
+    monkeypatch.setattr(_sync, "load_config", lambda: {"api_key": "", "node_id": "x"})
+
+    def boom(*a, **k):
+        raise AssertionError("no network for a local-only node")
+
+    monkeypatch.setattr(ia.urllib.request, "urlopen", boom)
+    assert ia.send_cloud(_inc("blocked_on_user", "critical"), "msg") is False
+
+
+# ── prevention ───────────────────────────────────────────────────────────────
+
+def test_module_launch_flags_by_interpreter():
+    assert hook_ownership.module_launch_flags((3, 12)) == "-P"
+    assert hook_ownership.module_launch_flags((3, 9), user_site_install=False) == "-I"
+    assert hook_ownership.module_launch_flags((3, 9), user_site_install=True) == ""
+
+
+def test_dash_m_fallback_is_isolated_in_both_gates(monkeypatch, tmp_path):
+    import clawmetry.claude_code_gate as ccg
+    import clawmetry.runtime_gates as rg
+    bindir = tmp_path / "nolauncher" / "bin"
+    bindir.mkdir(parents=True)
+    for mod in (ccg, rg):
+        monkeypatch.setattr(mod.sys, "executable", str(bindir / "python3"))
+    flags = hook_ownership.module_launch_flags()
+    want = f" {flags} -m clawmetry hook " if flags else " -m clawmetry hook "
+    assert want in ccg._hook_command("http://127.0.0.1:8900")
+    assert want in rg._hook_command("cursor", "http://127.0.0.1:8900")
+
+
+@pytest.mark.skipif(sys.version_info < (3, 11), reason="-P needs Python 3.11")
+def test_dash_P_really_ignores_a_shadowing_checkout_in_cwd(tmp_path):
+    """The actual failure, reproduced: a ``clawmetry/`` folder in the agent's
+    working directory. With ``-P`` the import still resolves to the real one."""
+    shadow = tmp_path / "clawmetry"
+    shadow.mkdir()
+    (shadow / "__init__.py").write_text("SHADOW = True\n")
+    env = dict(os.environ, PYTHONPATH=_REPO_ROOT)
+    out = subprocess.run(
+        [sys.executable, "-P", "-c",
+         "import clawmetry; print(getattr(clawmetry, 'SHADOW', False))"],
+        cwd=str(tmp_path), env=env, capture_output=True, text=True, timeout=60)
+    assert out.returncode == 0, out.stderr
+    assert out.stdout.strip() == "False"

--- a/tests/test_runtime_gates_and_hooks.py
+++ b/tests/test_runtime_gates_and_hooks.py
@@ -882,7 +882,12 @@ def test_hook_command_quotes_interpreter_with_spaces(rt_gates, monkeypatch):
     cmd = rg._hook_command("copilot", "http://127.0.0.1:8900")
     parts = shlex.split(cmd)
     assert parts[0] == spacey
-    assert parts[1:4] == ["-m", "clawmetry", "hook"]
+    # The -m fallback carries an isolation flag (-P / -I) so the agent's
+    # working directory cannot shadow the package; see
+    # hook_ownership.module_launch_flags.
+    flags = rg.hook_ownership.module_launch_flags()
+    want = ([flags] if flags else []) + ["-m", "clawmetry", "hook"]
+    assert parts[1:1 + len(want)] == want
 
 
 @pytest.mark.parametrize("payload", [


### PR DESCRIPTION
**Why:** on 2026-09-11, ClawMetry's own Claude Code pre-tool hook blocked every tool call for about six hours, and nobody was told:

- At a daemon restart, the gate installer fell back to `python -m clawmetry`.
- Claude Code runs hooks in the agent's working directory. That directory held an older clawmetry checkout, which shadowed the installed package.
- The old CLI rejected the `hook` subcommand, and argparse exits **2**, which Claude Code reads as "block this tool call". So a gate that promises to fail open failed closed.
- The daemon ingested both hook errors, but `blocked_on_user` had no idea a hook-rejected call meant "blocked". Even a critical incident would only have reached an in-app banner, since Telegram needs setup and nothing else is zero-config.

**Three fixes:**

1. **Detect it.** `blocked_on_user` gains a hook path: the agent's recent tool results were rejected because a pre-tool hook *errored* (`PreToolUse:<Tool> hook error`, or Cursor/Copilot's event names), and nothing succeeded after.
   - It fires on 2 rejections, or 1 plus `blocked_wait_sec` idle.
   - It's **critical** when the failing hook is ClawMetry's own gate (the command contains `clawmetry hook `), otherwise a warning.
   - A deliberate hook *denial* (a policy a person set) does not count. A later successful call or a human reply clears it.
   - The detector kind is unchanged, so no parity lists move.
2. **Always tell someone.** In `incident_alerts.deliver_incident`, urgent incidents (any critical, or any `blocked_on_user`) now also go to:
   - `desktop`: a native notification (macOS `osascript`, Linux `notify-send`). Zero config. The text is passed as argv, never interpolated into AppleScript. Off with `CLAWMETRY_DESKTOP_ALERTS=0`.
   - `cloud`: on `cm_`-connected nodes, a POST to the new `POST /api/cloud/incidents/notify` (vivekchand/clawmetry-cloud#2391). It always emails the account owner and fans out to every enabled channel, PagerDuty included. One attempt with a 10s timeout; honours local-only mode; off with `CLAWMETRY_CLOUD_INCIDENT_ALERTS=0`. Counted as delivered only when cloud says something was.
   - Ordinary warnings are unchanged: no pop-ups, no email. The operator's mute and the 30-minute (session, kind) latch still apply.
3. **Stop the hook failing closed.** When no console script is found, the `-m` fallback in both `claude_code_gate` and `runtime_gates` (Cursor, Copilot) now runs isolated: `-P` on Python 3.11+, or `-I` on older interpreters unless clawmetry is a user-site install. The agent's working directory can no longer shadow the package. Ownership markers still match, and existing entries are replaced in place on the next pass.

**Tests:** new `tests/test_blocked_agent_always_notifies.py` (16 tests):
- detection: own gate is critical; a foreign hook is a warning; a single fresh error is quiet; recovery and a human reply clear it; a deliberate denial is ignored; `run_all` surfaces it;
- delivery: desktop and cloud for blocked or critical but not ordinary warnings; AppleScript injection impossible; env off-switches; the cloud POST shape; no network for local-only nodes;
- prevention: the flag matrix, both gates' fallback, and a real subprocess proving `-P` ignores a `clawmetry/` folder in cwd.

`tests/conftest.py` defaults both new channels off, so no unit test ever pops a notification or reaches cloud on a developer machine.

Touched suites: 272 passed locally. The one failure, `test_cc_gate_windowless_python_swap`, fails identically on a clean `origin/main` checkout. It's pre-existing (Windows backslash paths evaluated on macOS) and untouched here.

**Risk:**
- Urgent incidents now make noise by default: a desktop pop-up on this machine and an owner email via cloud, at most once per session and kind per 30 minutes.
- If that's too much, set either env var to 0, or mute the monitor in the Alerts tab.
- The hook command string changes once on existing installs; the installer replaces it in place.

No-PRD: bug fix. A blocked agent was recorded but reached no human, and the gate hook could fail closed. This closes both gaps without adding a product surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GPnEGaibiAyLXsHMRBZPci
