### PR TITLE
Show how long a question has really been waiting (UTC timestamps)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -879,6 +879,14 @@ jobs:
           CI: "true"
         run: python3 -m pytest tests/test_question_set_relay.py -q
 
+      # A hook-parked request is stamped ...Z (UTC); _seconds_since must not
+      # read it as local wall-clock (2026-09-11: a 4-minute-old question
+      # showed "waiting 2h 2m" on a CEST machine).
+      - name: Approval waiting time honours UTC
+        env:
+          CI: "true"
+        run: python3 -m pytest tests/test_seconds_since_utc.py -q
+
       # Mutation testing: does the suite actually catch bugs, or has it been
       # weakened into a tautology? Line coverage cannot tell the difference.
       # The score ratchets -- it may rise freely, and a drop fails the build.

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -20186,19 +20186,29 @@ def _build_cron_jobs(paths):
 
 
 def _seconds_since(ts) -> int:
-    """Seconds elapsed since an ISO-ish timestamp string (the store writes naive
-    local wall-clock), clamped to >= 0; returns 0 on any parse failure. Used so
-    the device's approval ``waiting_seconds`` is a real value, not always 0."""
+    """Seconds elapsed since an ISO-ish timestamp string, clamped to >= 0;
+    returns 0 on any parse failure. Used so the device's approval
+    ``waiting_seconds`` is a real value, not always 0.
+
+    A naive string is local wall-clock (most store rows); a ``Z`` or
+    ``+HH:MM`` suffix is honoured. Burned 2026-09-11: hook-parked approvals
+    are stamped ``...Z`` (UTC) and the ``Z`` was stripped, so on a CEST
+    machine every question read "waiting 2h 2m" the moment it was asked."""
     if not ts:
         return 0
     try:
-        from datetime import datetime
-        s = str(ts).strip().replace("Z", "")
+        from datetime import datetime, timezone
+        s = str(ts).strip()
+        utc = s.endswith("Z")
+        if utc:
+            s = s[:-1] + "+00:00"
         try:
             dt = datetime.fromisoformat(s)
         except ValueError:
             dt = datetime.fromisoformat(s.split(".")[0].split("+")[0])
-        ref = datetime.now(dt.tzinfo) if dt.tzinfo else datetime.now()
+            if utc:
+                dt = dt.replace(tzinfo=timezone.utc)
+        ref = datetime.now(timezone.utc) if dt.tzinfo else datetime.now()
         return max(0, int((ref - dt).total_seconds()))
     except Exception:
         return 0

--- a/tests/test_seconds_since_utc.py
+++ b/tests/test_seconds_since_utc.py
@@ -1,0 +1,65 @@
+"""``sync._seconds_since`` must honour a UTC ``Z`` suffix.
+
+Burned 2026-09-11: hook-parked AskUserQuestion approvals are stamped
+``created_at=...Z`` (UTC). ``_seconds_since`` stripped the ``Z`` and compared
+the result against local wall-clock, so on a CEST machine the cloud strip said
+"waiting 2h 2m" for a question asked four minutes earlier. Naive strings are
+still local wall-clock, which is what most store rows carry.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from clawmetry.sync import _seconds_since
+
+pytestmark = pytest.mark.skipif(not hasattr(time, "tzset"),
+                                reason="needs time.tzset (POSIX)")
+
+
+@pytest.fixture(autouse=True)
+def _cest():
+    old = os.environ.get("TZ")
+    os.environ["TZ"] = "Europe/Amsterdam"
+    time.tzset()
+    yield
+    if old is None:
+        os.environ.pop("TZ", None)
+    else:
+        os.environ["TZ"] = old
+    time.tzset()
+
+
+def _utc_ago(secs):
+    return datetime.now(timezone.utc) - timedelta(seconds=secs)
+
+
+def test_z_suffix_is_utc_not_local():
+    ts = _utc_ago(240).strftime("%Y-%m-%dT%H:%M:%SZ")
+    assert 235 <= _seconds_since(ts) <= 250
+
+
+def test_offset_with_microseconds():
+    ts = _utc_ago(30).isoformat()
+    assert 25 <= _seconds_since(ts) <= 40
+
+
+def test_short_fraction_with_z_falls_back_but_stays_utc():
+    # Python 3.9's fromisoformat rejects a 3-digit fraction; the fallback must
+    # still treat the value as UTC.
+    ts = _utc_ago(60).strftime("%Y-%m-%dT%H:%M:%S") + ".123Z"
+    assert 55 <= _seconds_since(ts) <= 70
+
+
+def test_naive_is_local_wall_clock():
+    ts = (datetime.now() - timedelta(seconds=90)).strftime("%Y-%m-%dT%H:%M:%S")
+    assert 85 <= _seconds_since(ts) <= 100
+
+
+@pytest.mark.parametrize("bad", [None, "", "not a time", 42])
+def test_garbage_is_zero(bad):
+    assert _seconds_since(bad) == 0


### PR DESCRIPTION
Founder P0 (2026-09-11): the cloud "waiting on you" strip said **"waiting 2h 2m"** for an AskUserQuestion that was about 4 minutes old. So it looked like one question kept popping back for hours.

**Cause:** `sync._seconds_since` stripped the `Z` from `created_at` and compared the result against local wall-clock. Hook-parked approvals are stamped in UTC (`routes/hooks.py::_utcnow` → `...Z`), so on a CEST machine every wait read 2h too long. The same number feeds `deviceSummary.approval.waiting_seconds` (strip + desk device).

**Fix:** a `Z` / `+HH:MM` suffix is honoured. A naive string is still local wall-clock, which is what most store rows carry. The fallback parser (3-digit fractions on py3.9) keeps UTC too.

**Test:** `tests/test_seconds_since_utc.py` pins TZ=Europe/Amsterdam. 8/8 pass, and 2 fail on `origin/main`. It's wired into `ci.yml` next to the question-set relay step.

Companion cloud PR vivekchand/clawmetry-cloud#2409 fixes the strip itself. Its one-slot dismiss memory let the "stuck" notice and the question take turns popping back. Alert keys held live counts. A closed-window card stayed up until the next snapshot.

No-PRD: bug fix to an existing waiting-time field; no product behaviour change beyond correct numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qpn5Qvn6hWr36EkyEJ42WG