### PR TITLE
Activity heatmap: SQL buckets, node-local hours, runtime scoping

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,14 +217,6 @@ jobs:
         run: python3 -m pytest tests/test_providers_pricing.py tests/test_pricing_accuracy.py -q
 
       # Named explicitly because this repo's CI runs FILE LISTS, not
-      # `pytest tests/`. The heatmap buckets on the node-local clock and
-      # scopes by runtime; both are the kind of thing that regresses quietly
-      # (the hosted card drew an all-zero grid for months before anyone
-      # noticed it was not simply a quiet week).
-      - name: Activity heatmap buckets local hours and scopes by runtime
-        run: python3 -m pytest tests/test_activity_heatmap_runtime_scope.py -q
-
-      # Named explicitly because this repo's CI runs FILE LISTS, not
       # `pytest tests/`: a guard added without a line here runs in no job at
       # all. Covers the half `gen_module_map.py --check` cannot: every
       # blueprint dashboard.py registers is in the map, and CLAUDE.md /
@@ -780,6 +772,7 @@ jobs:
             tests/test_scan_read_cache.py \
             tests/test_cache_push_gating.py \
             tests/test_usage_cache_trends_local_store.py \
+            tests/test_activity_heatmap_runtime_scope.py \
             tests/test_transcript_local_store.py \
             tests/test_snapshot_transcripts_runtime_fair.py \
             tests/test_moat_perf_benchmark.py \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,6 +217,14 @@ jobs:
         run: python3 -m pytest tests/test_providers_pricing.py tests/test_pricing_accuracy.py -q
 
       # Named explicitly because this repo's CI runs FILE LISTS, not
+      # `pytest tests/`. The heatmap buckets on the node-local clock and
+      # scopes by runtime; both are the kind of thing that regresses quietly
+      # (the hosted card drew an all-zero grid for months before anyone
+      # noticed it was not simply a quiet week).
+      - name: Activity heatmap buckets local hours and scopes by runtime
+        run: python3 -m pytest tests/test_activity_heatmap_runtime_scope.py -q
+
+      # Named explicitly because this repo's CI runs FILE LISTS, not
       # `pytest tests/`: a guard added without a line here runs in no job at
       # all. Covers the half `gen_module_map.py --check` cannot: every
       # blueprint dashboard.py registers is in the map, and CLAUDE.md /

--- a/clawmetry/cost_windows.py
+++ b/clawmetry/cost_windows.py
@@ -170,3 +170,41 @@ def day_expr_sql(col: str = "ts") -> str:
         f"COALESCE(CAST(CAST(TRY_CAST({col} AS TIMESTAMPTZ) AS DATE) AS VARCHAR),"
         f" substr({col}, 1, 10))"
     )
+
+
+def local_hour(ts):
+    """Node-local hour of day (0-23) for a source timestamp, or ``None``.
+
+    The hour twin of :func:`local_day`, for the activity heatmap's
+    (day x hour) buckets. Same clock rule: an offset-carrying timestamp is
+    converted to node-local first, a naive one is already local. A heatmap
+    that skipped the conversion drew a UTC-writing runtime's evening work in
+    the small hours — the same two-clocks bug ADR-046 closed for days.
+    """
+    s = str(ts or "").strip()
+    if not s:
+        return None
+    try:
+        dt = datetime.fromisoformat(_normalize_ts(s))
+    except (TypeError, ValueError):
+        # Fall back to the literal hour field of an ISO-ish string.
+        hh = s[11:13]
+        return int(hh) if hh.isdigit() and 0 <= int(hh) <= 23 else None
+    if dt.tzinfo is None:
+        return dt.hour
+    return dt.astimezone().hour
+
+
+def hour_expr_sql(col: str = "ts") -> str:
+    """SQL for the same hour bucket, for DuckDB.
+
+    Mirrors :func:`day_expr_sql`: ``TRY_CAST`` to TIMESTAMPTZ (which DuckDB
+    renders in the session timezone, i.e. node-local, and which treats a
+    naive string as already local), with a COALESCE onto the literal hour
+    field so an unparseable row lands where the old string-prefix code put
+    it instead of vanishing from the grid.
+    """
+    return (
+        f"COALESCE(CAST(EXTRACT(hour FROM TRY_CAST({col} AS TIMESTAMPTZ)) AS INTEGER),"
+        f" TRY_CAST(substr({col}, 12, 2) AS INTEGER))"
+    )

--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -652,8 +652,11 @@ _HEARTBEAT_DATA_MAX_VALUE_BYTES = 64 * 1024
 # class ADR-046 exists to close, so a test pins them against each other.
 from clawmetry.cost_windows import day_expr_sql as _day_expr_sql  # noqa: E402
 from clawmetry.cost_windows import local_day as _local_day  # noqa: E402
+from clawmetry.cost_windows import hour_expr_sql as _hour_expr_sql  # noqa: E402
+from clawmetry.cost_windows import now_local as _cw_now_local  # noqa: E402
 
 _DAY_EXPR = _day_expr_sql("ts")
+_HOUR_EXPR = _hour_expr_sql("ts")
 
 # ── Two-layer schema (multi-agent) ──────────────────────────────────────────
 #
@@ -18493,6 +18496,133 @@ class LocalStore(TrailStoreMixin):
             with _AGG_CACHE_LOCK:
                 _AGG_CACHE[_ck] = (time.monotonic(), _rows)
         return _rows
+
+    def activity_heatmap(
+        self,
+        *,
+        days: int = 7,
+        runtime: str | None = None,
+    ) -> dict[str, Any]:
+        """(day x hour) event counts for the activity heatmap, aggregated in SQL.
+
+        One GROUP BY instead of shipping every event row to Python: the
+        previous heatmap path pulled up to 50k rows per render and bucketed
+        them in a loop, which is both slow and capped — a busy node's 30-day
+        window is well past 50k events, so the oldest days quietly came back
+        empty. It also stripped the timezone off each row, which put a
+        UTC-writing runtime's work in the wrong hour; ``_DAY_EXPR`` /
+        ``_HOUR_EXPR`` bucket on the node-local clock (ADR-046) instead.
+
+        ``runtime`` scopes to one runtime by session-id prefix, so the hosted
+        per-runtime view never shows another runtime's activity (FLYWHEEL
+        SS1c). Returns::
+
+            {"days": [{"date": "YYYY-MM-DD", "hours": [24 ints]}, ...],
+             "max": <busiest single hour>, "n_days": N}
+
+        Days with no events are present with a zero row — the grid is a fixed
+        shape, and a missing day would silently shift the calendar.
+        """
+        n_days = max(1, min(90, int(days or 7)))
+        now = _cw_now_local()
+        first = (now - timedelta(days=n_days - 1)).strftime("%Y-%m-%d")
+        # Two filters on purpose: the raw ``ts >= ?`` uses idx_events_ts to
+        # skip the bulk of the table (widened by a day so a UTC-stamped row
+        # near the boundary is not dropped before the local-day filter sees
+        # it), then the exact day filter runs on that slice only.
+        raw_floor = (now - timedelta(days=n_days)).strftime("%Y-%m-%d")
+        clauses = ["ts >= ?", f"{_DAY_EXPR} >= ?"]
+        params: list[Any] = [raw_floor, first]
+        _rt_clause, _rt_params = _runtime_session_id_clause(runtime)
+        if _rt_clause:
+            clauses.append(_rt_clause)
+            params.extend(_rt_params)
+        sql = f"""
+            SELECT {_DAY_EXPR} AS day, {_HOUR_EXPR} AS hr, COUNT(*) AS n
+            FROM events
+            WHERE {" AND ".join(clauses)}
+            GROUP BY 1, 2
+        """
+        grid: dict[str, list[int]] = {}
+        for i in range(n_days - 1, -1, -1):
+            grid[(now - timedelta(days=i)).strftime("%Y-%m-%d")] = [0] * 24
+        try:
+            rows = self._fetch(sql, params)
+        except Exception:
+            log.debug("activity_heatmap: query failed", exc_info=True)
+            rows = []
+        for r in rows:
+            day, hr, n = r[0], r[1], r[2]
+            if hr is None or day not in grid:
+                continue
+            h = int(hr)
+            if 0 <= h <= 23:
+                grid[day][h] += int(n or 0)
+        max_val = max((max(hours) for hours in grid.values()), default=0)
+        return {
+            "days": [{"date": d, "hours": grid[d]} for d in sorted(grid)],
+            "max": max_val,
+            "n_days": n_days,
+        }
+
+    def activity_heatmap_by_runtime(self, *, days: int = 30) -> dict[str, Any]:
+        """Every runtime's activity grid plus the node-wide one, in ONE scan.
+
+        The snapshot builder needs a grid per runtime so the hosted dashboard
+        can re-scope the heatmap with the runtime switcher. Calling
+        :meth:`activity_heatmap` once per runtime would re-scan the events
+        table N+1 times per sync cycle; this groups by the runtime prefix
+        instead and splits in Python.
+
+        Returns ``{"all": <grid>, "<runtime>": <grid>, ...}`` where each grid
+        is the :meth:`activity_heatmap` shape. Runtimes with no events in the
+        window are absent (empty == nothing ran).
+        """
+        n_days = max(1, min(90, int(days or 30)))
+        now = _cw_now_local()
+        first = (now - timedelta(days=n_days - 1)).strftime("%Y-%m-%d")
+        raw_floor = (now - timedelta(days=n_days)).strftime("%Y-%m-%d")
+        placeholders = ", ".join(["?"] * len(_NON_OPENCLAW_RUNTIME_PREFIXES))
+        rt_expr = (
+            f"CASE WHEN split_part(session_id, ':', 1) IN ({placeholders})"
+            f" THEN split_part(session_id, ':', 1) ELSE 'openclaw' END"
+        )
+        params: list[Any] = list(_NON_OPENCLAW_RUNTIME_PREFIXES) + [raw_floor, first]
+        sql = f"""
+            SELECT {rt_expr} AS rt, {_DAY_EXPR} AS day, {_HOUR_EXPR} AS hr,
+                   COUNT(*) AS n
+            FROM events
+            WHERE ts >= ? AND {_DAY_EXPR} >= ?
+            GROUP BY 1, 2, 3
+        """
+        dates = [
+            (now - timedelta(days=i)).strftime("%Y-%m-%d")
+            for i in range(n_days - 1, -1, -1)
+        ]
+        grids: dict[str, dict[str, list[int]]] = {"all": {d: [0] * 24 for d in dates}}
+        try:
+            rows = self._fetch(sql, params)
+        except Exception:
+            log.debug("activity_heatmap_by_runtime: query failed", exc_info=True)
+            return {}
+        for r in rows:
+            rt, day, hr, n = r[0] or "openclaw", r[1], r[2], int(r[3] or 0)
+            if hr is None or day not in grids["all"]:
+                continue
+            h = int(hr)
+            if not (0 <= h <= 23):
+                continue
+            grids.setdefault(rt, {d: [0] * 24 for d in dates})
+            grids[rt][day][h] += n
+            grids["all"][day][h] += n
+        out: dict[str, Any] = {}
+        for rt, grid in grids.items():
+            out[rt] = {
+                "days": [{"date": d, "hours": grid[d]} for d in dates],
+                "max": max((max(hours) for hours in grid.values()), default=0),
+                "n_days": n_days,
+            }
+        return out
 
     # ── ops / maintenance ──────────────────────────────────────────────
 

--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -17702,9 +17702,23 @@ async function loadHeatmap(days) {
   if (btn7) btn7.className = _heatmapDays === 7 ? 'time-btn active' : 'time-btn';
   if (btn30) btn30.className = _heatmapDays === 30 ? 'time-btn active' : 'time-btn';
   try {
-    var data = await fetch('/api/heatmap?days=' + _heatmapDays).then(r => r.json());
+    // Runtime-scoped like every other card on this tab: without ?runtime the
+    // hosted per-runtime view drew node-wide hours under one runtime's name
+    // (FLYWHEEL 1c).
+    var _hmRt = _cmRuntimeFilter();
+    var _hmQs = '/api/heatmap?days=' + _heatmapDays +
+      ((_hmRt && _hmRt !== 'all') ? '&runtime=' + encodeURIComponent(_hmRt) : '');
+    var data = await fetch(_hmQs).then(r => r.json());
     var grid = document.getElementById('heatmap-grid');
     if (!grid) return;
+    if (!data || !data.days || !data.days.length) {
+      grid.innerHTML = '<span style="color:#555">' + t("app.no_activity_data", null, "No activity data") + '</span>';
+      return;
+    }
+    // What a cell counts depends on the source: DuckDB counts events, the
+    // cloud fallback counts sessions. Say which, rather than labelling a
+    // session count "events".
+    var unit = data.unit || 'events';
     var maxVal = Math.max(1, data.max);
     var html = '<div class="heatmap-label"></div>';
     for (var h = 0; h < 24; h++) { html += '<div class="heatmap-hour-label">' + (h < 10 ? '0' : '') + h + '</div>'; }
@@ -17718,7 +17732,7 @@ async function loadHeatmap(days) {
         else if (intensity < 0.5) color = '#2a6a3a';
         else if (intensity < 0.75) color = '#4a9a2a';
         else color = '#6adb3a';
-        html += '<div class="heatmap-cell" style="background:' + color + ';" title="' + day.label + ' ' + (hi < 10 ? '0' : '') + hi + ':00 — ' + val + ' events"></div>';
+        html += '<div class="heatmap-cell" style="background:' + color + ';" title="' + day.label + ' ' + (hi < 10 ? '0' : '') + hi + ':00 — ' + val + ' ' + unit + '"></div>';
       });
     });
     grid.innerHTML = html;

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -17783,6 +17783,31 @@ def _build_autonomy_snapshot():
         return {}
 
 
+def _build_activity_heatmap_snapshot():
+    """30-day (day x hour) activity grid, node-wide and per runtime.
+
+    Why it rides the snapshot: the hosted Cost tab's Activity Heatmap read
+    ``/api/heatmap``, whose cloud handler has no events to count (the cloud
+    stores an opaque encrypted blob by design) and so returned a grid of
+    zeros — a card that has been blank for every hosted user since the
+    events read was removed. The daemon has the data and is the only side
+    that can bucket it, so it ships the finished grid and the cloud
+    interceptor decrypts and draws it. Cloud stays blind; E2E preserved.
+
+    ``{"all": grid, "<runtime>": grid, ...}``; ``{}`` when the store is
+    unreachable. One GROUP BY per cycle for every runtime at once.
+    """
+    try:
+        from clawmetry import local_store as _ls_hm
+        store = _ls_hm.get_store()
+        if store is None:
+            return {}
+        return store.activity_heatmap_by_runtime(days=30) or {}
+    except Exception as _e_hm:
+        log.debug("snapshot: activity heatmap slice failed: %s", _e_hm)
+        return {}
+
+
 def _build_usage_snapshot():
     """Usage tab slices (anomalies, cost-comparison, cache-trends, cost-breakdown,
     spend-optimization, forecast). Trial-bug #12: these Usage cards were blank on
@@ -23973,6 +23998,8 @@ def sync_system_snapshot(config: dict, state: dict, paths: dict) -> int:
         "evals": evals_slice,
         "activityToday": _collect_activity_counters_today() or {},
         "activityTodayByRuntime": _activity_by_rt,
+        # Cost tab heatmap (day x hour), node-wide + per runtime.
+        "activityHeatmap": _build_activity_heatmap_snapshot(),
         "outcomes": _outcomes_slice_for_snapshot(),
         "outcomesByRuntime": _outcomes_by_rt,
         # 7d-over-7d trend behind the Quality tab's "is it getting better?"

--- a/docs/MODULE_MAP.md
+++ b/docs/MODULE_MAP.md
@@ -155,7 +155,7 @@ The pip-installable package: CLI, sync daemon, DuckDB store, detectors, enforcem
 | `clawmetry/connector_health.py` | small | Connector liveness — turn the daemon's ``connector.health`` signal stream into a per-channel ok/degraded/down verdict. |
 | `clawmetry/context_coverage.py` | small | Which context-blowout signals we can actually see, per runtime. |
 | `clawmetry/context_windows.py` | medium | Context-window sizing across every runtime ClawMetry ingests. |
-| `clawmetry/cost_windows.py` | small | One definition of "today", "this week" and "this month" for every cost surface. |
+| `clawmetry/cost_windows.py` | medium | One definition of "today", "this week" and "this month" for every cost surface. |
 | `clawmetry/cursor_connector.py` | medium | Opt-in pull of Cursor cloud-agent usage, with the operator's own key. |
 | `clawmetry/daemon_registration.py` | medium | one place that knows how to make the sync daemon survive a reboot/logoff/crash, on every OS. |
 | `clawmetry/deepeval_bridge.py` | medium | optional DeepEval metric engine (local-first). |

--- a/routes/health.py
+++ b/routes/health.py
@@ -873,9 +873,16 @@ def api_reliability():
         return jsonify({"error": str(e), "direction": "insufficient_data"}), 500
 
 
-def _try_local_store_heatmap(n_days: int):
-    """Issue #1088 fast path for /api/heatmap. Bucket events into a (days × 24h)
-    grid using DuckDB ``query_events`` instead of scanning every log + JSONL.
+def _try_local_store_heatmap(n_days: int, runtime: str | None = None):
+    """Issue #1088 fast path for /api/heatmap. Returns the (days × 24h) grid
+    from DuckDB instead of scanning every log + JSONL.
+
+    The bucketing is a SQL GROUP BY inside ``LocalStore.activity_heatmap``.
+    It used to be a Python loop over up to 50k raw event rows shipped through
+    the daemon proxy, which (a) marshalled tens of MB per render and (b)
+    capped the window, so a busy node's oldest days came back empty, and
+    (c) stripped each row's timezone, drawing a UTC-writing runtime's work
+    in the wrong hour.
 
     Tries the daemon HTTP proxy FIRST (cross-process safe — under the standard
     install the daemon owns the writer lock and direct opens fail), then falls
@@ -887,65 +894,45 @@ def _try_local_store_heatmap(n_days: int):
       - the events table is empty inside the requested window
       - any unexpected error happens
     """
-    now = datetime.now()
-    cutoff = now - timedelta(days=n_days)
-    since_iso = cutoff.replace(microsecond=0).isoformat()
-    rows = None
+    grid = None
     try:
         from routes.local_query import local_store_via_daemon
-        # Heatmap is bounded: 90 days × 24h = 2160 cells. 50k events is a
-        # generous cap that covers a very busy single-user node and still
-        # finishes in <50ms on a laptop.
-        rows = local_store_via_daemon("query_events", limit=50000, since=since_iso)
+        grid = local_store_via_daemon(
+            "activity_heatmap", days=n_days, runtime=runtime
+        )
     except Exception:
-        rows = None
+        grid = None
     # Single-process fallback: open the DuckDB ourselves (tests / dev mode).
-    if rows is None:
+    if not isinstance(grid, dict):
         try:
             from clawmetry import local_store
             store = local_store.get_store(read_only=True)
-            rows = store.query_events(since=since_iso, limit=50000)
+            grid = store.activity_heatmap(days=n_days, runtime=runtime)
         except Exception:
             return None
-    if not rows:
+    if not isinstance(grid, dict) or not grid.get("days"):
+        return None
+    if not grid.get("max"):
+        # No events in the window — let the legacy file scan have a go
+        # rather than painting a confidently empty grid.
         return None
 
-    grid: dict[str, list[int]] = {}
-    day_labels = []
-    for i in range(n_days - 1, -1, -1):
-        d = now - timedelta(days=i)
-        ds = d.strftime("%Y-%m-%d")
-        grid[ds] = [0] * 24
-        lbl = d.strftime("%b %d") if n_days > 7 else d.strftime("%a %d")
-        day_labels.append({"date": ds, "label": lbl})
-
-    counted = 0
-    for ev in rows:
-        ts = ev.get("ts")
-        if not ts:
-            continue
-        try:
-            dt = datetime.fromisoformat(str(ts).replace("Z", "+00:00"))
-        except Exception:
-            continue
-        # Drop tz to match the naive ``datetime.now()`` grid keys.
-        if dt.tzinfo is not None:
-            dt = dt.replace(tzinfo=None)
-        day_key = dt.strftime("%Y-%m-%d")
-        if day_key in grid:
-            grid[day_key][dt.hour] += 1
-            counted += 1
-    if counted == 0:
-        return None
-
-    max_val = max(max(hours) for hours in grid.values()) if grid else 0
     days_out = []
-    for dl in day_labels:
-        days_out.append({"label": dl["label"], "hours": grid.get(dl["date"], [0] * 24)})
+    for row in grid["days"]:
+        try:
+            d = datetime.strptime(row.get("date") or "", "%Y-%m-%d")
+        except (TypeError, ValueError):
+            continue
+        lbl = d.strftime("%b %d") if n_days > 7 else d.strftime("%a %d")
+        hours = row.get("hours") or [0] * 24
+        days_out.append({"label": lbl, "date": row.get("date"), "hours": hours})
+    if not days_out:
+        return None
     return {
         "days": days_out,
-        "max": max_val,
+        "max": int(grid.get("max") or 0),
         "n_days": n_days,
+        "runtime": runtime or "all",
         "_source": "local_store",
     }
 
@@ -955,22 +942,51 @@ def api_heatmap():
     """Activity heatmap - events per hour for the last N days (default 7, max 90).
 
     Query params:
-      days: int  number of days to show (1-90, default 7)
+      days:    int  number of days to show (1-90, default 7)
+      runtime: str  scope to one runtime (claude_code, codex, openclaw, …).
+                    Absent / "all" = node-wide. The DuckDB path filters by
+                    session-id prefix; the legacy file scan below is
+                    OpenClaw-only by construction, so a runtime-scoped
+                    request never falls through to it.
     """
     import dashboard as _d
     try:
         n_days = max(1, min(90, int(request.args.get("days", 7))))
     except (ValueError, TypeError):
         n_days = 7
+    runtime = (request.args.get("runtime") or "").strip().lower()
+    if runtime in ("", "all"):
+        runtime = None
 
     # Epic #964 / Issue #1088 — opt-in DuckDB fast path. When
     # CLAWMETRY_LOCAL_STORE_READ=1 AND the store has events in the window,
     # serve from DuckDB via the daemon HTTP proxy (cross-process safe).
     # Falls through to the JSONL/log scan otherwise.
     if is_local_store_read_enabled():
-        fast = _try_local_store_heatmap(n_days)
+        fast = _try_local_store_heatmap(n_days, runtime)
         if fast is not None:
             return jsonify(fast)
+
+    if runtime:
+        # The file scan below reads OpenClaw logs + OpenClaw session JSONL
+        # only. Returning it for ?runtime=codex would draw OpenClaw's hours
+        # under a Codex heading. Hand back the empty grid in the right shape
+        # instead, so the card renders its calendar rather than collapsing.
+        _blank = datetime.now()
+        return jsonify({
+            "days": [
+                {
+                    "label": (_blank - timedelta(days=i)).strftime(
+                        "%b %d" if n_days > 7 else "%a %d"
+                    ),
+                    "date": (_blank - timedelta(days=i)).strftime("%Y-%m-%d"),
+                    "hours": [0] * 24,
+                }
+                for i in range(n_days - 1, -1, -1)
+            ],
+            "max": 0, "n_days": n_days,
+            "runtime": runtime, "_source": "unavailable",
+        })
 
     now = datetime.now()
     # Initialize N days × 24 hours grid

--- a/routes/health.py
+++ b/routes/health.py
@@ -897,6 +897,12 @@ def _try_local_store_heatmap(n_days: int, runtime: str | None = None):
     grid = None
     try:
         from routes.local_query import local_store_via_daemon
+        # Internal daemon RPC (``/__local_query__/<method>``), gated by
+        # ``routes/local_query._DAEMON_METHODS`` — not the q/1 shape registry
+        # in ``clawmetry/query_contract.py``, which governs the PUBLIC
+        # ``/api/local/query?shape=`` surface and the cloud relay. Adding a
+        # fast-path method means the allowlist (checked by
+        # ``make lint-daemon-allowlist``), not a new public shape.
         grid = local_store_via_daemon(
             "activity_heatmap", days=n_days, runtime=runtime
         )

--- a/routes/local_query.py
+++ b/routes/local_query.py
@@ -718,6 +718,11 @@ def http_query():
 # which is a smaller foot-gun but still a foot-gun.
 
 _DAEMON_METHODS = frozenset({
+    # Activity heatmap (day x hour event counts), aggregated in SQL. The
+    # route used to pull 50k raw event rows through this proxy and bucket
+    # them in Python; on a busy node the cap silently emptied the oldest
+    # days of the 30-day grid.
+    "activity_heatmap",
     # Cohort compare + similar runs (WO-60): routes/cohort.py reads both
     # through the proxy; the similarity walk runs in the daemon process.
     "query_cohort_sessions",

--- a/tests/test_activity_heatmap_runtime_scope.py
+++ b/tests/test_activity_heatmap_runtime_scope.py
@@ -1,0 +1,130 @@
+"""Activity heatmap: SQL bucketing, node-local hours, per-runtime scoping.
+
+The hosted Cost tab drew an all-zero heatmap for every user because the
+cloud handler had nothing to count (see ``clawmetry-cloud`` cm-cloud-heatmap).
+The daemon-side half of that fix is here: one SQL GROUP BY that buckets on
+the node-local clock and can be scoped to a single runtime, plus the
+per-runtime split the snapshot ships.
+
+Pinned here:
+  * a UTC-stamped event and a local-stamped one at the same instant land in
+    the SAME hour (the old Python path stripped the offset instead),
+  * ``?runtime=`` scopes by session-id prefix and an unknown runtime returns
+    zero rather than the node-wide total (FLYWHEEL 1c),
+  * the per-runtime split reconciles with the single-runtime query.
+"""
+
+from __future__ import annotations
+
+import importlib
+import time
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+
+def _wait_flush(store, t: float = 2.0) -> None:
+    deadline = time.monotonic() + t
+    while time.monotonic() < deadline:
+        if store.health()["ring_depth"] == 0:
+            return
+        time.sleep(0.02)
+
+
+@pytest.fixture
+def fresh_store(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "1")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_READ", "1")
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    yield ls
+    try:
+        ls.get_store().stop(flush=True)
+    except Exception:
+        pass
+
+
+def _seed(store):
+    """Two events at the same instant, one written local, one written UTC."""
+    local_noon = datetime.now().astimezone().replace(
+        hour=12, minute=0, second=0, microsecond=0
+    )
+    store.ingest({
+        "id": "ev-local", "node_id": "n", "agent_id": "main",
+        "session_id": "claude_code:aaa", "event_type": "message",
+        "ts": local_noon.isoformat(),
+    })
+    store.ingest({
+        "id": "ev-utc", "node_id": "n", "agent_id": "main",
+        "session_id": "codex:bbb", "event_type": "message",
+        "ts": local_noon.astimezone(timezone.utc).isoformat().replace("+00:00", "Z"),
+    })
+    _wait_flush(store)
+    return local_noon
+
+
+def test_utc_and_local_events_share_one_local_hour(fresh_store):
+    store = fresh_store.get_store()
+    noon = _seed(store)
+    grid = store.activity_heatmap(days=1)
+    hours = grid["days"][-1]["hours"]
+    assert hours[noon.hour] == 2, hours
+    assert sum(hours) == 2
+
+
+def test_runtime_scopes_by_session_prefix(fresh_store):
+    store = fresh_store.get_store()
+    noon = _seed(store)
+    cc = store.activity_heatmap(days=1, runtime="claude_code")
+    cx = store.activity_heatmap(days=1, runtime="codex")
+    assert cc["days"][-1]["hours"][noon.hour] == 1
+    assert cx["days"][-1]["hours"][noon.hour] == 1
+    # An unrecognised runtime must return zero, never the node-wide total.
+    unknown = store.activity_heatmap(days=1, runtime="__nope__")
+    assert unknown["max"] == 0
+    assert sum(sum(d["hours"]) for d in unknown["days"]) == 0
+
+
+def test_split_reconciles_with_single_runtime_query(fresh_store):
+    store = fresh_store.get_store()
+    _seed(store)
+    split = store.activity_heatmap_by_runtime(days=1)
+    assert set(split) >= {"all", "claude_code", "codex"}
+    for rt in ("claude_code", "codex"):
+        assert split[rt]["days"] == store.activity_heatmap(days=1, runtime=rt)["days"]
+    # Node-wide row is the sum of its parts.
+    assert sum(sum(d["hours"]) for d in split["all"]["days"]) == 2
+
+
+def test_grid_is_a_fixed_shape(fresh_store):
+    store = fresh_store.get_store()
+    _seed(store)
+    grid = store.activity_heatmap(days=30)
+    assert len(grid["days"]) == 30
+    assert all(len(d["hours"]) == 24 for d in grid["days"])
+    today = datetime.now().astimezone().strftime("%Y-%m-%d")
+    assert grid["days"][-1]["date"] == today
+    first = (datetime.now().astimezone() - timedelta(days=29)).strftime("%Y-%m-%d")
+    assert grid["days"][0]["date"] == first
+
+
+def test_route_passes_runtime_through(fresh_store):
+    store = fresh_store.get_store()
+    _seed(store)
+    import importlib as _il
+    from flask import Flask
+    mod = _il.import_module("routes.health")
+    _il.reload(mod)
+    app = Flask(__name__)
+    app.register_blueprint(getattr(mod, "bp_health"))
+    c = app.test_client()
+
+    body = c.get("/api/heatmap?days=1&runtime=codex").get_json()
+    assert body["_source"] == "local_store"
+    assert body["runtime"] == "codex"
+    assert body["max"] == 1
+    # Unknown runtime: no fall-through to the node-wide file scan.
+    body = c.get("/api/heatmap?days=1&runtime=__nope__").get_json()
+    assert body["max"] == 0


### PR DESCRIPTION
## The bug

The Cost tab's Activity Heatmap is an empty grid on the hosted dashboard — every user, every runtime, 7d and 30d. Reported with screenshots today for both Claude Code (2237 sessions) and Codex (25 sessions) on `app.clawmetry.com/cloud/node/<node>`.

It is not a data problem. `clawmetry-cloud`'s `/api/heatmap` handler builds a 7x24 block of zeros and returns it:

```python
# Events table read removed (epic #1032 — events reads dead). The heatmap
# grid is now empty until the heartbeat-piggyback path supplies bucketed
# activity counts.
```

Nothing ever supplied them. The cloud cannot: it stores an E2E-encrypted blob and never sees an event. The daemon is the only side that can bucket this, so it ships the finished grid in the snapshot and the cloud decrypts and draws it — the same shape as `cm-cloud-activity`, `cm-cloud-outcomes` and the rest. Cloud stays blind.

Locally the endpoint works (verified: `max 1866`, `_source local_store`), so this PR is the daemon half plus three defects the local path had anyway.

## What changed

* **`LocalStore.activity_heatmap(days, runtime)`** — bucketing is one SQL `GROUP BY`. It used to pull up to 50k raw event rows through the daemon proxy and loop over them in Python: tens of MB marshalled per render, and a cap that silently emptied the oldest days of a busy node's 30-day window.
* **Node-local hours** — `cost_windows.hour_expr_sql` / `local_hour`, the hour twins of ADR-046's day bucket. The old path stripped each row's offset, so a UTC-writing runtime's afternoon was drawn in the small hours. Test pins a UTC-stamped and a local-stamped event at the same instant landing in the same cell.
* **`?runtime=`** — scopes by session-id prefix; an unknown runtime returns zero, never the node-wide total (FLYWHEEL 1c). `app.js` sends the active runtime. The legacy file scan reads OpenClaw logs only, so a runtime-scoped request that reaches it returns the empty grid *in shape* rather than OpenClaw's hours under a Codex heading.
* **`activity_heatmap_by_runtime`** — every runtime plus node-wide in ONE scan, so the new `activityHeatmap` snapshot slice costs one query per sync cycle, not N+1.

## Verification

* `tests/test_activity_heatmap_runtime_scope.py` — 5 cases, all green; registered in `ci.yml` (this repo runs file lists).
* `tests/test_duckdb_coverage_batch_2026_05_13.py -k heatmap` still green.
* `make lint-py39 lint-daemon-allowlist lint-module-map lint-ci-test-coverage` green; no new `ruff` findings in any touched file (per-file counts identical to `origin/main`).
* Split and single-runtime queries reconcile by assertion, so per-runtime grids sum to the node-wide one by construction.

Cloud half (the `cm-cloud-heatmap` interceptor) goes up next and needs this version pinned.

No-PRD: user-reported defect — a card that has rendered blank for every hosted user since the events read was removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JSWiABbwBYWBdmdupVheAL