### PR TITLE
Harden CI: the pip bootstrap step installs from a hash-pinned set

### DIFF
--- a/.github/requirements/pip-bootstrap.txt
+++ b/.github/requirements/pip-bootstrap.txt
@@ -1,0 +1,45 @@
+# Hash-pinned install set for the pip bootstrap step.
+#
+# Direct requirements: pip
+#
+# This is the `python -m pip install --upgrade pip` that opens a job, before
+# anything else is installed. It was the last unpinned resolve left in the
+# jobs that already install everything else with --require-hashes: the job
+# would fetch whatever pip PyPI served that minute, and then use THAT pip to
+# verify every hash below it. Pinning the verifier is the point -- a
+# hash-checked install is only worth as much as the installer doing the
+# checking.
+#
+# `--upgrade` is not needed and not used: naming an exact version installs
+# exactly that version over whatever actions/setup-python shipped, which is
+# what the upgrade was reaching for anyway.
+#
+# Installed with `pip install --require-hashes`, which refuses to install
+# anything not listed here with a matching hash -- so the job gets the exact
+# artifacts this file names, or it fails. pip has no dependencies of its own,
+# so the whole closure is the one name.
+#
+# Each version lists the sha256 of EVERY distribution PyPI publishes for it
+# (wheels for each platform, plus the sdist). pip accepts a download that
+# matches any one of them, so the pin does not quietly depend on the runner
+# resolving to the same wheel this file was generated against. That is what
+# lets the same file serve the ubuntu/macos/windows matrix in
+# overhead-bench.yml.
+#
+# pip 26.x requires Python >= 3.10. Every job installing this file runs on
+# 3.11 (all ten call sites pin `python-version: "3.11"`). A job on 3.9 must
+# not use this file without pinning a pip that supports it.
+#
+# Updating: Dependabot owns the routine bumps (see the /.github/requirements
+# pip entry in .github/dependabot.yml) and rewrites the hashes with them. A
+# pin with no updater is the frozen end of the same problem an unpinned
+# install is at the other end of.
+#
+# Regenerating by hand, on Linux / CPython 3.11 to match the job:
+#   pip install --dry-run --ignore-installed --report r.json pip
+# then, for each resolved name==version, take every sha256 under `urls` in
+# https://pypi.org/pypi/<name>/<version>/json.
+
+pip==26.2.1 \
+    --hash=sha256:71138adf1f4ca900cdb7d289c21b7494329f2332b6d85f0e1c42108c0384ed3e \
+    --hash=sha256:f6ad667e89a1fe78046c8f13232b247200f5258d7828f3f7883d660878e0813f

--- a/.github/requirements/pip-build-bootstrap.txt
+++ b/.github/requirements/pip-build-bootstrap.txt
@@ -1,0 +1,60 @@
+# Hash-pinned install set for the pip + build bootstrap step.
+#
+# Direct requirements: pip build
+#
+# The three jobs that build the wheel from source open with
+# `python -m pip install --upgrade pip build`. That is the same bootstrap
+# pinned in pip-bootstrap.txt, plus PyPA `build`, which is the tool that
+# produces the artifact those jobs then test. An unpinned resolve there means
+# the wheel under test was assembled by whatever build backend PyPI served
+# that minute.
+#
+# Deliberately a SECOND file rather than folding `build` into
+# pip-bootstrap.txt. Seven of the ten bootstrap call sites do not build
+# anything -- three of them bootstrap a throwaway venv that the E2E suites
+# then use to prove a freshly installed wheel boots on its own. Adding
+# `build` and its closure to those venvs would widen the dependency surface
+# the test is measuring, which is exactly the bug an isolated-venv test
+# exists to catch. Keeping the two sets apart keeps every job's installed set
+# identical to what it was before this pin.
+#
+# Installed with `pip install --require-hashes`, which refuses to install
+# anything not listed here with a matching hash. Every transitive dependency
+# is present because --require-hashes demands the whole closure; `packaging`
+# and `pyproject_hooks` are build's, not padding.
+#
+# `colorama` is deliberately absent: build declares it only under
+# `os_name == "nt"`, and all three call sites run on ubuntu-latest. A Windows
+# job adopting this file needs colorama added, or pip will refuse the install
+# rather than silently skip it.
+#
+# Each version lists the sha256 of EVERY distribution PyPI publishes for it
+# (wheels for each platform, plus the sdist). pip accepts a download that
+# matches any one of them, so the pin does not quietly depend on the runner
+# resolving to the same wheel this file was generated against.
+#
+# pip 26.x and build 1.6.x require Python >= 3.10. All three call sites pin
+# `python-version: "3.11"`.
+#
+# Updating: Dependabot owns the routine bumps (see the /.github/requirements
+# pip entry in .github/dependabot.yml) and rewrites the hashes with them. A
+# pin with no updater is the frozen end of the same problem an unpinned
+# install is at the other end of.
+#
+# Regenerating by hand, on Linux / CPython 3.11 to match the job:
+#   pip install --dry-run --ignore-installed --report r.json pip build
+# then, for each resolved name==version, take every sha256 under `urls` in
+# https://pypi.org/pypi/<name>/<version>/json.
+
+build==1.6.1 \
+    --hash=sha256:ecd351a4be9d35a9eaaba244a7687143c9c7d4aea6ac964e7e7ddab20cbcf4e7 \
+    --hash=sha256:51cc11666391ab6f092070437ac747002ff46f3e4113a3622177ee6b488bfc53
+packaging==26.3 \
+    --hash=sha256:d7193f7c8e4e93f444fde0262bf90af30e16fa0ad0ad44cb553c87339b23cd1c \
+    --hash=sha256:94edc256424af38762eb31306eed28beb9f0efc50a8837492c9d6fd6004aed79
+pip==26.2.1 \
+    --hash=sha256:71138adf1f4ca900cdb7d289c21b7494329f2332b6d85f0e1c42108c0384ed3e \
+    --hash=sha256:f6ad667e89a1fe78046c8f13232b247200f5258d7828f3f7883d660878e0813f
+pyproject_hooks==1.2.0 \
+    --hash=sha256:9e5c6bfa8dcc30091c74b0cf803c81fdd29d94f01992a7707bc97babb1141913 \
+    --hash=sha256:1e859bd5c40fae9448642dd871adf459e5e2084186e8d2c2a79a824c970da1f8

--- a/.github/workflows/api-latency-smoke.yml
+++ b/.github/workflows/api-latency-smoke.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Build wheel
         if: matrix.source == 'wheel'
         run: |
-          python -m pip install --upgrade pip build
+          python -m pip install --require-hashes -r .github/requirements/pip-build-bootstrap.txt
           python -m build --wheel
 
       - name: Install into isolated venv
@@ -63,7 +63,7 @@ jobs:
           SOURCE: ${{ matrix.source }}
         run: |
           python -m venv /tmp/vsmoke
-          /tmp/vsmoke/bin/pip install --upgrade pip
+          /tmp/vsmoke/bin/pip install --require-hashes -r .github/requirements/pip-bootstrap.txt
           if [ "$SOURCE" = "pypi" ]; then
             /tmp/vsmoke/bin/pip install --no-cache-dir clawmetry flask waitress cryptography duckdb requests
           else

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1371,12 +1371,12 @@ jobs:
           python-version: "3.11"
       - name: Build wheel
         run: |
-          python -m pip install --upgrade pip build
+          python -m pip install --require-hashes -r .github/requirements/pip-build-bootstrap.txt
           python -m build --wheel
       - name: Install wheel in isolated venv
         run: |
           python -m venv /tmp/vwheel
-          /tmp/vwheel/bin/pip install --upgrade pip
+          /tmp/vwheel/bin/pip install --require-hashes -r .github/requirements/pip-bootstrap.txt
           /tmp/vwheel/bin/pip install dist/clawmetry-*.whl flask waitress cryptography pytest requests
       - name: Verify runtime assets shipped in wheel
         run: |
@@ -1466,7 +1466,7 @@ jobs:
           cache: pip
       - name: Install ClawMetry (editable) + eval deps
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --require-hashes -r .github/requirements/pip-bootstrap.txt
           pip install -e . pyyaml httpx
       - name: Check kill-switch
         id: gate

--- a/.github/workflows/cross-repo-handoff.yml
+++ b/.github/workflows/cross-repo-handoff.yml
@@ -102,7 +102,7 @@ jobs:
         # tests/test_workflow_yaml_valid.py resolve and check the file.
         working-directory: oss
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --require-hashes -r .github/requirements/pip-bootstrap.txt
           pip install --require-hashes \
             -r .github/requirements/cross-repo-handoff.txt
 

--- a/.github/workflows/oss-golden-path.yml
+++ b/.github/workflows/oss-golden-path.yml
@@ -66,13 +66,13 @@ jobs:
       # the full E2E flow.
       - name: Build wheel
         run: |
-          python -m pip install --upgrade pip build
+          python -m pip install --require-hashes -r .github/requirements/pip-build-bootstrap.txt
           python -m build --wheel
 
       - name: Install wheel in isolated venv
         run: |
           python -m venv /tmp/oss-golden
-          /tmp/oss-golden/bin/pip install --upgrade pip
+          /tmp/oss-golden/bin/pip install --require-hashes -r .github/requirements/pip-bootstrap.txt
           /tmp/oss-golden/bin/pip install \
             dist/clawmetry-*.whl \
             flask waitress cryptography duckdb requests \

--- a/.github/workflows/overhead-bench.yml
+++ b/.github/workflows/overhead-bench.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Install
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --require-hashes -r .github/requirements/pip-bootstrap.txt
           python -m pip install -e . requests
 
       # --quick keeps a shared runner under a couple of minutes. The full run


### PR DESCRIPTION
**Product record:** No-PRD: CI-only change under `.github/`; no product behaviour is touched.

**Risk:** Low, and contained to CI. If a hash or version in either new file is wrong, the affected job fails loudly at its first step with a pip hash-mismatch error — there is no silent-wrong mode, and nothing is published or deployed from these five workflows. Undone by reverting the commit. Nothing in flight collides: no other open PR touches `.github/requirements/`. The one behaviour change to reason about is that pip is now installed at an exact version rather than "latest", which is the point of the change.

---

## Summary

- The jobs that already install everything else with `--require-hashes` still opened with a bare `python -m pip install --upgrade pip`. That resolve was unpinned, so the job fetched whatever pip PyPI served that minute and then used **that** pip to verify every hash below it. A hash-checked install is only worth as much as the installer doing the checking.
- Nine call sites across five workflows now install from one of two new hash-pinned sets. This closes 9 of the 49 open `PinnedDependenciesID` findings, continuing the batches merged in #5889, #5897, #5899, #5902, #5903, #5907 and #5915.
- `--upgrade` is gone because naming an exact version does the same job: pip 26.2.1 is installed over whatever `actions/setup-python` shipped, which is what the upgrade was reaching for anyway.

### The two files

| File | Contents | Sites |
|---|---|---|
| `.github/requirements/pip-bootstrap.txt` | `pip` | 6 |
| `.github/requirements/pip-build-bootstrap.txt` | `pip`, `build`, `packaging`, `pyproject_hooks` | 3 |

Deliberately **two** files rather than one. Six of the nine sites do not build anything, and three of those bootstrap a throwaway venv that the E2E suites then use to prove a freshly installed wheel boots on its own. Adding `build` and its closure to those venvs would widen the dependency surface the test is measuring — which is exactly the bug an isolated-venv test exists to catch. As it stands, every job's installed set is byte-for-byte what it was before this PR, with the versions now fixed.

Both files join the existing `/.github/requirements` Dependabot entry, so the pins move rather than freeze — the same pin/updater pairing the sibling files document.

### Scope, and what is deliberately left out

This PR touches only the **PR-triggered** workflows, so its own CI exercises all nine hunks. The remaining seven bootstrap sites are left for separate changes, for reasons that are not "ran out of time":

- `conformance-heartbeat.yml` (2), `desktop-artifacts.yml` (2), `release-canary.yml` (1), `release-on-merge.yml` (1) — none are `pull_request`-triggered, so no PR can validate a change to them before it lands on `main`. Pinning the release pipeline's bootstrap on a run that cannot test it is how you find out at release time.
- `pr-screenshots.yml` (1) — it checks out into `head/` and `base/`, so there is no `.github/` at the workspace root and the reference has to name one of the two trees. That is a trust decision (`head/` is PR-author-controlled), not a path fix, and it deserves its own review. It would also fail on this PR, since `base` is `main` and would not yet contain the file.

## Test plan

- [x] Every workflow file parses: `python3 -c "import yaml,glob; [yaml.safe_load(open(f)) for f in glob.glob('.github/workflows/*.yml')]"` — 40/40 OK
- [x] Both sets install under `--require-hashes` in a clean 3.11 venv, and pip ends at 26.2.1 in each — i.e. the replacement does what `--upgrade pip` did
- [x] `python -m build --wheel` with the pinned build toolchain produces `clawmetry-*-py3-none-any.whl`, so the three build sites still build
- [x] Simulated the `cross-repo-handoff` install order (`pip-bootstrap.txt` then `cross-repo-handoff.txt`) in one venv — no version conflict; both pin `packaging==26.3` identically
- [x] `tests/test_workflow_yaml_valid.py`, `tests/test_action_refs_pinned.py`, `tests/test_ci_workflow_invocations_are_real.py` — 613 passed, 370 skipped
- [x] `make lint-ci-test-coverage`, `lint-runtime-count`, `lint-module-map`, `lint-daemon-allowlist` — all green
- [x] `make lint-py` fails identically (231 errors, all in `dashboard.py`) on this branch and on a clean `main`, so it is pre-existing and unrelated; this diff contains no Python

Hashes were generated by the procedure the sibling requirements files document: `pip install --dry-run --ignore-installed --report` on Linux / CPython 3.11 to match the jobs, then every `sha256` under `urls` in the PyPI JSON for each resolved version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011qRmtoZTzuS7CxzZ9GnsU9

---
_Generated by [Claude Code](https://claude.ai/code/session_011qRmtoZTzuS7CxzZ9GnsU9)_