### PR TITLE
ci: skip Cross-Browser Tests on Dependabot PRs

### DIFF
--- a/.github/workflows/browserstack.yml
+++ b/.github/workflows/browserstack.yml
@@ -18,6 +18,8 @@ jobs:
     name: Cross-Browser Tests
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    # Dependabot PRs run without repo secrets; skip rather than fail.
+    if: github.actor != 'dependabot[bot]'
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
## Problem

Every Dependabot PR fails the E2E Gate because BrowserStack secrets (`BROWSERSTACK_USERNAME`, `BROWSERSTACK_ACCESS_KEY`) are not passed to Dependabot workflow runs. GitHub's security model intentionally withholds repository secrets from Dependabot. The `browserstack/github-actions/setup-env` action then fails immediately:

```
Action Failed: Input required and not supplied: username
Action Failed: BROWSERSTACK_ACCESS_KEY not found.
```

Observed failing on PRs #5909 and #5910 (and presumably #5911, #5912).

## Fix

Add a job-level `if: github.actor != 'dependabot[bot]'` condition to the `cross-browser` job. The job is skipped entirely for Dependabot PRs. BrowserStack coverage is not relevant to lock-file bumps and CI scanner requirement pins.

## What is not changed

- Behaviour on human PRs with the `browserstack` label: unchanged
- Behaviour on merges to main: unchanged
- All BrowserStack steps, pinned action SHAs, and local tunnel config: unchanged

No-PRD: CI infrastructure fix, no product behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LAkDSjSE565ZtADVdfRnie

---
_Generated by [Claude Code](https://claude.ai/code/session_01LAkDSjSE565ZtADVdfRnie)_