### PR TITLE
[RELEASE] OpenExecutive as the 32nd runtime (carries #5921)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - **Also fixed:** `muse_code` was missing from `sync._RUNTIME_PREFIXES` and app.js `_CM_RT_PREFIXES`, so its sessions were bucketed as openclaw there.
 - **Verified:** `tests/test_openexecutive_runtime_wiring.py` (13 tests, in CI), and the adapter against a store written by OpenExecutive's own storage code at upstream 8b2a9a7.
 - **Carries:** #5921.
+- **Released:** carries #5921 (merged as `e0537a0fbc`). The adapter ships in clawmetry-pro 0.7.26, already served by the cloud (clawmetry-cloud #2424); 0.7.27 (clawmetry-pro #247) follows with the zero-usage honesty fix found by a real end-to-end turn.
 
 ### Fixed: a correct emailed code dropped you back on "Sign in to open the dashboard" (2026-09-12)
 - **Why:** a paying customer reported it after reinstalling: enter the email, enter the code from the email, and the local dashboard shows the sign-in card again, every time. The login wall accepts only the gateway token. Email sign-in succeeded against the cloud but handed the page no credential: it cleared the signed-out marker and reloaded, relying on zero-click `/api/auth/detected-token`. That endpoint refuses unless every strict loopback check passes (client address, Host header, no proxy headers, loopback bind). Wherever one of them fails, zero-click fails on every load, so a correct code reloaded into the same wall forever.


### PR DESCRIPTION
CHANGELOG entry for **#5921**, merged as `e0537a0fbc`. This PR exists to trigger the publish; it changes `CHANGELOG.md` and nothing else.

## What is being released

OpenExecutive (SenteLabsAI/OpenExecutive) becomes runtime 32: catalogue, loader spec, session-prefix sets, probe, declared records (tokens and cost PARTIAL, since specialist agents write no usage row), memory catalogue, reopen hint, and a Guard verdict that says in a sentence why pause and stop are not offered (one API server serves every conversation). Also fixes `muse_code` missing from two session-prefix sets.

The adapter itself is in clawmetry-pro 0.7.26, which the cloud already serves (verified: `/api/license/download` returns `clawmetry_pro-0.7.26-py3-none-any.whl` on both hosts). It stays inert on nodes until this release names it in `_FAMILY_ADAPTER_SPECS`.

Verified end to end on a real OpenExecutive install (local Ollama model): a real turn with CFO and CSO consults was read back from the live store.

## After this publishes

- Crack the published wheel and grep `clawmetry/sync.py` for `clawmetry_pro.adapters.openexecutive` and `clawmetry/entitlements.py` for `"openexecutive"` before trusting the version.
- The cloud `Dockerfile` pin is auto-bumped from OSS; then verify `GET /api/runtimes` includes `openexecutive`.
- Merge clawmetry-landing #809 (its catalogue check reads OSS main) and run `CLAWMETRY_LIVE_CHECKS=1 pytest tests/test_runtime_public_surfaces.py`.

No-PRD: CHANGELOG entry only; the product record is on the feature PR #5921 (Extended Runtime Support, AC-GOV-ERS-010).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015D9pee1kCZ8NanY9bZirq4