### PR TITLE
Heartbeat every 2s while a person's decision can still reach the agent

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -886,6 +886,15 @@ jobs:
           CI: "true"
         run: python3 -m pytest tests/test_question_set_relay.py -q
 
+      # A decision made on a cloud surface is drained by a heartbeat, and the
+      # main loop's heartbeat lands at the END of a cycle: on 2026-09-11 a
+      # 90-second ingest pass swallowed a whole 3-minute answer window and the
+      # person's answer reached nobody. These pin the fast path.
+      - name: Answer-window heartbeat
+        env:
+          CI: "true"
+        run: python3 -m pytest tests/test_answer_window_heartbeat.py -q
+
       # A hook-parked request is stamped ...Z (UTC); _seconds_since must not
       # read it as local wall-clock (2026-09-11: a 4-minute-old question
       # showed "waiting 2h 2m" on a CEST machine).

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -15823,6 +15823,18 @@ def _ingest_keepalive_heartbeat(config: dict) -> bool:
 _ANSWER_WINDOW_POLL_SEC = 2.0
 
 
+def _approval_deadline_ms(row: dict) -> int:
+    """End of a hook-parked approval's window (``args.deadline_ms``), or 0.
+
+    Also read by ``_build_device_summary`` further down: a request past its
+    window is not offered on any surface."""
+    args = row.get("args") if isinstance(row.get("args"), dict) else {}
+    try:
+        return max(0, int(args.get("deadline_ms") or 0))
+    except (TypeError, ValueError):
+        return 0
+
+
 def _answer_window_open(now_ms: "int | None" = None) -> bool:
     """True while a parked approval is still inside its answer window.
 
@@ -22672,15 +22684,6 @@ def _build_loops_slice(store):
         if len(out) >= _LOOPS_SLICE_MAX:
             break
     return out
-
-
-def _approval_deadline_ms(row: dict) -> int:
-    """End of a hook-parked approval's window (``args.deadline_ms``), or 0."""
-    args = row.get("args") if isinstance(row.get("args"), dict) else {}
-    try:
-        return max(0, int(args.get("deadline_ms") or 0))
-    except (TypeError, ValueError):
-        return 0
 
 
 def _device_question_set(row: dict) -> list:

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -15803,6 +15803,87 @@ def _ingest_keepalive_heartbeat(config: dict) -> bool:
         return True
 
 
+# ── Answer-window heartbeat ────────────────────────────────────────────────
+# A parked approval is a person's decision an agent is blocked on, and the
+# runtime waits only a few minutes before its own terminal prompt takes over.
+# The decision travels on the cloud relay, which is drained BY A HEARTBEAT —
+# and the main loop's heartbeat lands at the END of a cycle, so one heavy
+# ingest pass can swallow the whole window.
+#
+# Burned 2026-09-11: an answer clicked on the cloud strip 22 s before the
+# deadline was drained 5 s AFTER it. The daemon had spent 90 s syncing 7,388
+# events between two heartbeats, the question went to the terminal, and the
+# person's answer reached nobody. Every surface was correct; the delivery was
+# simply late.
+#
+# While a window is open this thread heartbeats every couple of seconds, so an
+# answer (or an Approve/Deny) reaches the waiting hook in seconds. It costs one
+# indexed read of the pending queue when nobody is waiting, and nothing at all
+# on a node with no cloud account.
+_ANSWER_WINDOW_POLL_SEC = 2.0
+
+
+def _answer_window_open(now_ms: "int | None" = None) -> bool:
+    """True while a parked approval is still inside its answer window.
+
+    Reads the pending queue's ``args.deadline_ms``, stamped by the gate-hook
+    receiver when it parks a call. A request without one carries no runtime
+    clock and never holds this fast path open. Never raises."""
+    try:
+        from clawmetry import local_store
+        rows = local_store.get_store().query_approvals(
+            status="pending", limit=50) or []
+    except Exception:
+        return False
+    now_ms = int(time.time() * 1000) if now_ms is None else int(now_ms)
+    for r in rows:
+        if not isinstance(r, dict):
+            continue
+        deadline_ms = _approval_deadline_ms(r)
+        if deadline_ms and deadline_ms > now_ms:
+            return True
+    return False
+
+
+def _answer_window_tick(config: dict) -> bool:
+    """One pass: heartbeat when (and only when) somebody is still waiting.
+    Returns True when a heartbeat was sent. Never raises."""
+    if not (config or {}).get("api_key"):
+        return False
+    try:
+        from clawmetry.config import is_cloud_disabled
+        if is_cloud_disabled():
+            return False
+    except Exception:
+        pass
+    if not _answer_window_open():
+        return False
+    try:
+        send_heartbeat(config)
+        return True
+    except Exception as e:  # noqa: BLE001
+        log.debug("answer-window heartbeat failed (non-fatal): %s", e)
+        return False
+
+
+def _start_answer_window_heartbeat(config: dict, stop_event=None) -> None:
+    """Start the background thread that keeps the relay drained while a
+    person's decision is still reachable. Never raises."""
+    def _run():
+        while not (stop_event is not None and stop_event.is_set()):
+            try:
+                _answer_window_tick(config)
+            except Exception as e:  # noqa: BLE001
+                log.debug("answer-window heartbeat tick failed: %s", e)
+            if stop_event is not None:
+                stop_event.wait(timeout=_ANSWER_WINDOW_POLL_SEC)
+            else:
+                time.sleep(_ANSWER_WINDOW_POLL_SEC)
+
+    threading.Thread(target=_run, daemon=True,
+                     name="answer-window-heartbeat").start()
+
+
 # Session.extra keys a family adapter may stamp on a CHILD session (subagent /
 # workflow run / workflow agent) that ride into the ``subagents`` row's data
 # blob verbatim. Everything the orchestration surfaces read lives here; the
@@ -25019,6 +25100,17 @@ def run_daemon() -> None:
                  f"(policies: {_approvals.POLICIES_PATH})")
     except Exception as _e:
         log.warning(f"approvals watcher failed to start: {_e}")
+
+    # ── Answer-window heartbeat ──────────────────────────────────────────
+    # While a parked approval is still reachable, drain the relay every few
+    # seconds so a decision made on a cloud surface arrives before the
+    # runtime's own prompt takes over (see _answer_window_open).
+    try:
+        _start_answer_window_heartbeat(config)
+        log.info("answer-window heartbeat thread started "
+                 f"({_ANSWER_WINDOW_POLL_SEC}s while someone is waiting)")
+    except Exception as _e:
+        log.warning(f"answer-window heartbeat failed to start: {_e}")
 
     # ── Inbound approval decisions ────────────────────────────────────
     # Deliberately NOT started here. Bringing a decision back from a chat

--- a/tests/test_answer_window_heartbeat.py
+++ b/tests/test_answer_window_heartbeat.py
@@ -1,0 +1,187 @@
+"""A person's answer reaches the agent while it can still be used.
+
+A parked approval (Claude Code's PreToolUse gate holding a tool call or an
+AskUserQuestion) gives the human a few minutes; after that the runtime's own
+terminal prompt takes over. A decision made on a cloud surface travels on the
+relay queue, which the daemon drains only when it heartbeats — and the main
+loop heartbeats at the END of a cycle.
+
+Burned 2026-09-11 (verified live): an answer clicked on the cloud strip at
+20:46:37 UTC, 22 s before the 20:47:00 deadline, was still queued when the
+window closed. The node's heartbeats that minute were 20:45:35 then 20:47:05:
+a 90-second gap spent syncing 7,388 events. The question went to the terminal
+and the answer reached nobody.
+
+These pin the fast path that closes that gap: while a window is open the
+daemon heartbeats every couple of seconds, and when nobody is waiting it does
+not heartbeat at all (an idle node must stay idle).
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+import time
+
+import pytest
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+
+@pytest.fixture
+def sync_mod(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "1")
+
+    sys.modules.pop("clawmetry.local_store", None)
+    sys.modules.pop("clawmetry.sync", None)
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    ls.mark_writer_owner()
+    import clawmetry.sync as s
+    importlib.reload(s)
+
+    yield s
+
+    try:
+        ls.get_store().stop(flush=True)
+    except Exception:
+        pass
+
+
+@pytest.fixture
+def store():
+    from clawmetry import local_store
+    return local_store.get_store()
+
+
+@pytest.fixture
+def config():
+    return {"node_id": "node-test", "api_key": "cm_test"}
+
+
+@pytest.fixture
+def beats(monkeypatch, sync_mod):
+    sent = []
+    monkeypatch.setattr(sync_mod, "send_heartbeat",
+                        lambda cfg: sent.append(cfg) or True)
+    return sent
+
+
+def _ms(offset_s: float) -> int:
+    return int((time.time() + offset_s) * 1000)
+
+
+def _park(store, approval_id, *, deadline_ms, status="pending", questions=True):
+    args = {"tool_name": "AskUserQuestion", "on_timeout": "ask"}
+    if deadline_ms is not None:
+        args["deadline_ms"] = deadline_ms
+    if questions:
+        args["_cm_questions"] = [{
+            "question": "Ship it?", "header": "Release", "multiSelect": False,
+            "options": [{"label": "Ship", "description": ""},
+                        {"label": "Hold", "description": ""}],
+        }]
+    store.ingest_approval({
+        "id": approval_id, "requestor_session_id": "claude_code:s1",
+        "action": "AskUserQuestion: 1 question", "args": args, "status": status,
+        "created_at": "2026-09-11T20:43:59Z",
+    })
+
+
+# ── is anybody still waiting? ───────────────────────────────────────────────
+
+def test_open_while_the_window_has_time_left(sync_mod, store):
+    _park(store, "q1", deadline_ms=_ms(120))
+    assert sync_mod._answer_window_open() is True
+
+
+def test_closed_once_the_window_has_passed(sync_mod, store):
+    _park(store, "q1", deadline_ms=_ms(-1))
+    assert sync_mod._answer_window_open() is False
+
+
+def test_a_decided_request_holds_nothing_open(sync_mod, store):
+    _park(store, "q1", deadline_ms=_ms(120), status="answered")
+    assert sync_mod._answer_window_open() is False
+
+
+def test_a_request_without_a_window_holds_nothing_open(sync_mod, store):
+    """An ordinary approval carries no runtime clock: it must not pin the
+    daemon to a 2-second heartbeat for as long as it sits in the queue."""
+    _park(store, "b1", deadline_ms=None, questions=False)
+    assert sync_mod._answer_window_open() is False
+
+
+def test_an_empty_queue_is_closed(sync_mod):
+    assert sync_mod._answer_window_open() is False
+
+
+def test_a_binary_request_inside_its_window_also_counts(sync_mod, store):
+    """Approve/Deny is relayed the same way and is just as time-bound."""
+    _park(store, "b1", deadline_ms=_ms(60), questions=False)
+    assert sync_mod._answer_window_open() is True
+
+
+# ── the tick ────────────────────────────────────────────────────────────────
+
+def test_tick_heartbeats_while_someone_is_waiting(sync_mod, store, config, beats):
+    _park(store, "q1", deadline_ms=_ms(120))
+    assert sync_mod._answer_window_tick(config) is True
+    assert beats == [config]
+
+
+def test_tick_is_silent_when_nobody_is_waiting(sync_mod, store, config, beats):
+    _park(store, "q1", deadline_ms=_ms(-1))
+    assert sync_mod._answer_window_tick(config) is False
+    assert beats == []
+
+
+def test_tick_does_nothing_without_a_cloud_account(sync_mod, store, beats):
+    _park(store, "q1", deadline_ms=_ms(120))
+    assert sync_mod._answer_window_tick({"node_id": "n"}) is False
+    assert beats == []
+
+
+def test_tick_respects_local_only_mode(sync_mod, store, config, beats, monkeypatch):
+    _park(store, "q1", deadline_ms=_ms(120))
+    import clawmetry.config as cfg_mod
+    monkeypatch.setattr(cfg_mod, "is_cloud_disabled", lambda: True)
+    assert sync_mod._answer_window_tick(config) is False
+    assert beats == []
+
+
+def test_a_store_failure_never_raises(sync_mod, config, beats, monkeypatch):
+    from clawmetry import local_store
+
+    def boom(*a, **k):
+        raise RuntimeError("store is busy")
+
+    monkeypatch.setattr(local_store, "get_store", boom)
+    assert sync_mod._answer_window_open() is False
+    assert sync_mod._answer_window_tick(config) is False
+    assert beats == []
+
+
+# ── the thread ──────────────────────────────────────────────────────────────
+
+def test_thread_beats_repeatedly_then_stops(sync_mod, store, config, beats, monkeypatch):
+    import threading
+    monkeypatch.setattr(sync_mod, "_ANSWER_WINDOW_POLL_SEC", 0.01)
+    _park(store, "q1", deadline_ms=_ms(120))
+    stop = threading.Event()
+    sync_mod._start_answer_window_heartbeat(config, stop_event=stop)
+    deadline = time.time() + 3.0
+    while len(beats) < 2 and time.time() < deadline:
+        time.sleep(0.02)
+    stop.set()
+    assert len(beats) >= 2, "the relay must be drained repeatedly while waiting"
+    time.sleep(0.1)
+    seen = len(beats)
+    time.sleep(0.1)
+    assert len(beats) == seen, "the thread must stop when asked"


### PR DESCRIPTION
Product record: https://factory.8090.ai/project/b415065f-ab2f-4f53-8864-0c009fd098cb/requirements/bc980410-e77a-4307-9355-37de9681f74f (REQ-OBS-GHA-RA-005: a decision reaches the node that holds the request).

## Why (measured, not theorised)
The question-set work (#5873 + clawmetry-cloud #2401) shipped and I tested it live. The strip rendered Claude Code's question with its real options, and the click reached cloud. The agent never got the answer.

| time (UTC) | what |
|---|---|
| 20:43:59 | Claude Code asks; the gate parks it, window ends 20:47:00 |
| 20:45:35 | node heartbeat |
| 20:46:37 | **answer clicked on the strip**; cloud accepts it in 10 ms and queues it for the node |
| 20:47:00 | window closes, hook falls back to the terminal, row → `timeout` |
| 20:47:05 | **next node heartbeat** — 5 s too late |

The 90-second gap was one ingest pass ("Synced 7388 events"). The relay queue is drained ONLY by a heartbeat, and the main loop heartbeats at the END of a cycle; `_ingest_keepalive_heartbeat` is throttled to 20 s and only fires inside heavy per-item loops. The 2 s "approvals watcher" scans tool calls and policies — it does not heartbeat. So on a busy node the answer window is a lottery.

## What
- `_answer_window_open()` — is any pending approval still inside its window (`args.deadline_ms`, stamped by the gate-hook receiver when it parks a call)? A request without one carries no runtime clock and never holds the fast path open.
- `_answer_window_tick()` — heartbeat when, and only when, somebody is still waiting.
- `_start_answer_window_heartbeat()` — daemon thread started in `run_daemon` beside the approvals watcher; 2 s cadence while a window is open.

Idle cost: one indexed read of the pending queue every 2 s, and nothing at all on a node with no cloud account or in local-only mode.

## Tests
`tests/test_answer_window_heartbeat.py` (13): window open / passed / decided row / no deadline / empty queue / binary request also counts; the tick heartbeats only while someone waits, is silent without an account and in local-only mode, never raises when the store is busy; the thread beats repeatedly and stops when asked. Wired into the CI store-invariants job (the test-file coverage ratchet requires it).

Green with `tests/test_question_set_relay.py`, `test_adaptive_heartbeat.py`, `test_heartbeat_dispatch.py` (37 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E6hs9PdXYMNtaB6tDi9dFb