### PR TITLE
Do not re-file a field-failure signature that was just closed

### DIFF
--- a/.github/workflows/field-failure-issues.yml
+++ b/.github/workflows/field-failure-issues.yml
@@ -148,6 +148,41 @@ jobs:
               --search "\"$TITLE\" in:title state:open" \
               --json number,updatedAt --jq '.[0]' || echo "")
 
+            # A signature stays in the 30-day aggregate long after its fix
+            # ships, so an issue closed on the strength of a fix is STILL being
+            # reported. Dedupe searches open issues only, so the next tick found
+            # nothing, filed a fresh issue, and produced a second copy of a
+            # signature somebody had just triaged: #5829-#5834 were closed at
+            # 07:49 and re-filed as #5853-#5858 within hours.
+            #
+            # Before filing, look for a RECENTLY CLOSED issue with this title.
+            # Finding one means "already triaged, still ageing out", so comment
+            # there instead of opening a duplicate. Older closures still get a
+            # new issue: a signature returning after the window really is news.
+            if [ -z "$EXISTING" ] || [ "$EXISTING" = "null" ]; then
+              CLOSED=$(gh issue list --repo "$REPO" \
+                --search "\"$TITLE\" in:title state:closed" \
+                --json number,closedAt --jq '.[0]' || echo "")
+              if [ -n "$CLOSED" ] && [ "$CLOSED" != "null" ]; then
+                cnum=$(jq -r .number <<<"$CLOSED")
+                cat=$(jq -r .closedAt <<<"$CLOSED")
+                cage=$(( $(date -u +%s) - $(date -u -d "$cat" +%s 2>/dev/null || echo 0) ))
+                # One aggregate window. Inside it the signature cannot yet have
+                # stopped, so a report proves nothing about whether the fix worked.
+                if [ "$cage" -lt "$(( ${window:-30} * 86400 ))" ]; then
+                  if [ "$cage" -gt 86400 ]; then
+                    gh issue comment "$cnum" --repo "$REPO" --body \
+                      "Still in the aggregate: $installs distinct install(s), $events event(s) in the last ${window} days (last seen $last, latest shell ${ver:-unknown}). This issue is closed and the signature has not aged out yet, so this is not evidence the fix failed. Reopen only if it is still reported after $(date -u -d "$cat +${window} days" +%Y-%m-%d 2>/dev/null || echo 'the window closes')." \
+                      || echo "could not comment on #$cnum"
+                    echo "noted on recently-closed #$cnum ($TITLE)"
+                  else
+                    echo "skip: recently closed #$cnum, noted less than a day ago ($TITLE)"
+                  fi
+                  continue
+                fi
+              fi
+            fi
+
             if [ -n "$EXISTING" ] && [ "$EXISTING" != "null" ]; then
               num=$(jq -r .number <<<"$EXISTING")
               updated=$(jq -r .updatedAt <<<"$EXISTING")

--- a/tests/test_field_failure_autoclose.py
+++ b/tests/test_field_failure_autoclose.py
@@ -198,3 +198,44 @@ def test_a_daemon_failure_cannot_collide_with_a_bootstrap_failure():
     daem = _title_for("daemon_failed", "store_unwritable", "Darwin", "3.12")
     assert boot != daem, (boot, daem)
     assert daem == "[field-failure] daemon: store_unwritable on Darwin (py 3.12)", daem
+
+
+# ------------------------------------------- a closed signature is not re-filed
+
+# A signature stays in the 30-day aggregate long after its fix ships, so an
+# issue closed on the strength of a fix is still being reported. Dedupe searches
+# OPEN issues only, so the next tick found nothing and filed a duplicate:
+# #5829-#5834 were closed at 07:49 and re-filed as #5853-#5858 within hours,
+# putting a second copy of a signature in front of whoever had just triaged it.
+
+
+def _filing_script():
+    doc = yaml.safe_load(open(WORKFLOW, encoding="utf-8"))
+    return doc["jobs"]["file-issues"]["steps"][0]["run"]
+
+
+def test_the_filer_looks_for_a_recently_closed_issue_before_creating_one():
+    src = _filing_script()
+    assert "state:closed" in src, (
+        "the filer never looks for a closed issue with this title, so a "
+        "signature closed while still in the aggregate window is re-filed"
+    )
+    # The closed lookup must happen BEFORE the create.
+    assert src.index("state:closed") < src.index("gh issue create")
+
+
+def test_the_closed_lookup_is_bounded_by_the_aggregate_window():
+    """Older than the window and a recurrence really is news, so it should get a
+    fresh issue. Without a bound, a signature could never be filed again."""
+    src = _filing_script()
+    assert "86400" in src and "window" in src
+    assert "continue" in src, "nothing skips the create path"
+
+
+def test_the_note_does_not_claim_the_fix_failed():
+    """A report inside the window proves nothing about the fix: the signature
+    cannot have aged out yet. Saying otherwise would send someone to re-debug a
+    bug that is already fixed."""
+    src = _filing_script()
+    assert "not evidence the fix failed" in src
+    assert "Reopen only if" in src


### PR DESCRIPTION
Do not re-file a signature that was just closed

Six field-failure issues were auto-filed overnight (#5853-#5858). They are
duplicates: same six signatures as #5829-#5834, which another session closed as
COMPLETED at 07:49 having found a root cause. The filer's next tick found no
OPEN issue for those titles and created fresh ones within hours.

That is the dedupe working as written and still producing the wrong outcome. A
signature stays in the 30-day aggregate long after its fix ships, so an issue
closed on the strength of a fix is STILL being reported. Searching open issues
only guarantees a duplicate lands in front of whoever just triaged it, and the
duplicate reads as "the fix did not work" when it is only the window not having
elapsed.

The filer now looks for a recently closed issue with the same title before
creating one. Inside the aggregate window it comments there instead, saying
plainly that a report in this period is not evidence the fix failed and naming
the date after which a recurrence would be. Older than the window it still
files: a signature returning after a full window of silence really is news.

Three tests, all proven red against the pre-fix workflow: the closed lookup
exists and precedes the create, it is bounded by the window so a signature can
still be filed again, and the note does not claim the fix failed.

Also correcting myself. I commented on #5829-#5834 at around 11:00 saying they
were "left open deliberately, because the next report is the evidence either
way". They had been closed three hours earlier. I asserted a state I had not
checked, on six issues at once, and the reasoning in that comment was built on
it.

Worth recording for whoever reads those issues: the versions in #5853-#5858 are
0.12.855 through 0.12.860, all predating the suspend fix in 0.12.863, and every
timestamp is before it shipped. So they are not evidence about that fix either.
The real cause found since is a bare save_state() in the daemon loop (#5861).

No-PRD: fixes churn in the field-failure filer; no product surface changes.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Xb6A5G74JiMe3zHFs1JZEP
