### PR TITLE
Fix: remove stale C3/C4/C5 PR refs from c6-pr-gate comment body

### DIFF
--- a/.github/workflows/c6-pr-gate.yml
+++ b/.github/workflows/c6-pr-gate.yml
@@ -125,15 +125,7 @@ jobs:
           [Apply required E2E status checks (C6)](https://github.com/vivekchand/clawmetry/actions/workflows/apply-required-checks.yml)
           -- confirm=APPLY, pat_token=paste-token-here
 
-          ### Also: merge these 3 pending PRs to clear C3/C4/C5
-
-          Three criteria are AMBER with CI-green PRs waiting for merge:
-
-          - **C3** (landing golden path required check): [clawmetry-landing#678](https://github.com/vivekchand/clawmetry-landing/pull/678)
-          - **C4** (cross-repo handoff AES-GCM fidelity): [clawmetry#5269](https://github.com/vivekchand/clawmetry/pull/5269)
-          - **C5** (cloud node tab screenshots): [clawmetry-cloud#2143](https://github.com/vivekchand/clawmetry-cloud/pull/2143)
-
-          _E2E epic tracking: [#5266](https://github.com/vivekchand/clawmetry/issues/5266). Current state: C1 OSS golden path GREEN, C2 cloud GREEN, C7 quarantine GREEN. AMBER: C3 (merge landing#678), C4 (merge #5269), C5 cloud (merge cloud#2143), C6 (this Settings fix)._"
+          _E2E epic tracking: [#5266](https://github.com/vivekchand/clawmetry/issues/5266). Current state: C1-C5 and C7 are GREEN. C6 (this Settings fix) is the sole remaining gap._"
 
           existing_id=$(gh api -X GET \
             "repos/${REPO}/issues/${PR}/comments" \


### PR DESCRIPTION
## Summary

`c6-pr-gate.yml` posts a bot comment on every PR while C6 (required-status-checks) is AMBER. That comment still contained a "Also: merge these 3 pending PRs to clear C3/C4/C5" section referencing PRs #678, #5269, and cloud#2143 -- all of which merged months ago. C3/C4/C5 have been GREEN since 2026-08-28.

Every PR opened while C6 is AMBER was getting a misleading comment that sent reviewers on a dead-end hunt for already-merged PRs.

**Changes:**
- Removed the stale "Also: merge these 3 pending PRs" section (9 lines)
- Updated the status footer from the old AMBER list to: "C1-C5 and C7 are GREEN. C6 (this Settings fix) is the sole remaining gap."

No functional change: the gate logic, the how-to-close instructions, and the @vivekchand mention are all unchanged.

## C6 close path (for the reviewer)

C6 still needs one of these (any takes under 2 min):
- Settings UI: Settings > Branches > Edit main > add `E2E Gate (required)` (repeat for cloud + landing)
- Terminal: `bash scripts/close-c6.sh`
- Actions UI with fine-grained PAT: `apply-required-checks.yml` > Run workflow > confirm=APPLY

No-PRD: cosmetic workflow fix removing stale content from a bot comment body.

Tracking: https://github.com/vivekchand/clawmetry/issues/5266

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BhfJb9zxNhVBQ2JbJs5Xqn

---
_Generated by [Claude Code](https://claude.ai/code/session_01BhfJb9zxNhVBQ2JbJs5Xqn)_