### PR TITLE
Give the OpenClaw run ledger a home: Queue Lanes in Crons (#5721)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -538,6 +538,15 @@ jobs:
       - name: Anomaly baselines reach the card
         run: python3 -m pytest tests/test_anomaly_baselines_reach_the_card.py -q
 
+      # /api/run-ledger and its snapshot slice shipped in every wheel with zero
+      # UI consumers after PR #5668 cut the only tab that read them (#5721).
+      # The rollup now lives in Crons as the Queue Lanes panel; these pin that
+      # the panel is actually reached, that cloud reads the snapshot slice
+      # rather than the hosted endpoint's honest-but-empty fallback, and that
+      # the empty state names why it is empty instead of spinning forever.
+      - name: Queue Lanes panel is reachable
+        run: python3 -m pytest tests/test_queue_lanes_panel_is_reachable.py -q
+
       # A Pro node stopped syncing for 12 hours (2026-09-08) because sync.pid
       # named a pid the OS had recycled onto an unrelated process: every
       # launchd respawn read "alive" and exited, and `clawmetry status` still

--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -14480,6 +14480,8 @@ async function loadCrons() {
     renderCrons();
     // Load cron health summary panel
     loadCronHealth();
+    // Load the OpenClaw queue-lane rollup (issue #5721)
+    loadQueueLanes();
     // Load multi-node cron status from fleet nodes
     loadCronsMultiNode();
     // Load cron health monitor (GH #302)
@@ -14504,6 +14506,117 @@ async function loadCrons() {
             + '</div>';
     if (listEl) listEl.innerHTML = msg;
     console.warn('loadCrons failed', e);
+  }
+}
+
+// ---------------------------------------------------------------- Queue Lanes
+// OpenClaw records every background run in one ledger, and `runtime` IS the
+// queue lane: `cron`, `subagent`, `cli`. `sync.py::sync_run_ledger` mirrors
+// that ledger into DuckDB and `/api/run-ledger` has served the rollup since
+// #2100, but PR #5668 cut the only tab that read it, so both the endpoint and
+// the snapshot slice shipped in every wheel with zero UI consumers (#5721).
+//
+// This is that rollup, in Crons rather than in a tab of its own: `cron` is one
+// of the three lanes, Crons is already in the nav, and a rollup is a panel's
+// worth of content.
+//
+// Cloud reads the `runLedger` snapshot slice, not the endpoint. On the hosted
+// server `/api/run-ledger` is an oss-passthrough that finds no local DuckDB
+// and honestly returns empty lists, so fetching it there would paint a
+// false-empty panel over a node that has runs.
+var _QUEUE_LANE_LABELS = { cron: 'Cron', subagent: 'Sub-agents', cli: 'CLI' };
+
+function _queueLaneBadge(color, text) {
+  return '<span style="font-size:11px;background:' + color + '22;color:' + color
+       + ';border-radius:6px;padding:2px 8px;white-space:nowrap;">' + escHtml(text) + '</span>';
+}
+
+// Split out from loadQueueLanes so the empty state and the rollup can both be
+// exercised without a store or a network round trip.
+function renderQueueLanes(lanes) {
+  lanes = Array.isArray(lanes) ? lanes : [];
+  var html = '<div class="card" style="padding:14px;">';
+  html += '<div style="display:flex;align-items:center;gap:10px;margin-bottom:10px;flex-wrap:wrap;">';
+  html += '<span style="font-size:13px;font-weight:700;color:var(--text-primary);">&#x1F6E4;&#xFE0F; Queue Lanes</span>';
+  html += '<span style="font-size:11px;color:var(--text-muted);">OpenClaw background runs by lane: cron jobs, sub-agents, CLI turns</span>';
+  html += '</div>';
+
+  if (!lanes.length) {
+    // Name why it is empty. An endless "Loading..." over an empty ledger is
+    // what got the old Queue Lanes tab hidden in 44acaa72f, and what put six
+    // dead panels on the cloud Security tab.
+    html += '<div style="font-size:12px;color:var(--text-muted);line-height:1.7;">'
+         +  'No background runs recorded on this node, and this is the finished '
+         +  'state, not a spinner. ClawMetry mirrors OpenClaw\'s run ledger '
+         +  '(<code>state/openclaw.sqlite</code> on OpenClaw 2026.6.5 and newer, '
+         +  '<code>tasks/runs.sqlite</code> on 2026.5.x). An empty rollup means '
+         +  'either an OpenClaw older than those, or a node that has not run a '
+         +  'cron job, sub-agent or background CLI task yet.'
+         +  '</div>';
+    return html + '</div>';
+  }
+
+  html += '<div style="display:grid;gap:6px;">';
+  lanes.forEach(function(l) {
+    l = l || {};
+    var total   = Number(l.total || 0);
+    var ok      = Number(l.succeeded || 0);
+    var failed  = Number(l.failed || 0);
+    var running = Number(l.running || 0);
+    var queued  = Number(l.queued || 0);
+    var name    = _QUEUE_LANE_LABELS[l.lane] || String(l.lane || 'unknown');
+
+    html += '<div style="display:flex;align-items:center;gap:8px;padding:6px 10px;background:var(--bg-secondary);border-radius:8px;border:1px solid var(--border-secondary);flex-wrap:wrap;">';
+    html += '<span style="font-size:12px;font-weight:600;color:var(--text-primary);min-width:92px;">' + escHtml(name) + '</span>';
+    if (running) html += _queueLaneBadge('#3b82f6', running + ' running');
+    if (queued)  html += _queueLaneBadge('#f59e0b', queued + ' queued');
+    if (ok)      html += _queueLaneBadge('#22c55e', ok + ' succeeded');
+    if (failed)  html += _queueLaneBadge('#ef4444', failed + ' failed');
+    html += '<span style="font-size:11px;color:var(--text-muted);margin-left:auto;white-space:nowrap;">'
+         +  total + ' total'
+         +  (l.last_event_at ? ' &middot; last ' + escHtml(timeAgo(Number(l.last_event_at))) : '')
+         +  '</span>';
+    html += '</div>';
+
+    // A lane that mostly fails is the whole reason to look at this panel. On
+    // the node this was built against, 104 of 106 cron runs had failed with
+    // "heartbeat skipped: no-route" and no surface said so.
+    if (total >= 5 && failed * 2 >= total) {
+      html += '<div style="font-size:11px;color:#ef4444;padding:0 10px 2px;">'
+           +  failed + ' of ' + total + ' runs in this lane failed.'
+           +  '</div>';
+    }
+  });
+  html += '</div>';
+  return html + '</div>';
+}
+
+async function loadQueueLanes() {
+  var panel = document.getElementById('cron-queue-lanes');
+  if (!panel) return;
+  try {
+    var lanes = null;
+    if (window.CLOUD_MODE && typeof window.__cmSnap === 'function') {
+      var sp = await window.__cmSnap();
+      lanes = sp && sp.runLedger && sp.runLedger.lanes;
+    } else {
+      // limit=1 because this panel reads `lanes` only; the rollup is computed
+      // store-side and does not need the `runs` array.
+      var data = await (typeof fetchJsonWithTimeout === 'function'
+        ? fetchJsonWithTimeout('/api/run-ledger?limit=1', 8000)
+        : fetch('/api/run-ledger?limit=1').then(function(r) { return r.json(); }));
+      lanes = data && data.lanes;
+    }
+    panel.innerHTML = renderQueueLanes(lanes);
+  } catch (e) {
+    // Say it failed. Do not fall through to the empty state, which claims
+    // there are no runs.
+    panel.innerHTML = '<div class="card" style="padding:14px;font-size:13px;color:var(--text-error);">'
+      + 'Failed to load queue lanes: ' + escHtml(String((e && e.message) || e))
+      + ' <button onclick="loadQueueLanes()" style="margin-left:8px;background:transparent;'
+      + 'border:1px solid var(--border-primary);color:var(--text-secondary);border-radius:4px;'
+      + 'padding:2px 10px;font-size:11px;cursor:pointer;">Retry</button></div>';
+    console.warn('loadQueueLanes failed', e);
   }
 }
 

--- a/clawmetry/templates/tabs/crons.html
+++ b/clawmetry/templates/tabs/crons.html
@@ -18,6 +18,11 @@
     </label>
   </div>
   <div id="cron-health-panel" style="margin-bottom:12px;"></div>
+  <!-- Queue Lanes rollup (issue #5721) — rendered by loadQueueLanes() in app.js.
+       No data-i18n keys here on purpose: the strings are built in JS, like the
+       Cron Health Monitor above, so this panel does not need a new key in all
+       35 locale catalogs to ship. -->
+  <div id="cron-queue-lanes" style="margin-bottom:12px;"></div>
   <div id="crons-multi-node" style="display:none;margin-bottom:12px;"></div>
   <div class="cron-view-tabs" role="tablist">
     <button class="cron-view-tab active" data-view="active" onclick="setCronView('active')"><span data-i18n="crons.view_active">Active</span> <span class="cron-view-count" id="crons-count-active"></span></button>

--- a/docs/ci_test_coverage_baseline.json
+++ b/docs/ci_test_coverage_baseline.json
@@ -7,7 +7,7 @@
     "Ratchet down by running --update-baseline after wiring new tests in.",
     "Related: issue #5813"
   ],
-  "total": 1138,
-  "listed": 206,
-  "unlisted_max": 932
+  "total": 1143,
+  "listed": 212,
+  "unlisted_max": 931
 }

--- a/routes/scheduler.py
+++ b/routes/scheduler.py
@@ -1,15 +1,20 @@
 """routes/scheduler.py — OpenClaw run-ledger + queue-lane endpoints.
 
-OpenClaw 2026.5.x records every background run — sub-agents
+OpenClaw records every background run — sub-agents
 (``runtime='subagent'``), cron jobs (``runtime='cron'``) and inline
-CLI/agent turns (``runtime='cli'``) — in a unified SQLite ledger at
-``~/.openclaw/tasks/runs.sqlite``. The sync daemon mirrors it into the
-DuckDB ``run_ledger`` table (``clawmetry/sync.py:sync_run_ledger``).
+CLI/agent turns (``runtime='cli'``) — in one SQLite ledger. **The file
+moved**: 2026.6.5+/2026.7.x keep ``task_runs`` in the unified
+``~/.openclaw/state/openclaw.sqlite``, while 2026.5.x wrote a standalone
+``~/.openclaw/tasks/runs.sqlite``. ``sync._openclaw_task_ledger_paths()``
+is the authority and ingests from every candidate that exists; do not
+hardcode either path here. The daemon mirrors the rows into the DuckDB
+``run_ledger`` table (``clawmetry/sync.py:sync_run_ledger``).
 
 This module exposes that ledger so three observability surfaces share
 one source of truth:
 
-  GET /api/run-ledger          — lanes rollup + recent runs (Scheduler tab)
+  GET /api/run-ledger          — lanes rollup + recent runs (Crons tab
+                                 Queue Lanes panel, #5721)
   GET /api/run-ledger/tree     — sub-agent fan-out tree (parent -> children)
 
 ``runtime`` IS the OpenClaw queue lane, so the lanes rollup is the live
@@ -56,8 +61,10 @@ def api_run_ledger():
 
     Query params: ``runtime`` (lane filter), ``status``, ``limit`` (<=1000).
     Returns ``{lanes, runs, _source}``. Never 500s — an empty ledger (fresh
-    sync, OpenClaw < 2026.5, or daemon mid-restart) returns empty lists so
-    the tab renders an honest "no background runs yet" state.
+    sync, an OpenClaw predating the ledger, or a daemon mid-restart) returns
+    empty lists, and the Queue Lanes panel in Crons renders an honest
+    "no background runs on this node" state naming those causes rather than
+    a spinner.
     """
     try:
         limit = max(1, min(1000, int(request.args.get("limit", 200))))

--- a/tests/test_queue_lanes_panel_is_reachable.py
+++ b/tests/test_queue_lanes_panel_is_reachable.py
@@ -1,0 +1,148 @@
+"""The Queue Lanes rollup must actually be reached, and must never spin.
+
+`/api/run-ledger` has been served, tested and shipped in every wheel since
+#2100. PR #5668 then cut the unreachable "Sub-Agents & Queue Lanes" tab, and
+took the endpoint's only UI consumer with it: measured on `origin/main` before
+this panel landed, `grep -c run-ledger` over `app.js` and every shipped tab
+template returned **0**. Issue #5721 is that gap.
+
+`tests/test_every_tab_is_reachable.py` covers *tabs*: a template with no
+`switchTab` caller. A panel inside an existing tab needs its own check, because
+nothing about it is a tab: it is a `<div id=...>` that only exists on screen if
+some function writes to it, and only runs if some other function calls that.
+Both halves of that chain are asserted here.
+
+The second half of the guard is the honest empty state. `/api/run-ledger`
+deliberately never raises: a fresh sync, an OpenClaw predating the run ledger,
+or a daemon mid-restart all return `{"lanes": [], "runs": []}`. A panel that
+renders "Loading..." over that lies forever, which is exactly what got the old
+tab hidden in 44acaa72f ("perpetually stuck on Loading... with no useful
+content") and what put six dead panels on the cloud Security tab. So the empty
+branch must say it is finished and name why it is empty.
+
+Static checks over the shipped assets. No server, no store, no browser.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+APP_JS = (REPO / "clawmetry" / "static" / "js" / "app.js").read_text(encoding="utf-8")
+CRONS_HTML = (
+    REPO / "clawmetry" / "templates" / "tabs" / "crons.html"
+).read_text(encoding="utf-8")
+SCHEDULER_PY = (REPO / "routes" / "scheduler.py").read_text(encoding="utf-8")
+
+PANEL_ID = "cron-queue-lanes"
+
+
+def _render_body() -> str:
+    """`renderQueueLanes`'s body, as shipped, with `//` comments stripped.
+
+    The comments explain what the empty state must not say, and quote the copy
+    it must not use. Matching raw text would fail on the explanation rather
+    than on the code: assert on what runs, not on the prose describing it.
+    """
+    i = APP_JS.index("function renderQueueLanes(")
+    j = APP_JS.index("\nasync function loadQueueLanes(", i)
+    return "\n".join(
+        ln for ln in APP_JS[i:j].splitlines() if not ln.lstrip().startswith("//")
+    )
+
+
+def test_the_panel_container_exists_in_the_crons_tab():
+    assert f'id="{PANEL_ID}"' in CRONS_HTML, (
+        f"no #{PANEL_ID} container in the Crons tab, so nothing the renderer "
+        "writes can ever appear on screen"
+    )
+
+
+def test_something_writes_to_the_panel():
+    assert f"getElementById('{PANEL_ID}')" in APP_JS, (
+        f"#{PANEL_ID} is in the template but no JS looks it up: an empty div "
+        "that ships in every wheel"
+    )
+
+
+def test_the_loader_is_actually_called():
+    """A loader nobody calls is the #5668 shape all over again."""
+    callers = [
+        ln.strip()
+        for ln in APP_JS.splitlines()
+        if "loadQueueLanes()" in ln
+        and not ln.strip().startswith("async function")
+        and not ln.strip().startswith("//")
+    ]
+    # The Retry button inside the error branch calls itself; that is not a
+    # caller for reachability purposes.
+    real = [ln for ln in callers if "onclick=" not in ln]
+    assert real, (
+        "loadQueueLanes() is defined and never called from a tab loader, so "
+        "the panel renders on no code path"
+    )
+
+
+def test_the_loader_reaches_the_endpoint_that_had_no_consumer():
+    assert "/api/run-ledger" in APP_JS, (
+        "the panel does not read /api/run-ledger, which is the endpoint #5721 "
+        "exists to give a home to"
+    )
+
+
+def test_cloud_reads_the_snapshot_slice_not_the_endpoint():
+    """On the hosted server /api/run-ledger is an oss-passthrough with no local
+    DuckDB behind it, so it honestly returns empty lists. Fetching it in
+    CLOUD_MODE would paint the empty state over a node that has runs: the
+    false-empty-tab bug class, again."""
+    i = APP_JS.index("async function loadQueueLanes(")
+    body = APP_JS[i:i + 2000]
+    assert "CLOUD_MODE" in body and "runLedger" in body, (
+        "loadQueueLanes has no CLOUD_MODE branch reading the `runLedger` "
+        "snapshot slice, so the hosted panel would always look empty"
+    )
+
+
+def test_the_empty_state_says_it_is_finished_and_why():
+    body = _render_body()
+    i = body.index("if (!lanes.length)")
+    j = body.index("return html", i)
+    empty = body[i:j]
+
+    assert "Loading" not in empty, (
+        "the empty branch says 'Loading', the exact copy that got the old "
+        "Queue Lanes tab hidden in 44acaa72f"
+    )
+    # Both causes named, so a reader can tell "your OpenClaw is too old" from
+    # "nothing has run yet" without opening a shell.
+    assert "openclaw.sqlite" in empty, "empty state does not name the ledger it read"
+    assert "2026" in empty, "empty state does not name an OpenClaw version floor"
+    assert re.search(r"not a spinner|finished state", empty), (
+        "empty state does not tell the reader it has stopped working"
+    )
+
+
+def test_a_failed_load_is_not_reported_as_an_empty_ledger():
+    """The catch branch must say the fetch failed. Falling through to
+    renderQueueLanes([]) would claim the node has no background runs because
+    the request timed out."""
+    i = APP_JS.index("async function loadQueueLanes(")
+    j = APP_JS.index("\nasync function loadCronHealth(", i)
+    catch = APP_JS[APP_JS.index("} catch (e) {", i):j]
+    assert "Failed to load queue lanes" in catch
+    assert "renderQueueLanes" not in catch, (
+        "the error path renders the lanes view, so a failed fetch is "
+        "indistinguishable from an empty ledger"
+    )
+
+
+def test_the_route_docstring_does_not_pin_the_superseded_ledger_path():
+    """OpenClaw 2026.6.5+ moved `task_runs` into the unified
+    `state/openclaw.sqlite`; `sync._openclaw_task_ledger_paths()` reads both.
+    A docstring naming only `tasks/runs.sqlite` sent this investigation to a
+    directory that does not exist on a current install."""
+    head = SCHEDULER_PY[:SCHEDULER_PY.index('"""', 3) + 3]
+    assert "state/openclaw.sqlite" in head, (
+        "routes/scheduler.py still documents only the 2026.5.x ledger path"
+    )


### PR DESCRIPTION
## Summary

`/api/run-ledger` has been served, tested and shipped in every wheel since #2100. PR #5668 cut the unreachable "Sub-Agents and Queue Lanes" tab and took the endpoint's only UI consumer with it. Measured on `origin/main` before this branch: **zero** references to `run-ledger` across `static/js/app.js` and every shipped tab template. The store query, the endpoint, the snapshot slice and their tests all ship to every user, and nobody can see any of it. That gap is issue #5721.

## The blocking check, done first

#5721 required proof that the endpoint returns lanes on a real OpenClaw node before any UI, because shipping a panel over an empty ledger is exactly what got the old tab hidden in `44acaa72f`. It does. Live on this node (OpenClaw 2026.9.3):

```json
GET /api/run-ledger?limit=1
{"lanes": [{"lane": "cron", "total": 106, "succeeded": 2, "failed": 104,
            "running": 0, "queued": 0, "last_event_at": 1789139737921}]}
```

**104 of 106 cron runs had failed**, over days, with `heartbeat skipped: no-route`, and no surface in the product said so.

The issue's own note that the endpoint returned `{"lanes": [], "runs": []}` was accurate when written and is now stale: OpenClaw 2026.6.5+ moved `task_runs` into the unified `~/.openclaw/state/openclaw.sqlite`, and `sync._openclaw_task_ledger_paths()` reads it.

## What this adds

A **Queue Lanes** rollup inside the existing Crons tab, per #5721's proposed shape: `cron` is one of the three lanes, Crons is already in the nav, and a rollup is a panel's worth of content, not a page's. Per lane it shows running, queued, succeeded, failed, total and last activity, and spells out the proportion in words when a lane is mostly failing.

Three things the predecessor got wrong, each pinned by a guard:

1. **The empty state says it has finished, and names why.** Both real causes, so a reader can tell which applies without opening a shell: an OpenClaw predating the ledger, or a node that has run no background task yet. The old tab said "Loading..." forever, which is also what put six dead panels on the cloud Security tab.
2. **A failed fetch reports that it failed**, with a retry. Falling through to the empty state would claim the node has no background runs because the request timed out.
3. **Cloud reads the `runLedger` snapshot slice, not the endpoint.** On the hosted server `/api/run-ledger` is an oss-passthrough with no local DuckDB behind it, so fetching it there would paint a false-empty panel over a node that has runs.

`routes/scheduler.py` documented only `~/.openclaw/tasks/runs.sqlite`, a directory that does not exist on a current install. Corrected and pinned.

No new i18n keys. The panel builds its strings in JS like the Cron Health Monitor directly above it, so it does not need a key added to 35 locale catalogs to ship.

## Verification

Rendered live in a browser against this branch, real data, panel reached by `loadCrons()` with no manual call:

```
🛤️ Queue Lanes  OpenClaw background runs by lane: cron jobs, sub-agents, CLI turns
Cron    2 succeeded   104 failed        106 total · last 30m ago
104 of 106 runs in this lane failed.
```

`getBoundingClientRect()` on the panel: 1160 x 118.5 at y=466, so it is on screen and not a zero-height div.

All 8 guards were proven **red against `origin/main`** in a separate worktree before being trusted, and are green here:

```
origin/main       8 failed
this branch       8 passed
```

One of them caught my own mistake while writing it: the first version matched the word "Loading" against the comment that explains why the empty state must not say "Loading". Fixed to strip `//` comments and assert on code, not the prose describing it.

Wired into the `ci.yml` lint job by name, since an unlisted test file here runs in no job at all. CI test-coverage ratchet tightened from 932 to 931.

## Found while verifying, not fixed here

The screenshot shows **Cron Health: 3 healthy** directly above **104 of 106 runs in this lane failed**, for the same job. `/api/cron/health-summary` reports `heartbeat-main` as `health: ok`, `consecutiveFailures: 0`, `runs7d: null`: it has no run history at all, so it calls everything healthy. That is a real defect and it is not this panel's, so it gets its own issue rather than scope creep here.

Requirement: https://factory.8090.ai/project/b415065f-ab2f-4f53-8864-0c009fd098cb/requirements/2de2935e-612b-434d-8925-4b81755211d2

Closes #5721

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xb6A5G74JiMe3zHFs1JZEP
