### PR TITLE
Make the message count reach sessions already recorded

### DIFF
--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -15096,11 +15096,18 @@ def _family_ingest_rev() -> str:
     ingest, so without the bump every idle Codex session keeps its
     "# AGENTS.md instructions for …" title, locally and in the sealed cloud
     ``title_blob``.
+
+    ``/t2`` (2026-09-11): the family cloud row started carrying
+    ``event_count``, the only count the cloud stores and the number the hosted
+    session page renders as "Messages". That row is written only when a
+    session is processed, so without the bump every session already recorded
+    keeps "Messages 0" until it happens to grow again. Same rule as above: a
+    change to what ingest writes needs a salt, or it reaches new sessions only.
     """
     try:
         import importlib.metadata as _ilm
 
-        return _ilm.version("clawmetry-pro") + "/ctx1/q2/t1"
+        return _ilm.version("clawmetry-pro") + "/ctx1/q2/t2"
     except Exception:
         return ""
 

--- a/tests/test_injected_context.py
+++ b/tests/test_injected_context.py
@@ -13,6 +13,7 @@ on the reporting machine.
 from __future__ import annotations
 
 import json
+import re
 
 import pytest
 
@@ -189,4 +190,9 @@ def test_family_ingest_rev_is_salted_for_the_title_rule():
     from clawmetry import sync
 
     with patch.object(ilm, "version", return_value="9.9.9"):
-        assert sync._family_ingest_rev().endswith("/t1")
+        # The salt moves whenever what ingest WRITES changes (/t2 added
+        # event_count to the family cloud row). Pin that one is present, not
+        # which: pinning the exact value turns every future bump into a test
+        # edit, and the contract is "a change to ingest output carries a salt".
+        salt = sync._family_ingest_rev().rsplit("/", 1)[-1]
+        assert re.fullmatch(r"t\d+", salt), salt


### PR DESCRIPTION
Follow-up to #5891, which is already released in 0.12.871.

## Why

#5891 added `event_count` to the family cloud row: the number the hosted session page renders as "Messages". But that row is written **only when a session is processed**, and the daemon skips sessions whose events have not advanced (`family_event_high_water`, stamped `<ts>@@<ingest-rev>`).

So the fix reaches a session the next time it grows, and no other. Every session already recorded keeps `Messages 0` indefinitely - which is most of them.

Verified live on app.clawmetry.com after 0.12.871: a session still being written shows **Messages 688 · $15.53**, while the idle Codex session from the original report still reads **Messages 0**.

## What

Bump the family ingest salt to `/t2`, which re-reads each family session once. This is exactly the rule ADR-003 of the feature blueprint states: *a change to what ingest writes needs a salt, or it applies to new sessions only.*

The test that pinned the exact salt (`/t1`) now pins its **shape** (`t<digits>`). Pinning the value turns every future bump into a test edit, while the contract worth holding is that a salt is present at all.

## Testing

`tests/test_injected_context.py` + `tests/test_family_cloud_row_event_count.py`: 38 passed.

No-PRD: completes a user-reported display fix so it reaches existing history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0183r5LYZZeESUW91ffsQ2AV