### PR TITLE
Harden CI: the live-E2E jobs install from a hash-pinned set

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1212,7 +1212,15 @@ jobs:
         # duckdb is in requirements.txt and used by the dashboard's local
         # event store; without it the server crashes on import and the
         # health check silently times out.
-        run: pip install flask pytest pytest-playwright requests duckdb
+        #
+        # playwright-e2e.txt is the hash-pinned set the other Playwright jobs
+        # (e2e-nightly, quarantine-sweep) already install from, and it carries
+        # every package this line resolved loosely -- Flask, pytest,
+        # pytest-playwright, requests, duckdb -- at the same Python 3.11 this
+        # job pins.
+        run: >-
+          pip install --require-hashes
+          -r .github/requirements/playwright-e2e.txt
       - name: Cache Playwright browsers
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
@@ -1554,7 +1562,13 @@ jobs:
         with:
           gateway-token: moat-live-e2e-token
       - name: Install Python deps
-        run: pip install flask pytest waitress duckdb cryptography requests
+        # ci-tests.txt is the hash-pinned set seven sibling jobs in this file
+        # already install from, and it carries every package this line resolved
+        # loosely -- Flask, pytest, waitress, duckdb, cryptography, requests --
+        # at the same Python 3.11 this job pins.
+        run: >-
+          pip install --require-hashes
+          -r .github/requirements/ci-tests.txt
       - name: Run live OpenClaw E2E
         env:
           # User-provided key (private repo secret) so OpenClaw can make a


### PR DESCRIPTION
## What

`ci.yml`'s `e2e-critical` and `live-openclaw-e2e` each installed their Python deps from a loose `pip install a b c` line, so every run resolved whatever the index served that minute with no integrity check on any artifact. Both now install with `pip install --require-hashes` from a file under `.github/requirements/`, which refuses anything not listed with a matching hash.

This continues the batch started in #5889 / #5897 / #5899 / #5902 / #5903 / #5907 and closes out the loose installs in this file that can be closed safely today.

## No new hashes

Neither job needed a new requirements file. Both dependency sets are already covered by sets this repository generated and proves in CI:

| Job | Previously resolved loosely | Now installs from | Already proven by |
|---|---|---|---|
| `e2e-critical` | flask, pytest, pytest-playwright, requests, duckdb | `playwright-e2e.txt` | `e2e-nightly`, `quarantine-sweep` |
| `live-openclaw-e2e` | flask, pytest, waitress, duckdb, cryptography, requests | `ci-tests.txt` | seven sibling jobs in this file |

Both files are Python 3.11 sets and both of these jobs pin 3.11 with `setup-python`, so this reuses a pin already exercised on a runner rather than introducing hashes that have never been resolved.

## Why `api-tests` and `lint` are not in this batch

They hold the remaining loose installs in this file, and that version match is exactly why they are excluded. `api-tests` runs a **3.9** matrix leg and `lint` is **3.9 only**, while `ci-tests.txt` pins `cffi==2.1.1` and `cryptography==50.0.1` — both 3.10+ only, per the dependency notes in `CLAUDE.md`. Pointing either at these files would take those legs red. They need a 3.9-compatible set, which is its own change.

The install-from-source and install-from-wheel smoke jobs (`pip-install`, `wheel-install`, `eval-suite`) are deliberately left loose: resolving clawmetry's own dependencies from the index is the thing they exist to test.

## The guard stays honest

`tests/test_workflow_yaml_valid.py::test_pytest_jobs_install_what_conftest_needs` reads a `-r` file this repo owns and checks its contents, precisely so that moving package names out of a `run:` line does not silently retire the guard for that job (the concern #5907 called out). Both changed jobs still **assert**, not skip — confirmed by node id.

## Verification

Run on Linux / CPython 3.11.15, matching what both jobs pin with `setup-python` on `ubuntu-latest`:

- `pip install --require-hashes -r` each file into a clean venv: **succeeds** for both.
- Every module the two `run:` lines previously named imports from the resulting environment (flask 3.1.3, duckdb 1.5.5, requests 2.34.2, cryptography 50.0.1, waitress, pytest, pytest-playwright, playwright).
- All **40** workflow files still parse: `python3 -c "import yaml,glob; [yaml.safe_load(open(f)) for f in glob.glob('.github/workflows/*.yml')]"`
- `tests/test_workflow_yaml_valid.py` + `tests/test_ci_workflow_invocations_are_real.py` → **594 passed, 369 skipped**, unchanged from before this edit.
- `tests/test_action_refs_pinned.py`, `tests/test_e2e_nightly_workflow.py` → pass.

## Scope

One concern, one workflow file, 16 insertions / 2 deletions. No `permissions:` block is added or removed. Under `.github/`, so exempt from the product-record gate.

No-PRD: CI-only change under `.github/`, no product code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ndb2qBqQjscpQY4KjXJxXA

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ndb2qBqQjscpQY4KjXJxXA)_