### PR TITLE
Cost optimizer: tell a hole from a zero (cloud #2322 renderer half)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -556,6 +556,13 @@ jobs:
       - name: Pseudolocale gate can go red
         run: python3 -m pytest tests/test_pseudolocale_gate_can_fail.py -q
 
+      # provenance.js exists because "a zero and a hole are identical once
+      # they are formatted". The Cost tiles route through it; the cost
+      # optimizer modal did not, and printed $0.000 on a hosted node whose
+      # own snapshot carried spending.today = 272.36 (cloud #2322).
+      - name: Cost optimizer tells a hole from a zero
+        run: python3 -m pytest tests/test_cost_optimizer_zero_is_not_unknown.py -q
+
       # A Pro node stopped syncing for 12 hours (2026-09-08) because sync.pid
       # named a pid the OS had recycled onto an unrelated process: every
       # launchd respawn read "alive" and exited, and `clawmetry status` still

--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -26604,13 +26604,27 @@ function loadCostOptimizerData(isRefresh) {
     var html = '';
 
     // ══ SECTION 1: Cost Overview ══════════════════════════════════
-    var todayCost = data.todayCost || 0;
-    var monthCost = data.projectedMonthlyCost || 0;
+    // `data.todayCost || 0` then `.toFixed(3)` printed "$0.000" for a figure
+    // nobody had read, which is the exact confusion provenance.js exists to
+    // stop: "a zero and a hole are identical once they are formatted".
+    // Measured live on the hosted dashboard 2026-09-11, the optimizer showed
+    // $0.000 while the same snapshot carried spending.today = 272.36.
+    // cmMoney paints a real measured zero as "$0.00" and an absent figure as
+    // a dimmed "not available" pill, and carries the basis/formula/window in
+    // the tooltip. Same call the Cost tiles already use.
+    var _cm = window.cmMoney;
+    function _costCell(key, label, dp) {
+      if (_cm) return _cm(data, key, { label: label });
+      // Older bundle with no provenance module: keep the previous shape
+      // rather than inventing a second unknown convention here.
+      var v = data[key];
+      return v == null ? 'not available' : '$' + Number(v).toFixed(dp);
+    }
     html += '<div class="cost-overview">';
     html += '<div class="cost-overview-header">💰 Cost Overview</div>';
     html += '<div class="cost-overview-row">';
-    html += '<div class="cost-overview-item"><span class="cost-overview-label">Today</span><span class="cost-overview-value">$' + todayCost.toFixed(3) + '</span></div>';
-    html += '<div class="cost-overview-item"><span class="cost-overview-label">Month Projected</span><span class="cost-overview-value">$' + monthCost.toFixed(2) + '</span></div>';
+    html += '<div class="cost-overview-item"><span class="cost-overview-label">Today</span><span class="cost-overview-value">' + _costCell('todayCost', 'Cost today', 3) + '</span></div>';
+    html += '<div class="cost-overview-item"><span class="cost-overview-label">Month Projected</span><span class="cost-overview-value">' + _costCell('projectedMonthlyCost', 'Projected month', 2) + '</span></div>';
     html += '</div>';
     if (data.potentialSavings) {
       html += '<div class="savings-highlight">[prod] ' + data.potentialSavings + '</div>';

--- a/docs/ci_test_coverage_baseline.json
+++ b/docs/ci_test_coverage_baseline.json
@@ -7,7 +7,7 @@
     "Ratchet down by running --update-baseline after wiring new tests in.",
     "Related: issue #5813"
   ],
-  "total": 1147,
-  "listed": 219,
+  "total": 1149,
+  "listed": 221,
   "unlisted_max": 928
 }

--- a/tests/test_cost_optimizer_zero_is_not_unknown.py
+++ b/tests/test_cost_optimizer_zero_is_not_unknown.py
@@ -1,0 +1,103 @@
+"""The cost optimizer must not print a hole as "$0.000".
+
+`provenance.js` exists for exactly this failure, and says so in its own header:
+
+    A failed read once shipped as "$0.00" and was read, correctly, as a real
+    result: a zero and a hole are identical once they are formatted. Here they
+    never share a shape.
+
+The Cost tiles use it (`window.cmProv.money`). `loadCostOptimizerData` did not:
+
+    var todayCost = data.todayCost || 0;
+    ... '$' + todayCost.toFixed(3)
+
+`|| 0` turns null, undefined and a missing key into a confident `$0.000`.
+
+Measured on the hosted dashboard 2026-09-11, `/api/cost-optimizer` returned
+`todayCost: 0` and `projectedMonthlyCost: 0` while the same snapshot carried
+`spending.today = 272.361546` with a full provenance block (basis "derived",
+formula, source, window). The modal rendered `$0.000` over a real $272 day.
+The cloud half of that is clawmetry-cloud#2322; this is the renderer half, so
+that an absent figure can never again be painted as free usage.
+
+Static checks over the shipped bundle. The behavioural claim, that `cmMoney`
+renders an absent figure and a measured zero differently, is a property of
+`provenance.js` and is exercised there.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+APP_JS = (REPO / "clawmetry" / "static" / "js" / "app.js").read_text(encoding="utf-8")
+PROV_JS = (
+    REPO / "clawmetry" / "static" / "js" / "provenance.js"
+).read_text(encoding="utf-8")
+
+
+def _optimizer_body() -> str:
+    """`loadCostOptimizerData`, `//` comments stripped.
+
+    The comments quote the old expression to explain why it was wrong, so
+    matching raw text would assert against the explanation rather than the
+    code.
+    """
+    i = APP_JS.index("function loadCostOptimizerData(")
+    j = APP_JS.index("\nfunction ", i + 10)
+    return "\n".join(
+        ln for ln in APP_JS[i:j].splitlines() if not ln.lstrip().startswith("//")
+    )
+
+
+def test_the_provenance_module_is_still_the_one_place():
+    """If this ever stops existing, the guards below are meaningless."""
+    assert "window.cmMoney" in PROV_JS
+    assert "cmProv" in PROV_JS
+
+
+def test_cost_overview_does_not_coalesce_a_missing_figure_to_zero():
+    body = _optimizer_body()
+    assert "data.todayCost || 0" not in body, (
+        "`|| 0` is back: a missing or null cost renders as a confident $0.000"
+    )
+    assert "data.projectedMonthlyCost || 0" not in body, (
+        "`|| 0` is back on the projection"
+    )
+
+
+def test_cost_overview_renders_through_the_provenance_formatter():
+    body = _optimizer_body()
+    assert "cmMoney" in body, (
+        "the cost overview does not use cmMoney, so an absent figure and a "
+        "real $0.00 render identically again"
+    )
+    for key in ("todayCost", "projectedMonthlyCost"):
+        assert re.search(rf"_costCell\(\s*'{key}'", body), (
+            f"{key} is not rendered through the provenance-aware cell"
+        )
+
+
+def test_no_raw_tofixed_on_a_cost_in_the_overview():
+    """`.toFixed` on a possibly-absent cost is the shape of the bug, whatever
+    the coalesce looks like."""
+    body = _optimizer_body()
+    # Anchor on code, not on the section comment: the comments are stripped.
+    i = body.index("cost-overview-header")
+    overview = body[i:body.index("expensiveOps", i)]
+    assert "todayCost.toFixed" not in overview
+    assert "monthCost.toFixed" not in overview
+
+
+def test_the_fallback_path_does_not_invent_a_second_unknown_convention():
+    """A bundle without provenance.js must still not print $0.000 for a hole.
+    It says 'not available', matching the module's own wording, rather than
+    inventing a third way to say the same thing."""
+    body = _optimizer_body()
+    i = body.index("_costCell")
+    cell = body[i:i + 700]
+    assert "not available" in cell, (
+        "the no-provenance fallback has no unknown branch, so older bundles "
+        "keep printing a fabricated zero"
+    )


### PR DESCRIPTION
The renderer half of clawmetry-cloud#2322.

## The bug, measured live

On the hosted dashboard, `/api/cost-optimizer` returned:

```json
{"todayCost": 0, "projectedMonthlyCost": 0, "_source": "snapshot.machineInfo"}
```

rendered as **$0.000**. The **same snapshot**, loaded by the **same interceptor**, carried:

```json
"spending": {
  "today": 272.361546,
  "month": 2857.006895,
  "provenance": {"today": {"basis": "derived",
    "formula": "the runtime's own cost when it reported one, otherwise measured token counts priced against the provider's published rate card",
    "source": "DuckDB rollups on this node, this tick",
    "window": "today, the local calendar day"}}
}
```

A real $272 day shown as free.

## Why this is a renderer bug too

`provenance.js` was written for exactly this, and says so in its own header:

> A failed read once shipped as "$0.00" and was read, correctly, as a real result: a zero and a hole are identical once they are formatted. Here they never share a shape.

The Cost tiles route through it. `loadCostOptimizerData` did not:

```js
var todayCost = data.todayCost || 0;
... '$' + todayCost.toFixed(3)
```

`|| 0` collapses null, undefined and a missing key into a confident `$0.000`. So even after cloud starts sending a real figure (clawmetry-cloud#2322), an absent one would still render as free usage. That is the half this PR closes.

## What changed

Both figures render through `cmMoney`, the same call the Cost tiles use. Driving the **shipped** `provenance.js`, the three cases stop sharing a shape:

| input | renders |
|---|---|
| absent | `not available` · *no basis* |
| real measured zero | `$0.00` · *measured* |
| real derived spend | `$272.36` · *derived* |

The no-provenance fallback (an older bundle) says `not available` rather than inventing a third way to phrase the same thing.

## Verification

`tests/test_cost_optimizer_zero_is_not_unknown.py`: 5 guards, **4 proven red against `origin/main`** and green here. The fifth asserts `provenance.js` still exists and passes on both by design, since the other four are meaningless without it.

Wired into the `ci.yml` lint job by name. Coverage ratchet tightened to 928.

The cloud half, which hardcodes the zero and will send the measured figure with its provenance, is filed as clawmetry-cloud#2322 and goes up separately.

No-PRD: renders an absent figure honestly instead of as $0.000; no new surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xb6A5G74JiMe3zHFs1JZEP
