### PR TITLE
[RELEASE] The message count reaches sessions already recorded (carries #5894)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -551,3 +551,9 @@
 - **What:** the family cloud row now carries `event_count` too, the same raw-row count the OpenClaw path sends. The cloud upsert keeps `GREATEST(existing, new)`, so a read capped by `_family_event_read_cap()` can never walk a session's count backwards. No cloud-side change: the column the page already reads simply stops being empty.
 - **Verified:** `tests/test_family_cloud_row_event_count.py` drives the real `sync_family_runtimes` with a fake adapter (4 events, `message_count=2`), captures the cloud push and asserts the row carries `event_count == 4` while `message_count` stays. Runs in CI.
 - **Carries:** #5891.
+
+### Fixed: the message count now reaches sessions already recorded (2026-09-11)
+- **Why:** 0.12.871 added `event_count` to the family cloud row, the number the hosted session page renders as "Messages". That row is written only when a session is processed, and the daemon skips sessions whose events have not advanced (`family_event_high_water`). So the fix reached a session the next time it grew and no other: every session already recorded kept "Messages 0" indefinitely. Measured live on app.clawmetry.com after 0.12.871: a session still being written showed "Messages 688", while the idle Codex session from the original report still showed 0.
+- **What:** the family ingest salt moves to `/t2`, which re-reads each family session once. This is the rule the feature blueprint's ADR-003 states: a change to what ingest writes needs a salt, or it applies to new sessions only.
+- **Also:** the test that pinned the exact salt now pins its shape (`t` followed by digits). Pinning the value turns every future bump into a test edit, while the contract worth holding is that a salt is present at all.
+- **Carries:** #5894.


### PR DESCRIPTION
Publishes the ingest salt bump merged in #5894.

0.12.871 added `event_count` to the family cloud row, the number the hosted session page renders as "Messages". That row is written only when a session is processed, and the daemon skips sessions whose events have not advanced, so the fix reached a session the next time it grew and no other.

Measured live on app.clawmetry.com after 0.12.871: a session still being written showed **Messages 688 · $15.53**, while the idle Codex session from the original report still showed **Messages 0**. The salt moves to `/t2`, which re-reads each family session once.

The blueprint's ADR-003 now states the general rule (a salt is bumped whenever what ingest *writes* changes), after drift-bot correctly pointed out that the original wording scoped it to the title rule only.

Product record: [A session is titled by the person, not by the context its harness injects](https://factory.8090.ai/project/b415065f-ab2f-4f53-8864-0c009fd098cb/requirements/4452ce1b-9f6d-4f36-b04f-ccc38b4efcde)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0183r5LYZZeESUW91ffsQ2AV