### PR TITLE
The hosted session page counted zero messages for every non-OpenClaw runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -820,6 +820,7 @@ jobs:
             tests/test_insights_outcome_templates.py \
             tests/test_event_shape.py \
             tests/test_injected_context.py \
+            tests/test_family_cloud_row_event_count.py \
             tests/test_schema_v15_migration.py \
             tests/test_session_cost_intel.py \
             tests/test_session_intent.py \

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -16353,6 +16353,18 @@ def sync_family_runtimes(config: dict, state: dict, paths: dict) -> int:
                     "total_tokens": int(s.total_tokens or 0),
                     "cost_usd": s.cost_usd,
                     "message_count": int(s.message_count or 0),
+                    # The hosted session page renders "Messages" from
+                    # sessions.event_count, which is the ONLY count the cloud
+                    # stores (its sessions table has no message_count column).
+                    # The OpenClaw row has always sent it; this one never did,
+                    # so every Codex / Cursor / Claude Code session read
+                    # "Messages 0" beside a full transcript (founder report
+                    # 2026-09-11: a Codex session showing 0 against 371
+                    # messages locally). len(_events) is the same raw-row count
+                    # the OpenClaw path sends, and the cloud upsert keeps the
+                    # GREATEST of old and new, so a read capped by
+                    # _family_event_read_cap() can never walk the number back.
+                    "event_count": len(_events),
                     "runtime": runtime,
                     "model": s.model or "",
                     # Cost-intelligence (foundation): carried to the cloud so the

--- a/tests/test_family_cloud_row_event_count.py
+++ b/tests/test_family_cloud_row_event_count.py
@@ -1,0 +1,132 @@
+"""The hosted session page said "Messages 0" for every non-OpenClaw runtime.
+
+Founder report 2026-09-11: a Codex session page on app.clawmetry.com showed
+``Messages 0`` beside a transcript the local store counts as 371 messages.
+
+The cloud's ``sessions`` table has **no message_count column**. The one count
+it stores is ``event_count`` (``clawmetry-cloud/routes/api.py``), and the
+hosted page renders "Messages" straight from it
+(``routes/team_sessions.py``: ``int(r.get('event_count') or 0)``). The
+OpenClaw cloud row has always carried that key; the family row (claude_code,
+codex, cursor, …) carried ``message_count`` instead, which the cloud drops on
+the floor, so the column stayed 0 for every one of those sessions.
+
+Pins the key on the family cloud row. The cloud upsert keeps
+``GREATEST(existing, new)``, so a read capped by ``_family_event_read_cap()``
+can never walk a session's count backwards.
+"""
+
+from __future__ import annotations
+
+import importlib
+import time
+from unittest.mock import patch
+
+import pytest
+
+from clawmetry.adapters.base import (
+    AgentAdapter,
+    Capability,
+    DetectResult,
+    Event,
+    Session,
+)
+
+_UUID = "cccccccc-1111-2222-3333-444444444444"
+
+
+def _ev(role, content, i=0):
+    return Event(agent="claude_code", session_id=_UUID, id=f"e{i}",
+                 type="message", ts=float(i), role=role, content=content)
+
+
+def _fake_adapter(sessions, events_by_sid):
+    class _Fake(AgentAdapter):
+        name = "claude_code"
+        display_name = "Claude Code"
+
+        def detect(self):
+            return DetectResult(name=self.name, display_name=self.display_name,
+                                detected=True, session_count=len(sessions))
+
+        def list_sessions(self, limit=100):
+            return sessions
+
+        def list_events(self, session_id, limit=500):
+            return events_by_sid.get(session_id, [])
+
+        def capabilities(self):
+            return {Capability.SESSIONS, Capability.EVENTS}
+
+    return _Fake
+
+
+@pytest.fixture
+def isolated_sync(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / "claude"))
+    monkeypatch.setenv("CLAWMETRY_OPENCLAW_DIR", str(tmp_path / ".openclaw"))
+    import clawmetry.local_store as ls
+    import clawmetry.sync as sync
+    importlib.reload(ls)
+    importlib.reload(sync)
+    monkeypatch.setattr(ls, "_daemon_registered", lambda: False)
+    monkeypatch.delenv("CLAWMETRY_ROLE", raising=False)
+    yield sync, ls, tmp_path
+    try:
+        ls.get_store().stop(flush=True)
+    except Exception:
+        pass
+
+
+def _session_rows(calls):
+    """Every dict in the captured ``_post`` payloads that looks like a session
+    row. The endpoint's arg order is not the contract under test; carrying the
+    count is."""
+    found = []
+
+    def walk(obj):
+        if isinstance(obj, dict):
+            if "session_id" in obj and "runtime" in obj:
+                found.append(obj)
+            for v in obj.values():
+                walk(v)
+        elif isinstance(obj, (list, tuple)):
+            for v in obj:
+                walk(v)
+
+    walk(calls)
+    return found
+
+
+def test_family_cloud_row_carries_event_count(isolated_sync):
+    sync, ls, _tmp = isolated_sync
+    sessions = [Session(agent="claude_code", id=_UUID, started_at=1000.0,
+                        ended_at=1010.0, message_count=2)]
+    events = {_UUID: [_ev("user", "add a dark mode toggle", 0),
+                      _ev("assistant", "on it", 1),
+                      _ev("user", "and a light one", 2),
+                      _ev("assistant", "done", 3)]}
+    calls = []
+
+    def _capture(*args, **kwargs):
+        calls.append({"args": list(args), "kwargs": dict(kwargs)})
+        return {}
+
+    with patch.object(sync, "_family_adapter_classes",
+                      lambda: [_fake_adapter(sessions, events)]), \
+         patch.object(sync, "_sync_allowed", return_value=True), \
+         patch.object(sync, "_post", side_effect=_capture):
+        sync.sync_family_runtimes(
+            {"node_id": "n", "api_key": "k"}, {}, {})
+
+    rows = [r for r in _session_rows(calls)
+            if str(r.get("session_id", "")).endswith(_UUID)]
+    assert rows, "no family session row reached the cloud push"
+    row = rows[0]
+    # The column the hosted page actually reads.
+    assert row.get("event_count") == 4
+    # message_count stays too: it is the honest per-row turn count the local
+    # store keeps, and older cloud servers ignore unknown keys either way.
+    assert row.get("message_count") == 2


### PR DESCRIPTION
Founder report 2026-09-11 (screenshot): a Codex session page on app.clawmetry.com read **Messages 0** and **Cost \$0.00** beside a transcript the local store counts as **371 messages**.

## Why

The cloud's `sessions` table has **no `message_count` column**. The one count it stores is `event_count` (`clawmetry-cloud/routes/api.py`), and the hosted session page renders "Messages" straight from it:

```python
# clawmetry-cloud/routes/team_sessions.py
'messages': int(r.get('event_count') or 0),
```

The OpenClaw cloud row has always sent `event_count`. The **family** row (claude_code, codex, cursor, copilot, …) sent `message_count` instead, which the cloud ignores, so the column stayed `0` for every non-OpenClaw session ever synced.

## What

The family cloud row now carries `event_count` as well, the same raw-row count the OpenClaw path sends. The cloud upsert keeps `GREATEST(existing, new)`, so a read capped by `_family_event_read_cap()` can never walk a session's count backwards. **No cloud-side change is needed** - the column it already reads simply stops being empty.

## Testing

`tests/test_family_cloud_row_event_count.py` drives the real `sync_family_runtimes` with a fake adapter (4 events, `message_count=2`), captures the cloud push, and asserts the session row carries `event_count == 4` while `message_count` stays. Added to the CI job list.

## Not in this PR

The same screenshot showed **Cost \$0.00** while the list row for that session showed \$3.40. Those two hosted surfaces disagree, so they are reading different sources; that needs live cloud data to pin down and is not guessed at here.

No-PRD: user-reported display bug; restores the count the page was always meant to show.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0183r5LYZZeESUW91ffsQ2AV