### PR TITLE
Answer the agent's question from anywhere, and retire dead requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -857,6 +857,15 @@ jobs:
           CI: "true"
         run: python3 -m pytest tests/test_store_invariants.py -q
 
+      # An agent's question (Claude Code AskUserQuestion) reaches the snapshot
+      # with its options, a sealed answer from the cloud strip lands on the
+      # stored request, and a request nothing is waiting on is retired rather
+      # than offered forever (2026-09-11: one sat on the strip for 2h38m).
+      - name: Question-set approvals relay
+        env:
+          CI: "true"
+        run: python3 -m pytest tests/test_question_set_relay.py -q
+
       # Mutation testing: does the suite actually catch bugs, or has it been
       # weakened into a tautology? Line coverage cannot tell the difference.
       # The score ratchets -- it may rise freely, and a drop fails the build.

--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -9053,6 +9053,58 @@ class LocalStore(TrailStoreMixin):
                   str(approval_id)])
         return 1
 
+    def expire_stale_approvals(self, grace_seconds: int = 120) -> int:
+        """Retire pending approvals whose waiter is gone.
+
+        A hook-parked approval records its window's end in
+        ``args.deadline_ms``, and the hook that parked it writes the timeout
+        itself when the window ends. If that hook dies first (its receiver
+        restarted, Claude Code cancelled it), nothing ever closes the row:
+        the runtime has already fallen back to its own prompt, yet every
+        surface keeps offering buttons that can no longer reach it. Burned
+        2026-09-11: a question sat on the cloud strip for 2h38m.
+
+        Flips rows more than ``grace_seconds`` past their deadline to
+        ``expired`` (a question hook reads that as "ask the terminal", never
+        as a refusal). Rows without a deadline are left alone. Returns rows
+        expired. Never raises into the daemon loop.
+        """
+        if self._read_only:
+            return 0
+        from datetime import datetime, timezone
+        cutoff_ms = int((time.time() - max(30, int(grace_seconds))) * 1000)
+        expired = 0
+        try:
+            with self._write_lock:
+                rows = self._conn.execute(
+                    "SELECT id, args FROM approvals WHERE status = 'pending'"
+                ).fetchall()
+                now_iso = datetime.now(timezone.utc).isoformat()
+                for approval_id, raw in rows:
+                    try:
+                        text = (raw.decode("utf-8")
+                                if isinstance(raw, (bytes, bytearray)) else raw)
+                        args = json.loads(text) if text else {}
+                        deadline_ms = int((args or {}).get("deadline_ms") or 0)
+                    except Exception:
+                        continue
+                    if not deadline_ms or deadline_ms >= cutoff_ms:
+                        continue
+                    self._conn.execute("""
+                        UPDATE approvals
+                        SET status = 'expired', decision = 'expired',
+                            decision_reason = ?, resolver = 'sweep',
+                            resolved_at = ?
+                        WHERE id = ? AND status = 'pending'
+                    """, ["nothing was waiting on this request any more; "
+                          "the agent had already moved on", now_iso,
+                          str(approval_id)])
+                    expired += 1
+        except Exception:
+            log.debug("local store: expire_stale_approvals failed",
+                      exc_info=True)
+        return expired
+
     # ── review_queue helpers (issue #1615) ────────────────────────────────
     def ingest_review_sample(self, sample: dict[str, Any]) -> int:
         """Insert one sampled session into the review queue.

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -12415,6 +12415,83 @@ def _apply_pending_write(qtype: str, q: dict, owner_hash: str | None = None) -> 
     raise ValueError(f"unhandled write type: {qtype}")
 
 
+def _apply_answer_decision(q: dict, approval_id: str, resolver: str,
+                           reason) -> None:
+    """``decision='answer'``: the person answered a question the agent asked
+    (Claude Code AskUserQuestion) from the cloud strip, not from the local
+    Approvals tab.
+
+    The pick arrives as ``sealed_answers``: the browser encrypts
+    ``{"answers": {...}}`` with this node's E2E key (the key the question
+    arrived under), so the cloud relays it without reading it. It is then
+    validated against the question set the hook stored, exactly like a local
+    answer (``question_sets.apply_answer_decision``), and the waiting hook
+    resumes the session with it.
+
+    Anything wrong (no key, a seal from another key, a label that is not one
+    of the options, the row already decided or expired) leaves the row as it
+    is: the hook hands the question to the terminal at its deadline. Never a
+    fabricated answer, never raises."""
+    sealed = q.get("sealed_answers")
+    if not isinstance(sealed, str) or not sealed.strip():
+        log.warning("approval_decision %s: answer carries no sealed_answers",
+                    approval_id)
+        return
+    try:
+        key = str(load_config().get("encryption_key") or "")
+        opened = decrypt_payload(sealed.strip(), key) if key else None
+    except Exception as e:
+        log.warning("approval_decision %s: sealed answer unreadable (%s)",
+                    approval_id, type(e).__name__)
+        return
+    answers = opened.get("answers") if isinstance(opened, dict) else None
+    if not isinstance(answers, dict) or not answers:
+        log.warning("approval_decision %s: sealed answer has no answers",
+                    approval_id)
+        return
+    try:
+        from clawmetry import local_store
+        from clawmetry import question_sets as qsets
+        store = local_store.get_store()
+        row = next((r for r in (store.query_approvals(status="pending",
+                                                      limit=500) or [])
+                    if isinstance(r, dict) and r.get("id") == approval_id),
+                   None)
+    except Exception as e:
+        log.warning("approval_decision %s: local_store unavailable: %s",
+                    approval_id, e)
+        return
+    if row is None:
+        log.debug("[approval] %s relayed answer: no pending row (already "
+                  "decided, expired, or another node)", approval_id)
+        return
+
+    def _write(method: str, **kwargs) -> bool:
+        try:
+            getattr(store, method)(**kwargs)
+            return True
+        except Exception as we:
+            log.warning("approval_decision %s: %s failed: %s",
+                        approval_id, method, we)
+            return False
+
+    ok, msg, _code = qsets.apply_answer_decision(
+        approval_id, row, answers, resolver=resolver, reason=reason,
+        write=_write)
+    if not ok:
+        log.warning("[approval] %s relayed answer rejected: %s",
+                    approval_id, msg)
+        return
+    log.info("[approval] %s answered via %s", approval_id, resolver)
+    try:
+        from clawmetry import audit as _audit
+        _audit.audit_event("approval.decision", actor=resolver,
+                           target=approval_id, result="answered",
+                           source="cloud-relay")
+    except Exception:
+        pass
+
+
 def _apply_approval_decision(q: dict) -> None:
     """Flip an approvals row in local DuckDB based on a cloud-relayed
     decision. Used by `_dispatch_pending_queries`.
@@ -12432,6 +12509,9 @@ def _apply_approval_decision(q: dict) -> None:
         return
     resolver = (q.get("resolver") or "cloud-relay").strip()
     reason = q.get("reason")
+    if decision == "answer":
+        _apply_answer_decision(q, approval_id, resolver, reason)
+        return
     try:
         from clawmetry import local_store
         store = local_store.get_store()
@@ -20822,6 +20902,15 @@ def _refresh_attention_cache(store) -> int:
         store.expire_stale_hook_attention(ATTENTION_HOOK_MAX_AGE_SECONDS)
     except Exception as _pe:  # noqa: BLE001
         log.debug("attention-detect: persist failed (continuing): %s", _pe)
+    # Same safety valve for the approvals queue: a hook that died before its
+    # window ended leaves a row every surface would keep offering buttons on.
+    try:
+        n_expired = store.expire_stale_approvals()
+        if n_expired:
+            log.info("[approval] expired %d request(s) nothing was waiting on",
+                     n_expired)
+    except Exception as _ae:  # noqa: BLE001
+        log.debug("approval sweep failed (continuing): %s", _ae)
     return len(items)
 
 
@@ -22438,6 +22527,43 @@ def _build_loops_slice(store):
     return out
 
 
+def _approval_deadline_ms(row: dict) -> int:
+    """End of a hook-parked approval's window (``args.deadline_ms``), or 0."""
+    args = row.get("args") if isinstance(row.get("args"), dict) else {}
+    try:
+        return max(0, int(args.get("deadline_ms") or 0))
+    except (TypeError, ValueError):
+        return 0
+
+
+def _device_question_set(row: dict) -> list:
+    """The approval's question set (``args._cm_questions``, stored by the
+    hook receiver from Claude Code's AskUserQuestion), trimmed for the
+    snapshot: what a surface needs to render the options and nothing else.
+    Empty when the approval is an ordinary yes/no request."""
+    args = row.get("args") if isinstance(row.get("args"), dict) else {}
+    out = []
+    for q in (args.get("_cm_questions") or [])[:4]:
+        if not isinstance(q, dict) or not q.get("question"):
+            continue
+        options = [
+            {"label": str(o.get("label"))[:120],
+             "description": str(o.get("description") or "")[:240]}
+            for o in (q.get("options") or [])[:4]
+            if isinstance(o, dict) and o.get("label")
+        ]
+        if not options:
+            continue
+        out.append({
+            "question": str(q.get("question"))[:400],
+            "header": str(q.get("header") or "")[:40],
+            "multiSelect": bool(q.get("multiSelect")),
+            "allow_free_text": bool(q.get("allow_free_text")),
+            "options": options,
+        })
+    return out
+
+
 def _build_device_summary(spending, daily_usage, efficiency=None):
     """Compact, all-runtime payload for a WiFi hardware companion.
 
@@ -22572,8 +22698,16 @@ def _build_device_summary(spending, daily_usage, efficiency=None):
         pass
     try:
         from clawmetry import waste_flags as _wf
+        now_ms = int(time.time() * 1000)
+        # Only requests something is still waiting on. A hook-parked row
+        # carries its window's end in args.deadline_ms; once that has passed
+        # the runtime has already fallen back to its own terminal prompt, so
+        # Approve/Deny (or an answer) could no longer reach it. Burned
+        # 2026-09-11: a question sat on the cloud strip for 2h38m after the
+        # gate hook lost its receiver and the terminal had taken over.
         ap = [r for r in (store.query_approvals(status="pending", limit=200) or [])
-              if isinstance(r, dict)]
+              if isinstance(r, dict)
+              and not (0 < _approval_deadline_ms(r) <= now_ms)]
         if ap:
             oldest = min(ap, key=lambda r: (r.get("created_at") or ""))
             sid = oldest.get("requestor_session_id") or ""
@@ -22586,6 +22720,17 @@ def _build_device_summary(spending, daily_usage, efficiency=None):
                 # field and got 0 every time because we never sent it (#contract).
                 "waiting_seconds": _seconds_since(oldest.get("created_at")),
             }
+            deadline_ms = _approval_deadline_ms(oldest)
+            if deadline_ms:
+                summary["approval"]["deadline_ms"] = deadline_ms
+            questions = _device_question_set(oldest)
+            if questions:
+                # The runtime asked a question (Claude Code AskUserQuestion),
+                # not for permission: surfaces render its options, and the
+                # pick comes back as an `answer` decision. Rides the E2E
+                # snapshot, so the cloud never reads the question.
+                summary["approval"]["kind"] = "question_set"
+                summary["approval"]["questions"] = questions
     except Exception:
         pass
     # Surface a "something is stuck" alert from the daemon's loop-detection

--- a/tests/test_question_set_relay.py
+++ b/tests/test_question_set_relay.py
@@ -1,0 +1,212 @@
+"""A question the agent asks can be answered from anywhere, not just approved.
+
+Claude Code's AskUserQuestion is parked by the gate hook as a question-set
+approval (clawmetry/question_sets.py). Until now only the local Approvals tab
+knew that: the snapshot's ``deviceSummary.approval`` carried no questions, so
+the cloud strip and the desk device offered Approve/Deny, which cannot answer
+a question at all. Burned 2026-09-11: "Was that intentional?" with three
+options showed up on the cloud strip as Approve / Deny, 2h38m after the
+terminal had already taken it over.
+
+Covers:
+  * the snapshot carries the question set and the window's end;
+  * a request past its window is not offered (its waiter is gone);
+  * ``expire_stale_approvals`` retires such rows, and only those;
+  * a cloud-relayed ``answer`` (sealed with the node key) lands as an
+    ``answered`` row the waiting hook turns into updatedInput; a wrong
+    label or an unreadable seal leaves the row pending (the terminal takes
+    over at the deadline, never a fabricated answer).
+"""
+
+from __future__ import annotations
+
+import base64
+import importlib
+import json
+import os
+import time
+
+import pytest
+
+QUESTION = "PR #5869 was closed by your account. Was that intentional?"
+QUESTIONS = [{
+    "question": QUESTION,
+    "header": "PR #5869",
+    "multiSelect": False,
+    "options": [
+        {"label": "Reopen and ship it", "description": "Not intentional."},
+        {"label": "Intentional: don't release", "description": "Leave it closed."},
+        {"label": "Split it up", "description": "Separate PRs."},
+    ],
+}]
+
+
+@pytest.fixture
+def sync_with_store(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "5")
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    ls.mark_writer_owner()
+
+    import clawmetry.sync as sync
+    importlib.reload(sync)
+    yield sync, ls
+    try:
+        ls.get_store().stop(flush=True)
+    except Exception:
+        pass
+
+
+def _park(store, approval_id, *, deadline_ms, questions=QUESTIONS,
+          created_at="2026-09-11T18:12:35Z"):
+    args = {"tool_name": "AskUserQuestion", "deadline_ms": deadline_ms,
+            "on_timeout": "ask", "tool_input": {"questions": questions}}
+    if questions:
+        args["_cm_questions"] = questions
+    store.ingest_approval({
+        "id": approval_id, "requestor_session_id": "claude_code:s1",
+        "action": "AskUserQuestion: 1 question — PR #5869",
+        "args": args, "status": "pending", "created_at": created_at,
+    })
+
+
+def _row(store, approval_id):
+    return next(r for r in store.query_approvals(limit=50)
+                if r.get("id") == approval_id)
+
+
+def _now_ms():
+    return int(time.time() * 1000)
+
+
+# ── snapshot ────────────────────────────────────────────────────────────────
+
+def test_snapshot_carries_the_questions_and_the_window(sync_with_store):
+    sync, ls = sync_with_store
+    store = ls.get_store()
+    deadline = _now_ms() + 150_000
+    _park(store, "q1", deadline_ms=deadline)
+    ap = sync._build_device_summary({}, {})["approval"]
+    assert ap["id"] == "q1"
+    assert ap["kind"] == "question_set"
+    assert ap["deadline_ms"] == deadline
+    (q,) = ap["questions"]
+    assert q["question"] == QUESTION and q["header"] == "PR #5869"
+    assert [o["label"] for o in q["options"]] == [
+        "Reopen and ship it", "Intentional: don't release", "Split it up"]
+    assert q["multiSelect"] is False
+
+
+def test_a_yes_no_approval_carries_no_questions(sync_with_store):
+    sync, ls = sync_with_store
+    store = ls.get_store()
+    _park(store, "b1", deadline_ms=_now_ms() + 60_000, questions=None)
+    ap = sync._build_device_summary({}, {})["approval"]
+    assert ap["id"] == "b1"
+    assert "questions" not in ap and "kind" not in ap
+
+
+def test_a_request_past_its_window_is_not_offered(sync_with_store):
+    sync, ls = sync_with_store
+    store = ls.get_store()
+    _park(store, "dead", deadline_ms=_now_ms() - 1000,
+          created_at="2026-09-11T18:00:00Z")
+    assert sync._build_device_summary({}, {})["approval"] is None
+    # A live one behind it is still offered.
+    _park(store, "live", deadline_ms=_now_ms() + 60_000,
+          created_at="2026-09-11T18:05:00Z")
+    assert sync._build_device_summary({}, {})["approval"]["id"] == "live"
+
+
+# ── sweep ───────────────────────────────────────────────────────────────────
+
+def test_sweep_expires_only_rows_whose_waiter_is_gone(sync_with_store):
+    _sync, ls = sync_with_store
+    store = ls.get_store()
+    _park(store, "gone", deadline_ms=_now_ms() - 10 * 60_000)
+    _park(store, "in_grace", deadline_ms=_now_ms() - 10_000)
+    _park(store, "open", deadline_ms=_now_ms() + 60_000)
+    store.ingest_approval({"id": "no_deadline", "action": "exec",
+                           "args": {"command": "ls"}, "status": "pending"})
+    assert store.expire_stale_approvals(grace_seconds=120) == 1
+    assert _row(store, "gone")["status"] == "expired"
+    assert _row(store, "gone")["resolver"] == "sweep"
+    for aid in ("in_grace", "open", "no_deadline"):
+        assert _row(store, aid)["status"] == "pending", aid
+
+
+# ── relayed answers ─────────────────────────────────────────────────────────
+
+def _key():
+    return base64.urlsafe_b64encode(os.urandom(32)).decode()
+
+
+def _relay(sync, monkeypatch, key, answers=None, sealed=None):
+    monkeypatch.setattr(sync, "load_config", lambda: {"encryption_key": key})
+    if sealed is None:
+        sealed = sync.encrypt_payload({"answers": answers}, key)
+    sync._apply_approval_decision({
+        "type": "approval_decision", "id": "q1", "decision": "answer",
+        "sealed_answers": sealed, "resolver": "dashboard:abcd1234",
+    })
+
+
+def test_a_sealed_answer_lands_as_answered(sync_with_store, monkeypatch):
+    sync, ls = sync_with_store
+    store = ls.get_store()
+    _park(store, "q1", deadline_ms=_now_ms() + 60_000)
+    _relay(sync, monkeypatch, _key(), {QUESTION: "Reopen and ship it"})
+    row = _row(store, "q1")
+    assert row["status"] == "answered"
+    assert row["resolver"] == "dashboard:abcd1234"
+    assert row["args"]["_cm_answers"] == {QUESTION: "Reopen and ship it"}
+    # The hook's reply is built from exactly this row.
+    from clawmetry import question_sets as qsets
+    assert qsets.validate_answers(row["args"]["_cm_questions"],
+                                  row["args"]["_cm_answers"]) is None
+
+
+def test_a_label_that_is_not_an_option_is_rejected(sync_with_store, monkeypatch):
+    sync, ls = sync_with_store
+    store = ls.get_store()
+    _park(store, "q1", deadline_ms=_now_ms() + 60_000)
+    _relay(sync, monkeypatch, _key(), {QUESTION: "Delete the repo"})
+    assert _row(store, "q1")["status"] == "pending"
+
+
+def test_an_answer_sealed_with_another_key_is_ignored(sync_with_store, monkeypatch):
+    sync, ls = sync_with_store
+    store = ls.get_store()
+    _park(store, "q1", deadline_ms=_now_ms() + 60_000)
+    wrong = sync.encrypt_payload({"answers": {QUESTION: "Split it up"}}, _key())
+    _relay(sync, monkeypatch, _key(), sealed=wrong)
+    row = _row(store, "q1")
+    assert row["status"] == "pending"
+    assert "_cm_answers" not in row["args"]
+
+
+def test_browser_style_unpadded_seal_is_readable(sync_with_store, monkeypatch):
+    """The cloud strip seals with WebCrypto and strips base64 padding."""
+    sync, ls = sync_with_store
+    store = ls.get_store()
+    _park(store, "q1", deadline_ms=_now_ms() + 60_000)
+    key = _key()
+    from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+    iv = os.urandom(12)
+    ct = AESGCM(base64.urlsafe_b64decode(key)).encrypt(
+        iv, json.dumps({"answers": {QUESTION: "Split it up"}}).encode(), None)
+    sealed = base64.urlsafe_b64encode(iv + ct).decode().rstrip("=")
+    _relay(sync, monkeypatch, key, sealed=sealed)
+    assert _row(store, "q1")["status"] == "answered"
+
+
+def test_an_answer_after_the_window_changes_nothing(sync_with_store, monkeypatch):
+    sync, ls = sync_with_store
+    store = ls.get_store()
+    _park(store, "q1", deadline_ms=_now_ms() - 10 * 60_000)
+    store.expire_stale_approvals(grace_seconds=120)
+    _relay(sync, monkeypatch, _key(), {QUESTION: "Reopen and ship it"})
+    assert _row(store, "q1")["status"] == "expired"


### PR DESCRIPTION
Product record: https://factory.8090.ai/project/b415065f-ab2f-4f53-8864-0c009fd098cb/requirements/a8fd0512-9bee-4209-9cee-80b732d0f130 (Approval Decisions Beyond Yes/No: surfaces render the full question set rather than an approve/deny pair; an expired question follows the runtime fallback rule).

## Why
Claude Code's `AskUserQuestion` is already parked as a question-set approval (WO-52 phase 1), and the local Approvals tab renders it with its options. But the snapshot's `deviceSummary.approval` carried no questions, so the cloud strip and the desk device showed **Approve / Deny**, and neither answers a question.

Separately, a request whose gate hook died is offered forever. On 2026-09-11, *"PR #5869 was closed by your account. Was that intentional?"* (3 options) sat on the cloud strip for **2h38m**. Its `deadline_ms` had passed three minutes after it was created, and the terminal had already taken the question over. The gate client fails open when its receiver drops, and nothing ever closes the row it leaves behind.

## What
- **`deviceSummary.approval`** gains:
  - `kind: "question_set"`
  - `questions` (question, header, multiSelect, options with label and description; trimmed)
  - `deadline_ms`

  It rides the E2E snapshot, so the cloud never reads the question.
- **Dead requests are not offered.** Rows past `args.deadline_ms` are skipped. `local_store.expire_stale_approvals()` flips rows more than 120s past their deadline to `expired`, which a question hook reads as "ask the terminal", never as a refusal. It runs next to `expire_stale_hook_attention`.
- **The `approval_decision` relay accepts `decision: "answer"` with `sealed_answers`.** The browser seals `{answers}` with this node's E2E key. The daemon unseals it with `decrypt_payload` and validates it against the stored set via `question_sets.apply_answer_decision`, the same path the local decision walls use, and the waiting hook resumes the session with `updatedInput`. If anything is wrong (no key, a foreign seal, an unknown label, the row already decided) the row is left pending, so the terminal takes over at the deadline. It never fabricates an answer.

Paired cloud PR: vivekchand/clawmetry-cloud#2401 (the strip renders the options; `/api/cloud/device/approve` relays `answer`, and also relays approve/deny for hook-parked rows that used to 404).

## Tests
`tests/test_question_set_relay.py` (9):
- the snapshot carries the questions and the window
- a yes/no approval carries no questions
- a request past its window is not offered, while a live one behind it is
- the sweep expires only rows whose waiter is gone
- a sealed answer lands as `answered`, and the hook can validate it
- an unknown label is rejected
- a foreign key is ignored
- a browser-style unpadded seal is readable
- an answer after the window changes nothing

Together with `test_device_summary_snapshot.py` and `test_hooks_claude_code.py`, everything passes. `tests/test_hooks.py` (15 errors) and `test_approvals_duckdb_watcher.py::test_late_ingested_event_with_stale_ts_still_evaluated` fail identically on a clean `origin/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E6hs9PdXYMNtaB6tDi9dFb